### PR TITLE
weather@mockturtl update 3.6.1

### DIFF
--- a/weather@mockturtl/CHANGELOG.md
+++ b/weather@mockturtl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.6.1
 
-- Make translating conditions more consistent across all providers
+- Make translating conditions more consistent across all providers and clarify purpose of "Translate conditions" settings toggle
 - Stop applet loop when applet is removed
 - Add missing dewpoint from Open-Meteo
 - Fix

--- a/weather@mockturtl/CHANGELOG.md
+++ b/weather@mockturtl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.6.1
+
+- Make translating conditions more consistent across all providers
+- Stop applet loop when applet is removed
+- Add missing dewpoint from Open-Meteo
+- Fix
+  [[weather@mockturtl] Applet Bug #6048](https://github.com/linuxmint/cinnamon-spices-applets/issues/6048), Fix [weather@mockturtl: Hourly weather forecast is not displayed #6046](https://github.com/linuxmint/cinnamon-spices-applets/issues/6046) - Rename OpenWeatherMap name internally so people fall back to the default Open-Meteo so no user-action is needed.
+
 ## 3.6.0
 
 - Add eslint and fix all eslint errors

--- a/weather@mockturtl/files/weather@mockturtl/3.8/settings-schema.json
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/settings-schema.json
@@ -498,7 +498,8 @@
 	"translateCondition": {
 		"type": "checkbox",
 		"default": true,
-		"description": "Translate conditions"
+		"description": "Provider should translate conditions if available",
+		"tooltip": "Should your provider translate the conditions to your language if your locale is supported by the provider. Otherwise the applet will use it's own translation system."
 	},
 	"shortConditions": {
 		"type": "checkbox",

--- a/weather@mockturtl/files/weather@mockturtl/3.8/settings-schema.json
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/settings-schema.json
@@ -198,7 +198,7 @@
 		"tooltip": "You can choose between several different weather forecast providers. Some providers require a API key to work, some have regional limits, differ in forecast length, and they all need a functional internet connection to work. The options are described in detail on the Cinnamon Spices Website which you can access with the button on the Help tab.",
 		"options": {
 			"Open-Meteo": "OpenMeteo",
-			"OpenWeatherMap": "OpenWeatherMap",
+			"OpenWeatherMap": "OpenWeatherMap_Open",
 			"MET Norway": "MetNorway",
 			"DMI Denmark": "DanishMI",
 			"Deutscher Wetterdienst (Germany only)": "DeutscherWetterdienst",

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -16965,7 +16965,7 @@ function OpenMeteoCurrentWeatherToData(data) {
             speed: KPHtoMPS(data.wind_speed_10m),
             degree: data.wind_direction_10m,
         },
-        dewPoint: null,
+        dewPoint: CelsiusToKelvin(data.dewpoint_2m),
         extra_field: {
             name: _("Feels like"),
             value: CelsiusToKelvin(data.apparent_temperature),
@@ -17057,7 +17057,7 @@ class OpenMeteo extends BaseProvider {
             params: {
                 latitude: loc.lat,
                 longitude: loc.lon,
-                current: "temperature_2m,relative_humidity_2m,apparent_temperature,is_day,precipitation,rain,showers,snowfall,weather_code,surface_pressure,wind_speed_10m,wind_direction_10m,wind_gusts_10m",
+                current: "temperature_2m,dewpoint_2m,relative_humidity_2m,apparent_temperature,is_day,precipitation,rain,showers,snowfall,weather_code,surface_pressure,wind_speed_10m,wind_direction_10m,wind_gusts_10m",
                 hourly: "temperature_2m,precipitation_probability,precipitation,rain,showers,snowfall,snow_depth,weather_code,wind_speed_10m,wind_direction_10m,is_day",
                 daily: "weather_code,temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,sunrise,sunset",
                 timezone: "auto",

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -9473,11 +9473,8 @@ function OnSameDay(date1, date2) {
 function ValidTimezone(tz) {
     return DateTime.utc().setZone(tz).isValid;
 }
-function ProcessCondition(condition, shouldTranslate) {
-    condition = CapitalizeFirstLetter(condition);
-    if (shouldTranslate)
-        condition = _(condition);
-    return condition;
+function ProcessCondition(condition) {
+    return CapitalizeFirstLetter(condition);
 }
 function LocalizedColon(locale) {
     if (locale == null)
@@ -11227,8 +11224,8 @@ class MetUk extends BaseProvider {
 ;
 
 ;// CONCATENATED MODULE: ./src/3_8/providers/openweathermap/payload/common.ts
-
-const OWM_SUPPORTED_LANGS = ["af", "al", "ar", "az", "bg", "ca", "cz", "da", "de", "el", "en", "eu", "fa", "fi",
+const OWM_SUPPORTED_LANGS = [
+    "af", "al", "ar", "az", "bg", "ca", "cz", "da", "de", "el", "en", "eu", "fa", "fi",
     "fr", "gl", "he", "hi", "hr", "hu", "id", "it", "ja", "kr", "la", "lt", "mk", "no", "nl", "pl",
     "pt", "pt_br", "ro", "ru", "se", "sk", "sl", "sp", "es", "sr", "th", "tr", "ua", "uk", "vi", "zh_cn", "zh_tw", "zu"
 ];
@@ -11256,67 +11253,165 @@ function ConvertLocaleToOWMLang(systemLocale) {
     }
     return lang;
 }
-const openWeatherMapConditionLibrary = [
-    _("Thunderstorm with light rain"),
-    _("Thunderstorm with rain"),
-    _("Thunderstorm with heavy rain"),
-    _("Light thunderstorm"),
-    _("Thunderstorm"),
-    _("Heavy thunderstorm"),
-    _("Ragged thunderstorm"),
-    _("Thunderstorm with light drizzle"),
-    _("Thunderstorm with drizzle"),
-    _("Thunderstorm with heavy drizzle"),
-    _("Light intensity drizzle"),
-    _("Drizzle"),
-    _("Heavy intensity drizzle"),
-    _("Light intensity drizzle rain"),
-    _("Drizzle rain"),
-    _("Heavy intensity drizzle rain"),
-    _("Shower rain and drizzle"),
-    _("Heavy shower rain and drizzle"),
-    _("Shower drizzle"),
-    _("Light rain"),
-    _("Moderate rain"),
-    _("Heavy intensity rain"),
-    _("Very heavy rain"),
-    _("Extreme rain"),
-    _("Freezing rain"),
-    _("Light intensity shower rain"),
-    _("Shower rain"),
-    _("Heavy intensity shower rain"),
-    _("Ragged shower rain"),
-    _("Light snow"),
-    _("Snow"),
-    _("Heavy snow"),
-    _("Sleet"),
-    _("Shower sleet"),
-    _("Light rain and snow"),
-    _("Rain and snow"),
-    _("Light shower snow"),
-    _("Shower snow"),
-    _("Heavy shower snow"),
-    _("Mist"),
-    _("Smoke"),
-    _("Haze"),
-    _("Sand, dust whirls"),
-    _("Fog"),
-    _("Sand"),
-    _("Dust"),
-    _("Volcanic ash"),
-    _("Squalls"),
-    _("Tornado"),
-    _("Clear"),
-    _("Clear sky"),
-    _("Sky is clear"),
-    _("Clouds"),
-    _("Few clouds"),
-    _("Scattered clouds"),
-    _("Broken clouds"),
-    _("Overcast clouds")
-];
 
 ;// CONCATENATED MODULE: ./src/3_8/providers/openweathermap/payload/condition.ts
+
+
+function OWMMainToTranslated(condition) {
+    switch (condition) {
+        case "Thunderstorm":
+            return _("Thunderstorm");
+        case "Drizzle":
+            return _("Drizzle");
+        case "Rain":
+            return _("Rain");
+        case "Snow":
+            return _("Snow");
+        case "Clear":
+            return _("Clear");
+        case "Clouds":
+            return _("Clouds");
+        case "Mist":
+            return _("Mist");
+        case "Smoke":
+            return _("Smoke");
+        case "Haze":
+            return _("Haze");
+        case "Dust":
+            return _("Dust");
+        case "Fog":
+            return _("Fog");
+        case "Sand":
+            return _("Sand");
+        case "Ash":
+            return _("Ash");
+        case "Squall":
+            return _("Squall");
+        case "Tornado":
+            return _("Tornado");
+        default:
+            logger_Logger.Error("Unknown weather condition main: " + condition);
+            return condition;
+    }
+}
+function OWMDescToTranslated(description) {
+    switch (description) {
+        case "thunderstorm with light rain":
+            return _("Thunderstorm with light rain");
+        case "thunderstorm with rain":
+            return _("Thunderstorm with rain");
+        case "thunderstorm with heavy rain":
+            return _("Thunderstorm with heavy rain");
+        case "light thunderstorm":
+            return _("Light thunderstorm");
+        case "thunderstorm":
+            return _("Thunderstorm");
+        case "heavy thunderstorm":
+            return _("Heavy thunderstorm");
+        case "ragged thunderstorm":
+            return _("Ragged thunderstorm");
+        case "thunderstorm with light drizzle":
+            return _("Thunderstorm with light drizzle");
+        case "thunderstorm with drizzle":
+            return _("Thunderstorm with drizzle");
+        case "thunderstorm with heavy drizzle":
+            return _("Thunderstorm with heavy drizzle");
+        case "light intensity drizzle":
+            return _("Light intensity drizzle");
+        case "drizzle":
+            return _("Drizzle");
+        case "heavy intensity drizzle":
+            return _("Heavy intensity drizzle");
+        case "light intensity drizzle rain":
+            return _("Light intensity drizzle rain");
+        case "drizzle rain":
+            return _("Drizzle rain");
+        case "heavy intensity drizzle rain":
+            return _("Heavy intensity drizzle rain");
+        case "shower rain and drizzle":
+            return _("Shower rain and drizzle");
+        case "heavy shower rain and drizzle":
+            return _("Heavy shower rain and drizzle");
+        case "shower drizzle":
+            return _("Shower drizzle");
+        case "light rain":
+            return _("Light rain");
+        case "moderate rain":
+            return _("Moderate rain");
+        case "heavy intensity rain":
+            return _("Heavy intensity rain");
+        case "very heavy rain":
+            return _("Very heavy rain");
+        case "extreme rain":
+            return _("Extreme rain");
+        case "freezing rain":
+            return _("Freezing rain");
+        case "light intensity shower rain":
+            return _("Light intensity shower rain");
+        case "shower rain":
+            return _("Shower rain");
+        case "heavy intensity shower rain":
+            return _("Heavy intensity shower rain");
+        case "ragged shower rain":
+            return _("Ragged shower rain");
+        case "light snow":
+            return _("Light snow");
+        case "snow":
+            return _("Snow");
+        case "heavy snow":
+            return _("Heavy snow");
+        case "sleet":
+            return _("Sleet");
+        case "light shower sleet":
+            return _("Light shower sleet");
+        case "shower sleet":
+            return _("Shower sleet");
+        case "light rain and snow":
+            return _("Light rain and snow");
+        case "rain and snow":
+            return _("Rain and snow");
+        case "light shower snow":
+            return _("Light shower snow");
+        case "shower snow":
+            return _("Shower snow");
+        case "heavy shower snow":
+            return _("Heavy shower snow");
+        case "mist":
+            return _("Mist");
+        case "smoke":
+            return _("Smoke");
+        case "haze":
+            return _("Haze");
+        case "sand/dust whirls":
+            return _("Sand, dust whirls");
+        case "fog":
+            return _("Fog");
+        case "sand":
+            return _("Sand");
+        case "dust":
+            return _("Dust");
+        case "volcanic ash":
+            return _("Volcanic ash");
+        case "squalls":
+            return _("Squalls");
+        case "tornado":
+            return _("Tornado");
+        case "clear sky":
+        case "sky is clear":
+            return _("Clear sky");
+        case "few clouds":
+            return _("Few clouds");
+        case "scattered clouds":
+            return _("Scattered clouds");
+        case "broken clouds":
+            return _("Broken clouds");
+        case "overcast clouds":
+            return _("Overcast clouds");
+        default:
+            logger_Logger.Error("Unknown weather condition description: " + description);
+            return description;
+    }
+}
 function OWMIconToBuiltInIcons(icon) {
     switch (icon) {
         case "10d":
@@ -11406,8 +11501,8 @@ function OWMIconToCustomIcon(icon) {
 
 
 
-function OWMOneCallToWeatherData(json) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o;
+function OWMOneCallToWeatherData(json, conditionsTranslated) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u;
     const weather = {
         coord: {
             lat: json.lat,
@@ -11429,10 +11524,10 @@ function OWMOneCallToWeatherData(json) {
         humidity: json.current.humidity,
         dewPoint: json.current.dew_point,
         condition: {
-            main: (_c = (_b = (_a = json === null || json === void 0 ? void 0 : json.current) === null || _a === void 0 ? void 0 : _a.weather) === null || _b === void 0 ? void 0 : _b[0]) === null || _c === void 0 ? void 0 : _c.main,
-            description: (_f = (_e = (_d = json === null || json === void 0 ? void 0 : json.current) === null || _d === void 0 ? void 0 : _d.weather) === null || _e === void 0 ? void 0 : _e[0]) === null || _f === void 0 ? void 0 : _f.description,
-            icons: OWMIconToBuiltInIcons((_j = (_h = (_g = json === null || json === void 0 ? void 0 : json.current) === null || _g === void 0 ? void 0 : _g.weather) === null || _h === void 0 ? void 0 : _h[0]) === null || _j === void 0 ? void 0 : _j.icon),
-            customIcon: OWMIconToCustomIcon((_m = (_l = (_k = json === null || json === void 0 ? void 0 : json.current) === null || _k === void 0 ? void 0 : _k.weather) === null || _l === void 0 ? void 0 : _l[0]) === null || _m === void 0 ? void 0 : _m.icon)
+            main: conditionsTranslated ? (_c = (_b = (_a = json === null || json === void 0 ? void 0 : json.current) === null || _a === void 0 ? void 0 : _a.weather) === null || _b === void 0 ? void 0 : _b[0]) === null || _c === void 0 ? void 0 : _c.main : OWMMainToTranslated((_f = (_e = (_d = json === null || json === void 0 ? void 0 : json.current) === null || _d === void 0 ? void 0 : _d.weather) === null || _e === void 0 ? void 0 : _e[0]) === null || _f === void 0 ? void 0 : _f.main),
+            description: conditionsTranslated ? (_j = (_h = (_g = json === null || json === void 0 ? void 0 : json.current) === null || _g === void 0 ? void 0 : _g.weather) === null || _h === void 0 ? void 0 : _h[0]) === null || _j === void 0 ? void 0 : _j.description : OWMDescToTranslated((_m = (_l = (_k = json === null || json === void 0 ? void 0 : json.current) === null || _k === void 0 ? void 0 : _k.weather) === null || _l === void 0 ? void 0 : _l[0]) === null || _m === void 0 ? void 0 : _m.description),
+            icons: OWMIconToBuiltInIcons((_q = (_p = (_o = json === null || json === void 0 ? void 0 : json.current) === null || _o === void 0 ? void 0 : _o.weather) === null || _p === void 0 ? void 0 : _p[0]) === null || _q === void 0 ? void 0 : _q.icon),
+            customIcon: OWMIconToCustomIcon((_t = (_s = (_r = json === null || json === void 0 ? void 0 : json.current) === null || _r === void 0 ? void 0 : _r.weather) === null || _s === void 0 ? void 0 : _s[0]) === null || _t === void 0 ? void 0 : _t.icon)
         },
         extra_field: {
             name: _("Feels Like"),
@@ -11466,8 +11561,8 @@ function OWMOneCallToWeatherData(json) {
             temp_min: day.temp.min,
             temp_max: day.temp.max,
             condition: {
-                main: day.weather[0].main,
-                description: day.weather[0].description,
+                main: conditionsTranslated ? day.weather[0].main : OWMMainToTranslated(day.weather[0].main),
+                description: conditionsTranslated ? day.weather[0].description : OWMDescToTranslated(day.weather[0].description),
                 icons: OWMIconToBuiltInIcons(day.weather[0].icon),
                 customIcon: OWMIconToCustomIcon(day.weather[0].icon)
             },
@@ -11481,8 +11576,8 @@ function OWMOneCallToWeatherData(json) {
             date: DateTime.fromSeconds(hour.dt, { zone: json.timezone }),
             temp: hour.temp,
             condition: {
-                main: hour.weather[0].main,
-                description: hour.weather[0].description,
+                main: conditionsTranslated ? hour.weather[0].main : OWMMainToTranslated(hour.weather[0].main),
+                description: conditionsTranslated ? hour.weather[0].description : OWMDescToTranslated(hour.weather[0].description),
                 icons: OWMIconToBuiltInIcons(hour.weather[0].icon),
                 customIcon: OWMIconToCustomIcon(hour.weather[0].icon)
             },
@@ -11505,7 +11600,7 @@ function OWMOneCallToWeatherData(json) {
     }
     weather.hourlyForecasts = hourly;
     const alerts = [];
-    for (const alert of (_o = json.alerts) !== null && _o !== void 0 ? _o : []) {
+    for (const alert of (_u = json.alerts) !== null && _u !== void 0 ? _u : []) {
         alerts.push({
             sender_name: alert.sender_name,
             level: "unknown",
@@ -11594,7 +11689,7 @@ class OpenWeatherMapOneCall extends BaseProvider {
         if (!json)
             return null;
         json.id = cachedID !== null && cachedID !== void 0 ? cachedID : idPayload === null || idPayload === void 0 ? void 0 : idPayload.id;
-        return OWMOneCallToWeatherData(json);
+        return OWMOneCallToWeatherData(json, !!params.lang);
     }
     ;
     ConstructParams(loc, key) {
@@ -16805,8 +16900,8 @@ class OpenMeteo extends BaseProvider {
 ;// CONCATENATED MODULE: ./src/3_8/providers/openweathermap/payload/forecast_daily.ts
 
 
-function OWMDailyForecastsToData(forecast, timezone = "local") {
-    var _a, _b, _c, _d, _e, _f, _g, _h;
+function OWMDailyForecastsToData(forecast, conditionsTranslated, timezone = "local") {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
     const result = [];
     for (const day of forecast) {
         const data = {
@@ -16814,10 +16909,10 @@ function OWMDailyForecastsToData(forecast, timezone = "local") {
             temp_max: day.temp.max,
             temp_min: day.temp.min,
             condition: {
-                main: (_b = (_a = day.weather) === null || _a === void 0 ? void 0 : _a[0]) === null || _b === void 0 ? void 0 : _b.main,
-                description: (_d = (_c = day.weather) === null || _c === void 0 ? void 0 : _c[0]) === null || _d === void 0 ? void 0 : _d.description,
-                icons: OWMIconToBuiltInIcons((_f = (_e = day.weather) === null || _e === void 0 ? void 0 : _e[0]) === null || _f === void 0 ? void 0 : _f.icon),
-                customIcon: OWMIconToCustomIcon((_h = (_g = day.weather) === null || _g === void 0 ? void 0 : _g[0]) === null || _h === void 0 ? void 0 : _h.icon)
+                main: conditionsTranslated ? (_b = (_a = day.weather) === null || _a === void 0 ? void 0 : _a[0]) === null || _b === void 0 ? void 0 : _b.main : OWMMainToTranslated((_d = (_c = day.weather) === null || _c === void 0 ? void 0 : _c[0]) === null || _d === void 0 ? void 0 : _d.main),
+                description: conditionsTranslated ? (_f = (_e = day.weather) === null || _e === void 0 ? void 0 : _e[0]) === null || _f === void 0 ? void 0 : _f.description : OWMDescToTranslated((_h = (_g = day.weather) === null || _g === void 0 ? void 0 : _g[0]) === null || _h === void 0 ? void 0 : _h.description),
+                icons: OWMIconToBuiltInIcons((_k = (_j = day.weather) === null || _j === void 0 ? void 0 : _j[0]) === null || _k === void 0 ? void 0 : _k.icon),
+                customIcon: OWMIconToCustomIcon((_m = (_l = day.weather) === null || _l === void 0 ? void 0 : _l[0]) === null || _m === void 0 ? void 0 : _m.icon)
             }
         };
         result.push(data);
@@ -16829,8 +16924,8 @@ function OWMDailyForecastsToData(forecast, timezone = "local") {
 
 
 
-function OWMWeatherToWeatherData(weather, timezone = "local") {
-    var _a, _b, _c, _d;
+function OWMWeatherToWeatherData(weather, conditionsTranslated, timezone = "local") {
+    var _a, _b, _c, _d, _e, _f;
     return {
         date: DateTime.fromSeconds(weather.dt, { zone: timezone }),
         sunrise: DateTime.fromSeconds(weather.sys.sunrise, { zone: timezone }),
@@ -16842,10 +16937,10 @@ function OWMWeatherToWeatherData(weather, timezone = "local") {
             url: `https://openweathermap.org/city/${weather.id}`
         },
         condition: {
-            main: (_a = weather.weather) === null || _a === void 0 ? void 0 : _a[0].main,
-            description: (_b = weather.weather) === null || _b === void 0 ? void 0 : _b[0].description,
-            icons: OWMIconToBuiltInIcons((_c = weather.weather) === null || _c === void 0 ? void 0 : _c[0].icon),
-            customIcon: OWMIconToCustomIcon((_d = weather.weather) === null || _d === void 0 ? void 0 : _d[0].icon)
+            main: conditionsTranslated ? (_a = weather.weather) === null || _a === void 0 ? void 0 : _a[0].main : OWMMainToTranslated((_b = weather.weather) === null || _b === void 0 ? void 0 : _b[0].main),
+            description: conditionsTranslated ? (_c = weather.weather) === null || _c === void 0 ? void 0 : _c[0].description : OWMDescToTranslated((_d = weather.weather) === null || _d === void 0 ? void 0 : _d[0].description),
+            icons: OWMIconToBuiltInIcons((_e = weather.weather) === null || _e === void 0 ? void 0 : _e[0].icon),
+            customIcon: OWMIconToCustomIcon((_f = weather.weather) === null || _f === void 0 ? void 0 : _f[0].icon)
         },
         wind: {
             speed: weather.wind.speed,
@@ -16884,20 +16979,21 @@ class OpenWeatherMapOpen extends BaseProvider {
         this.supportHourlyPrecipVolume = false;
     }
     async GetWeather(loc, cancellable, config) {
+        const params = this.ConstructParams(loc);
         const current = await HttpLib.Instance.LoadJsonSimple({
             url: "https://api.openweathermap.org/data/2.5/weather",
             cancellable,
-            params: this.ConstructParams(loc)
+            params: params
         });
         const daily = await HttpLib.Instance.LoadJsonSimple({
             url: "https://api.openweathermap.org/data/2.5/forecast/daily",
             cancellable,
-            params: this.ConstructParams(loc)
+            params: params
         });
         if (!current || !daily) {
             return null;
         }
-        return Object.assign(Object.assign({}, OWMWeatherToWeatherData(current, config.Timezone)), { forecasts: OWMDailyForecastsToData(daily.list, config.Timezone) });
+        return Object.assign(Object.assign({}, OWMWeatherToWeatherData(current, !!params.lang, config.Timezone)), { forecasts: OWMDailyForecastsToData(daily.list, !!params.lang, config.Timezone) });
     }
     ConstructParams(loc) {
         const params = {
@@ -19607,17 +19703,17 @@ The contents of the file saved from the applet help page goes here
             weatherInfo.coord.lon = locationData.lon;
         if (weatherInfo.hourlyForecasts == null)
             weatherInfo.hourlyForecasts = [];
-        weatherInfo.condition.main = ProcessCondition(weatherInfo.condition.main, this.config._translateCondition);
-        weatherInfo.condition.description = ProcessCondition(weatherInfo.condition.description, this.config._translateCondition);
+        weatherInfo.condition.main = ProcessCondition(weatherInfo.condition.main);
+        weatherInfo.condition.description = ProcessCondition(weatherInfo.condition.description);
         for (const forecast of weatherInfo.forecasts) {
             const condition = forecast.condition;
-            condition.main = ProcessCondition(condition.main, this.config._translateCondition);
-            condition.description = ProcessCondition(condition.description, this.config._translateCondition);
+            condition.main = ProcessCondition(condition.main);
+            condition.description = ProcessCondition(condition.description);
         }
         for (const forecast of weatherInfo.hourlyForecasts) {
             const condition = forecast.condition;
-            condition.main = ProcessCondition(condition.main, this.config._translateCondition);
-            condition.description = ProcessCondition(condition.description, this.config._translateCondition);
+            condition.main = ProcessCondition(condition.main);
+            condition.description = ProcessCondition(condition.description);
         }
         return weatherInfo;
     }

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -16143,7 +16143,35 @@ class WeatherUnderground extends BaseProvider {
     }
 }
 
+;// CONCATENATED MODULE: ./src/3_8/providers/pirate_weather/types/common.ts
+
+
+function PirateWeatherSummaryToTranslated(summary) {
+    switch (summary) {
+        case "Clear":
+            return _("Clear");
+        case "Partly Cloudy":
+            return _("Partly Cloudy");
+        case "Rain":
+            return _("Rain");
+        case "Cloudy":
+            return _("Cloudy");
+        case "Snow":
+            return _("Snow");
+        case "Wind":
+            return _("Wind");
+        case "Fog":
+            return _("Fog");
+        case "Sleet":
+            return _("Sleet");
+        default:
+            logger_Logger.Error(`Unknown PirateWeatherSummary: ${summary}`);
+            return summary;
+    }
+}
+
 ;// CONCATENATED MODULE: ./src/3_8/providers/pirate_weather/pirateWeather.ts
+
 
 
 
@@ -16180,7 +16208,7 @@ class PirateWeather extends BaseProvider {
                     userError: true,
                     detail: "no key",
                     service: "pirate_weather",
-                    message: _("Please Make sure you\nentered the API key that you have from DarkSky")
+                    message: _("Please Make sure you\nentered the API key that you have from Pirate Weather")
                 });
                 return false;
             }
@@ -16229,8 +16257,8 @@ class PirateWeather extends BaseProvider {
                 humidity: json.currently.humidity * 100,
                 dewPoint: this.ToKelvin(json.currently.dewPoint, unit),
                 condition: {
-                    main: json.currently.summary,
-                    description: json.currently.summary,
+                    main: PirateWeatherSummaryToTranslated(json.currently.summary),
+                    description: PirateWeatherSummaryToTranslated(json.currently.summary),
                     icons: this.ResolveIcon(json.currently.icon, { sunrise: sunrise, sunset: sunset }),
                     customIcon: this.ResolveCustomIcon(json.currently.icon)
                 },
@@ -16248,8 +16276,8 @@ class PirateWeather extends BaseProvider {
                     temp_min: this.ToKelvin(day.temperatureLow, unit),
                     temp_max: this.ToKelvin(day.temperatureHigh, unit),
                     condition: {
-                        main: day.summary,
-                        description: day.summary,
+                        main: PirateWeatherSummaryToTranslated(day.summary),
+                        description: PirateWeatherSummaryToTranslated(day.summary),
                         icons: this.ResolveIcon(day.icon),
                         customIcon: this.ResolveCustomIcon(day.icon)
                     },
@@ -16262,8 +16290,8 @@ class PirateWeather extends BaseProvider {
                     date: DateTime.fromSeconds(hour.time, { zone: json.timezone }),
                     temp: this.ToKelvin(hour.temperature, unit),
                     condition: {
-                        main: hour.summary,
-                        description: hour.summary,
+                        main: PirateWeatherSummaryToTranslated(hour.summary),
+                        description: PirateWeatherSummaryToTranslated(hour.summary),
                         icons: this.ResolveIcon(hour.icon, { sunrise: sunrise, sunset: sunset }, DateTime.fromSeconds(hour.time, { zone: json.timezone })),
                         customIcon: this.ResolveCustomIcon(hour.icon)
                     },

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -17144,7 +17144,7 @@ class OpenWeatherMapOpen extends BaseProvider {
         super(...arguments);
         this.needsApiKey = false;
         this.prettyName = _("OpenWeatherMap");
-        this.name = "OpenWeatherMap";
+        this.name = "OpenWeatherMap_Open";
         this.maxForecastSupport = 7;
         this.maxHourlyForecastSupport = 0;
         this.website = "https://openweathermap.org/";
@@ -17217,7 +17217,7 @@ const { IconType: config_IconType } = imports.gi.St;
 const { get_language_names, TimeZone } = imports.gi.GLib;
 const { Settings: config_Settings } = imports.gi.Gio;
 const ServiceClassMapping = {
-    "OpenWeatherMap": (app) => new OpenWeatherMapOpen(app),
+    "OpenWeatherMap_Open": (app) => new OpenWeatherMapOpen(app),
     "OpenWeatherMap_OneCall": (app) => new OpenWeatherMapOneCall(app),
     "MetNorway": (app) => new MetNorway(app),
     "Weatherbit": (app) => new Weatherbit(app),

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -17874,6 +17874,10 @@ class WeatherLoop {
     async Start() {
         logger_Logger.Info("Main Loop started.");
         while (true) {
+            if (this.IsStray()) {
+                logger_Logger.Info("Applet removed, stopping loop.");
+                return;
+            }
             await this.DoCheck({ immediate: false });
             await delay(this.LoopInterval());
         }

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -16763,8 +16763,8 @@ function OpenMeteoWeatherCodeToCondition(code, isDay) {
             return {
                 icons: !isDay ? ["weather-few-clouds-night"] : ["weather-few-clouds"],
                 customIcon: !isDay ? "night-alt-cloudy-symbolic" : "day-cloudy-symbolic",
-                main: _("Mainly clear"),
-                description: _("Mainly clear")
+                main: _("Few clouds"),
+                description: _("Few clouds")
             };
         case 2:
             return {

--- a/weather@mockturtl/files/weather@mockturtl/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/metadata.json
@@ -3,7 +3,7 @@
   "name": "Weather",
   "description": "View your local weather forecast",
   "max-instances": 3,
-  "version": "3.6.0",
+  "version": "3.6.1",
   "multiversion": true,
   "cinnamon-version": ["2.2", "2.4", "2.6", "2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.4", "4.6", "4.8"]
 }

--- a/weather@mockturtl/files/weather@mockturtl/po/ar.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ar.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-02-16 11:25+0100\n"
 "Last-Translator: Yaron Sheffer <yaronf@gmx.com>\n"
 "Language-Team: Hebrew <none@example.com>\n"
@@ -20,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr ""
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr ""
 
@@ -88,8 +88,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -101,12 +101,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -120,7 +120,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -128,55 +128,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "يحمل الطقس الحالي..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "يحمل طقس المستقبل..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "يحمل..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "درجة الحرارة:"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "الرطوبة:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "الضغط:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "الريح:"
@@ -185,15 +185,15 @@ msgstr "الريح:"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -201,17 +201,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -247,15 +247,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -266,13 +266,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -281,12 +281,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "ثلج كثيف"
@@ -294,38 +295,41 @@ msgstr "ثلج كثيف"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "مطر متجمد"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "مطر متجمد"
@@ -333,168 +337,175 @@ msgstr "مطر متجمد"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "مطر متجمد"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "مطر متجمد"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "رذاذ متجمد"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "رذاذ متجمد"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "رذاذ متجمد"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "ثلج كثيف"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "ثلج"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "تساقط ثلوج"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "عواصف رعدية"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "ضبابي"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "غائم"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "غائم في أغلبه"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "غائم جزئياً"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "غائم في أغلبه"
@@ -502,42 +513,45 @@ msgstr "غائم في أغلبه"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "صافٍ"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "مشمس"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -559,13 +573,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -574,136 +588,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "غائم"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "صافٍ"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "معتدل"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "ثلج كثيف"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "ثلج كثيف"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "ثلج كثيف"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "ثلج كثيف"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "رشات ثلجية متفرقة"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "رشات ثلجية خفيفة"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "رشات ثلجية متفرقة"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -712,47 +727,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "مطر ثلجي"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "סعواصف رعدية متفرقة"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "رشات متفرقة"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "رشات ثلجية متفرقة"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "رشات ثلجية متفرقة"
@@ -762,20 +778,20 @@ msgstr "رشات ثلجية متفرقة"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -804,330 +820,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "رشات ثلجية خفيفة"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "رذاذ"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "ثلج كثيف"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "رشات متفرقة"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "بَرَد"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "رشات ثلجية متفرقة"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "ثلج كثيف"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "عواصف رعدية"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "وابل رعدي"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "عواصف رعدية"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "عواصف رعدية"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "عواصف رعدية شديدة"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "عواصف رعدية معزولة"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "عواصف رعدية"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "رذاذ"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "خليط من المطر والبَرَد"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "رذاذ متجمد"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "مطر متجمد"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "رشات مطر"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "رشات مطر"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "خليط من المطر والثلج"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "خليط من المطر والثلج"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "رشات مطر"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "ثلج كثيف"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "دخانيّ"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "سديم"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "غبار"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "إعصار"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "غائم"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "رشات متفرقة"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1135,76 +1171,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "غائم جزئياً"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "غائم في أغلبه"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "تساقط ثلوج"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "مطر متجمد"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "إعصار استوائي"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "عاصفة مدارية"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "حار"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "بارد"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1244,79 +1280,79 @@ msgstr "الجمعة"
 msgid "Saturday"
 msgstr "السبت"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "ش"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "ش ق"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "ق"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "ج ق"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "ج"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "ج غ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "غ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "ش غ"
 
@@ -1361,7 +1397,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "عاصفة مدارية"
@@ -1371,7 +1407,7 @@ msgstr "عاصفة مدارية"
 msgid "Severe Thunderstorms"
 msgstr "عواصف رعدية شديدة"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "عواصف رعدية"
 
@@ -1390,19 +1426,19 @@ msgstr "خليط من المطر والمطر الثلجي"
 msgid "Mixed Snow and Sleet"
 msgstr "خليط من الثلج والمطر الثلجي"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "رذاذ متجمد"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "مطر متجمد"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "رشات مطر"
 
@@ -1416,12 +1452,12 @@ msgstr "تساقط ثلوج"
 msgid "Light Snow Showers"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "هبوب ثلوج"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "ضبابي"
 
@@ -1433,63 +1469,64 @@ msgstr "دخانيّ"
 msgid "Blustery"
 msgstr "ريح عاصف"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "عاصف"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "غائم في أغلبه"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "غائم جزئياً"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "غائم في أغلبه"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "خليط من المطر والبَرَد"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "عواصف رعدية معزولة"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "סعواصف رعدية متفرقة"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "رشات متفرقة"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "ثلج كثيف"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "رشات ثلجية متفرقة"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "ثلج كثيف"
@@ -1517,452 +1554,487 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "رشات ثلجية خفيفة"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "غداً"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "هبوب ثلوج"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "رذاذ متجمد"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "رذاذ متجمد"
+msgid "Light shower rain"
+msgstr "رشات ثلجية خفيفة"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "ثلج كثيف"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "تساقط ثلوج"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "رشات ثلجية متفرقة"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "مطر متجمد"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "غداً"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "هبوب ثلوج"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "رذاذ متجمد"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "رشات ثلجية متفرقة"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "خليط من المطر والثلج"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "خليط من المطر والثلج"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "رشات ثلجية متفرقة"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "غائم جزئياً"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "هبوب ثلوج"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "هبوب ثلوج"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "ثلج كثيف"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "رشات متفرقة"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "خليط من المطر والثلج"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "خليط من المطر والثلج"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "خليط من المطر والثلج"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "خليط من المطر والمطر الثلجي"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "رشات ثلجية متفرقة"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "غائم في أغلبه"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "غائم في أغلبه"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "تساقط ثلوج"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "رشات ثلجية خفيفة"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "ثلج كثيف"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "عواصف رعدية"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "عواصف رعدية"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2354,7 +2426,6 @@ msgid "Weather conditions"
 msgstr ""
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr ""
 
@@ -2629,6 +2700,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/be.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/be.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2023-02-03 18:53+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,65 +18,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Памылка"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Памылка сэрвіса"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Няправільны ключ API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Няправільны фармат месцазнаходжаньня"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Ключ заблякаваны"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Немагчыма знайсьці месцазнаходжаньне"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Няма ключу API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Няма месцазнаходжаньня"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Адсутнічаюць пакункі"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Месцазнаходжаньне не падтрымліваецца"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Надвор'е"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Націсьніце каб адкрыць"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Абнавіць"
 
@@ -86,8 +86,8 @@ msgstr "API вярнуў код статусу між 400 і 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Захаваньне месцазнаходжаньня"
 
@@ -100,13 +100,13 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Немагчыма атрымаць інфармацыі пра надвор'е"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Нечаканая памылка падчас абнаўленьня надвор'я, гл. логі ў Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -122,7 +122,7 @@ msgstr "Памылка сеткі, гл. логі ў Looking Glass"
 msgid "As of"
 msgstr "У стане на"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "З дапамогай"
 
@@ -130,52 +130,52 @@ msgstr "З дапамогай"
 msgid "from you"
 msgstr "ад вас"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "мм"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "у"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "міляў"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "км"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Загрузка бягучага надвор'я ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Загрузка прагнозу надвор'я ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Загрузка ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Тэмпэратура"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Вільготнасьць"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Ціск"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Вецер"
 
@@ -185,16 +185,16 @@ msgstr ""
 "Пераканайцеся, што Вы ўвялі месцазнаходжаньне, ці скарыстайцеся аўтаматычным "
 "месцазнаходжаньнем"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Немагчыма знайсьці месцазнаходжаньне па адрасе, праверце дакладнасьць даных"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Не атрымалася выклікаць Geolocation API, гл. логі ў Looking Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Увага"
 
@@ -204,17 +204,17 @@ msgstr ""
 "Вы можаце захаваць правільныя месцазнаходжаньні толькі калі аплет не "
 "абнаўляецца"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Вы ня можаце захаваць няправільнае месцазнаходжаньне"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Інфармацыя"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Месцазнаходжаньне ўжо захаванае"
 
@@ -252,15 +252,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Адчуваецца як"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Не атрымалася апрацаваць інфармацыю пра надвор'е"
 
@@ -273,7 +273,7 @@ msgstr ""
 "ці спачатку атрымайце яго на https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -281,7 +281,7 @@ msgstr ""
 "Калі ласка, пераканайцеся, што\n"
 "уведзены ключ API правільны і ваш акаўнт не заблякаваны"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -292,252 +292,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Моцны дождж"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Дождж"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Лёгкі дождж"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Моцны ледзяны дождж"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Ледзяны дождж"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Лёгкі ледзяны дождж"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Лёгкая ледзяная імжа"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Ледзяная імжа"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Лёгкая імжа"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Моцны град"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Град"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Лёгкі град"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Моцны сьнегапад"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Сьнегапад"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Лёгкі сьнегапад"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Кароткачасовыя сьнегапады"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Навальніца"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Лёгкі туман"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Туман"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Пахмурна"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Пераважна воблачна"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Малавоблачна"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Пераважна ясна"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Ясна"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Сонечна"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Невядома"
 
@@ -561,7 +575,7 @@ msgstr ""
 "Калі ласка, увядзіце ключ API у наладах,\n"
 "ці спачатку атрымайце яго на https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -569,7 +583,7 @@ msgstr ""
 "Калі ласка, пераканайцеся, што\n"
 "вы ўвялі ключ API, атрыманы ад DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Не атрымалася знайсьці месцазнаходжаньне"
 
@@ -578,122 +592,123 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Сэрвіс месцазнаходжаньня адказаў з памылкамі, гл. логі ў Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Воблачна"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Ясна"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Пагода"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Моцны дождж з навальніцай"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Моцныя залевы"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Моцныя залевы з навальніцай"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Моцны мокры сьнегапад"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Моцны мокры сьнегапад з навальніцай"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Моцны дождж з мокрым сьнегам"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Моцны дождж з мокрым сьнегам і навальніцай"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Моцны сьнегапад з навальніцай"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Моцны сьнегапад"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Моцны сьнегапад з навальніцай"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Лёгкі дождж з навальніцай"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Кароткачасовыя залевы"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Кароткачасовыя залевы з навальніцай"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Невялікі мокры сьнег"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Невялікі мокры сьнег з навальніцай"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Кароткачасовыя залевы з мокрым сьнегам"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Кароткачасовыя залевы з мокрым сьнегам і навальніцай"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Лёгкі сьнег з навальніцай"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Кароткачасовыя сьнегапады"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Кароткачасовыя сьнегапады з навальніцай"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Дождж з навальніцай"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Залевы"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Залевы з навальніцай"
 
@@ -702,45 +717,46 @@ msgstr "Залевы з навальніцай"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Мокры сьнег"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Мокры сьнег з навальніцай"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Залева з мокрым сьнегам"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Залева з мокрым сьнегам і навальніцай"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Сьнег з навальніцай"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Сьнег"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Сьнегапад з навальніцай"
 
@@ -749,20 +765,20 @@ msgstr "Сьнегапад з навальніцай"
 msgid "Unexpected response from API"
 msgstr "Нечаканы адказ ад API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Бачнасьць"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Не атрымалася апрацаваць інфармацыю пра бягучае надвор'е"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Не атрымалася апрацаваць прагноз надвор'я"
 
@@ -791,94 +807,98 @@ msgid "Excellent - More than"
 msgstr "Выдатная - больш за"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Туман"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Пахмурна"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Кароткачасовая залева"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Імжа"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Моцная залева"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Дождж са сьнегам"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Град"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Моцны град"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Лёгкі сьнегапад"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Моцны сьнегапад"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Навальніца"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Залева з навальніцай"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Калі ласка, пераканайцеся, што месцазнаходжаньне ў наладах у правільным "
 "фармаце"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Пераканайцеся, што вы ўвялі правільны ключ у наладах"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -886,212 +906,228 @@ msgstr ""
 "Месцазнаходжаньне ня знойдзена, пераканайцеся, што яно даступна і ў "
 "правільным фармаце"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Калі гэтая праблема паўтараецца, калі ласка, зьвярніцеся да аўтара аплета"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Нечаканая памылка, гл. логі ў Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Навальніца зь лэгкім дажджом"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Навальніца з дажджом"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Навальніца з моцным дажджом"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Лёгкая навальніца"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Моцная навальніца"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Ірваная навальніца"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Навальніца зь лёгкай імжою"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Навальніца зь імжою"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Навальніца з моцнай імжою"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Слабая імжа"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Моцная імжа"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Лёгкі імжысты дождж"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Імжысты дождж"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Моцны імжысты дождж"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Залева зь імжой"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Моцная залева зь імжой"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Імжыстая залева"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Сярэдні дождж"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Моцны дождж"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Вельмі моцны дождж"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Вельмі моцны дождж"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Лёгкая залева"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Залева"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Моцная залева"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Месцамі залева"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Мокры сьнег"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Лёгкі дождж са сьнегам"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Дождж са сьнегам"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Лёгкі сьнег"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Сьнегапад"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Моцны сьнегапад"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Дым"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Туман"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Пясок, пылавыя віхры"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Пясок"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Пыл"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Вулканічны попел"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Шквал"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Сьмерч"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Яснае неба"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Воблачна"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Месцамі воблачна"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Рассыпістыя аблокі"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Перарывістыя аблокі"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Хмарна"
 
@@ -1099,72 +1135,72 @@ msgstr "Хмарна"
 msgid "Could not get forecast for your area"
 msgstr "Не ўдалося атрымаць прагноз для вашай мясцовасьці"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Месцазнаходжаньне па-за ЗША, скарыстайцеся іншым сэрвісам."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Не атрымалася апрацаваць пагадзінны прагноз"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Ясна і ветрана"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Месцамі воблачна і ветрана"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Перарывістыя аблокі і ветрана"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Пераважна воблачна і ветрана"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Пахмурна і ветрана"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Сьнег з дажджом"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Імжысты дождж са сьнегам"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Ураган"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Шторм"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Трапічны шторм"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Сьпякотна"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Халодна"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Завіруха"
 
@@ -1204,79 +1240,79 @@ msgstr "Пятніца"
 msgid "Saturday"
 msgstr "Субота"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Штыль"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Лёгкі ветрык"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Лёгкі вецер"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Слабы вецер"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Умераны вецер"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Сьвежы вецер"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Моцны вецер"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Амаль шторм"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Шторм"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Моцны шторм"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Вельмі моцны шторм"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "Пн"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "ПнУ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "У"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "ПдУ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "Пд"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "ПдЗ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "З"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "ПнЗ"
 
@@ -1327,7 +1363,7 @@ msgid ""
 msgstr ""
 "Нечаканая памылка падчас абнаўленьня надвор'я, гл. логі ў Looking Glass"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Трапічны шторм"
 
@@ -1335,7 +1371,7 @@ msgstr "Трапічны шторм"
 msgid "Severe Thunderstorms"
 msgstr "Моцныя навальніцы"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Навальніцы"
 
@@ -1351,17 +1387,17 @@ msgstr "Дождж з мокрым сьнегам"
 msgid "Mixed Snow and Sleet"
 msgstr "Сьнег з мокрым сьнегам"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Ледзяная імжа"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Ледзяны дождж"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Залевы"
 
@@ -1373,11 +1409,11 @@ msgstr "Сьнежныя парывы"
 msgid "Light Snow Showers"
 msgstr "Невялікія сьнегапады"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Завіруха"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Туманна"
 
@@ -1389,54 +1425,55 @@ msgstr "Дымна"
 msgid "Blustery"
 msgstr "Парывісты вецер"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Ветрана"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Пераважна воблачна"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Малавоблачна"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Пераважна сонечна"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Дождж с градам"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Асобныя навальніцы"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Месцамі навальніцы"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Месцамі залевы"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Моцны дождж"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Месцамі сьнегавыя залевы"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Моцны сьнег"
 
@@ -1465,11 +1502,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1477,322 +1514,361 @@ msgstr ""
 "MET Office UK пакрывае толькі тэрыторыю Велікабрытаніі, калі ласка, "
 "пераканайцеся, што вашае месцазнаходжаньне ў гэтай краіне"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Ня знойдзены даныя для месцазнаходжаньня"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Вельмі слабая"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Менш за {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Выдатная"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Больш за {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Слабая"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Між {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Сярэдняя"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Добрая"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Вельмі добрая"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Шквал"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Лёгкі сьнег"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Лёгкі вецер"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Моцны вецер"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Завіруха"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Моцная імжа"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Моцны імжысты дождж"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Лёгкі сьнег"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Лёгкі імжысты дождж"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Моцны сьнегапад"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Пылавая бура"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Сьнег з дажджом"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Ледзяны імжысты дождж"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Сьнег"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Моцны ледзяны імжысты дождж"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Лёгкая ледзяны імжысты дождж"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Марозны туман"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Лёгкі вецер"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Моцны вецер"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Завіруха"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Моцны імжысты дождж"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Лёгкі імжысты дождж"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Пылавая бура"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Ледзяны імжысты дождж"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Моцны ледзяны імжысты дождж"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Лёгкая ледзяны імжысты дождж"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Сьмерч"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Залева з градам"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Лёд"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Маланкі бяз грому"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Ападкі побач"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Моцны дождж са сьнегам"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Лёгкі дождж са сьнегам"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Неба прасьвятляецца"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Неба цямнее"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Неба бязь зьменаў"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Дым ці смуга"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Сьнег і залевы"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Навальніца без ападкаў"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Алмазны пыл"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Пераменная воблачнасьць"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Калі ласка, пераканайцеся, што уведзены ключ API правільны"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "НЯ ЗНОЙДЗЕНА"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Замеці"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Лёгкі сьнегапад"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Умераны сьнегапад"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Умераныя залевы"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Дождж са сьнегам"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Моцны дождж са сьнегам"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Калі ласка, абярыце іншы сэрвіс ці іншые месцазнаходжаньне"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "Уведзены ключ API нядзейсны."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Уведзенае месцазнаходжаньне ня знойдзена."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Моцны шторм"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Дождж са сьнегам"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Дождж з мокрым сьнегам"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Сьнегапады"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Брыз"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Халодна"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Пераважна ясна"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Калі ласка, пераканайцеся, што\n"
+"вы ўвялі ключ API, атрыманы ад Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr "Сэрвіс месцазнаходжаньня адказаў з памылкамі, гл. логі ў Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Пераважна ясна"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Сьнег з дажджом"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Лёгкі сьнег"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Моцны сьнегапад"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Навальніца зь лэгкім дажджом"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Навальніца з дажджом"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Адчуваецца як"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 #, fuzzy
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
@@ -1801,7 +1877,7 @@ msgstr ""
 "Немагчыма атрымаць налады, файл ня знойдзены па шляху\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1809,105 +1885,105 @@ msgstr ""
 "Немагчыма атрымаць зьмест файлу наладаў па шляху\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Пераканайцеся, што Вы ўвялі месцазнаходжаньне, ці скарыстайцеся аўтаматычным "
 "месцазнаходжаньнем"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Гэты сэрвіс патрабуе ключ API для працы"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Кропка расы"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Ападкі скончацца на працягу {precipEnd} хвілінаў"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Ападкі ня скончацца на працягу гадзіны"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Ападкі пачнуцца на працягу {precipStart} хвілінаў"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Памылка загрузкі прагнозу, глядзіце логі, каб даведацца падрабязьней"
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "У стане на {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} ад вас"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Назва станцыі: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Лакацыя: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Памылка захаваньня інфармацыі пра адладку"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Немагчыма атрымаць інфармацыі пра надвор'е"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Інфармацыя пра адладку пасьпяхова захаваная"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Захавана у {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2309,7 +2385,6 @@ msgid "Weather conditions"
 msgstr "Умовы надвор'я"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Перакладаць умовы надвор'я"
 
@@ -2619,6 +2694,17 @@ msgstr "Паказваць напрамак ветру як тэкст"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Напрыклад ПдУ, Пн замест іконак напрамкаў."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/bg.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/bg.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl 2.4.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2023-03-23 12:17+0200\n"
 "Last-Translator: Angel Ivanov <angel.ivanov@outlook.com>\n"
 "Language-Team: български <>\n"
@@ -21,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Грешка"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Грешка в услугата"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Неправилен API ключ"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Неправилен формат на местоположението"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Блокиран ключ"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Местоположението не е открито"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Не е въведен API ключ"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Не е въведено местоположение"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Липсващи пакети"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Местоположението не се поддържа от избрания доставчик на прогноза"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Аплет за Времето"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Натиснете за да се отвори"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Обнови"
 
@@ -89,8 +89,8 @@ msgstr "API отговори със статус код между 400 и 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Запазване на Местоположение"
 
@@ -103,14 +103,14 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Неуспешно зареждане на прогнозата"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Възникна неизвестна грешка при обновлението на аплета за Времето, \n"
 "моля проверете лога в Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -126,7 +126,7 @@ msgstr "Мрежова грешка, моля проверете логовет�
 msgid "As of"
 msgstr "Обновена в"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Благодарение на"
 
@@ -134,52 +134,52 @@ msgstr "Благодарение на"
 msgid "from you"
 msgstr "от вас"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "мм"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "инча"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "мили"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "км"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Зареждане на текущата прогноза ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Зареждане на прогнозата за времето ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Зареждане ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Температура"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Влажност"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Налягане"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Вятър"
 
@@ -189,19 +189,19 @@ msgstr ""
 "Проверете дали сте въвели местоположение или използвайте\n"
 "Автоматичното му определяне"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Местоположението не може да бъде намерено по зададения адрес. Моля, "
 "проверете дали адреса е верен"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Повикването на API за определяне на местоположението не беше успешно. "
 "Проверете Looking Glass за грешки."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Предупреждение"
 
@@ -211,17 +211,17 @@ msgstr ""
 "Запазването на правилно зададено местоположение е възможно само когато "
 "аплета не се обновява"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Запазването на грешно местоположение е невъзможно"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Инфo"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Местоположението вече е запазено"
 
@@ -259,15 +259,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Усеща се като"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Неуспешна обработка на прогнозата"
 
@@ -280,7 +280,7 @@ msgstr ""
 "или вземете такъв от https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -288,7 +288,7 @@ msgstr ""
 "Моля проверете дали сте\n"
 "въвели правилния API ключ"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -299,252 +299,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Силен дъжд"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Дъжд"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Слаб дъжд"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Силен леден дъжд"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Леден дъжд"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Слаб леден дъжд"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Леко ледено ръмене"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Ледено ръмене"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Слабо ръмене"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Град"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Градушка"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Градушка"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Силен сняг"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Сняг"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Слаб сняг"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Лек снеговалеж"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Гръмотевици"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Слаба мъгла"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Мъгла"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Облачно"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Облачно"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Разкъсана облачност"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Слънчево"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Неизвестно"
 
@@ -568,7 +582,7 @@ msgstr ""
 "Моля въведете API ключ в Настройките\n"
 "или вземете такъв от https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -576,7 +590,7 @@ msgstr ""
 "Моля проверете, че сте\n"
 "въвели правилния API ключ от DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Неуспешно получаване на местоположението"
 
@@ -587,122 +601,123 @@ msgstr ""
 "Услугата за получаване на местоположението отговори с грешка, моля проверете "
 "логовете в Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Облачност"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Ясно небе"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Ясно"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Силен дъжд с гръмотевици"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Силен дъжд"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Силен дъжд с гръмотевици"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Силна суграшица"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Силна суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Силна суграшица"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Силна суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Силен сняг с гръмотевици"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Силен сняг"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Силен сняг с гръмотевици"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Слаб дъжд с гръмотевици"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Слаб дъжд"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Слаб дъжд с гръмотевици"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Суграшица"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Суграшица"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Слаб сняг с гръмотевици"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Слаб сняг"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Слаб сняг с гръмотевици"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Дъжд и гръмотевици"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Дъжд"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Дъжд и гръмотевици"
 
@@ -711,45 +726,46 @@ msgstr "Дъжд и гръмотевици"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Суграшица"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Суграшица"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Сняг с гръмотевици"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Сняг"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Сняг с гръмотевици"
 
@@ -758,20 +774,20 @@ msgstr "Сняг с гръмотевици"
 msgid "Unexpected response from API"
 msgstr "Неочаквано съобщение от API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Видимост"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Неуспешна обработка на текущата прогноза"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Неуспешна обработка на прогнозата"
 
@@ -800,94 +816,98 @@ msgid "Excellent - More than"
 msgstr "Отлична - Повече от"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Мъгла"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Облачно"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Слаб дъжд"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Ръмене"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Силен дъжд"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Суграшица"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Градушка"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Градушка"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Слаб сняг"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Силен сняг"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Гръмотевици"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Гръмотевици"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Моля, проверете дали местоположението е въведено в правилния формат в "
 "Настройките"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Проверете дали сте въвели правилния ключ в Настройките"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -895,211 +915,227 @@ msgstr ""
 "Местоположението не е намерено, проверете дали съществува и че е въведено в "
 "правилният формат"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Ако проблема продължавате, моля свържете се с автора на този аплет"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Неизвестна грешка, моля проверете логовете в Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Гръмотевици с слаб дъжд"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Гръмотевици с дъжд"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Гръмотевици със силен дъжд"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Слаби гръмотевици"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Силни гръмотевици"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Частични гръмотевици"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Гръмотевици с леко ръмене"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Гръмотевици с ръмене"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Гръмотевици със силно ръмене"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Леко ръмене"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Леко ръмене"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Ситен дъжд"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Силине дъжд"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Умерен дъжд"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Много силен дъжд"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Порой"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Слаб дъжд"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Дъжд"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Частичен дъжд"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Суграшица"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Слаб дъжд и сняг"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Дъжд и сняг"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Слаб сняг"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Силен сняг"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Силен сняг"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Дим"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Лека мъгла"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Пясък, пепел и вятър"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Пясък"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Пепел"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Вулканичен прах"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Шквалове"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Торнадо"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Ясно небе"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Облачно"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Лека облачност"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Разкъсана облачност"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Разкъсана облачност"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Облачно"
 
@@ -1107,73 +1143,73 @@ msgstr "Облачно"
 msgid "Could not get forecast for your area"
 msgstr "Няма прогноза за вашето местоположение"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "Местоположението е извън САЩ. Моля, използвайте друг доставчик на прогноза."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Неуспешна обработка на Почасовата Прогноза"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Ясно и ветровито"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Лека облачност и вятър"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Разкъсана облачност и вятър"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Облачно и ветровито"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Облачно и ветровито"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Сняг"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Леден дъжд и сняг"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Ураган"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Буря"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Тропическа буря"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Горещо"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Студено"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Виелица"
 
@@ -1213,79 +1249,79 @@ msgstr "Петък"
 msgid "Saturday"
 msgstr "Събота"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Спокойно"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Лек вятър"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Лек вятър"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Лек вятър"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Умерен вятър"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Освежаващ вятър"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Силен вятър"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Вятър"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Вятър"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Силен вятър"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Силна буря"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "С"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "СИ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "И"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "ЮИ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "Ю"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "ЮЗ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "З"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "СЗ"
 
@@ -1337,7 +1373,7 @@ msgstr ""
 "Неизвестна грешка при получаване на прогнозата, проверете Looking Glass за "
 "повече информация"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Тропическа буря"
 
@@ -1345,7 +1381,7 @@ msgstr "Тропическа буря"
 msgid "Severe Thunderstorms"
 msgstr "Силни гръмотевици"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Гръмотевици"
 
@@ -1361,17 +1397,17 @@ msgstr "Дъжд и суграшица"
 msgid "Mixed Snow and Sleet"
 msgstr "Сняг и суграшица"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Леден дъжд"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Леден дъжд"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Дъжд"
 
@@ -1383,11 +1419,11 @@ msgstr "Лек снеговалеж"
 msgid "Light Snow Showers"
 msgstr "Слаб сняг"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Сняг и вятър"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Мъгла"
 
@@ -1399,54 +1435,55 @@ msgstr "Дим"
 msgid "Blustery"
 msgstr "Силен вятър"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Ветровито"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Облачно"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Разкъсана облачност"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Слънчево"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Дъжд и градушка"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Частични гръмотевици"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Частични гръмотевици"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Частични валижи"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Силен дъжд"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Частичен снеговалеж"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Силен сняг"
 
@@ -1477,11 +1514,11 @@ msgstr ""
 "  {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1489,276 +1526,320 @@ msgstr ""
 "Met Office UK работи само за Обединеното Кралство. Потвърдете, че вашето "
 "местоположение е в тази страна"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Прогнозата за това местоположението не е налична"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Много лоша"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "По-малко от {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Отлична"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Повече от {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Лоша"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Между {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Умерена"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Добра"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Много добра"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Шквалове"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Слаб сняг"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Слаб вятър"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Силен вятър"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Навяващ сняг"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Силно ръмене"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Силно ръмене/дъжд"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Слаб сняг"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Леко ръмене/дъжд"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Силен сняг"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Пясъчна буря"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Сняг"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Ледено ръмене/леден дъжд"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Сняг"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Силно ледено ръмене/леден дъжд"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Слабо ледено ръмене/леден дъжд"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Замръзнала мъгла"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Слаб вятър"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Силен вятър"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Навяващ сняг"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Силно ръмене/дъжд"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Леко ръмене/дъжд"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Пясъчна буря"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Ледено ръмене/леден дъжд"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Силно ледено ръмене/леден дъжд"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Слабо ледено ръмене/леден дъжд"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Фуниеобразен облак/торнадо"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Градушка"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Лед"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Светкавици без гръмотевици"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Очаквани валежи"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Силен дъжд и сняг"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Слаб дъжд и сняг"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Изчезващи облаци"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Увеличаващи се облаци"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Без промяна"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Дим"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Сняг и дъжд"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Гръмотевици без валежи"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Диамантен прах"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Разкъсана облачност"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Проверете дали сте въвели правилния API ключ"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "Не е открито"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Сняг и вятър"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Слаб сняг"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Умерен снеговалеж"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Умерен дъжд"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Дъжд и сняг"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Силен дъжд и сняг"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Моля, изберете друг доставчик на прогноза или местоположение"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "API ключа, който използвате е невалиден."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Местоположение, което указахте не е намерено."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Силна буря"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Дъжд и сняг"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Дъжд и суграшица"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Сняг"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Ветровито"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Студено"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Предимно ясно"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Моля проверете дали сте\n"
+"въвели правилния API ключ от Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1767,46 +1848,41 @@ msgstr ""
 "Услугата за получаване на местоположението отговори с грешка, моля проверете "
 "логовете в Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Ясно"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Сняг"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Слаб сняг"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Силен сняг"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Гръмотевици с слаб дъжд"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Гръмотевици с дъжд"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Усеща се като"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1814,7 +1890,7 @@ msgstr ""
 "Настройките не бяха извлечени. Файлът не беше открит в\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1822,107 +1898,107 @@ msgstr ""
 "Настройките не бяха извлечени от файлът, който се намира в\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Проверете дали сте въвели местоположение или използвайте\n"
 "Автоматичното му определяне"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Избраният доставчик на прогноза изисква API ключ за да работи"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Точка на оросяване"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Валежът ще спре след {precipEnd} минути"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Валежът няма да спре до час"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Валежът ще започне след {precipStart} минути"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Обработката на данните за прогнозата беше неуспешна. Вижте лог файла за "
 "повече информация."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Обновена в {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} от вас"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Име на станцията: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Област: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Грешка при запазването на дебъг информацията"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Неуспешно зареждане на прогнозата"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Дебъг информацията е запазена успешно"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Запазен в {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2328,7 +2404,6 @@ msgid "Weather conditions"
 msgstr "Метеорологични условия"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Превеждане на метеорологичните условия"
 
@@ -2637,6 +2712,17 @@ msgstr "Показване на посоката на вятъра като те
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Като ЮИ, С вместо със стрелки указващи посоката."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/ca.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ca.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: 3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2011-06-15 00:41+0200\n"
 "Last-Translator: Pau Iranzo <paugnu@gmail.com>\n"
 "Language-Team: Softcatalà\n"
@@ -20,65 +20,65 @@ msgstr ""
 "X-Project-Style: default\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr ""
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr ""
 
@@ -88,8 +88,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -101,12 +101,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -120,7 +120,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -128,55 +128,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "S'està carregant el temps actual..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "S'està carregant el temps futur..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "S'està carregant..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "Temperatura:"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "Humitat:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "Pressió:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "Vent:"
@@ -185,15 +185,15 @@ msgstr "Vent:"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -201,17 +201,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -247,15 +247,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -266,13 +266,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -281,12 +281,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "Nevada forta"
@@ -294,38 +295,41 @@ msgstr "Nevada forta"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "Pluja glaçada"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "Pluja glaçada"
@@ -333,168 +337,175 @@ msgstr "Pluja glaçada"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Pluja glaçada"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "Pluja glaçada"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "Plugims gelats"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Plugims gelats"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "Plugims gelats"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Nevada forta"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Neu"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "Ràfegues de neu"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "Tempestes"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "Boirós"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Ennuvolat"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Majoritàriament ennuvolat"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Parcialment ennuvolat"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "Majoritàriament ennuvolat"
@@ -502,42 +513,45 @@ msgstr "Majoritàriament ennuvolat"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Clar"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Assolellat"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -559,13 +573,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -574,136 +588,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "Ennuvolat"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "Clar"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Bon temps"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "Nevada forta"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "Nevada forta"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "Nevada forta"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "Nevada forta"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "Cobert"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "Precipitacions lleugeres de neu"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "Cobert"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -712,47 +727,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Aiguaneu"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "Tempestes elèctriques aïllades"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "Pluges aïllades"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Cobert"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "Cobert"
@@ -762,20 +778,20 @@ msgstr "Cobert"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -804,330 +820,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "Precipitacions lleugeres de neu"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Plugim"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "Nevada forta"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "Pluges aïllades"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Calamarsa"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "Cobert"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "Nevada forta"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "Tempestes"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "Tempestes"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "Tempestes"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "Tempestes"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "Tempestes elèctriques severes"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "Tempestes aïllades"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "Tempestes"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "Plugim"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "Barreja de pluja i calamarsa"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "Plugims gelats"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "Pluja glaçada"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "Ruixats"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "Ruixats"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "Barreja de pluja i neu"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "Barreja de pluja i neu"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "Ruixats"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "Nevada forta"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "Fumat"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Boirina"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Pols"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "Ennuvolat"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "Pluges aïllades"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1135,76 +1171,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "Parcialment ennuvolat"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "Majoritàriament ennuvolat"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "Ràfegues de neu"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "Pluja glaçada"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Huracà"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tempesta tropical"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Calor"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Fred"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1244,79 +1280,79 @@ msgstr "Divendres"
 msgid "Saturday"
 msgstr "Dissabte"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr ""
 
@@ -1361,7 +1397,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "Tempesta tropical"
@@ -1371,7 +1407,7 @@ msgstr "Tempesta tropical"
 msgid "Severe Thunderstorms"
 msgstr "Tempestes elèctriques severes"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Tempestes"
 
@@ -1390,19 +1426,19 @@ msgstr "Barreja de pluja i calamarsa"
 msgid "Mixed Snow and Sleet"
 msgstr "Barreja de neu i calamarsa"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "Plugims gelats"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "Pluja glaçada"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Ruixats"
 
@@ -1416,12 +1452,12 @@ msgstr "Ràfegues de neu"
 msgid "Light Snow Showers"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "Neu aixecada pel vent"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Boirós"
 
@@ -1433,63 +1469,64 @@ msgstr "Fumat"
 msgid "Blustery"
 msgstr "Tempestuós"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Ventades"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "Majoritàriament ennuvolat"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "Parcialment ennuvolat"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "Majoritàriament ennuvolat"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "Barreja de pluja i calamarsa"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Tempestes aïllades"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Tempestes elèctriques aïllades"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Pluges aïllades"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "Nevada forta"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Xàfecs de neu dispersos"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Nevada forta"
@@ -1517,452 +1554,487 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Precipitacions lleugeres de neu"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "Demà"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "Neu aixecada pel vent"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "Plugims gelats"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "Plugims gelats"
+msgid "Light shower rain"
+msgstr "Precipitacions lleugeres de neu"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Nevada forta"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Ràfegues de neu"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Cobert"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "Pluja glaçada"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Demà"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Neu aixecada pel vent"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Plugims gelats"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "Cobert"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "Barreja de pluja i neu"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "Barreja de pluja i neu"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "Cobert"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "Parcialment ennuvolat"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Neu aixecada pel vent"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "Neu aixecada pel vent"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "Nevada forta"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "Pluges aïllades"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Barreja de pluja i neu"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "Barreja de pluja i neu"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Barreja de pluja i neu"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Barreja de pluja i calamarsa"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Cobert"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Majoritàriament ennuvolat"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Majoritàriament ennuvolat"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Ràfegues de neu"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Precipitacions lleugeres de neu"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Nevada forta"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Tempestes"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Tempestes"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2354,7 +2426,6 @@ msgid "Weather conditions"
 msgstr ""
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr ""
 
@@ -2629,6 +2700,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/cs.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/cs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 3.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-02-04 19:07+0100\n"
 "Last-Translator: Bohuslav Kotál <fotobob1@centrum.cz>\n"
 "Language-Team: \n"
@@ -20,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Chyba"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Chyba služby"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Nesprávný API klíč"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Chybný lokační formát"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Klíč je blokován"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Místo se nedaří najít"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Chybí API klíč"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Poloha není k dispozici"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Chybějící balíky"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Lokalita nemá pokrytí"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Applet Počasí"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Klikněte pro zobrazení"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Znovunačtení"
 
@@ -88,8 +88,8 @@ msgstr "API vrátilo stavový kód mezi 400 a 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Uložení lokace"
 
@@ -101,14 +101,14 @@ msgstr "Automaticky zjištěná lokace nemůže být uložena, je nám líto"
 msgid "Could not get weather information"
 msgstr "Nelze zjistit informace o počasí"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Neočekávaná chyba při získávání předpovědi, detaily jsou dostupné v logu "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +124,7 @@ msgstr "Chyba připojení. Zkotroluj log pro více detailů"
 msgid "As of"
 msgstr "Naposledy v"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Zdoj předpovědi"
 
@@ -132,52 +132,52 @@ msgstr "Zdoj předpovědi"
 msgid "from you"
 msgstr "od vás"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "v"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mil"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Načítání aktuálního počasí ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Načítání předpovědi počasí ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Načítá se ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Teplota"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Vlhkost"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Tlak"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vítr"
 
@@ -186,17 +186,17 @@ msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Ujistěte se, že je zadána lokalita nebo zapnuto její automatické nastavení"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Nedaří se zjistit lokalitu podle zadané adresy, zkontrolujte správnost zadání"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nepodařilo se kontaktovat geolokační API. Detaily jsou v Looking Glass logu."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Varování"
 
@@ -205,17 +205,17 @@ msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Uložit lze pouze validní lokace a to v době, kdy se applet neaktualizuje"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Nelze uložit neplatnou lokalitu"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Informace"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Lokalita je již uložena"
 
@@ -253,15 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Pocitově"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Nepodařilo se zpracovat informace o počasí"
 
@@ -274,7 +274,7 @@ msgstr ""
 "nebo nejdříve získejte na https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -282,7 +282,7 @@ msgstr ""
 "Ujistěte se, že klíč API\n"
 "je vložen správně a váš účet není uzamčen"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -293,252 +293,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Průtrž mračen"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Déšť"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Slabý déšť"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Silný mrznoucí déšť"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Mrznoucí déšť"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Slabý mrznoucí déšť"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Slabé mrznoucí mrholení"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Mrznoucí mrholení"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Slabé mrholení"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Silný zmrzlý déšť"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Zmrzlý déšť"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Slabý zmrzlý déšť"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Silné sněžení"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Sněžení"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Lehké sněžení"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Sněhový poprašek"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Bouřka"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Slabá mlha"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Mlha"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Zataženo"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Převážně zataženo"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Polojasno"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Převážně jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Slunečno"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Neznámo"
 
@@ -562,7 +576,7 @@ msgstr ""
 "Vložte klíč API v nastavení\n"
 "nebo jej získejte na https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -570,7 +584,7 @@ msgstr ""
 "Ujistěte se, že je\n"
 "vložen API klič získaný na DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Nedaří se zjistit polohu"
 
@@ -580,122 +594,123 @@ msgid ""
 msgstr ""
 "Lokační služba odpověděla s chybami, detaily jsou v logu v Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Oblačnost"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Jasno"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Hezky"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Průtrž mračen s bouřkou"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Silné dešťové přeháňky"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Bouřka a intenzivní přeháňky"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Silný mrznoucí déšť"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Silný mrznoucí déšť déšť s bouřkou"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Přeháňky silného mrznoucího deště"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Přeháňky silného deště se sněhem a bouřka"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Sněhová vánice s bouřkou"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Přeháňky sněhové vánice"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Přeháňky sněhové vánice a bouřka"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Slabý déšť a bouřka"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Slabé dešťové přeháňky"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Slabé dešťové přeháňky a bouřka"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Slabý déšť se sněhem"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Slabý déšť se sněhem a bouřka"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Lehké přeháňky deště se sněhem"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Lehké přeháňky deště se sněhem a bouřka"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Slabé sněžení a bouřka"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Slabé sněhové přeháňky"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Slabé sněhové přeháňky a bouřka"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Bouřka s deštěm"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Dešťové přeháňky"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Dešťové přeháňky a bouřka"
 
@@ -704,45 +719,46 @@ msgstr "Dešťové přeháňky a bouřka"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Plískanice"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Déšť se sněhem a bouřka"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Přeháňky deště se sněhem"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Přeháňky deště se sněhem a bouřka"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Sněžení s bouřkou"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Sněhové přeháňky"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Sněhové přeháňky s bouřkou"
 
@@ -751,20 +767,20 @@ msgstr "Sněhové přeháňky s bouřkou"
 msgid "Unexpected response from API"
 msgstr "Neočekávaná odpověď z API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Dohlednost"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Zpracování informací o aktuálním počasí selhalo"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Zpracování informací s předpovědí selhalo"
 
@@ -793,93 +809,97 @@ msgid "Excellent - More than"
 msgstr "Vynikající - více než"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Opar"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Zataženo"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Slabá dešťová přeháňka"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Mrholení"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Silná dešťová přeháňka"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Přeháňka mrznoucího deště"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Kroupy"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Přeháňka krupobití"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Slabá sněhová přeháňka"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Silná sněhová přeháňka"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Bouřka"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Bouřková přeháňka"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Ujistěte se prosím, že je v nastaveních lokalita zadána ve správném formátu"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Ujistěte se, že je zadán správný klíč v nastavení"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -887,211 +907,227 @@ msgstr ""
 "Lokalita nenalezena. Ujistěte se, že je zvolená lokalita dostupná a je ve "
 "správném formátu"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Pokud problém přetrvává, kontaktujte prosím autora appletu"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Neznámá chyba, detaily jsou v logu Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Bouřka se slabým deštěm"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Bouřka s deštěm"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Bouřka s přívalovým deštěm"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Slabá bouřka"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Silná bouřka"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Roztroušené bouřky"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Bouřka s mírným mrholením"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Bouřka s mrholením"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Bouřka se silným mžením"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Slabé mrholení"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Silné mžení"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Slabé mrholení"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Mrholení"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Intenzivní mrholení"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Přeháňky a mrholení"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Průtrže a mrholení"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Občasné mrholení"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Mírný déšť"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Velmi silný déšť"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Průtrž mračen"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Extrémní dešťové srážky"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Slabé přeháňky"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Dešťové přeháňky"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Vydatné dešťové přeháňky"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Lokální přeháňky"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Plískanice"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Slabý déšť se sněhem"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Déšť se sněhem"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Lehké sněhové přeháňky"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Sněhové přeháňky"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Silné sněhové přeháňky"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Kouř"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Kouřmo"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Víření prachu a písku"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Písek"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Prach"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Sopečný popílek"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Nárazy větru"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornádo"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Bezoblačná obloha"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Zataženo"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Skoro jasno"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Polojasno"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Skoro zataženo"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Zataženo"
 
@@ -1099,72 +1135,72 @@ msgstr "Zataženo"
 msgid "Could not get forecast for your area"
 msgstr "Nepodařilo se získat předpověď pro vaší oblast"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokalita leží mimo území USA, použijte jiného poskytovatele."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Zpracování hodinových předpovědí selhalo"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Jasno a větrno"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Skoro jasno a větrno"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Částečně zataženo a větrno"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Převážně zataženo a větrno"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Zataženo a větrno"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Déšť se sněhem"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Mrznoucí déšť a sněžení"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Hurikán"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Bouře"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropická bouře"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Horko"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Zima"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Sněhová bouře"
 
@@ -1204,79 +1240,79 @@ msgstr "Pátek"
 msgid "Saturday"
 msgstr "Sobota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Bezvětří"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Vánek"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Lehká bríza"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Mírná bríza"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Střední bríza"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Svěží bríza"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Silná bríza"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Vítr dosahující síly vichřice"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Vichřice"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Silná vichřice"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Ničivá bouře"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "JV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "J"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "JZ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "SZ"
 
@@ -1328,7 +1364,7 @@ msgstr ""
 "Nastala neznámá chyba při pokusu získat předpověď.\n"
 "Detaily jsou v Looking Glass logu"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropická bouře"
 
@@ -1336,7 +1372,7 @@ msgstr "Tropická bouře"
 msgid "Severe Thunderstorms"
 msgstr "Extrémní bouřky"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Bouřky"
 
@@ -1352,17 +1388,17 @@ msgstr "Déšť a zmrzlý déšť"
 msgid "Mixed Snow and Sleet"
 msgstr "Sněžení a mrznoucí déšť"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Mrznoucí mrholení"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Mrznoucí déšť"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Přeháňky"
 
@@ -1374,11 +1410,11 @@ msgstr "Sněhový poprašek"
 msgid "Light Snow Showers"
 msgstr "Mírné sněhové přeháňky"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Přízemní sníh"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Mlhavo"
 
@@ -1390,54 +1426,55 @@ msgstr "Kouřmo"
 msgid "Blustery"
 msgstr "Větrno"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Větrno"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Převážně zataženo"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Částečně zataženo"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Převážně slunečno"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Déšť a kroupy"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Ojedinělé bouřky"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Rozptýlené bouřky"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Rozptýlené přeháňky"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Průtrž mračen"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Rozptýlené sněhové přeháňky"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Sněhová vánice"
 
@@ -1466,11 +1503,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office Velká Británie"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1478,277 +1515,321 @@ msgstr ""
 "MET Office UK zajišťuje předpověď pouze pro Vekou Británii, ujistěte se, že "
 "je zadaná lokalita v této zemi"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Data pro lokalitu se nedaří najít"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Velmi špatná"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Méně než {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Vynikající"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Více než {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Špatná"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Mezi {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Průměrná"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Dobrá"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Velmi dobrá"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Nárazy větru"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Lehké sněhové přeháňky"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Slabý vítr"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Silný vítr"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Sněhové jazyky"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Silné mžení"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Silné mrholení/déšť"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Lehké sněhové přeháňky"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Slabé mrholení/déšť"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Silné sněhové přeháňky"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Prachová bouře"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Déšť se sněhem"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Mrznoucí mrholení/déšť"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Sněhové přeháňky"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Silné mrznoucí mrholení/déšť"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Slabé mrznoucí mrholení/déšť"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Namrzající mlha"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Slabý vítr"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Silný vítr"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Sněhové jazyky"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Silné mrholení/déšť"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Slabé mrholení/déšť"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Prachová bouře"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Mrznoucí mrholení/déšť"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Silné mrznoucí mrholení/déšť"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Slabé mrznoucí mrholení/déšť"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Trychtýřový mrak/tornádo"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Přeháňky s kroupami"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Náledí"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Blesky bez bouřky"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Srážky poblíž"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Silný déšť a sněžení"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Slabý déšť a sněžení"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Ubývání oblačnosti"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Přibývání oblačnosti"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Oblačnost stabilní"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Kouř nebo opar"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Sněhové a dešťové přeháňky"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Bouřka bez srážek"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Diamantový prach"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Částečné zataženo"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 "Ujistěte se, že je\n"
 "API klič vložen správně"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NENALEZENO"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Přízemní sníh"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Lehké sněžení"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Mírné sněžení"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Mírné dešťové přeháňky"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Déšť se sněhem"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Silný déšť a sněžení"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Vyberte prosím jiného poskytovatele předpovědi"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "Zadaný API klíč není platný."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Zadaná lokalita nebyla nalezena."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Silná bouře"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Déšť se sněhem"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Déšť a zmrzlý déšť"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Sněhové přeháňky"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Větrno"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Mráz"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Skoro jasno"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Ujistěte se, že je vložen klíč API\n"
+"který jste získal od Climacell"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1756,46 +1837,41 @@ msgstr ""
 "Lokační služba nedokázala najít polohu počítače, detaily jsou v logu v "
 "Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Převážně jasno"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Déšť se sněhem"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Lehké sněhové přeháňky"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Silné sněhové přeháňky"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Bouřka se slabým deštěm"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Bouřka s deštěm"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Pocitově"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1803,7 +1879,7 @@ msgstr ""
 "Nepodařilo se načíst nastavení, soubor nebyl nebyl nalezen v umístění\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1811,104 +1887,104 @@ msgstr ""
 "Nepodařilo se načíst obsah nastavení z umístění\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Ujistěte se, že je lokalita zadána nebo místo toho přepněte na automatické "
 "zjištění lokace."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Poskytovatel předpovědi k činnosti vyžaduje API klíč"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Rosný bod"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Srážky ustanou za {precipEnd} minut"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Srážky lze očekávat po celou následující hodinu"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Za {precipStart} minut začnou padat srážky"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Selhala analýza předpovědi, více detailů je v Záznamech."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Aktualizováno {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} od vás"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Jméno stanice: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Oblast: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Nepodařilo se uložit debug informace"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Nelze zjistit informace o počasí"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Debug informace úspěšně uloženy"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Uloženo do {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2306,7 +2382,6 @@ msgid "Weather conditions"
 msgstr "Meteorologická terminologie"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Použít lokalizované meteorologické výrazy"
 
@@ -2613,6 +2688,17 @@ msgstr "Zobrazit směr větru textově"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Například JV či S namísto ikonek s šipkou."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/da.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/da.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: 1.4.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2023-12-25 11:54+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: dansk <dansk@dansk-gruppen.dk>\n"
@@ -21,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Fejl"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Tjenestefejl"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Forkert API-nøgle"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Forkert lokalitetsformat"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Nøgle blokeret"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Kan ikke finde lokaliteten"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Ingen API-nøgle"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Ingen lokalitet"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Manglende pakker"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Lokaliteten er ikke dækket"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Vejret"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "…"
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Klik for at åbne"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Opdatér"
 
@@ -89,8 +89,8 @@ msgstr "API'en returnerede statuskode mellem 400 og 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Lokalitetslager"
 
@@ -102,12 +102,12 @@ msgstr "Du kan desværre ikke gemme en automatisk indhentet lokalitet"
 msgid "Could not get weather information"
 msgstr "Kunne ikke hente oplysninger om vejret"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr "Uventet fejl under genindlæsning af vejret. Se loggene i Luppen"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +123,7 @@ msgstr "Netværksfejl. Se loggene i Luppen"
 msgid "As of"
 msgstr "Fra"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Leveret af"
 
@@ -131,52 +131,52 @@ msgstr "Leveret af"
 msgid "from you"
 msgstr "fra dig"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "i"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Henter nuværende vejrdata …"
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Henter fremtidige vejrdata …"
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Indlæser …"
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Luftfugtighed"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Tryk"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vind"
 
@@ -186,15 +186,15 @@ msgstr ""
 "Sikr dig, at du har angivet en lokalitet eller brug automatisk lokalitet i "
 "stedet"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr "Kunne ikke finde lokalitet baseret på adressen. Tjek, om den er rigtig"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Kunne ikke kalde Geolocation-API'en. Se loggene i Luppen for fejl."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Advarsel"
 
@@ -203,17 +203,17 @@ msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Du kan kun gemme korrekte lokaliteter, når panelprogrammet ikke genindlæser"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Du kan ikke gemme en forkert lokalitet"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Information"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Lokaliteten er allerede gemt"
 
@@ -250,15 +250,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Føles som"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Kunne ikke behandle vejrinformation"
 
@@ -271,7 +271,7 @@ msgstr ""
 "eller hent først en på https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -279,7 +279,7 @@ msgstr ""
 "Sikr dig, at du har indtastet\n"
 "API-nøglen korrekt og din konto ikke er låst"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -290,252 +290,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Kraftig regn"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Regn"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Let regn"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Kraftig isslag"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Isslag"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Let isslag"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Let isslag"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Isslag"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Let støvregn"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Stor mængde ispiller"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Ispiller"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Lille mængde ispiller"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Kraftig sne"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Sne"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Let sne"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Lette snebyger"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Tordenvejr"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Let tåge"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Tåge"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Overskyet"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Næsten overskyet"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Delvist skyet"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Overvejende klart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Klart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Solrigt"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Ukendt"
 
@@ -559,7 +573,7 @@ msgstr ""
 "Indtast API-nøglen under indstillinger,\n"
 "eller hent først en på https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -567,7 +581,7 @@ msgstr ""
 "Sikr dig, at du har indtastet\n"
 "API-nøglen, som du har fra DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Kunne ikke hente lokalitet"
 
@@ -576,122 +590,123 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Lokalitetstjenesten svarede med fejl. Se loggene i Luppen"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Skydække"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Klart vejr"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Opholdsvejr"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Kraftig regn og torden"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Kraftige regnbyger"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Kraftig regnbyger og torden"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Kraftig slud"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Kraftig slud og torden"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Kraftige sludbyger"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Kraftige sludbyger og torden"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Kraftig sne og torden"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Kraftige snebyger"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Kraftig snebyger og torden"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Let regn og torden"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Lette regnbyger"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Lette regnbyger og torden"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Let slud"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Let slud og torden"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Lette sludbyger"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Lette sludbyger og torden"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Let sne og torden"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Lette snebyger"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Lette snebyger og torden"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Regn og torden"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Regnbyger"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Regnbyger og torden"
 
@@ -700,45 +715,46 @@ msgstr "Regnbyger og torden"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Slud"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Slud og torden"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Sludbyger"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Sludbyger og torden"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Sne og torden"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Snebyger"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Snebyger og torden"
 
@@ -747,20 +763,20 @@ msgstr "Snebyger og torden"
 msgid "Unexpected response from API"
 msgstr "Uventet svar fra API'en"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Sigtbarhed"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Kunne ikke behandle aktuelle vejrinformation"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Kunne ikke behandle vejrudsigtsinformation"
 
@@ -789,92 +805,96 @@ msgid "Excellent - More than"
 msgstr "Fremragende - mere end"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Dis"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Overskyet"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Lette regnbyger"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Støvregn"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Kraftige regnbyger"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Sludbyger"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Hagl"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Haglbyger"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Lette snebyger"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Kraftige snebyger"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Tordenvejr"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Tordenbyger"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Sikr dig, at lokalitet er i det rigtige format under indstillinger"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Sikr dig, at du har indtastet den rigtige nøgle under indstillinger"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -882,211 +902,227 @@ msgstr ""
 "Lokalitet ikke fundet. Sikr dig, at lokaliteten er tilgængelig eller er i "
 "det rigtige format"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Kontakt forfatteren af panelprogrammet, hvis problemet varer ved"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Ukendt fejl. Se loggene i Luppen"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Tordenvejr med let regn"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Tordenvejr med regn"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Tordenvejr med kraftig regn"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Let tordenvejr"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Kraftigt tordenvejr"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Ujævnt tordenvejr"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Tordenvejr med let støvregn"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Tordenvejr med støvregn"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Tordenvejr med kraftig støvregn"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Let støvregn"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Kraftig støvregn"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Let finregn"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Finregn"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Kraftig finregn"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Bygeregn og støvregn"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Kraftig bygeregn og støvregn"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Bygestøvregn"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Moderat regn"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Kraftig regn"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Meget kraftig regn"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Ekstrem regn"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Lette regnbyger"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Regnbyger"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Kraftige regnbyger"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Ujævne regnbyger"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Sludbyger"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Let regn og sne"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Regn og sne"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Lette snebyger"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Snebyger"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Kraftige snebyger"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Røg"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Dis"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Sand, støvhvirvler"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Sand"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Støv"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkansk aske"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Vindstød"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Skyfrit"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Skyer"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Få skyer"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Spredte skyer"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Spredt skydække"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Overskyet"
 
@@ -1094,72 +1130,72 @@ msgstr "Overskyet"
 msgid "Could not get forecast for your area"
 msgstr "Kunne ikke hente vejrudsigten for dit område"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Området er uden for USA - brug en anden udbyder."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Kunne ikke behandle timebaseret vejrudsigtsinformation"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Klart og blæsende"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Få skyer og blæsende"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Delvist skyet og blæsende"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Næsten overskyet og blæsende"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Overskyet og blæsende"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Slud"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Isslag og sne"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Tyfon"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Storm"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropisk storm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Varmt"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Koldt"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Snestorm"
 
@@ -1199,79 +1235,79 @@ msgstr "Fredag"
 msgid "Saturday"
 msgstr "Lørdag"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Stille"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Let luft"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Let brise"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Blid brise"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Moderat brise"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Frisk brise"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Stærk brise"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Tæt på kuling"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Kuling"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Stormende kuling"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Kraftig storm"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NØ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "Ø"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SØ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NV"
 
@@ -1323,7 +1359,7 @@ msgstr ""
 "Ukendt fejl opstod i forsøget på at hente vejret. Se Lup-loggen for mere "
 "information"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropisk storm"
 
@@ -1331,7 +1367,7 @@ msgstr "Tropisk storm"
 msgid "Severe Thunderstorms"
 msgstr "Kraftige tordenbyger"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Tordenvejr"
 
@@ -1347,17 +1383,17 @@ msgstr "Blandet regn og slud"
 msgid "Mixed Snow and Sleet"
 msgstr "Blandet sne og slud"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Isslag"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Isslag"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Byger"
 
@@ -1369,11 +1405,11 @@ msgstr "Lette snebyger"
 msgid "Light Snow Showers"
 msgstr "Lette snebyger"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Fygesne"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Tåget"
 
@@ -1385,54 +1421,55 @@ msgstr "Røg"
 msgid "Blustery"
 msgstr "Susende"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Blæsende"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Næsten overskyet"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Delvist skyet"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Overvejende solrigt"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Blandet regn og hagl"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Lokale tordenbyger"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Spredte tordenbyger"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Spredte byger"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Kraftig regn"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Spredte snebyger"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Kraftig sne"
 
@@ -1461,331 +1498,370 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr "Met Office UK dækker kun UK. Sikr dig, at din lokalitet er i landet"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Data blev ikke fundet for lokaliteten"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Meget dårlig"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Mindre end {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Fremragende"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mere end {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Dårlig"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Mellem {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Moderat"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "God"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Meget god"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Vindstød"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Lette snebyger"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "Meteorologisk institutt Norge"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Let vind"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Stærk vind"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Fygesne"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Kraftig støvregn"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Kraftig støvregn/regn"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Lette snebyger"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Let støvregn/regn"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Kraftige snebyger"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Støvstorm"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Slud"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Isslag"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Snebyger"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Kraftig isslag"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Let isslag"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Iståge"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Let vind"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Stærk vind"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Fygesne"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Kraftig støvregn/regn"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Let støvregn/regn"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Støvstorm"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Isslag"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Kraftig isslag"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Let isslag"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Tragtskt/tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Haglbyger"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Is"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Lyn uden torden"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Nedbør i nærheden"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Kraftig regn og sne"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Let regn og sne"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Aftagende skydække"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Tiltagende skydække"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Uændret skydække"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Røg eller dis"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Sne- og regnbyger"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Tordenvejr uden nedbør"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Isnåle"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Delvist skyet"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Sikr dig, at du har indtastet API-nøglen korrekt"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Danmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "IKKE FUNDET"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Fygesne"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Let sne"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Moderat sne"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Moderate regnbyger"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Blandet regn og sne"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Kraftig regn og sne"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Vælg en anden udbyder eller lokalitet"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "Den angivne API-nøgle er ugyldig."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Dn angivne lokalitet blev ikke fundet."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Stærk storm"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Rain and Snow"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Regn og slud"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Snebyger"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Let blæsende"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Køligt"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Overvejende klart"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Sikr dig, at du har indtastet\n"
+"API-nøglen, som du har fra Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr "Lokalitetstjenesten svarede med fejl. Se loggene i Luppen"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Overvejende klart"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Slud"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Lette snebyger"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Kraftige snebyger"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Tordenvejr med let regn"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Tordenvejr med regn"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Føles som"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1793,7 +1869,7 @@ msgstr ""
 "Kunne ikke hente konfigurationen. Filen blev ikke fundet under stien\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1801,105 +1877,105 @@ msgstr ""
 "Kunne ikke hente indholdet af konfigurationsfilen under stien\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Sikr dig, at du har angivet en lokalitet eller brug automatisk lokalitet i "
 "stedet"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Denne udbyder kræver en API-nøgle for at virke"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Dugpunkt"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Nedbøren vil ophøre om {precipEnd} minutter"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Nedbøren vil ikke ophøre den næste time"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Nedbøren vil begynde om {precipStart} minutter"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Tolkning af vejrudsigt mislykkedes. Se loggen for flere detaljer."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Fra"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} fra dig"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Stationsnavn: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Område: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Der opstod en fejl, da fejlsøgningsinformation skulle gemmes"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Kunne ikke hente oplysninger om vejret"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Fejlsøgningsinformation blev gemt"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Gemt i {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2298,7 +2374,6 @@ msgid "Weather conditions"
 msgstr "Vejrforhold"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Oversæt vejrforholdene"
 
@@ -2606,6 +2681,17 @@ msgstr "Vis vindretning som tekst"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "F.eks. SØ, N i stedet for retningsikoner."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/de.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/de.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl 2.6.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-06-02 12:02+0200\n"
 "Last-Translator: bigjr slade <bigjrslade@gmail.com>\n"
 "Language-Team: \n"
@@ -22,65 +22,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Fehler"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Dienst Fehler"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Falscher API-Schlüssel"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Falsches Standort-Format"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Schlüssel blockiert"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Kann Standort nicht ermitteln"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Kein Api-Schlüssel"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Kein Standort"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Fehlende Pakete"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Standort nicht abgedeckt"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Wetter-Applet"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "…"
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Zum Öffnen anklicken"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Neu laden"
 
@@ -90,8 +90,8 @@ msgstr "Die API lieferte einen Statuscode zwischen 400 und 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Standortspeicher"
 
@@ -103,14 +103,14 @@ msgstr "Sie können einen automatisch erhaltenen Ort leider nicht speichern"
 msgid "Could not get weather information"
 msgstr "Konnte keine Wetterinformationen abrufen"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Unerwarteter Fehler beim Aktualisieren des Wetters, siehe Logs in Looking "
 "Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -126,7 +126,7 @@ msgstr "Netzwerkfehler, bitte überprüfen Sie die Protokolle in Looking Glass"
 msgid "As of"
 msgstr "Stand"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Unterstützt von"
 
@@ -134,52 +134,52 @@ msgstr "Unterstützt von"
 msgid "from you"
 msgstr "Von dir"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Aktuelles Wetter wird geladen ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Zukünftiges Wetter wird geladen ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Wird geladen ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Luftfeuchtigkeit"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Luftdruck"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Wind"
 
@@ -189,18 +189,18 @@ msgstr ""
 "Stellen sie sicher, dass ein Ort eingegeben wurde oder verwenden sie die "
 "Ortserkennung"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Kann keinen Ort basierend auf der Adresse finden, bitte überprüfen sie ihre "
 "Angaben"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Aufruf der Geolocation API fehlgeschlagen, siehe Looking Glass für Fehler."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Warnung"
 
@@ -210,17 +210,17 @@ msgstr ""
 "Sie können nur korrekte Orte speichern, wenn das Applet gerade nicht "
 "aktualisiert wird"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Sie können einen falschen Ort nicht speichern"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Ort ist bereits gespeichert"
 
@@ -259,15 +259,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Fühlt sich an wie"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Verarbeitung der Wetterinformationen fehlgeschlagen"
 
@@ -280,7 +280,7 @@ msgstr ""
 "oder holen Sie sich zuerst eine auf https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -288,7 +288,7 @@ msgstr ""
 "Bitte stellen Sie sicher, dass Sie\n"
 "den API-Schlüssel korrekt eingegeben haben und Ihr Konto nicht gesperrt ist"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -299,252 +299,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Starker Regen"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Regen"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Leichter Regen"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Starker Eisregen"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Eisregen"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Leichter Eisregen"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Leichter Frostnieselregen"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Frostnieselregen"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Leichter Nieselregen"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Schwere Eiskörner"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Eiskörner"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Leichte Eiskörner"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Starker Schneefall"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Schneefall"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Leichter Schneefall"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Gestöber"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Gewitter"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Leichter Nebel"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Nebel"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Bewölkt"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Grösstenteils bewölkt"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Teilweise bewölkt"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Weitgehend klar"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Klar"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Sonnig"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -568,13 +582,13 @@ msgstr ""
 "Bitte geben Sie den API-Schlüssel in den Einstellungen ein,\n"
 "oder holen Sie sich zuerst eine auf https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr "Bitte verwenden Sie den API-Schlüssel, den Sie von DarkSky haben"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Konnte den Standort nicht ermitteln"
 
@@ -584,122 +598,123 @@ msgid ""
 msgstr ""
 "Location Service antwortede mit Fehler, bitte sehen Sie in Looking Glass Logs"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Bewölkung"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Klarer Himmel"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Schön"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Starker Regen und Gewitter"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Starke Regenschauer"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Starke Regenschauer und Gewitter"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Schwerer Schneeregen"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Starker Schneeregen und Donner"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Starke Graupelschauer"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Heftige Graupelschauer und Gewitter"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Starker Schnee und Gewitter"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Starke Schneeschauer"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Heftige Schneeschauer und Gewitter"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Leichter Regen und Donner"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Leichte Regenschauer"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Leichte Regenschauer und Gewitter"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Leichter Schneeregen"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Leichter Schneeregen und Donner"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Leichte Graupelschauer"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Leichte Graupelschauer und Gewitter"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Leichter Schneefall und Gewitter"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Leichte Schneeschauer"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Leichte Schneeschauer und Gewitter"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Regen und Donner"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Regenschauer"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Regenschauer und Gewitter"
 
@@ -708,45 +723,46 @@ msgstr "Regenschauer und Gewitter"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Graupel"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Graupel und Donner"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Graupelschauer"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Graupelschauer und Gewitter"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Schnee und Donner"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Schneeschauer"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Schneeschauer und Gewitter"
 
@@ -755,20 +771,20 @@ msgstr "Schneeschauer und Gewitter"
 msgid "Unexpected response from API"
 msgstr "Unerwartete Antwort von API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Sichtweite"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Verarbeitung aktueller Wetterinformationen fehlgeschlagen"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Fehler bei der Verarbeitung der Vorhersage"
 
@@ -797,92 +813,96 @@ msgid "Excellent - More than"
 msgstr "Ausgezeichnet - Mehr als"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Nebel"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Bewölkt"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Leichter Regenschauer"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Niesel"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Starker Regenschauer"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Graupelschauer"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Hagel"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Hagelschauer"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Leichter Schneeschauer"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Starker Schneeschauer"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Donner"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Gewitterschauer"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Bitte stellen Sie sicher, dass der Ort das richtige Format hat"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Vergewissern Sie sich, dass Sie den richtigen Schlüssel verwenden"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -890,213 +910,229 @@ msgstr ""
 "Ort nicht gefunden, stellen Sie sicher, dass der Ort verfügbar ist oder im "
 "richtigen Format vorliegt"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Falls dieses Problem weiterhin besteht, kontaktieren Sie den Autor dieses "
 "Applets"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Unbekannter Fehler, bitte schauen sie in die Looking Glass Protokolle"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Gewitter mit leichtem Regen"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Gewitter mit Regen"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Gewitter mit starkem Regen"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Leichtes Gewitter"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Starkes Gewitter"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Immer wieder Gewitter"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Gewitter mit leichtem Nieselregen"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Gewitter mit Nieselregen"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Gewitter mit starkem Nieselregen"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Leichter Sprühregen"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Starker Nieselregen"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Leichter Nieselregen"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Nieselregen"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Starker Nieselregen"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Schauer- und Nieselregen"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Starker Regenschauer und Niesel"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Nieselregenschauer"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Mäßiger Regen"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Starker Regen"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Sehr starker Regen"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Extremer Regen"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Leichte Regenschauer"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Regenschauer"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Starker Regenschauer"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Immer wieder Regenschauer"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Graupelschauer"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Leichter Regen und Schnee"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Regen und Schnee"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Leichter Schneeschauer"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Schneeschauer"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Starker Schneeschauer"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Rauch"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Dunst"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Sand, Staubwirbel"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Sand"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Staub"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkanasche"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Böen"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Klarer Himmel"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Wolken"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Wenige Wolken"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Zerstreute Wolken"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Aufgelockert bewölkt"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Wolkenverhangen"
 
@@ -1104,73 +1140,73 @@ msgstr "Wolkenverhangen"
 msgid "Could not get forecast for your area"
 msgstr "Konnte keine Vorhersage für ihre Gegend abrufen"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "Standort außerhalb der USA, bitte verwenden Sie einen anderen Anbieter."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Verarbeitung der stündlichen Vorhersage fehlgeschlagen"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Klar und windig"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Wenig Wolken und windig"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Teilweise bewölkt und windig"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Meist bewölkt und windig"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Bewölkt und windig"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Schneeregen"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Eisregen und Schnee"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Hurrikan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Sturm"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropischer Sturm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Heiß"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Kalt"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Blizzard"
 
@@ -1210,79 +1246,79 @@ msgstr "Freitag"
 msgid "Saturday"
 msgstr "Samstag"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Ruhig"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Leichter Wind"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Leichte Briese"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Sanfte Briese"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Mäßige Briese"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Frische Briese"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Starke Briese"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Nahe Sturm"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Sturm"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Starker Sturm"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Heftiger Sturm"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SW"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "W"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NW"
 
@@ -1334,7 +1370,7 @@ msgstr ""
 "Unbekannter Fehler bei der Wettervorhersage, siehe Looking Glass logs für "
 "weitere Informationen"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropischer Sturm"
 
@@ -1342,7 +1378,7 @@ msgstr "Tropischer Sturm"
 msgid "Severe Thunderstorms"
 msgstr "Schwere Gewitter"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Gewitter"
 
@@ -1358,17 +1394,17 @@ msgstr "Gemischter Regen und Schneeregen"
 msgid "Mixed Snow and Sleet"
 msgstr "Gemischter Schnee und Schneeregen"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Gefrierender Regen"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Eisregen"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Schauer"
 
@@ -1380,11 +1416,11 @@ msgstr "Schneegestöber"
 msgid "Light Snow Showers"
 msgstr "Leichte Schneeschauer"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Schneetreiben"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Neblig"
 
@@ -1396,54 +1432,55 @@ msgstr "Rauchig"
 msgid "Blustery"
 msgstr "Stürmisch"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Windig"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Meist bewölkt"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Teilweise wolkig"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Größtenteils sonnig"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Gemischter Regen und Hagel"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Lokale Gewitter"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Vereinzelt Gewitter"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Vereinzelte Schauer"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Starker Regen"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Vereinzelt Schneeschauer"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Schwerer Schnee"
 
@@ -1472,11 +1509,11 @@ msgstr ""
 " {logFilePath} nicht gefunden."
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1484,429 +1521,469 @@ msgstr ""
 "MET Office UK deckt nur das Vereinigte Königreich ab, bitte stellen Sie "
 "sicher, dass Ihr Standort in diesem Land liegt."
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Keine Daten für dein Standort"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Sehr schlecht"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Weniger als {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Ausgezeichnet"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mehr als {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Schlecht"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Zwischen {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Mäßig"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Gut"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Sehr gut"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Böen"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Leichte Schauer"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
 # https://www.weatherbit.io/
 # is a weather plattform
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
+msgid "Heavy drizzle"
+msgstr "Starker Nieselregen"
+
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Leichter Schneeschauer"
+
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Starker Schneeschauer"
+
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Schneeregen"
+
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Schneeschauer"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
+msgid "Freezing fog"
+msgstr "Eisnebel"
+
 # https://www.tomorrow.io/
 # is a weather plattform
-#: 3.8/weather-applet.js:12849
+#: 3.8/weather-applet.js:13091
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:13058
+#: 3.8/weather-applet.js:13300
 msgid "Light wind"
 msgstr "Schwacher Wind"
 
-#: 3.8/weather-applet.js:13072
+#: 3.8/weather-applet.js:13314
 msgid "Strong wind"
 msgstr "Kräftiger Wind"
 
-#: 3.8/weather-applet.js:13422
+#: 3.8/weather-applet.js:13664
 msgid "US Weather"
 msgstr "US National Weather (nur US)"
 
 # https://www.visualcrossing.com/
-#: 3.8/weather-applet.js:13997
+#: 3.8/weather-applet.js:14239
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:14191
+#: 3.8/weather-applet.js:14433
 msgid "Blowing or drifting snow"
 msgstr "Schneeverwehungen"
 
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
-msgid "Heavy drizzle"
-msgstr "Starker Nieselregen"
-
-#: 3.8/weather-applet.js:14199
+#: 3.8/weather-applet.js:14441
 msgid "Heavy drizzle/rain"
 msgstr "Starker (Niesel-)Regen"
 
-#: 3.8/weather-applet.js:14201
+#: 3.8/weather-applet.js:14443
 msgid "Light drizzle/rain"
 msgstr "Leichter (Niesel-)Regen"
 
-#: 3.8/weather-applet.js:14203
+#: 3.8/weather-applet.js:14445
 msgid "Dust Storm"
 msgstr "Sandsturm"
 
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:14449
 msgid "Freezing drizzle/freezing rain"
 msgstr "Frostnieselregen/Eisregen"
 
-#: 3.8/weather-applet.js:14209
+#: 3.8/weather-applet.js:14451
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Starker Frostnieselregen/Eisregen"
 
-#: 3.8/weather-applet.js:14211
+#: 3.8/weather-applet.js:14453
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Leichter Frostnieselregen/Eisregen"
 
-#: 3.8/weather-applet.js:14213
-msgid "Freezing fog"
-msgstr "Eisnebel"
-
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Trichterwolke/Tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Hagelschauer"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Eis"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Blitzschlag ohne Donner"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Niederschlag in der Umgebung"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Starker Regen und Gewitter"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Leichter Regen und Schnee"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Abnehmende Bewölkung"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Zunehmende Bewölkung"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Himmel unverändert"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Rauch oder Dunst"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Schnee- und Regenschauer"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Gewitter ohne Niederschlag"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Polarschnee"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Teilweise bewölkt"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 "Bitte stellen Sie sicher, dass Sie den API-Schlüssel korrekt eingegeben haben"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Dänemark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NICHT GEFUNDEN"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Schneewehen"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Leichter Schneefall"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Mäßiger Schneefall"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Mäßige Regenschauer"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Regen und Schnee gemischt"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Starker Regen und Schnee gemischt"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Bitte wählen Sie einen anderen Anbieter oder Standort"
 
 # https://www.wunderground.com/
 # is a weatherplattform
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "Der von Ihnen angegebene API-Schlüssel ist ungültig."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Keine Daten für dein Standort."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Kräftiger Wind"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Regen und Schnee"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Regen und Graupel"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Schneeschauer"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Windig"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Kühl"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Überwegend klar"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "US National Weather (nur US)"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Bitte stellen Sie sicher, dass Sie den API-Schlüssel\n"
+"den Sie von Climacell haben eingeben"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 "Location Service antwort mit Fehler, bitte sehen Sie in Looking Glass Logs"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-msgid "Mainly clear"
-msgstr "Weitgehend klar"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 msgid "Snow grains"
 msgstr "Schneegriesel"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 msgid "Light showers"
 msgstr "Leichte Schauer"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 msgid "Heavy showers"
 msgstr "Starker Schauer"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 msgid "Thunderstorm with slight hail"
 msgstr "Gewitter mit leichtem Regen"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 msgid "Thunderstorm with hail"
 msgstr "Gewitter mit Regen"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr "Fühlt sich an wie"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr "Open Meteo"
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr "Konnte Konfiguration nicht abrufen, Datei  nicht im Pfad gefunden"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr "Konnte den Inhalt der Konfigurationsdatei im Pfad nicht abrufen"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Stellen sie sicher, dass ein Ort eingegeben wurde oder verwenden sie die "
 "Ortserkennung."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Dieser Anbieter benötigt einen API-Schlüssel um zu funktionieren"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Taupunkt"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Niederschlag wird innerhalb von {precipEnd} Minuten aufhören"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Niederschlag wird nicht innerhalb einer Stunde aufhören"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Niederschlag wird innerhalb von {precipStart} Minuten beginnen"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Parsen der Vorhersage ist fehlgeschlagen."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Stand {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} von Ihnen"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Station Name: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Gebiet: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr "{count} Wetter Alarme"
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Fehler beim Speichern der Debug-Informationen"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr "Konnte keine Wetterinformationen abrufen"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Debug-Informationen erfolgreich gespeichert"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Gespeichert in {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr "Kein Skript zur Verfügung gestellt"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr "Sie müssen zuerst ein Skript hinzufügen."
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr "Keine Wetterdaten"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr "Keine Wetterdaten zur Ausführung des Skripts"
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr "Skript erfolgreich ausgeführt"
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr "Ihr Skript wurde erfolgreich ausgeführt."
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr "Fehler beim Ausführen des Skripts"
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 "Das Skript meldet einen Fehler, weitere Informationen finden Sie in den "
@@ -2309,7 +2386,6 @@ msgid "Weather conditions"
 msgstr "Wetterbedingungen"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Wetterbedingungen übersetzen"
 
@@ -2627,6 +2703,17 @@ msgstr "Windrichtung als Text anzeigen"
 msgid "Like SE, N instead of direction icons."
 msgstr ""
 "Text N, O, S, W - NO, NW, SO, SW  anstelle der Richtungssymbole anzeigen."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/el.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/el.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: 3.0.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-04-14 15:52+0200\n"
 "Last-Translator: Vasilis Kosmidis <skyhirules@gmail.com>\n"
 "Language-Team: Ελληνικά <>\n"
@@ -22,66 +22,66 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 #, fuzzy
 msgid "Weather Applet"
 msgstr "Καιρός"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr ""
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Κάντε κλικ για να ανοίξει"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Ανανέωση"
 
@@ -91,8 +91,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -104,12 +104,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +123,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -131,55 +131,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Φόρτωση τρέχοντος καιρού ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Φόρτωση μελλοντικού καιρού ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Φόρτωση ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "Θερμοκρασία:"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "Υγρασία:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "Πίεση:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "Άνεμος:"
@@ -188,15 +188,15 @@ msgstr "Άνεμος:"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -204,17 +204,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -250,15 +250,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -269,13 +269,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -284,12 +284,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "Ισχυρή χιονόπτωση"
@@ -297,38 +298,41 @@ msgstr "Ισχυρή χιονόπτωση"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "Παγωμένη βροχή"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "Παγωμένη βροχή"
@@ -336,168 +340,175 @@ msgstr "Παγωμένη βροχή"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Παγωμένη βροχή"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "Παγωμένη βροχή"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "Παγωμένο ψιλόβροχο"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Παγωμένο ψιλόβροχο"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "Παγωμένο ψιλόβροχο"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Ισχυρή χιονόπτωση"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Χιόνι"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "Νυφάδες χιονιού"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "Καταιγίδες"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "Ομιχλώδης"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Συννεφιασμένος"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Κυρίως νεφελώδης"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Μερικώς νεφελώδης"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "Κυρίως νεφελώδης"
@@ -505,42 +516,45 @@ msgstr "Κυρίως νεφελώδης"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Αίθριος"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Ηλιόλουστος"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -562,13 +576,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -577,136 +591,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "Συννεφιασμένος"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "Αίθριος"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Αίθριος"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "Ισχυρή χιονόπτωση"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "Ισχυρή χιονόπτωση"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "Ισχυρή χιονόπτωση"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "Ισχυρή χιονόπτωση"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "Χιονοπτώσεις"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "Ελαφριά χιονόπτωση"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "Χιονοπτώσεις"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -715,47 +730,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Χιονόνερο"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "Διάσπαρτες καταιγίδες"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "Διάσπαρτες βροχοπτώσεις"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Χιονοπτώσεις"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "Χιονοπτώσεις"
@@ -765,20 +781,20 @@ msgstr "Χιονοπτώσεις"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -807,330 +823,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "Ελαφριά χιονόπτωση"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Ψιλόβροχο"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "Ισχυρή χιονόπτωση"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "Διάσπαρτες βροχοπτώσεις"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Χαλάζι"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "Χιονοπτώσεις"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "Ισχυρή χιονόπτωση"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "Καταιγίδες"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "Βροχοπτώσεις με κεραυνούς"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "Καταιγίδες"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "Καταιγίδες"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "Ισχυρές καταιγίδες"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "Μεμονωμένες καταιγίδες"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "Καταιγίδες"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "Ψιλόβροχο"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "Βροχή και χαλάζι"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "Παγωμένο ψιλόβροχο"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "Παγωμένη βροχή"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "Ισχυρές βροχοπτώσεις"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "Ισχυρές βροχοπτώσεις"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "Βροχή και χιόνι"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "Βροχή και χιόνι"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "Ισχυρές βροχοπτώσεις"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "Ισχυρή χιονόπτωση"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "Καπνώδης"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Ομίχλη"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Σκόνη"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Ανεμοστρόβιλος"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "Συννεφιασμένος"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "Διάσπαρτες βροχοπτώσεις"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1138,76 +1174,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "Μερικώς νεφελώδης"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "Κυρίως νεφελώδης"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "Νυφάδες χιονιού"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "Παγωμένη βροχή"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Τυφώνας"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Τροπική καταιγίδα"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Καυτός"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Κρύο"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1247,79 +1283,79 @@ msgstr "Παρασκευή"
 msgid "Saturday"
 msgstr "Σάββατο"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "Β"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "ΒΑ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "Α"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "ΝΑ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "Ν"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "ΝΔ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "Δ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "ΒΔ"
 
@@ -1364,7 +1400,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "Τροπική καταιγίδα"
@@ -1374,7 +1410,7 @@ msgstr "Τροπική καταιγίδα"
 msgid "Severe Thunderstorms"
 msgstr "Ισχυρές καταιγίδες"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Καταιγίδες"
 
@@ -1393,19 +1429,19 @@ msgstr "Βροχή και χιονόνερο"
 msgid "Mixed Snow and Sleet"
 msgstr "Χιόνι και χιονόνερο"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "Παγωμένο ψιλόβροχο"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "Παγωμένη βροχή"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Ισχυρές βροχοπτώσεις"
 
@@ -1419,12 +1455,12 @@ msgstr "Νυφάδες χιονιού"
 msgid "Light Snow Showers"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "Χιονοθύελλες"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Ομιχλώδης"
 
@@ -1436,63 +1472,64 @@ msgstr "Καπνώδης"
 msgid "Blustery"
 msgstr "Θορυβώδης"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Ανεμώδης"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "Κυρίως νεφελώδης"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "Μερικώς νεφελώδης"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "Κυρίως νεφελώδης"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "Βροχή και χαλάζι"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Μεμονωμένες καταιγίδες"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Διάσπαρτες καταιγίδες"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Διάσπαρτες βροχοπτώσεις"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "Ισχυρή χιονόπτωση"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Διάσπαρτες χιονοπτώσεις"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Ισχυρή χιονόπτωση"
@@ -1520,458 +1557,493 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Ελαφριά χιονόπτωση"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 #, fuzzy
 msgid "OpenWeatherMap"
 msgstr "Καιρός"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 #, fuzzy
 msgid "WeatherBit"
 msgstr "Καιρός"
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "Αύριο"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-#, fuzzy
-msgid "US Weather"
-msgstr "Καιρός"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "Χιονοθύελλες"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "Παγωμένο ψιλόβροχο"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "Παγωμένο ψιλόβροχο"
+msgid "Light shower rain"
+msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Ισχυρή χιονόπτωση"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Νυφάδες χιονιού"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Χιονοπτώσεις"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "Παγωμένη βροχή"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Αύριο"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+#, fuzzy
+msgid "US Weather"
+msgstr "Καιρός"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Χιονοθύελλες"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Παγωμένο ψιλόβροχο"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "Χιονοπτώσεις"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "Βροχή και χιόνι"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "Βροχή και χιόνι"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "Χιονοπτώσεις"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "Μερικώς νεφελώδης"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Χιονοθύελλες"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "Χιονοθύελλες"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "Ισχυρή χιονόπτωση"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "Διάσπαρτες βροχοπτώσεις"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Βροχή και χιόνι"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "Βροχή και χιόνι"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 #, fuzzy
 msgid "AccuWeather"
 msgstr "Καιρός"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Βροχή και χιόνι"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Βροχή και χιονόνερο"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Χιονοπτώσεις"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Κυρίως νεφελώδης"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "Καιρός"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Κυρίως νεφελώδης"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Νυφάδες χιονιού"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Ελαφριά χιονόπτωση"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Ισχυρή χιονόπτωση"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Καταιγίδες"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Καταιγίδες"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "Καιρός"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2372,7 +2444,6 @@ msgid "Weather conditions"
 msgstr "Μετάφραση καιρικών συνθηκών"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 #, fuzzy
 msgid "Translate conditions"
 msgstr "Μετάφραση καιρικών συνθηκών"
@@ -2651,6 +2722,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/es.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-05-30 11:09-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -20,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Error"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Error de servicio"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Clave de API incorrecta"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Formato de ubicación incorrecto"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Tecla bloqueada"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "No se pudo obtener la ubicación"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "No hay clave de API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Sin ubicación"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Paquetes perdidos"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Sin ubicación"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Applet del Clima"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Click para abrir"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Recargar"
 
@@ -88,8 +88,8 @@ msgstr "La API devolvió el código de estado entre 400 y 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Ubicación"
 
@@ -101,14 +101,14 @@ msgstr "No puede guardar una ubicación obtenida automáticamente, lo lamento"
 msgid "Could not get weather information"
 msgstr "No se pudo obtener información del Clima"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Error inesperado al actualizar información del Clima, por favor mire el log "
 "en Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +124,7 @@ msgstr "Error de red, mire los logs en Looking Glass"
 msgid "As of"
 msgstr "A partir de las"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Powered by"
 
@@ -132,52 +132,52 @@ msgstr "Powered by"
 msgid "from you"
 msgstr "de ti"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Cargando el clima actual..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Cargando pronóstico del clima..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Cargando..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Humedad"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Presión"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Viento"
 
@@ -186,19 +186,19 @@ msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Asegúrese de que ha introducido una ubicación o use la ubicación automática"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "No se pudo encontrar la ubicación según la dirección, verifique si es "
 "correcta"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Fallo en la llamada a la API de geolocalización, ver errores en Looking "
 "Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Advertencia"
 
@@ -208,17 +208,17 @@ msgstr ""
 "Sólo se puede guardar las ubicaciones correctas cuando el applet no se está "
 "actualizando"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "No puede guardar una ubicación incorrecta"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "La ubicación ya está guardada"
 
@@ -257,15 +257,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Sensación térmica"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "No se pudo procesar la información del Clima"
 
@@ -278,7 +278,7 @@ msgstr ""
 "u obtenga una primero en https://developer.tomorrow.io/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -286,7 +286,7 @@ msgstr ""
 "Asegúrese de que\n"
 "introdujo la clave de API correctamente y su cuenta no haya sido bloqueada"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -297,252 +297,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Lluvia muy intensa"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Lluvia"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Lluvia ligera"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Lluvia helada"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Lluvia helada"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Lluvia helada"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Llovizna helada"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Lluvia helada"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Llovizna ligera"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Granizo pesado"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Granizo"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Granizo ligero"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Nevada fuerte"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Nieve"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Nieve ligera"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Ráfagas"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Tormenta eléctrica"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Niebla ligera"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Bruma"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Nublado"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Mayormente nublado"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Mayormente soleado"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Despejado"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Soleado"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -566,7 +580,7 @@ msgstr ""
 "Introduzca una clave de API en la configuración,\n"
 "u obtenga una primero en https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -574,7 +588,7 @@ msgstr ""
 "Asegúrese de que\n"
 "introdujo la clave de API que ha obtenido desde DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "No se pudo obtener la ubicación"
 
@@ -585,122 +599,123 @@ msgstr ""
 "El servicio de ubicación respondió con errores, mire los logs en Looking "
 "Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Abundancia de nubes"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Cielo despejado"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Buen tiempo"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Fuerte aguacero y llovizna"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Lluvia muy intensa"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Chubascos y truenos"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Aguanieve"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Aguanieve y truenos"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Fuertes chubascos de Aguanieve"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Fuertes chubascos de Aguanieve y truenos"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Fuertes nevadas y truenos"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Fuertes nevadas"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Fuertes nevadas y truenos"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Lluvia ligera y truenos"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Lluvia ligera"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Lluvia ligera y truenos"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Lluvia ligera de Aguanieve"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Lluvia ligera de Aguanieve y truenos"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Lluvia ligera de Aguanieve"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Lluvia ligera de Aguanieve y truenos"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Ligera Nevada y truenos"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Ligeros chubascos de nieve"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Ligeros chubascos de nieve y truenos"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Lluvia y truenos"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Chubascos"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Chubascos y truenos"
 
@@ -709,45 +724,46 @@ msgstr "Chubascos y truenos"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Aguanieve"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Aguanieve y truenos"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Lluvia de Aguanieve"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Ligeros chubascos de Aguanieve y truenos"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Nieve y trueno"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Chubasco de nieve"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Chubasco de nieve y truenos"
 
@@ -756,20 +772,20 @@ msgstr "Chubasco de nieve y truenos"
 msgid "Unexpected response from API"
 msgstr "Respuesta inesperada de la API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Visibilidad"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "No se pudo procesar la información del clima actual"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "No se pudo procesar la información del pronóstico"
 
@@ -798,93 +814,97 @@ msgid "Excellent - More than"
 msgstr "Excelente - Más de"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Niebla"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Nubarrones"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Llovizna de intensidad ligera"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Llovizna"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Aguacero"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Chubascos de Aguanieve"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Granizo"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Fuertes granizadas"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Nevada ligera"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Nevada fuerte"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Truenos"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Tormenta de truenos"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Asegúrese de que la ubicación está en el formato correcto en la configuración"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Asegúrese de que introdujo la clave correcta en la configuración"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -892,211 +912,227 @@ msgstr ""
 "Ubicación no encontrada, asegúrese de que la ubicación está disponible o "
 "está en el formato correcto"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Si el problema persiste, contacte al autor de este applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Error desconocido, consulte los logs en Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Tormenta con lluvia ligera"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Tormenta con lluvia"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Tormenta con fuertes lluvias"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Tormenta ligera"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Tormenta fuerte"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Tormenta torrencial"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Tormenta con llovizna ligera"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Tormenta con llovizna"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Tormenta con fuerte llovizna"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Llovizna de intensidad ligera"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Llovizna de intensidad fuerte"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Llovizna de intensidad ligera"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Llovizna"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Llovizna de intensidad fuerte"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Aguacero y llovizna"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Fuerte aguacero y llovizna"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Aguacero"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Lluvia moderada"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Lluvia intensa"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Lluvia muy intensa"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Lluvia extrema"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Llovizna de intensidad ligera"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Aguacero"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Aguacero de intensidad fuerte"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Lluvia irregular"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Aguanieve"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Lluvia ligera y nieve"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Lluvia y nieve"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Ligeros chubascos de nieve"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Chubasco de nieve"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Fuertes chubascos de nieve"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Humo"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Niebla"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Arena, remolinos de polvo"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Arena"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Polvo"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Ceniza volcánica"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Borrascas"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornados"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Cielo despejado"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Nubarrones"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Pocas nubes"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Nubes dispersas"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Nubes rotas"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Totalmente cubierto"
 
@@ -1104,72 +1140,72 @@ msgstr "Totalmente cubierto"
 msgid "Could not get forecast for your area"
 msgstr "No se pudo obtener el pronóstico para su área"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "La ubicación está fuera de EE. UU., Utilice un proveedor diferente."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "No se pudo procesar la información del pronóstico"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Despejado y con viento"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Pocas nubes y viento"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Parcialmente nublado y con viento"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Mayormente nublado y con viento"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Nublado y con viento"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Lluvia helada"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Lluvia helada y nieve"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Huracán"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Tormenta"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tormenta tropical"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Caluroso"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Muy frío"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Ventisca"
 
@@ -1209,79 +1245,79 @@ msgstr "Viernes"
 msgid "Saturday"
 msgstr "Sábado"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Tranquilo"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Aire ligero"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Brisa ligera"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Brisa suave"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Brisa moderada"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Brisa fresca"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Brisa fuerte"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Vendaval moderado"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Vendaval"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Vendaval fuerte"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Tormenta violenta"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NO"
 
@@ -1333,7 +1369,7 @@ msgstr ""
 "Se produjo un error desconocido al obtener el Clima, consulte los registros "
 "de Looking Glass para más información"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tormenta tropical"
 
@@ -1341,7 +1377,7 @@ msgstr "Tormenta tropical"
 msgid "Severe Thunderstorms"
 msgstr "Tormenta eléctrica fuerte"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Tormenta eléctrica"
 
@@ -1357,17 +1393,17 @@ msgstr "Mezcla de Lluvia y Aguanieve"
 msgid "Mixed Snow and Sleet"
 msgstr "Mezcla de nieve y Aguanieve"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Llovizna helada"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Lluvia helada"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Chubasco de nieve"
 
@@ -1379,11 +1415,11 @@ msgstr "Copos de nieve"
 msgid "Light Snow Showers"
 msgstr "Ligeros chubascos de nieve"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Ventisca"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Neblinoso"
 
@@ -1395,54 +1431,55 @@ msgstr "Humo"
 msgid "Blustery"
 msgstr "Tempestuoso"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Viento"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Mayormente nublado"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Mayormente soleado"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Mezcla de lluvia y granizo"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Tormentas aisladas"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Tormentas eléctricas dispersas"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Chubascos dispersos"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Lluvia fuerte"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Chubascos de nieve dispersos"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Nevada fuerte"
 
@@ -1472,11 +1509,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1484,275 +1521,319 @@ msgstr ""
 "WindyMET Office UK solo cubre el Reino Unido, asegúrese de que su ubicación "
 "esté en el país"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "No se encontraron datos para la ubicación"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Muy pobre"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Menos que {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Excelente"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mas de {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Pobre"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Entre {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Moderada"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Bueno"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Muy bueno"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Borrascas"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Chubascos ligeros"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Viento ligero"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Viento fuerte"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Nieve soplada o a la deriva"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Llovizna"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Llovizna de intensidad fuerte"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Ligeros chubascos de nieve"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Llovizna de intensidad ligera"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Fuertes chubascos de nieve"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Tormenta de polvo"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Lluvia helada"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Llovizna helada fuerte/lluvia helada"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Chubasco de nieve"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Llovizna helada fuerte/lluvia helada"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Llovizna helada ligera/lluvia helada"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Niebla helada"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Viento ligero"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Viento fuerte"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Nieve soplada o a la deriva"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Llovizna de intensidad fuerte"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Llovizna de intensidad ligera"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Tormenta de polvo"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Llovizna helada fuerte/lluvia helada"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Llovizna helada fuerte/lluvia helada"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Llovizna helada ligera/lluvia helada"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Nube de embudo/tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Lluvias de granizo"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Hielo"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Rayo sin trueno"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Precipitación en las cercanías"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Lluvia fuerte y nieve"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Lluvia ligera y nieve"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Disminución de la cobertura del cielo"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Aumento de la cobertura del cielo"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Cielo sin cambios"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Humo o neblina"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Chubascos y nieve"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Tormenta sin lluvia"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Prismas de hielo"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Asegúrese de que introdujo la clave de API correcta"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NO ENCONTRADO"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Nieve soplada"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Nieve ligera"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Nieve moderada"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Lluvia moderada"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Lluvia y nieve"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Lluvia fuerte y nieve"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Por favor, seleccione otro proveedor o ubicación"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "La clave de la API que ha proporcionado no es válida."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "No se encontró la ubicación que proporcionó."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Tormenta fuerte"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Lluvia y nieve"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Lluvia y Aguanieve"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Chubasco de nieve"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Ventoso"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Gélido"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Mayormente despejado"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Asegúrese de que\n"
+"introdujo la clave de API que ha obtenido desde Climacell"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1760,39 +1841,35 @@ msgstr ""
 "El Servicio de Localización no pudo encontrar su ubicación, por favor vea "
 "los registros en Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-msgid "Mainly clear"
-msgstr "Mayormente claro"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 msgid "Snow grains"
 msgstr "Nieve en grano"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 msgid "Light showers"
 msgstr "Chubascos ligeros"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 msgid "Heavy showers"
 msgstr "Chubascos fuertes"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 msgid "Thunderstorm with slight hail"
 msgstr "Tormenta eléctrica con granizo ligero"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 msgid "Thunderstorm with hail"
 msgstr "Tormenta eléctrica con granizo"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr "Sensación térmica"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr "Abrir Meteo"
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1801,7 +1878,7 @@ msgstr ""
 "en la ruta\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1810,104 +1887,104 @@ msgstr ""
 "ruta\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Asegúrese de que ha introducido una ubicación o utilice Ubicación automática "
 "en su lugar."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Este proveedor requiere una clave API para operar"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Punto de rocío"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "La precipitación terminará en {precipEnd} minutos"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "La precipitación no terminará en una hora"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "La precipitación comenzará en {precipStart} minutos"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Error al analizar la pronósticos, consulte los registros para obtener más "
 "detalles."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "A partir de las {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} de usted"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Nombre de la estación: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Área: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr "{count} alerta(s) meteorológica(s)"
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Error al guardar la información de depuración"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr "No se pudo abrir el archivo {filePath} para escritura"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "La información de depuración se guardó correctamente"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Guardado en {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr "No se proporcionó ningún Script"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr "Primero debe agregar un script."
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr "Sin datos meteorológicos"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr "No hay datos meteorológicos para ejecutar el script"
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr "El script se ha ejecutado correctamente"
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr "Su script se ha ejecutado correctamente."
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr "Error al ejecutar el script"
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 "El script devuelve un error, consulte los registros para obtener más "
@@ -2313,7 +2390,6 @@ msgid "Weather conditions"
 msgstr "Condiciones meteorológicas"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Traducir condiciones"
 
@@ -2629,6 +2705,17 @@ msgstr "Mostrar la dirección del viento como texto"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Como SE o N, en lugar de iconos de dirección."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/eu.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/eu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2014-09-20 23:11+0200\n"
 "Last-Translator: Asier Iturralde Sarasola <asier.iturralde@gmail.com>\n"
 "Language-Team: Librezale <librezale@librezale.org\n"
@@ -19,65 +19,65 @@ msgstr ""
 "X-Generator: Virtaal 0.7.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Klikatu irekitzeko"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr ""
 
@@ -87,8 +87,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -100,12 +100,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -119,7 +119,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -127,55 +127,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Uneko eguraldia kargatzen..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Etorkizuneko eguraldia kargatzen..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Kargatzen..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "Tenperatura:"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "Hezetasuna:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "Presioa:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "Haizea:"
@@ -184,15 +184,15 @@ msgstr "Haizea:"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -200,17 +200,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -246,15 +246,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -265,13 +265,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -280,12 +280,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "Elur-jasa"
@@ -293,38 +294,41 @@ msgstr "Elur-jasa"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "Euri izoztua"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "Euri izoztua"
@@ -332,168 +336,175 @@ msgstr "Euri izoztua"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Euri izoztua"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "Euri izoztua"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "Zirimiri izoztua"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Zirimiri izoztua"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "Zirimiri izoztua"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Elur-jasa"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Elurra"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "Elur-jasak"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "Trumoi-ekaitzak"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "Lainotsua"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Hodeitsua"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Nagusiki hodeitsua"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Nahiko hodeitsua"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "Nagusiki hodeitsua"
@@ -501,42 +512,45 @@ msgstr "Nagusiki hodeitsua"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Garbia"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Eguzkitsua"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -558,13 +572,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -573,136 +587,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "Hodeitsua"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "Garbia"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Ona"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "Elur-jasa"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "Elur-jasa"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "Elur-jasa"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "Elur-jasa"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "Elur-zaparradak"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "Elur-zaparrada arinak"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "Elur-zaparradak"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -711,47 +726,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Elurbustia"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "Trumoi-ekaitz sakabanatuak"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "Zaparrada sakabanatuak"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Elur-zaparradak"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "Elur-zaparradak"
@@ -761,20 +777,20 @@ msgstr "Elur-zaparradak"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -803,330 +819,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "Elur-zaparrada arinak"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Zirimiria"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "Elur-jasa"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "Zaparrada sakabanatuak"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Kazkabarra"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "Elur-zaparradak"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "Elur-jasa"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "Trumoi-ekaitzak"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "Zaparrada ekaiztsuak"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "Trumoi-ekaitzak"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "Trumoi-ekaitzak"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "Trumoi-ekaitz gogorra"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "Trumoi-ekaitz isolatuak"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "Trumoi-ekaitzak"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "Zirimiria"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "Euria eta kazkabarra"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "Zirimiri izoztua"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "Euri izoztua"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "Zaparradak"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "Zaparradak"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "Euria eta elurra"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "Euria eta elurra"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "Zaparradak"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "Elur-jasa"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "Ketsua"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Gandua"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Hautsa"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornadoa"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "Hodeitsua"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "Zaparrada sakabanatuak"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1134,76 +1170,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "Nahiko hodeitsua"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "Nagusiki hodeitsua"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "Elur-jasak"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "Euri izoztua"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Urakana"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Ekaitz tropikala"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Beroa"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Hotza"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1243,79 +1279,79 @@ msgstr "Ostirala"
 msgid "Saturday"
 msgstr "Larunbata"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "I"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "IE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "HE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "H"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "HM"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "M"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "IM"
 
@@ -1360,7 +1396,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "Ekaitz tropikala"
@@ -1370,7 +1406,7 @@ msgstr "Ekaitz tropikala"
 msgid "Severe Thunderstorms"
 msgstr "Trumoi-ekaitz gogorra"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Trumoi-ekaitzak"
 
@@ -1389,19 +1425,19 @@ msgstr "Euria eta elurbustia"
 msgid "Mixed Snow and Sleet"
 msgstr "Elurra eta elurbustia"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "Zirimiri izoztua"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "Euri izoztua"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Zaparradak"
 
@@ -1415,12 +1451,12 @@ msgstr "Elur-jasak"
 msgid "Light Snow Showers"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "Elur-jasa haizetsua"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Lainotsua"
 
@@ -1432,63 +1468,64 @@ msgstr "Ketsua"
 msgid "Blustery"
 msgstr "Ekaitztsua"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Haizetsua"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "Nagusiki hodeitsua"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "Nahiko hodeitsua"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "Nagusiki hodeitsua"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "Euria eta kazkabarra"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Trumoi-ekaitz isolatuak"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Trumoi-ekaitz sakabanatuak"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Zaparrada sakabanatuak"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "Elur-jasa"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Elur-zaparrada sakabanatuak"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Elur-jasa"
@@ -1516,452 +1553,487 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Elur-zaparrada arinak"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "Bihar"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "Elur-jasa haizetsua"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "Zirimiri izoztua"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "Zirimiri izoztua"
+msgid "Light shower rain"
+msgstr "Elur-zaparrada arinak"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Elur-jasa"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Elur-jasak"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Elur-zaparradak"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "Euri izoztua"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Bihar"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Elur-jasa haizetsua"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Zirimiri izoztua"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "Elur-zaparradak"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "Euria eta elurra"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "Euria eta elurra"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "Elur-zaparradak"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "Nahiko hodeitsua"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Elur-jasa haizetsua"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "Elur-jasa haizetsua"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "Elur-jasa"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "Zaparrada sakabanatuak"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Euria eta elurra"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "Euria eta elurra"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Euria eta elurra"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Euria eta elurbustia"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Elur-zaparradak"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Nagusiki hodeitsua"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Nagusiki hodeitsua"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Elur-jasak"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Elur-zaparrada arinak"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Elur-jasa"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Trumoi-ekaitzak"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Trumoi-ekaitzak"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2358,7 +2430,6 @@ msgid "Weather conditions"
 msgstr "Itzuli egoera"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 #, fuzzy
 msgid "Translate conditions"
 msgstr "Itzuli egoera"
@@ -2637,6 +2708,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/fi.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/fi.po
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: 3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-04-07 18:55+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: suomi <>\n"
@@ -25,65 +25,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Virhe"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Palvelussa virhe"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Väärä API avain"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Väärä muoto sijainnissa"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Avain estetty"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Sijaintia ei löytynyt"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Ei API avainta"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Ei sijaintia"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Puuttuvat paketit"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Sijaintia ei löytynyt"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Sää"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Avaa napsauttamalla"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Päivitä"
 
@@ -93,8 +93,8 @@ msgstr "API palautti tilakoodin väliltä 400–500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Sijainti"
 
@@ -106,12 +106,12 @@ msgstr "Et voi tallentaa automaattisesti hankittua sijaintia"
 msgid "Could not get weather information"
 msgstr "Säätietoja ei voitu saada"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr "Odottamaton virhe päivitettäessä säätietoja, katso Looking Glass loki"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -127,7 +127,7 @@ msgstr "Verkko virhe, tarkista Looking Glass loki"
 msgid "As of"
 msgstr "Klo"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Tiedot toimitti"
 
@@ -135,52 +135,52 @@ msgstr "Tiedot toimitti"
 msgid "from you"
 msgstr "sinulta"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "asti"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "ml"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Ladataan säätietoja ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Ladataan tulevia säätietoja ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Ladataan ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Lämpötila"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Kosteus"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Ilmanpaine"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Tuuli"
 
@@ -188,16 +188,16 @@ msgstr "Tuuli"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "Varmista, että annoit sijainnin tai käytä automaattista sijaintia"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Sijaintia ei löytynyt osoitteen perusteella, tarkista että se on oikein"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Paikannuksen kutsuminen epäonnistui, katso Looking Glass virheet."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Varoitus"
 
@@ -205,17 +205,17 @@ msgstr "Varoitus"
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Voit tallentaa oikeat sijainnit vain, kun sovelma ei ole päivittymässä"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Et voi tallentaa virheellistä sijaintia"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Perustieto"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Sijainti on jo tallennettu"
 
@@ -253,15 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Tuntuu kuin"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Säätietojen käsittely epäonnistui"
 
@@ -274,7 +274,7 @@ msgstr ""
 "Hanki se ensin https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -282,7 +282,7 @@ msgstr ""
 "Oletko varma että,\n"
 "annoit API-avaimen oikein tai onko tunnuksesi voimassa"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -293,252 +293,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Voimakasta vesisadetta"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Sadetta"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Heikkoa vesisadetta"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Voimakasta jäätävää sadetta"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Jäätävää sadetta"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Kevyttä jäätävää sadetta"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Kevyttä jäätävää tihkua"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Jäätävää tihkua"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Kevyttä tihkua"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Rankat raekuurot"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Rakeita"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Pieniä rakeita"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Sakeaa lumisadetta"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Lumisadetta"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Kevyttä lumisadetta"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Puuskatuulia"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Ukkosmyrskyä"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Heikkoa sumua"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Sumua"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Pilvistä"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Enimmäkseen pilvistä"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Puolipilvistä"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Enimmäkseen selkeää"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Selkeää"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Aurinkoista"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Tuntematon virhe"
 
@@ -562,7 +576,7 @@ msgstr ""
 "Anna API-avain asetuksissa.\n"
 "Hanki se ensin https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -570,7 +584,7 @@ msgstr ""
 "Varmista, että antamasi\n"
 "API-avain on peräisin yritykseltä DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Sijaintia ei löytynyt"
 
@@ -579,122 +593,123 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Sijaintipalvelu vastasi virheillä. Katso Looking Glass loki"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Pilvistä"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Selkeää"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Selkeää"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Rankkasadetta ja ukkostaa"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Voimakkaita sadekuuroja"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Voimakkaita sadekuuroja ja ukkosta"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Voimakasta räntäsadetta"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Voimakasta räntäsadetta"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Voimakkaita räntäsateita"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Voimakkaita räntäsateita"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Runsasta lumisadetta"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Voimakasta lumisadetta"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Runsaita lumikuuroja"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Heikkoa vesisadetta ja ukkosta"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Heikkoja sadekuuroja"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Heikkoja sadekuuroja ja ukkosta"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Heikkoa räntäsadetta"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Heikkoa räntäsadetta"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Heikkoa räntäsadetta"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Heikkoa räntäsadetta"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Kevyttä lumisadetta"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Kevyttä lumisadetta"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Kevyttä lumisadetta"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Sadetta ja ukkosta"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Sadekuuroja"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Sadekuuroja ja ukkosta"
 
@@ -703,45 +718,46 @@ msgstr "Sadekuuroja ja ukkosta"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Räntää"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Räntää"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Räntäkuuroja"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Räntäkuuroja"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Lumikuuroja"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Lumikuuroja"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Lumikuuroja"
 
@@ -750,20 +766,20 @@ msgstr "Lumikuuroja"
 msgid "Unexpected response from API"
 msgstr "Odottamaton API:n vastaus"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Näkyvyys"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Säätietojen käsittely epäonnistui"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Forecast tietojen käsittely epäonnistui"
 
@@ -792,302 +808,322 @@ msgid "Excellent - More than"
 msgstr "Erinomainen - enemmän kuin"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Sumua"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Pilvistä"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Heikkoja sadekuuroja"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Tihkusadetta"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Voimakkaita sadekuuroja"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Räntäkuuroja"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Rakeita"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Raekuurot"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Kevyitä lumikuuroja"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Voimakkaita lumikuuroja"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Ukkosta"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Ukkoskuuroja"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Varmista, että asetuksissa sijainti on oikeassa muodossa"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Varmista, että annoit asetuksissa oikean avaimen"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr "Sijaintia ei löydy. Varmista, että paikkakunta on kirjoitettu oikein"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Jos ongelma jatkuu, ota yhteyttä tämän sovelman tekijään"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Tuntematon virhe, katso Looking Glass loki"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Ukkosta ja heikkoa vesisadetta"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Ukkosta ja sadekuuroja"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Ukkosta ja voimakasta vesisadetta"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Mahdollista ukkosta"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Voimakkaita ukkosmyrskyjä"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Yksittäisiä ukkosmyrskyjä"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Ukkoskuuroja ja tihkua"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Ukkoskuuroja ja tihkua"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Ukkoskuuroja ja voimakasta tihkusadetta"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Kevyttä tihkua"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Voimakasta tihkusadetta"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Kevyttä tihkusadetta"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Tihkusadetta"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Voimakkaasti tihkusadetta"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Sadekuuroja ja tihkusadetta"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Voimakkaita sadekuuroja ja tihkusadetta"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Tihkusadetta"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Kohtalaista vesisadetta"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Voimakasta sadetta"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Voimakasta vesisadetta"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Kovaa sadetta"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Kevyttä sadetta"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Sadekuuroja"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Voimakasta sadetta"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Hajanaisia sateita"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Sadekuuroja"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Heikkoa vesisadetta ja lunta"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Sadetta ja lunta"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Kevyt lumisade"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Lumisadetta"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Voimakasta lumisadetta"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Savua"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Usvaa"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Hiekkaa ja pölypyörteet"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Hiekkaa"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Pölyä"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkaanista tuhkaa"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Tuulenpuuskia"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Taivas on selkeä"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Pilvistä"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Muutamia pilviä"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Paikoin pilvistä"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Hajanaisia pilviä"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Pilvistä"
 
@@ -1095,72 +1131,72 @@ msgstr "Pilvistä"
 msgid "Could not get forecast for your area"
 msgstr "Alueellesi ei saatu ennustetta"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Sijainti on USA:n ulkopuolella, käytä toista palvelua."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Forecast tuntiennuste epäonnistui"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Selkeää ja tuulista"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Vähän pilviä ja tuulista"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Puolipilvistä ja tuulista"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Enimmäkseen pilvistä ja tuulista"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Pilvistä ja tuulista"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Lumisadetta"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Jäätävää sadetta"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Hurrikaani"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Myrsky"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Trooppinen myrsky"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Kuumaa"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Kylmää"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Myrsky"
 
@@ -1200,79 +1236,79 @@ msgstr "Perjantai"
 msgid "Saturday"
 msgstr "Launtai"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Tyyntä"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Kevyttä tuulta"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Heikkoa tuulta"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Hento tuulenvire"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Kohtalainen tuuli"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Raikasta tuulta"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Voimakasta tuulta"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Lähellä myrskyä"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Navakka tuuli"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Voimakas myrsky"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Raju myrsky"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "Pohjoinen"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "Koillinen"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "Itä"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "Kaakko"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "Etelä"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "Lounas"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "Länsi"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "Luode"
 
@@ -1324,7 +1360,7 @@ msgstr ""
 "Säätiedoissa tapahtui tuntematon virhe, katso lokista Looking Glass "
 "lisätietoja"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Trooppinen myrsky"
 
@@ -1332,7 +1368,7 @@ msgstr "Trooppinen myrsky"
 msgid "Severe Thunderstorms"
 msgstr "Hajanaisia ukkosmyrskyjä"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Ukkosmyrskyjä"
 
@@ -1348,17 +1384,17 @@ msgstr "Räntäsadetta ja loskaa"
 msgid "Mixed Snow and Sleet"
 msgstr "Lumisadetta ja loskaa"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Jäätävää tihkua"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Jäätävää sadetta"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Sadekuuroja"
 
@@ -1370,11 +1406,11 @@ msgstr "Lumikuuroja"
 msgid "Light Snow Showers"
 msgstr "Kevyitä lumisateita"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Lumipyry"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Sumua"
 
@@ -1386,54 +1422,55 @@ msgstr "Savua"
 msgid "Blustery"
 msgstr "Tuulista"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Tuulinen"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Enimmäkseen pilvistä"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Puolipilvistä"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Enimmäkseen aurinkoista"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Sadetta ja rakeita"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Mahdollista ukkosta"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Paikoin ukkosta"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Paikoin sadekuuroja"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Voimakasta vesisadetta"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Paikoin lumisadetta"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Sakeaa lumisadetta"
 
@@ -1462,11 +1499,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1474,320 +1511,359 @@ msgstr ""
 "MET Office UK kattaa vain Britanian. Varmista, että sijaintisi on tässä "
 "maassa"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Sijainnin tietoja ei löytynyt"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Hyvin huono"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Vähemmän kuin {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Erinomainen"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Enemmän kuin {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Huono"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Välillä {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Kohtalainen"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Hyvä"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Todella hyvä"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Tuulenpuuskia"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Kevyt lumisade"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Kevyt tuuli"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Kova tuuli"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Tuulista tai kinostuvaa lunta"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Voimakasta tihkusadetta"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Voimakasta tihkusadetta"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Kevyt lumisade"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Kevyttä tihkusadetta"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Voimakasta lumisadetta"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Pölypuuskia"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Lumisadetta"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Jäätävää sadetta"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Lumikuuroja"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Voimakasta jäätävää sadetta"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Kevyttä jäätävää tihkua"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Jäätyvää sumua"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Kevyt tuuli"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Kova tuuli"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Tuulista tai kinostuvaa lunta"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Voimakasta tihkusadetta"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Kevyttä tihkusadetta"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Pölypuuskia"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Jäätävää sadetta"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Voimakasta jäätävää sadetta"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Kevyttä jäätävää tihkua"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Pyörremyrsky"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Raekuuroja"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Jäätä"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Mahdollista ukkosta"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Sademäärä lähistöllä"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Voimakasta vesi ja lumisadetta"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Heikkoa vesisadetta ja lunta"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Taivas selkenee"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Taivas pilvistyy"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Taivas ennallaan"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Savua tai utua"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Lunta ja sadekuuroja"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Ukkosta ilman sadetta"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Timanttipölyä"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Puolipilvistä"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Oletko varma että, annoit API-avaimen oikein"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "Ei löydy"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Puuskittaista lumisadetta"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Heikosti lunta"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Kohtalaista lunta"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Kohtalaisia sadekuuroja"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Sadetta ja lunta"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Voimakkaasti sadetta"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Valitse toinen palveluntarjoaja tai sijainti"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "Antamasi API-avain on virheellinen."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Antamaasi sijaintia ei löytynyt."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Voimakas myrsky"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Sadetta ja lunta"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Sadetta ja räntää"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Lumisadetta"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Tuulinen"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Kylmä"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Enimmäkseen selkeää"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Varmista, että antamasi\n"
+"API-avain on peräisin yritykseltä Climacell"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr "Sijaintipalvelu ei löytänyt sinun sijaintia, katso Looking Glass loki"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Enimmäkseen selkeää"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Lumisadetta"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Kevyt lumisade"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Voimakasta lumisadetta"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Ukkosta ja heikkoa vesisadetta"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Ukkosta ja sadekuuroja"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Tuntuu kuin"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1795,7 +1871,7 @@ msgstr ""
 "Määrityksiä ei voitu noutaa, polusta ei löytynyt tiedostoa\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1803,102 +1879,102 @@ msgstr ""
 "Polun alaisen asetustiedoston sisältöä ei voitu hakea\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr "Varmista, että annoit sijaintisi tai käytä automaattista hakua."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Tämä palvelu vaatii API-avaimen"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Kastepiste"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Sade loppuu {precipEnd} minuutissa"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Sade ei lopu tunnin sisällä"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Sade alkaa {precipStart} minuutissa"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Ennusteen tekeminen epäonnistui. Katso lisätietoja lokeista."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Klo {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} sinusta"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Aseman nimi:: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Alue: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Virhe debug-tietojen tallentamisessa"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Säätietoja ei voitu saada"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Debug-tiedot tallennettu"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Tallennettu {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2298,7 +2374,6 @@ msgid "Weather conditions"
 msgstr "Sääolosuhteet"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Käännä olosuhteet suomeksi"
 
@@ -2603,6 +2678,17 @@ msgstr "Näytä tuulen suunta tekstinä"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Kuten Kaakko tai Pohjoinen suuntanuolien sijaan."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/fr.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/fr.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl 3.5.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-05-25 09:32+0200\n"
 "Last-Translator: FabRCT <fab.rct@gmail.com>\n"
 "Language-Team: Français <ecyrbe@gmail.com>\n"
@@ -22,65 +22,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Erreur"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Erreur du service"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Clé API incorrecte"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Format d'emplacement incorrect"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Clé bloquée"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Impossible de trouver l'emplacement"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Aucune clé API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Aucun emplacement"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Paquets manquants"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Emplacement non couvert"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Applet Météo"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Cliquez pour ouvrir"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Actualiser"
 
@@ -90,8 +90,8 @@ msgstr "L'API a renvoyé un code d'état compris entre 400 et 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Dépôt de localisation"
 
@@ -104,14 +104,14 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Impossible d'obtenir les informations"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Erreur inattendue en actualisant la météo, veuillez consulter les journaux "
 "dans Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -127,7 +127,7 @@ msgstr "Erreur réseau, veuillez consulter les journaux dans Looking Glass"
 msgid "As of"
 msgstr "À"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Données fournies par"
 
@@ -135,52 +135,52 @@ msgstr "Données fournies par"
 msgid "from you"
 msgstr "de vous"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "à"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Chargement de la météo..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Chargement des prévisions..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Chargement..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Température"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Humidité"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Pression"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vent"
 
@@ -190,18 +190,18 @@ msgstr ""
 "Assurez-vous d'avoir entré un emplacement ou utilisez la localisation "
 "automatique"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Impossible de trouver l'emplacement en fonction de l'adresse, veuillez "
 "vérifier si elle est correcte"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Échec de l'API de géolocalisation, consultez Looking Glass pour les erreurs."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Avertissement"
 
@@ -211,17 +211,17 @@ msgstr ""
 "Vous ne pouvez enregistrer les emplacements corrects que lorsque l'applet ne "
 "s'actualise pas"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Vous ne pouvez pas enregistrer un emplacement incorrect"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Information"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "L'emplacement est déjà enregistré"
 
@@ -261,15 +261,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "T° ressentie"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Échec du traitement de l'information météorologique"
 
@@ -282,7 +282,7 @@ msgstr ""
 "ou en obtenir une sur https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -290,7 +290,7 @@ msgstr ""
 "Veuillez vous assurer que vous avez\n"
 "saisi correctement la clé API et que votre compte n'est pas verrouillé"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -301,252 +301,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Forte pluie"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Pluie"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Pluie légère"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Pluie verglaçante intense"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Pluie verglaçante"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Pluie verglaçante légère"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Bruine verglaçante légère"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Bruine verglaçante"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Bruine légère"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Fort grésil"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Grésil"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Léger grésil"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Neige abondante"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Neige"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Neige légère"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Rafales"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Orage"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Brouillard léger"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Brouillard"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Nuageux"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Principalement nuageux"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Partiellement nuageux"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Principalement dégagé"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Clair"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Ensoleillé"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Inconnue"
 
@@ -570,7 +584,7 @@ msgstr ""
 "Veuillez saisir la clé API dans les paramètres,\n"
 "ou en obtenir une sur https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -578,7 +592,7 @@ msgstr ""
 "Veuillez vous assurer que vous avez\n"
 "saisi correctement la clé API récupérée sur DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Impossible d'obtenir l'emplacement"
 
@@ -589,122 +603,123 @@ msgstr ""
 "Le service de localisation a répondu avec des erreurs, veuillez consulter "
 "les journaux dans Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Nébulosité"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Ciel clair"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Beau"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Forte pluie et orage"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Fortes averses"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Fortes averses et orage"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Grêle"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Grêle avec orage"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Fortes averses de grésil"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Fortes averses de grésil et orage"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Importantes chutes de neige avec orages"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Fortes averses de neige"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Fortes averses de neige et orage"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Pluie légère et orage"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Averses de pluie légère"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Averses de pluie légère et orage"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Léger grésil"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Grésil avec orage"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Faibles averses de grésil"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Faibles averses de grésil et orage"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Neige légère avec orage"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Légères averses de neige"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Légères averses de neige et orage"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Pluie et orage"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Averses"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Averses et orage"
 
@@ -713,45 +728,46 @@ msgstr "Averses et orage"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Grésil"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Grésil et orage"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Averses de grésil"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Averses de grésil et orage"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Neige et orage"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Averses de neige"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Averses de neige et orage"
 
@@ -760,20 +776,20 @@ msgstr "Averses de neige et orage"
 msgid "Unexpected response from API"
 msgstr "Réponse inattendue de l'API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Visibilité"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Échec du traitement de l'information météorologique actuelle"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Échec du traitement des données de prévision"
 
@@ -802,93 +818,97 @@ msgid "Excellent - More than"
 msgstr "Excellente - Plus de"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Brouillard"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Ciel couvert"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Averses de pluie légère"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Bruine"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Fortes averses"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Averses de grésil"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Grêle"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Averses de grêle"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Légères averses de neige"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Fortes averses de neige"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Orage"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Averses et orage"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Veuillez vous assurer que l'emplacement est au bon format dans les paramètres"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Assurez-vous d'avoir saisi la bonne clé dans les paramètres"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -896,211 +916,227 @@ msgstr ""
 "Emplacement introuvable, assurez-vous que l'emplacement existe ou qu'il est "
 "dans le bon format"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Si ce problème persiste, veuillez contacter l'auteur de cette applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Erreur inconnue, veuillez consulter les journaux dans Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Orage avec pluie légère"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Orage avec pluie"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Orage avec forte pluie"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Orage léger"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Orage violent"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Orage isolé"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Orage avec bruine légère"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Orage avec bruine"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Orage avec forte bruine"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Bruine de faible intensité"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Bruine de forte intensité"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Bruine de faible intensité"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Pluie fine"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Bruine de forte intensité"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Pluie et bruine"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Pluie et bruine abondantes"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Bruine"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Pluie modérée"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Pluie de forte intensité"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Pluie très forte"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Pluie extrême"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Averses légères"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Averses"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Averses de forte intensité"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Averses irrégulières"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Averses de grésil"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Neige et pluie légère"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Pluie et neige"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Faibles averses de neige"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Averses de neige"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Fortes averses de neige"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Brouillard épais"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Brume"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Tourbillons de poussière, sable"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Sable"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Poussière"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Cendres volcaniques"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Bourrasques"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornade"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Le ciel est clair"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Nuageux"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Quelques nuages"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Nuages épars"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Nuages fragmentés"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Ciel couvert"
 
@@ -1108,74 +1144,74 @@ msgstr "Ciel couvert"
 msgid "Could not get forecast for your area"
 msgstr "Impossible d'obtenir les prévisions pour votre région"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "L'emplacement est en dehors des États-Unis, veuillez utiliser un autre "
 "fournisseur."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Échec du traitement des prévisions horaires"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Clair et venteux"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Quelques nuages et venteux"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Partiellement nuageux et venteux"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Principalement pluvieux et venteux"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Ciel couvert et venteux"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Neige mouillée"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Pluie verglaçante et neige"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Ouragan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Tempête"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tempête tropicale"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Chaud"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Froid"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Tempête de neige"
 
@@ -1215,79 +1251,79 @@ msgstr "Vendredi"
 msgid "Saturday"
 msgstr "Samedi"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Calme"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Très légère brise"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Légère brise"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Petite brise"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Jolie brise"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Bonne brise"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Vent frais"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Grand frais"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Coup de vent"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Fort coup de vent"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Violente tempête"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NO"
 
@@ -1340,7 +1376,7 @@ msgstr ""
 "Une erreur inconnue s'est produite lors de l'obtention de la météo, "
 "consultez les journaux Looking Glass pour plus d'informations"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tempête tropicale"
 
@@ -1348,7 +1384,7 @@ msgstr "Tempête tropicale"
 msgid "Severe Thunderstorms"
 msgstr "Orages violents"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Orages"
 
@@ -1364,17 +1400,17 @@ msgstr "Pluie et grésil"
 msgid "Mixed Snow and Sleet"
 msgstr "Neige et grésil"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Bruine verglaçante"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Pluie verglaçante"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Averses"
 
@@ -1386,11 +1422,11 @@ msgstr "Averses de neige"
 msgid "Light Snow Showers"
 msgstr "Légères chutes de neige"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Neige poudreuse"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Brumeux"
 
@@ -1402,54 +1438,55 @@ msgstr "Brouillard épais"
 msgid "Blustery"
 msgstr "Tempête"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Venteux"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Principalement nuageux"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Partiellement nuageux"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Principalement ensoleillé"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Pluie et grêle"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Orages isolés"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Orages dispersés"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Averses dispersées"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Forte pluie"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Averses de neige dispersées"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Importantes chutes de neige"
 
@@ -1479,11 +1516,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1491,275 +1528,319 @@ msgstr ""
 "MET Office UK ne couvre que le Royaume-Uni, veuillez vous assurer que votre "
 "emplacement est dans ce pays"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Les données n'ont pas été trouvées pour l'emplacement"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Très mauvaise"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Moins de {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Excellente"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Plus de {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Mauvais"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Entre {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Modérée"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Bon"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Très bonne"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Bourrasques"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Faibles averses"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Vent léger"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Vent fort"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "Météo aux États-Unis"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Neige poudreuse ou à la dérive"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Bruine abondante"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Bruine abondante/pluie"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Faibles averses de neige"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Bruine légère/pluie"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Fortes averses de neige"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Tempête de poussière"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Neige mouillée"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Bruine verglaçante/pluie verglaçante"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Averses de neige"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Bruine verglaçante abondante/pluie verglaçante"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Bruine verglaçante légère/pluie verglaçante"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Brouillard verglaçant"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Vent léger"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Vent fort"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "Météo aux États-Unis"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Neige poudreuse ou à la dérive"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Bruine abondante/pluie"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Bruine légère/pluie"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Tempête de poussière"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Bruine verglaçante/pluie verglaçante"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Bruine verglaçante abondante/pluie verglaçante"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Bruine verglaçante légère/pluie verglaçante"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Entonnoir nuageux/tornade"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Averses de grêle"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Glace"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Foudre sans tonnerre"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Précipitations à proximité"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Pluie et neige abondantes"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Pluie légère et neige"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Couverture nuageuse en diminution"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Couverture nuageuse en augmentation"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Ciel inchangé"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Fumée ou brume"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Averses de neige et de pluie"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Orage sans précipitations"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Poudrin de glace"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Partiellement nuageux"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Veuillez vous assurer que vous avez saisi correctement la clé API"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NON TROUVÉ"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Neige poudreuse"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Neige légère"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Neige modérée"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Averses de pluie modérées"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Mélange pluie et neige"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Mélange pluie et neige abondant"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Veuillez sélectionner un fournisseur ou un emplacement différent"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "La clé API que vous avez fournie n'est pas valide."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "L'emplacement que vous avez fourni n'a pas été trouvé."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Forte tempête"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Pluie et neige"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Pluie et grésil"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Averses de neige"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Venteux"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Glacial"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Principalement dégagé"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Veuillez vous assurer que vous avez\n"
+"saisi correctement la clé API récupérée sur Climacell"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1767,39 +1848,35 @@ msgstr ""
 "Le service de localisation a répondu avec des erreurs, veuillez consulter "
 "les journaux dans Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-msgid "Mainly clear"
-msgstr "Principalement dégagé"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 msgid "Snow grains"
 msgstr "Neige en grains"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 msgid "Light showers"
 msgstr "Faibles averses"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 msgid "Heavy showers"
 msgstr "Fortes averses"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 msgid "Thunderstorm with slight hail"
 msgstr "Orage avec grêle légère"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 msgid "Thunderstorm with hail"
 msgstr "Orage avec grêle"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr "T° ressentie"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr "Open Meteo"
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1808,7 +1885,7 @@ msgstr ""
 "les chemins\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1816,105 +1893,105 @@ msgstr ""
 "Impossible de lire le contenu du fichier de configuration suivant\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Assurez-vous d'avoir entré un emplacement ou utilisez la localisation "
 "automatique."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Ce fournisseur nécessite une clé API pour fonctionner"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Point de rosée"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "La précipitation s'arrêtera dans {precipEnd} minutes"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "La précipitation ne s'arrêtera pas dans l'heure"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "La précipitation commencera dans les {precipStart} minutes"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Échec de l'analyse des prévisions, consultez les journaux pour plus de "
 "détails."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "À {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} de vous"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Nom de la station: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Région: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr "{count} alerte(s) météo"
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Erreur lors de l'enregistrement des informations de débogage"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr "Impossible d'ouvrir le fichier {filePath} en écriture"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Informations de débogage enregistrées avec succès"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Enregistré dans {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "Météo aux États-Unis"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2322,7 +2399,6 @@ msgid "Weather conditions"
 msgstr "Conditions météorologiques"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Traduire les conditions météorologiques"
 
@@ -2640,6 +2716,17 @@ msgstr "Afficher la direction du vent sous forme de texte"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Comme « SE, N » au lieu d'icônes de direction."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 # Toutes les aides qui apparaissent sur fond jaune lors du survol de la souris se terminent par un point dans la traduction française. Un point a donc été ajouté ici par cohérence.
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/he.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/he.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl 3.1.6\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-12-11 20:13+0200\n"
 "Last-Translator: Avi Markovitz <avi.markovitz@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -23,65 +23,65 @@ msgstr ""
 "X-Poedit-SearchPath-0: weather.pot\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "שגיאה"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "שגיאת שירות"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "מפתח API שגוי"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "תבנית מקום שגויה"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "מפתח נחסם"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "לא ניתן למצוא מקום"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "אין מפתח API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "אין מיקום"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "חבילות חסרות"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "מיקום לא מכוסה"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "יישומון מזג־אוויר"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "נא להקיש לפתיחה"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "רענון"
 
@@ -91,8 +91,8 @@ msgstr "API החזיר קוד מצב בין 400 ו־500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "אחסון מיקום"
 
@@ -104,12 +104,12 @@ msgstr "לא ניתן לשמור מיקום שהושג באופן אוטומטי
 msgid "Could not get weather information"
 msgstr "לא ניתן לאחזר נתוני מזג־אויר"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr "שגיאה בלתי צפויה בעת רענון מזג־אויר, נא לעיין ביומן בלוקינג־גלאס"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -125,7 +125,7 @@ msgstr "שגיאת רשת, נא לבדוק יומנים בלוקינג־גלאס
 msgid "As of"
 msgstr "מאז"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "מועצם על־ידי"
 
@@ -133,52 +133,52 @@ msgstr "מועצם על־ידי"
 msgid "from you"
 msgstr "ממך"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "מילימטר"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "אינץ'"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "קמ״ש"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "טעינת מזג־אויר נוכחי..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "טעינת מזג־אויר עתידי..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "טעינה..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "מידות־חום"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "לחות"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "לחץ־אויר"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "רוח"
 
@@ -186,15 +186,15 @@ msgstr "רוח"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "נא לוודא שהוזן מיקום או לעשות שימוש במיקום אוטומטי במקום זאת"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr "לא ניתן למצוא מיקום המבוסס על כתובת, נא לבדוק שהכתובת נכונה"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "קריאה ל־API Geolocation כשלה, לשגיאות נא לעיין בלוקינג־גלאס."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "אזהרה"
 
@@ -202,17 +202,17 @@ msgstr "אזהרה"
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "ניתן לשמור מיקומים באופן תקין רק כאשר היישומון אינו במצב רענון"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "לא ניתן לשמור מיקום שגוי"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "מידע"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "המיקום כבר נשמר"
 
@@ -248,15 +248,15 @@ msgstr "טעינת נתונים מאחסון המיקום כשלה, נא לעי�
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "מרגיש כמו"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "כשל בעיבוד נתוני מזג אויר"
 
@@ -269,7 +269,7 @@ msgstr ""
 "או לקבל אחד תחילה מ־https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -277,7 +277,7 @@ msgstr ""
 "נא לוודא שמפתח API\n"
 "הוזן באופן תקין ושהחשבון לא נעול"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -288,252 +288,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "ממטרי גשם כבדים"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "גשם"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "גשם קל"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "גשם קופא כבד"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "גשם קופא"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "גשם קופא קל"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "רסס קופא קל"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "רסס קופא"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "רסס קל"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "כדורי קרח כבדים"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "כדורי קרח"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "כדורי קרח קלים"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "שלג כבד"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "שלג"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "שלג קל"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "פתיתי שלג"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "סופות רעמים"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "ערפל קל"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "ערפל"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "מעונן"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "מעונן לרוב"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "מעונן חלקית"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "בהיר לרוב"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "ניקוי"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "שמשי"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "לא ידוע"
 
@@ -557,7 +571,7 @@ msgstr ""
 "נא להזין מפתח API בהגדרות,\n"
 "או לקבל אחד תחילה מ־https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -565,7 +579,7 @@ msgstr ""
 "א לוודא שמפתח API\n"
 "שנתקבל מדרקסקיי הוזן"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "לא ניתן להשיג מיקום"
 
@@ -574,122 +588,123 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "שירות המיקום הגיב עם שגיאות, נא לעיין ביומנים בלוקניג־גלאס"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "עננות"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "שמיים בהירים"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "נאה"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "גשם כבד ורעמים"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "ממטרי גשם כבדים"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "ממטרי גשם כבדים ורעמים"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג כבדים"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים כבדים"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג כבדים"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים כבדים"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "ממטרי שלג כבדים ורעמים"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "ממטרי שלג כבדים"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "ממטרי שלג כבדים ורעמים"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "גשם קל ורעמים"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "ממטרי גשם קלים"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "ממטרי גשם קלים ורעמים"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "גֶּשֶׁם־שֶׁלֶג קל"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים קלים"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג קלים"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים קלים"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "ממטרי שלג קלים ורעמים"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "ממטרי שלג קלים"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "ממטרי שלג קלים ורעמים"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "גשם ורעמים"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "ממטרי גשם"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "ממטרי גשם ורעמים"
 
@@ -698,45 +713,46 @@ msgstr "ממטרי גשם ורעמים"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "גֶּשֶׁם־שֶׁלֶג"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "גֶּשֶׁם־שֶׁלֶג ורעמים"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "שלג ורעמים"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "ממטרי שלג"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "ממטרי שלג ורעמים"
 
@@ -745,20 +761,20 @@ msgstr "ממטרי שלג ורעמים"
 msgid "Unexpected response from API"
 msgstr "תגובת API לא צפויה"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "ראות"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "כשל בעיבוד נתוני מזג אויר נוכחי"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "כשל בעיבוד נתוני תחזית"
 
@@ -787,304 +803,324 @@ msgid "Excellent - More than"
 msgstr "מעולב - יותר מ־"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "ערפילים"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "מוּעָב"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "ממטרי גשם קלים"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "רסס"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "ממטרי גשם כבדים"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "ברד"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "מטר ברד"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "ממטרי שלג קל"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "מטר שלג כבד"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "רעמים"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "ממטר רעמים"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "נא לוודא שהמיקום\n"
 "הוזן בהגדרות בתבנית תקינה"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "נא לוודא שהוזן מפתח נכון בהגדרות"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr "המיקום לא נמצא, נא לוודא שהמיקום זמין או שהוא בתבנית הנכונה"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "אם הבעיה נמשכת, נא ליצור קשר עם כותב יישומון זה"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "שגיאה לא ידועה, נא לעיין ביומנים בלוקניג־גלאס"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "סופות רעמים עם גשם קל"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "סופות רעמים עם גשם"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "סופות רעמים עם גשם כבד"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "סופות רעמים קלה"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "סופות רעמים כבדה"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "סופות רעמים סוערת"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "סופות רעמים עם רסס קל"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "סופות רעמים עם רסס"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "סופות רעמים עם רסס כבד"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "רסס בעצימות נמוכה"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "רסס בעצימות גבוהה"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "רסס גשם בעצימות נמוכה"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "גשם רסס"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "רסס גשם בעצימות גבוהה"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "מטר גשם ורסס"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "מטר גשם ורסס כבד"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "מטר רסס"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "גשם מתון"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "גשם עצמתי מאוד"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "גשם כבד מאוד"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "גשם קיצוני"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "ממטרי גשם בעצימות נמוכה"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "מטר גשם"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "ממטרי גשם בעצימות גבוהה"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "מטר גשם סוער"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "מטר ברד"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "גשם קל ושלג"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "גשם ושלג"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "ממטרי שלג קל"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "מטר שלג"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "ממטרי שלג כבדים"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "עשן"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "אובך"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "חול, מערבולת אבק"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "חול"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "אבק"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "עפר וולקני"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "תזזי"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "טורנדו"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "שמיים בהירים"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "עננים"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "עננים מעטים"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "עננים פזורים"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "עננים שבורים"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "מוּעָב"
 
@@ -1092,72 +1128,72 @@ msgstr "מוּעָב"
 msgid "Could not get forecast for your area"
 msgstr "לא ניתן לאחזר תחזית למיקום שלכם"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "המיקום הוא מחוץ לארה\"ב, נא להשתמש בספק אחר."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "כשל בעיבוד נתוני תחזית שעתית"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "בהיר ומשבי־רוח"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "עננים מעטים ומשבי־רוח"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "מעונן חלקית ומשבי־רוח"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "מעונן לרוב ומשבי־רוח"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "מוּעָב ומשבי־רוח"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "גשם מושלג"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "גשם קופא ושלג"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "הוריקן"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "סערה"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "סופה טרופית"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "חם"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "קר"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "סוּפַת שֶׁלֶג"
 
@@ -1197,79 +1233,79 @@ msgstr "שישי"
 msgid "Saturday"
 msgstr "שבת"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "רגוע"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "אויר קל"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "משב קל"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "משב עדין"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "משב מתון"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "משב מרענן"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "משב חזק"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "קרוב לסוער"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "סוער"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "סערה חזקה"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "סערה אלימה"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "צפ'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "צמז'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "מז׳"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "דמז'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "ד'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "דמע'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "מע'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "צמע'"
 
@@ -1321,7 +1357,7 @@ msgstr ""
 "אירעה שגיאה לא ידועה בעת אחזור מזג־אויר,\n"
 "למידע נוסף, נא לעיין ביומנים בלוקניג־גלאס"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "סופה טרופית"
 
@@ -1329,7 +1365,7 @@ msgstr "סופה טרופית"
 msgid "Severe Thunderstorms"
 msgstr "סופות רעמים חמורות"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "סופות רעמים"
 
@@ -1345,17 +1381,17 @@ msgstr "גשם מעורב בשלג מימי"
 msgid "Mixed Snow and Sleet"
 msgstr "שלג מעורב בברד"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "רסס קופא"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "גשם קופא"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "ממטרים"
 
@@ -1367,11 +1403,11 @@ msgstr "פתיתי שלג"
 msgid "Light Snow Showers"
 msgstr "ממטרי שלג קלים"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "שלג נושב"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "מעורפל"
 
@@ -1383,54 +1419,55 @@ msgstr "אפוף עשן"
 msgid "Blustery"
 msgstr "רוחות עזות"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "משבי־רוח"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "מעונן לרוב"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "מעונן חלקית"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "שמשי לרוב"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "גשם מעורב בברד"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "סופות רעמים מקומיות"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "סופות רעמים פזורות"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "ממטרים פזורים"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "ממטרי גשם כבדים"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "ממטרי שלג פזורים"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "ממטרי שלג כבדים"
 
@@ -1459,339 +1496,378 @@ msgstr ""
 " {configFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "לא נמצא מידע למיקום"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "חלש מאוד"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "פחות מ־{distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "מצוין"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "יותר מ־{distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "חלש"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "בין {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "מתון"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "טוב"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "טוב מאוד"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "תזזי"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "ממטרי שלג קל"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "רוח קלה"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "רוח חזקה"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "מזג־אוויר ארה\"ב"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "ויזואל קרוסינג"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "שלג נושב או נסחף"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "רסס קבד"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "גשם/גשם־רסס כבד"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "ממטרי שלג קל"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "גשם/גשם־רסס קל"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "ממטרי שלג כבדים"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "סופת אבק"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "גשם מושלג"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "רסס קופא/גשם קופא"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "ממטרי שלג"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "רסס קופא/גשם קופא כבד"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "רסס קופא/גשם קופא קל"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "ערפל קופא"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "רוח קלה"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "רוח חזקה"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "מזג־אוויר ארה\"ב"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "ויזואל קרוסינג"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "שלג נושב או נסחף"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "גשם/גשם־רסס כבד"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "גשם/גשם־רסס קל"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "סופת אבק"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "רסס קופא/גשם קופא"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "רסס קופא/גשם קופא כבד"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "רסס קופא/גשם קופא קל"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "ענן משפך/טורנדו"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "ממטרי ברד"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "קרח"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "ברקים ללא רעמים"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "משקעים בקרבה"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "ממטרי גשם ושלג כבדים"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "גשם קל ושלג"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "הצטמצמות כיסוי שמים"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "התרחבות כיסוי שמים"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "שמיים ללא שינוי"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "עשן או אובך"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "ממטרי שלג וגשם"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "סופת רעמים ללא משקעים"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "אבק יהלומים"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "מעונן חלקית"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "נא לוודא שמפתח API הוזן נכון"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "לא נמצא"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "שלג נושב"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "שלג קליל"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "שלג מתון"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "ממטרי גשם מתונים"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "גשם מעורב בשלג"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "ממטרי גשם מעורב בשלג כבדים"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 #, fuzzy
 msgid "AccuWeather"
 msgstr "מזג־אוויר"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 #, fuzzy
 msgid "Weather Underground"
 msgstr "תנאי מזג־אוויר"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 #, fuzzy
 msgid "Strong Storm"
 msgstr "משב חזק"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "גשם ושלג"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "גשם מעורב בשלג מימי"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "ממטרי שלג"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "בהיר לרוב"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "מזג־אוויר ארה\"ב"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"נא לוודא שמפתח API\n"
+"שנתקבל מקלימאסל הוזן"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr "שירות המיקום הגיב עם שגיאות, נא לעיין ביומנים בלוקניג־גלאס"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "בהיר לרוב"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "גשם מושלג"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "ממטרי שלג קל"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "ממטרי שלג כבדים"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "סופות רעמים עם גשם קל"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "סופות רעמים עם גשם"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "מרגיש כמו"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 #, fuzzy
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
@@ -1800,7 +1876,7 @@ msgstr ""
 "לא ניתן לאחזר תצורה, לא נמצא קובץ בנתיב\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1808,107 +1884,107 @@ msgstr ""
 "לא ניתן לאחזר תכולת קובץ תצורה מנתיב\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr "נא לוודא שהוזן מיקום או לעשות שימוש במיקום אוטומטי במקום זאת"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "נדרש מפתח API לשרות זה על מנת שיפעל"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "נקודת הטל"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "משקעים יפסקו תוך {precipEnd} דקות"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "משקעים לא יפסקו תוך שעה"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "משקעים יחלו בעוד {precipStart} דקות"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "מאז {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 #, fuzzy
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} ממך"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 "שגיאה בשמירת מידע ניפוי־תקלים\n"
 "\n"
 "%s"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "לא ניתן לאחזר נתוני מזג־אויר"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "מידע ניפוי־תקלים נשמר בהצלחה"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "נשמר ל־{filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "מזג־אוויר ארה\"ב"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2303,7 +2379,6 @@ msgid "Weather conditions"
 msgstr "תנאי מזג־אוויר"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "תרגום תנאים"
 
@@ -2609,6 +2684,17 @@ msgstr "הצג כיוון רוח כמלל"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "כמו צמ', צ' במקום סמלי כיוון."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/hr.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/hr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2022-03-04 19:11+0100\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -21,65 +21,65 @@ msgstr ""
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Greška"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Greška usluge"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Neispravan API ključ"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Neispravan format lokacije"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Ključ je blokiran"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Nemoguć pronalazak lokacije"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Nema API ključa"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Nema lokacije"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Nedostaje paket"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Lokacija nije pokrivena"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Aplet vremena"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Klikni za otvaranje"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Osvježi"
 
@@ -89,8 +89,8 @@ msgstr "API je vratio kôd stanja između 400 i 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Pohrana lokacije"
 
@@ -102,14 +102,14 @@ msgstr "Ne možete spremiti automatski dobivenu lokaciju, nažalost"
 msgid "Could not get weather information"
 msgstr "Nemoguće dobivanje informacija vremena"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Dogodila se neočekivana greška pri osvježavanju vremena, pogledajte Cinnamon "
 "napredne kontrole i upravljanje"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -127,7 +127,7 @@ msgstr ""
 msgid "As of"
 msgstr "Nadopunjeno u"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Pogonjeno od strane"
 
@@ -135,52 +135,52 @@ msgstr "Pogonjeno od strane"
 msgid "from you"
 msgstr "od vas"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "u"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Učitavanje trenutne prognoze..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Učitavanje buduće prognoze..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Učitavanje..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Vlažnost"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Tlak"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vjetar"
 
@@ -190,18 +190,18 @@ msgstr ""
 "Pobrinite se da ste upisali lokaciju ili umjesto koristite Automatsku "
 "lokaciju"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Nemoguć pronalazak lokacije temeljene na adresi, provjerite je li ispravna"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Neuspjeli poziv Geolocation API-ja, pogledajte Napredne kontrole i "
 "upravljanja za više grešaka."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Upozorenje"
 
@@ -209,17 +209,17 @@ msgstr "Upozorenje"
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Možete spremiti samo ispravne lokacije kada se aplet ne osvježava"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Ne možete spremiti neispravnu lokaciju"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Informacije"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Lokacija je već spremljena"
 
@@ -257,15 +257,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Kao da je"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Neuspjela obrada informacija vremena"
 
@@ -278,7 +278,7 @@ msgstr ""
 "ili ga nabavite na https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -286,7 +286,7 @@ msgstr ""
 "Pobrinite se da ste upisali API ključ\n"
 "ispravno i vaš račun nije zaključan"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -297,252 +297,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Jaka kiša"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Kiša"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Slaba kiša"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Jaka ledena kiša"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Ledena kiša"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Slaba ledena kiša"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Slabo ledeno rominjanje"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Ledeno rominjanje"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Slabo rominjanje"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Jaka tuča"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Tuča"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Slaba tuča"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Jak snijeg"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Snijeg"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Slab snijeg"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Snježni pljusak"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Grmljavinski pljusak"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Slaba magla"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Magla"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Oblačno"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Pretežno oblačno"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Djelomično oblačno"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Pretežno vedro"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Vedro"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Sunčano"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Nepoznato"
 
@@ -566,7 +580,7 @@ msgstr ""
 "Upišite API ključ u postavkama,\n"
 "ili ga nabavite na https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -574,7 +588,7 @@ msgstr ""
 "Pobrinite se da ste upisali\n"
 "API ključ dobiven od DarkSkya"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Nemoguće dobivanje lokacije"
 
@@ -585,122 +599,123 @@ msgstr ""
 "Usluga lokacije je odgovorila greškom, pogledajte zapise u Cinnamon "
 "naprednim kontrolama i upravljanju"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Naoblaka"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Vedro"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Vedro"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Jaka olujna kiša"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Snažni snježni pljuskvi"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Snažni olujni snježni pljuskovi"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Jaka susnježica"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Jaka olujna susnježica"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Snažan snježni pljusak"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Snažan olujni snježni pljusak"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Jak snijeg s grmljavinom"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Snažan snježni pljusak"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Snažan snježni pljusak s grmljavinom"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Slaba kiša s grmljavinom"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Slabi pljuskovi"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Slabi pljuskovi s grmljavinom"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Slaba susnježica"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Slaba susnježica s grmljavinom"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Slab snježni pljusak"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Slab snježni pljusak s grmljavinom"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Slabi snjeg s grmljavinom"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Slab snježni pljusak"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Slab snježni pljusak s grmljavinom"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Kiša s grmljavinom"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Kišni pljuskovi"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Kišni pljuskovi s grmljavinom"
 
@@ -709,45 +724,46 @@ msgstr "Kišni pljuskovi s grmljavinom"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Susnježica"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Susnježica s grmljavinom"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Snježni pljusak"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Snježni pljusak s grmljavinom"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Snjeg s grmljavinom"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Snježni pljusak"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Snježni pljusak s grmljavinom"
 
@@ -756,20 +772,20 @@ msgstr "Snježni pljusak s grmljavinom"
 msgid "Unexpected response from API"
 msgstr "Neočekivan API odgovor"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Vidljivost"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Neuspjela obrada trenutnih informacija vremena"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Neuspjela obrada informacije prognoze"
 
@@ -798,92 +814,96 @@ msgid "Excellent - More than"
 msgstr "Izvrsno - Manje od"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Sumaglica"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Oblačno"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Slabi pljuskovi"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Rominjanje"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Jači pljuskovi"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Snježni pljusak"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Tuča"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Jaka tuča"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Slab snježni pljusak"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Snažan snježni pljusak"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Grmljavina"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Grmljavinski pljuskovi"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Pobrinite se da je lokacija u postavkama upisana ispravnim formatom"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Pobrinite se da ste upisali ispravan ključ u postavkama"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -891,213 +911,229 @@ msgstr ""
 "Lokacija nije pronađena, pobrinite se da je lokacija dostupna ili da je "
 "upisana u ispravnom formatu"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Ako se problem nastavi, kontaktirajte autora ovog apleta"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 "Nepoznata greška, pogledajte zapise Cinnamon naprednim kontrolama i "
 "upravljanju"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Grmljavinski pljusak sa slabom kišom"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Grmljavinski pljusak s kišom"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Grmljavinski pljusak s jakom kišom"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Slabi grmljavinski pljusak"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Snažni grmljavinski pljusak"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Oštri grmljavinski pljusak"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Grmljavinski pljusak sa slabim rominjanjem"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Grmljavinski pljusak s rominjanjem"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Grmljavinski pljusak s jačim rominjanjem"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Slabo rominjanje"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Jače rominjanje"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Kiša sa slabim rominjanjem"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Kiša s rominjanjem"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Kiša s jačim rominjanjem"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Pljusak s rominjanjem"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Jak pljusak s rominjanjem"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Pljusak s rominjanjem"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Umjerena kiša"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Jaka kiša"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Vrlo jaka kiša"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Olujna kiša"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Slabi pljuskovi"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Pljuskovi"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Jači pljuskovi"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Oštri pljuskovi"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Susnježica ili pljuskovi"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Slaba kiša sa snijegom"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Kiša sa snijegom"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Slab sniježni pljusak"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Sniježni pljusak"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Snažan sniježni pljusak"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Dim"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Izmaglica"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Pijesak, vrtlozi prašine"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Pijesak"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Prašina"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkanski pepeo"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Udari vjetra"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Vedro"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Oblačno"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Mjestimično oblačno"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Raspršeni oblaci"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Razbijeni oblaci"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Naoblaka"
 
@@ -1105,72 +1141,72 @@ msgstr "Naoblaka"
 msgid "Could not get forecast for your area"
 msgstr "Nemoguće dobivanje prognoze za vaše područje"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokacija je van SAD-a, koristite drugog pružatelja usluge."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Neuspjela obrada informacije prognoze po satu"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Vedro i vjetrovito"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Mjestimično oblačno i vjetrovito"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Djelomično oblačno i vjetrovito"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Pretežno oblačno i vjetrovito"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Oblačno i vjetrovito"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Susnježica"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Ledena kiša sa snijegom"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Uragan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Oluja"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropska oluja"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Vruće"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Hladno"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Mećava"
 
@@ -1210,79 +1246,79 @@ msgstr "Petak"
 msgid "Saturday"
 msgstr "Subota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Mirno"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Slabašan povjetarac"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Slabi povjetarac"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Lagani povjetarac"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Umjereni povjetarac"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Osvježavajući povjetarac"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Snažan povjetarac"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Umjeren vjetar"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Vjetar"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Snažan vjetar"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Snažna oluja"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "SI"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "I"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "JI"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "J"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "JZ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "SZ"
 
@@ -1334,7 +1370,7 @@ msgstr ""
 "Dogodila se nepoznata greška pri nabavljanju informacija vremena, pogledajte "
 "Napredne kontrole i upravljanja za više grešaka"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropska oluja"
 
@@ -1342,7 +1378,7 @@ msgstr "Tropska oluja"
 msgid "Severe Thunderstorms"
 msgstr "Grmljavinske oluje"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Oluje"
 
@@ -1358,17 +1394,17 @@ msgstr "Kiša sa susnježicom"
 msgid "Mixed Snow and Sleet"
 msgstr "Snijeg sa susnježicom"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Ledeno rominjanje"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Ledena kiša"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Pljuskovi"
 
@@ -1380,11 +1416,11 @@ msgstr "Snježni naleti"
 msgid "Light Snow Showers"
 msgstr "Slab sniježni pljusak"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Snježni zapusi"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Maglovito"
 
@@ -1396,54 +1432,55 @@ msgstr "Dim"
 msgid "Blustery"
 msgstr "Vijavica"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Vjetrovito"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Pretežno oblačno"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Djelomično oblačno"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Pretežno sunčano"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Kiša sa susnježicom"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Lokalne grmljavinske oluje"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Mjestimične grmljavinske oluje"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Mjestimični pljuskovi"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Jaka kiša"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Mjestimični snježni pljuskovi"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Jak snijeg"
 
@@ -1472,292 +1509,336 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Nema pronađenih podataka za lokaciju"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Vrlo slabo"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Manje od {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Izvrsno"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Više od {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Slabo"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Između {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Umjereno"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Dobro"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Vrlo dobro"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Udari vjetra"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Slab sniježni pljusak"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norveška"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Slab vjetar"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Snažan vjetar"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Snježni zapusi"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Jače rominjanje"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Kiša s jačim rominjanjem"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Slab sniježni pljusak"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Kiša sa slabim rominjanjem"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Snažan sniježni pljusak"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Pješčana oluja"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Susnježica"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Ledeno rominjanje s kišom"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Snježni pljusak"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Jako ledeno rominjanje s kišom"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Slabo ledeno rominjanje s kišom"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Ledena magla"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Slab vjetar"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Snažan vjetar"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Snježni zapusi"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Kiša s jačim rominjanjem"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Kiša sa slabim rominjanjem"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Pješčana oluja"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Ledeno rominjanje s kišom"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Jako ledeno rominjanje s kišom"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Slabo ledeno rominjanje s kišom"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Tornado/Pijavica"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Pljusak s tučom"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Led"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Munje bez grmljavine"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Oborine u blizini"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Jaka olujna kiša sa snjegom"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Slaba kiša sa snijegom"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Smanjenje naoblake"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Povećanje naoblake"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Naoblaka nepromjenjena"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Dim ili sumaglica"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Pljuskovi sa snjegom"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Grmljavinsko nevrijeme bez oborina"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Ledene iglice"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Djelomično oblačno"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Pobrinite se da ste upisali  API ključ ispravno"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NIJE PRONAĐENO"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Snježni zapusi"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Slab snijeg"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Umjereni snijeg"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Umjereni snježni pljuskvi"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Kiša sa snijegom"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Jaka kiša sa snijegom"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 #, fuzzy
 msgid "Weather Underground"
 msgstr "Vremenska stanja"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 #, fuzzy
 msgid "The location you provided was not found."
 msgstr "Nema postavljene lokacije"
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 #, fuzzy
 msgid "Strong Storm"
 msgstr "Snažan povjetarac"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Kiša sa snijegom"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Kiša sa susnježicom"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Snježni pljusak"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Pretežno vedro"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Pobrinite se da ste upisali\n"
+"API ključ dobiven od Climacella"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1766,46 +1847,41 @@ msgstr ""
 "Usluga lokacije je odgovorila greškom, pogledajte zapise u Cinnamon "
 "naprednim kontrolama i upravljanju"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Pretežno vedro"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Susnježica"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Slab sniježni pljusak"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Snažan sniježni pljusak"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Grmljavinski pljusak sa slabom kišom"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Grmljavinski pljusak s kišom"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Kao da je"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 #, fuzzy
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
@@ -1814,7 +1890,7 @@ msgstr ""
 "Nemoguće dobivanje podešavanja, datoteka nije pronađena u putanji\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1822,105 +1898,105 @@ msgstr ""
 "Nemoguće dobivanje sadržaja podešavanja u putanji\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Pobrinite se da ste upisali lokaciju ili umjesto koristite Automatsku "
 "lokaciju"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Ovaj pružatelj usluge zahtijeva API ključ kako bi radio"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Točka rošenja"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Oborine će završiti za {precipEnd} minuta"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Oborine neće završiti u sljedećih sat vremena"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Oborine će početi za {precipStart} minuta"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Obrada prognoze neuspjela, pogledajte zapise za više pojedinosti."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Kao da je {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} od vas"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Greška spremanja informacija otklanjanja grešaka"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Nemoguće dobivanje informacija vremena"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Informacije otklanjanja grešaka uspješno spremljene"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Spremljeno u {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2321,7 +2397,6 @@ msgid "Weather conditions"
 msgstr "Vremenska stanja"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Prevedi vremenska stanja"
 
@@ -2631,6 +2706,17 @@ msgstr "Prikaži smjer vjetra u obliku teksta"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Poput JI, S umjesto ikona smjera."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/hu.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: oversteer\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-02-09 19:05+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -20,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Hiba"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Szolgáltató hiba"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Rossz API-kulcs"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Hibás földrajzi helyzetformátum"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Kulcs ideiglenesen letilva"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Földrajzi helyzet nem található"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Nincs API-kulcs megadva"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "A földrajzi helyzet nincs megadva"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Hiányzó csomag"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "A földrajzi helyzetről nincs információ"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Időjárás kisalkalmazás"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "…"
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Megnyitás"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Frissítés"
 
@@ -88,8 +88,8 @@ msgstr "Az API 400 és 500 közötti állapotkóddal hibát jelzett"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Földrajzi helyzet tároló"
 
@@ -101,14 +101,14 @@ msgstr "Az automatikusan megállapított földrajzi helyzet nem menthető el"
 msgid "Could not get weather information"
 msgstr "Az időjárás információk nem kérhetők le"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Ismeretlen hiba lépett fel frissítés közben, a hibaüzenet megtekinthető a "
 "Looking Glass naplóban"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -126,7 +126,7 @@ msgstr ""
 msgid "As of"
 msgstr "Ekkorra:"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Időjárási-adatszolgáltató:"
 
@@ -134,52 +134,52 @@ msgstr "Időjárási-adatszolgáltató:"
 msgid "from you"
 msgstr "öntől"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "múlva"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Időjárás betöltése…"
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Időjárás-előrejelzés betöltése…"
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "(betöltés…)"
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Hőmérséklet"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Páratartalom"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Légnyomás"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Szél"
 
@@ -189,19 +189,19 @@ msgstr ""
 "Ellenőrizze hogy van-e földrajzi helyzet megadva vagy használja az "
 "automatikus helyzet-meghatározást"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Cím alapján nem található a földrajzi helyzet. Ellenőrizze a megadott "
 "adatokat"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nem sikerült a helymeghatározási API meghívása a hibaüzenetek megtekinthetők "
 "a Looking Glass naplóban."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
@@ -211,17 +211,17 @@ msgstr ""
 "Csak akkor távolítható el a földrajzi helyzet, ha a kisalkalmazás éppen nem "
 "áll frissítés alatt"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Nem menthető el a nem megfelelő földrajzi helyzet"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Információ"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "A földrajzi helyzet már el lett mentve"
 
@@ -260,15 +260,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Hőérzet"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Nem sikerült feldolgozni az időjárás-jelentést"
 
@@ -281,14 +281,14 @@ msgstr ""
 "vagy szerezzen egyet a https://developer.climacell.co/sign-up oldalról"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 "Ellenőrizze hogy az API kulcs helyes és a felhasználói fiók nincs blokkolva"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -299,252 +299,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Erős eső"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Eső"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Enyhe eső"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Erős ónos eső"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Ónos eső"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Szórványos ónos eső"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Enyhe ónos eső"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Jeges szitálás"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Enyhe szitáló eső"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Erős jég eső"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Jégeső"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Enyhe jégeső"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Erős havazás"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Havazás"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Enyhe havazás"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Széllökések"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Vihar"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Enyhe köd"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Köd"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Felhős"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Nagyrészt felhős"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Közepesen felhős"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Nagyrészt tiszta"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Tiszta"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Napos"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Ismeretlen hiba"
 
@@ -568,7 +582,7 @@ msgstr ""
 "API-kulcs megadása szükséges a beállításokban,\n"
 "vagy szerezzen egyet a https://darksky.net/dev/register oldalról"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -576,7 +590,7 @@ msgstr ""
 "Ellenőrizze, hogy a DarkSky szolgáltatótól származó\n"
 "API kulcsot helyesen adta meg"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Helyzetmeghatározás sikertelen"
 
@@ -587,122 +601,123 @@ msgstr ""
 "Földrajzi helymeghatározás nem sikerült, a naplóbejegyzések megtekinthetők a "
 "Looking Glass naplóban"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Felhőzet"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Tiszta égbolt"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Elfogadható"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Erős eső és mennydörgés"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Erős zivatarok"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Erős viharos záporeső és mennydörgés"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Erős havas eső"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Erős havas eső és mennydörgés"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Erős havas záporeső"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Erős havas záporeső és mennydörgés"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Erős havazás és mennydörgés"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Erős hózápor"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Erős zápor és szitáló eső"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Enyhe esőzés és mennydörgés"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Enyhe záporeső"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Enyhe záporeső és mennydörgés"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Gyenge havas eső"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Gyenge havas eső és mennydörgés"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Gyenge havas záporeső"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Gyenge havas esőzápor és mennydörgés"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Könnyű havazás és mennydörgés"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Enyhe hózáporok"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Könnyű hózáporok és mennydörgés"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Esőzés és mennydörgés"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Záporok"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Záporok és mennydörgés"
 
@@ -711,45 +726,46 @@ msgstr "Záporok és mennydörgés"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Havas eső"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Havas eső és mennydörgés"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Ónos záporeső"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Havas eső és mennydörgés"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Havazás és mennydörgés"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Hózápor"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Viharos havazás és mennydörgés"
 
@@ -758,20 +774,20 @@ msgstr "Viharos havazás és mennydörgés"
 msgid "Unexpected response from API"
 msgstr "Váratlan válasz az API részéről"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Láthatóság"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Nem sikerült feldolgozni a jelenlegi időjárás-jelentést"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Nem sikerült feldolgozni az időjárás-előrejelzést"
 
@@ -800,93 +816,97 @@ msgid "Excellent - More than"
 msgstr "Kiváló - Több mint"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Köd"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Borús"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Enyhe záporeső"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Szitáló eső"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Erős zápor"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Ónos záporeső"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Jégeső"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Jégzápor"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Enyhe elszórt hózápor"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Erős hózápor"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Mennydörgés"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Viharzápor"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Kérem ellenőrizze hogy a földrajzi helyzet megfelelő formátumban van megadva"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Ellenőrizze hogy az API kulcs korrekt a beállításokban"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -894,213 +914,229 @@ msgstr ""
 "Földrajzi helyzet nem található, ellenőrizze hogy a földrajzi helyzet "
 "elérhető és megfelelő formátumban van megadva"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Ha a hiba továbbra is fennáll, vegye fel a kapcsolatot a kisalkalmazás "
 "fejlesztőjével"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Ismeretlen hiba, a hibaüzenet megtekinthető a Looking Glass naplóban"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Vihar enyhe esővel"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Vihar"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Vihar erős esőzéssel"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Enyhe vihar"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Erős vihar"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Viharok"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Vihar enyhén szitáló esővel"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Vihar szitáló esővel"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Vihar erősen szitáló esővel"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Enyhe szitáló eső"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Erősen szitáló eső"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Enyhén szitáló eső"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Szitáló eső"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Erősen szitáló eső"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Zápor és szitáló eső"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Erős zápor és szitáló eső"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Szitáló záporeső"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Esőzés"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Erős eső"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Nagyon erős esőzés"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Hatalmas Esőzés"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Enyhe záporeső"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Záporeső"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Erős záporeső"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Szakadozott záporeső"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Havas záporeső"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Enyhe esőzés és havazás"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Esőzés és havazás"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Enyhe hózápor"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Elszórt havazás"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Erős hózápor"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Füst"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Pára"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Homok, porfelhők"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Homok"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Por"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkáni hamu"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Széllökések"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornádó"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Tiszta égbolt"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Felhős"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Enyhén felhős"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Elszórtan felhős"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Szakadozott felhőzet"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Borult idő"
 
@@ -1108,74 +1144,74 @@ msgstr "Borult idő"
 msgid "Could not get forecast for your area"
 msgstr "Nem szerezhető be időjárás-előrejelzés a megadott földrajzi helyzethez"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "Az Egyesült Államokon kívüli földrajzi helyzet esetén válasszon másik "
 "időjárás-előrejelzés szolgáltatót."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Nem sikerült feldolgozni az óránkénti időjárás-előrejelzést"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Tiszta és szeles"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Enyhén felhős és szeles"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Közepesen felhős és szeles"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Nagyrészt felhős és szeles"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Borult és szeles idő"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Havaseső"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Ónos eső és havazás"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Orkán"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Szélvész"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Trópusi vihar"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Forró"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Hideg"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Hóvihar"
 
@@ -1215,79 +1251,79 @@ msgstr "Péntek"
 msgid "Saturday"
 msgstr "Szombat"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Szélcsend"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Gyenge szellő"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Enyhe szellő"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Gyenge szél"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Mérsékelt szél"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Élénk szél"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Erős szél"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Viharos szél"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Élénk viharos szél"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Heves vihar"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Heves szélvész"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "É"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "ÉK"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "K"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "DK"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "„%s” nem található"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "DNY"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "NY"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "ÉNY"
 
@@ -1340,7 +1376,7 @@ msgstr ""
 "közben. További információkért tekintse meg a naplóbejegyzéseket a Looking "
 "Glass naplóban"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Trópusi vihar"
 
@@ -1348,7 +1384,7 @@ msgstr "Trópusi vihar"
 msgid "Severe Thunderstorms"
 msgstr "Veszélyes viharok"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Viharok"
 
@@ -1364,17 +1400,17 @@ msgstr "Eső és ónos eső vegyesen"
 msgid "Mixed Snow and Sleet"
 msgstr "Hó és ónos eső vegyesen"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Jeges szitálás"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Ónos eső"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Záporok"
 
@@ -1386,11 +1422,11 @@ msgstr "Hófúvás"
 msgid "Light Snow Showers"
 msgstr "Enyhe hózápor"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Hófúvás"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Ködös"
 
@@ -1402,54 +1438,55 @@ msgstr "Füstös"
 msgid "Blustery"
 msgstr "Heves"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Szeles"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Erősen felhős"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Közepesen felhős"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Nagyrészt napos"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Eső és jégeső"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Helyi viharok"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Hirtelen viharokkal"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Elszórt záporok"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Erős eső"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Elszórt hózáporok"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Erős havazás"
 
@@ -1478,11 +1515,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1490,276 +1527,320 @@ msgstr ""
 "A MET Office UK kizárólag Angliában érhető el. Bizonyosodjon meg róla, hogy "
 "a kiválasztott földrajzi hely Anglia területén van"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Nem található adat a földrajzi helyzethez"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Nagyon rossz"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Kevesebb mint {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Kiváló"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Több mint {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Rossz"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "{smallerDistance}-{biggerDistance} {distanceUnit} között"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Mérsékelt"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Jó"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Nagyon jó"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Széllökések"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Enyhe hózápor"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norvégia"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Enyhe szellő"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Erős szél"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Hófúvás vagy hócsuszamlás"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Erősen szitáló eső"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Erősen szitáló eső és eső"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Enyhe hózápor"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Enyhe szitáló eső"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Erős hózápor"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Porvihar"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Havaseső"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Jeges szitálás és ónos eső"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Hózápor"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Erősen szitáló ónos eső és ónos eső"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Enyhe jégszitálás és ónos eső"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Zúzmarás köd"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Enyhe szellő"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Erős szél"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Hófúvás vagy hócsuszamlás"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Erősen szitáló eső és eső"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Enyhe szitáló eső"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Porvihar"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Jeges szitálás és ónos eső"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Erősen szitáló ónos eső és ónos eső"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Enyhe jégszitálás és ónos eső"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Tölcsérfelhő és tornádó"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Jégzápor"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Jég"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Villámlás mennydörgés nélkül"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Csapadék a közelben"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Erős eső és havazás"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Enyhe esőzés és havazás"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Csökkenő felhőzet"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Növekvő felhőzet"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Változatlan fedettség"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Füst vagy köd"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Hózápor és záporeső"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Vihar lecsapás nélkül"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Jégtű"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Közepesen felhős"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Ellenőrizze hogy az API kulcsot helyesen adta meg"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Dánia"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NEM TALÁLHATÓ"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Hófúvás"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Enyhe havazás"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Hóesés"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Záporok"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Esőzés és havazás"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Erős eső és havazás"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 "Válasszon másik időjárás-előrejelzés szolgáltatót vagy földrajzi helyet"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "A megadott API-kulcs nem érvényes."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "A megadott földrajzi helyzethez nem található."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Heves szélvész"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Esőzés és havazás"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Eső és ónos eső vegyesen"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Hózápor"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Szeles"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Fagyos"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Nagyrészt tiszta"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Ellenőrizze, hogy a Climacell szolgáltatótól származó\n"
+"API kulcsot helyesen adta meg"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1767,46 +1848,41 @@ msgstr ""
 "Földrajzi helymeghatározás nem sikerült, a naplóbejegyzések megtekinthetők a "
 "Looking Glass naplóban"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Nagyrészt tiszta"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Havaseső"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Enyhe hózápor"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Erős hózápor"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Vihar enyhe esővel"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Vihar"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Hőérzet"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1814,7 +1890,7 @@ msgstr ""
 "Nem tölthető be a beállítófájl a megadott elérési útvonalról:\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1822,108 +1898,108 @@ msgstr ""
 "Nem tölthető be a beállítófájl tartalma a megadott elérési útvonalról:\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Ellenőrizze hogy van-e földrajzi helyzet megadva vagy használja az "
 "automatikus helyzet-meghatározást."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 "Ez az időjárás-előrejelzés szolgáltató API-kulcs használatát írj elő a "
 "szolgáltatása használatához"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Harmatpont"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "A csapadék {precipEnd} percen belül megszűnik"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "A csapadék nem szűnik meg egy órán belül"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "A csapadék {precipStart} percen belül esni kezd"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Az előrejelzés értelmezése nem sikerült. További részletekért tekintse meg a "
 "naplófájlokat."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Frissítve: {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} távolságra Öntől"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Állomásnév: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Térség: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Hiba lépett fel a hibakeresési információk elmentése közben"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Az időjárás információk nem kérhetők le"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "A hibakeresési információk sikeresen mentve"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Elmentve ide: {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2328,7 +2404,6 @@ msgid "Weather conditions"
 msgstr "Időjárási viszonyok"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Időjárási viszonyok lefordítása"
 
@@ -2645,6 +2720,17 @@ msgstr "Szél irányának megjelenítése szövegként"
 msgid "Like SE, N instead of direction icons."
 msgstr ""
 "Ehhez hasonló betűvel történő jelölés (DK vagy É) irány ikonok helyett."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/id.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/id.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl 3.2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2022-03-22 13:51+0700\n"
 "Last-Translator: Ruddy Pranata <ruddy.pranata@gmail.com>\n"
 "Language-Team: Ruddy Pranata <ruddy.pranata@gmail.com>\n"
@@ -20,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Kesalahan"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Kesalahan Layanan"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Kunci API salah"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Format Lokasi Salah"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Kunci Diblokir"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Tidak dapat menemukan lokasi"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "No Api Key"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Tidak ada Lokasi"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Paket Hilang"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Lokasi tidak tercakup"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Applet Cuaca"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Klik untuk membuka"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Menyegarkan"
 
@@ -88,8 +88,8 @@ msgstr "API mengembalikan kode status antara 400 dan 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Lokasi Toko"
 
@@ -101,14 +101,14 @@ msgstr "Anda tidak dapat menyimpan lokasi yang diperoleh secara otomatis, maaf"
 msgid "Could not get weather information"
 msgstr "Tidak bisa mendapatkan informasi cuaca"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Kesalahan Tak Terduga Saat Menyegarkan Cuaca, silakan lihat log in Looking "
 "Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +124,7 @@ msgstr "Kesalahan Jaringan, silakan periksa log di Looking Glass"
 msgid "As of"
 msgstr "Pada"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Dipersembahkan oleh"
 
@@ -132,52 +132,52 @@ msgstr "Dipersembahkan oleh"
 msgid "from you"
 msgstr "darimu"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Memuat cuaca saat ini..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Memuat cuaca masa depan..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Memuat ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Suhu"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Kelembaban"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Tekanan"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Angin"
 
@@ -186,17 +186,17 @@ msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Pastikan Anda memasukkan lokasi atau gunakan Lokasi otomatis sebagai gantinya"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Tidak dapat menemukan lokasi berdasarkan alamat, harap periksa apakah itu "
 "benar"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Gagal memanggil Geolocation API, lihat Looking Glass untuk kesalahan."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Peringatan"
 
@@ -205,17 +205,17 @@ msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Anda hanya dapat menyimpan lokasi yang benar ketika applet tidak menyegarkan"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Anda tidak dapat menyimpan lokasi yang salah"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Lokasi sudah disimpan"
 
@@ -253,15 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Terasa seperti"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Gagal Memproses Info Cuaca"
 
@@ -274,7 +274,7 @@ msgstr ""
 "atau dapatkan yang pertama di https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -282,7 +282,7 @@ msgstr ""
 "Harap Pastikan Anda\n"
 "memasukkan kunci API dengan benar dan akun Anda tidak terkunci"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -293,252 +293,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Hujan deras"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Hujan"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Hujan ringan"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Hujan es yang lebat"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Hujan beku"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Hujan es ringan"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Gerimis beku ringan"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Gerimis Beku"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Gerimis ringan"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Pelet es berat"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Pelet Es"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Pelet es ringan"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Salju tebal"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Salju"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Salju Ringan"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Kebingungan"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Hujan badai"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Kabut Tipis"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Kabut"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Berawan"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Sebagian besar berawan"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Berawan"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Sebagian besar jelas"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Jernih"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Cerah"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Tidak dikenal"
 
@@ -562,7 +576,7 @@ msgstr ""
 "Silakan masukkan kunci API di pengaturan,\n"
 "atau dapatkan yang pertama di https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -570,7 +584,7 @@ msgstr ""
 "Harap Pastikan Anda\n"
 "memasukkan kunci API yang Anda miliki dari DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Tidak dapat memperoleh lokasi"
 
@@ -580,122 +594,123 @@ msgid ""
 msgstr ""
 "Layanan Lokasi merespons dengan kesalahan, silakan lihat log di Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Keadaan mendung"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Langit cerah"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Terang"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Hujan lebat dan guntur"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Hujan deras"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Hujan deras disertai petir"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Hujan es lebat"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Hujan es lebat dan guntur"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Hujan es lebat"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Hujan es lebat dan guntur"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Salju lebat dan guntur"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Hujan salju lebat"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Hujan salju lebat dan guntur"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Hujan ringan dan guntur"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Hujan rintik-rintik"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Hujan ringan dan guntur"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Hujan es ringan"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Hujan es ringan dan guntur"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Hujan es ringan"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Hujan es ringan dan guntur"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Salju ringan dan guntur"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Hujan salju ringan"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Hujan salju ringan dan guntur"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Hujan dan guntur"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Gerimis"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Hujan deras dan guntur"
 
@@ -704,45 +719,46 @@ msgstr "Hujan deras dan guntur"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Hujan Es"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Hujan es dan guntur"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Hujan es"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Hujan es dan guntur"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Salju dan guntur"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Hujan salju"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Hujan salju dan guntur"
 
@@ -751,20 +767,20 @@ msgstr "Hujan salju dan guntur"
 msgid "Unexpected response from API"
 msgstr "Respons tak terduga dari API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Visibilitas"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Gagal Memproses Info Cuaca Saat Ini"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Gagal Memproses Info Prakiraan"
 
@@ -793,303 +809,323 @@ msgid "Excellent - More than"
 msgstr "Luar biasa - Lebih dari"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Kabut"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Mendung"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Light rain shower"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Gerimis"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Hujan deras"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Mandi hujan es"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Hujan Es"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Hujan es"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Hujan salju ringan"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Hujan salju lebat"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Guruh"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Hujan petir"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Pastikan Lokasi dalam format yang benar di Pengaturan"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Pastikan Anda memasukkan kunci yang benar di pengaturan"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 "Lokasi tidak ditemukan, pastikan lokasi tersedia atau dalam format yang benar"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Jika masalah ini berlanjut, silakan hubungi Penulis applet ini"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Kesalahan Tidak Diketahui, silakan lihat log di Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Badai petir disertai hujan ringan"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Badai petir dengan hujan"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Badai petir disertai hujan lebat"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Badai petir ringan"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Badai petir yang hebat"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Badai petir"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Badai petir dengan gerimis ringan"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Badai petir dengan gerimis"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Badai petir dengan gerimis lebat"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Gerimis dengan intensitas ringan"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Gerimis dengan intensitas tinggi"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Hujan gerimis intensitas ringan"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Hujan gerimis"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Hujan gerimis dengan intensitas tinggi"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Mandi hujan dan gerimis"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Hujan deras dan gerimis"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Hujan gerimis"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Hujan Sedang"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Hujan dengan intensitas tinggi"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Hujan sangat deras"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Hujan ekstrim"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Hujan pancuran intensitas ringan"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Mandi Hujan"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Hujan deras dengan intensitas tinggi"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Hujan deras"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Hujan Es"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Hujan ringan dan salju"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Hujan dan salju"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Hujan salju ringan"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Mandi salju"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Hujan salju lebat"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Berasap"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Kabut"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Pasir, pusaran debu"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Pasir"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Debu"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Abu vulkanik"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Badai"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Angin Topan"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Langit cerah"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Awan"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Sedikit awan"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Awan Tersebar"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Berawan Sebagian"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Awan Mendung"
 
@@ -1097,72 +1133,72 @@ msgstr "Awan Mendung"
 msgid "Could not get forecast for your area"
 msgstr "Tidak bisa mendapatkan perkiraan untuk wilayah Anda"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokasi di luar AS, harap gunakan penyedia lain."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Gagal Memproses Info Prakiraan Per Jam"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Cerah dan berangin"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Sedikit awan dan berangin"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Sebagian berawan dan berangin"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Sebagian besar berawan dan berangin"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Mendung dan berangin"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Hujan Bersalju"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Hujan dan salju yang membekukan"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Angin Ribut"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Badai"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Badai Tropis"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Panas"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Dingin"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Badai Salju"
 
@@ -1202,79 +1238,79 @@ msgstr "Jum'at"
 msgid "Saturday"
 msgstr "Sabtu"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Tenang"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Udara Ringan"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Angin Sepoi-sepoi"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Hembusan Angin Pelan"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Angin Sedang"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Angin Segar"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Angin Kencang"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Dekat Angin Kencang"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Angin Ribut"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Angin Ribut Kuat"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Badai Dahsyat"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "U"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "TL"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "T"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "TS"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "BD"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "B"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "BL"
 
@@ -1326,7 +1362,7 @@ msgstr ""
 "Terjadi kesalahan yang tidak diketahui saat memperoleh cuaca, lihat log "
 "Looking Glass untuk informasi lebih lanjut"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Badai Tropis"
 
@@ -1334,7 +1370,7 @@ msgstr "Badai Tropis"
 msgid "Severe Thunderstorms"
 msgstr "Badai Petir yang Parah"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Badai Petir"
 
@@ -1350,17 +1386,17 @@ msgstr "Campuran Hujan dan Hujan es"
 msgid "Mixed Snow and Sleet"
 msgstr "Campuran Salju dan Hujan es"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Gerimis Beku"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Hujan Beku"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Gerimis"
 
@@ -1372,11 +1408,11 @@ msgstr "Hujan Salju"
 msgid "Light Snow Showers"
 msgstr "Hujan Salju Ringan"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Salju Berangin"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Berkabut"
 
@@ -1388,54 +1424,55 @@ msgstr "Berasap"
 msgid "Blustery"
 msgstr "Kencang"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Berangin"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Sebagian Besar Berawan"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Berawan"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Umumnya cerah"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Campuran Hujan dan Hujan es"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Badai Petir Terisolasi"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Badai Petir Terisolasi"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Hujan Tersebar"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Hujan Deras"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Hujan Salju Tersebar"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Salju Berat"
 
@@ -1464,292 +1501,336 @@ msgstr ""
 "  {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Bertemu Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Data tidak ditemukan untuk lokasi"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Sangat Buruk"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Kurang dari {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Sangat Baik"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Lebih dari {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Buruk"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Antara {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Sedang"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Bagus"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Sangat Baik"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Badai"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Hujan salju ringan"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Angin sepoi-sepoi"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Angin Kencang"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Penyeberangan Visual"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Meniup atau melayang salju"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Gerimis Lebat"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Gerimis/hujan lebat"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Hujan salju ringan"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Gerimis/hujan ringan"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Hujan salju lebat"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Badai Debu"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Hujan Bersalju"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Gerimis beku/hujan beku"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Hujan salju"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Hujan gerimis/hujan yang membekukan"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Gerimis beku ringan/hujan beku"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Kabut Beku"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Angin sepoi-sepoi"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Angin Kencang"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Penyeberangan Visual"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Meniup atau melayang salju"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Gerimis/hujan lebat"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Gerimis/hujan ringan"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Badai Debu"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Gerimis beku/hujan beku"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Hujan gerimis/hujan yang membekukan"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Gerimis beku ringan/hujan beku"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Awan corong/tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Hujan es"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Es"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Petir tanpa guntur"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Curah hujan di sekitarnya"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Hujan lebat dan salju"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Hujan ringan dan salju"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Cakupan langit berkurang"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Cakupan langit meningkat"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Langit tidak berubah"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Asap atau kabut"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Hujan salju dan hujan"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Badai petir tanpa presipitasi"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Debu Berlian"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Sebagian berawan"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Pastikan Anda memasukkan kunci API dengan benar"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "Tidak Ditemukan"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Meniup Salju"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Sedikit salju"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Salju sedang"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Curah hujan sedang"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Campuran hujan dan salju"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Hujan lebat bercampur salju"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 #, fuzzy
 msgid "Weather Underground"
 msgstr "Kondisi Cuaca"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 #, fuzzy
 msgid "Strong Storm"
 msgstr "Angin Kencang"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Hujan dan salju"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Campuran Hujan dan Hujan es"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Hujan salju"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Sebagian besar jelas"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Harap Pastikan Anda\n"
+"memasukkan kunci API yang Anda miliki dari Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1757,46 +1838,41 @@ msgid ""
 msgstr ""
 "Layanan Lokasi merespons dengan kesalahan, silakan lihat log di Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Sebagian besar jelas"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Hujan Bersalju"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Hujan salju ringan"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Hujan salju lebat"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Badai petir disertai hujan ringan"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Badai petir dengan hujan"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Terasa seperti"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 #, fuzzy
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
@@ -1805,7 +1881,7 @@ msgstr ""
 "Tidak dapat mengambil konfigurasi, file tidak ditemukan di bawah jalur\n"
 "  {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1813,104 +1889,104 @@ msgstr ""
 "Tidak bisa mendapatkan konten file konfigurasi di bawah jalur\n"
 "  {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Pastikan Anda memasukkan lokasi atau gunakan Lokasi otomatis sebagai gantinya"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Penyedia ini memerlukan kunci API untuk beroperasi"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Titik Embun"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Curah hujan akan berakhir dalam {precipEnd} menit"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Curah hujan tidak akan berakhir dalam waktu satu jam"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Curah hujan akan mulai dalam {precipStart} menit"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Penguraian perkiraan gagal, lihat log untuk detail selengkapnya."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Pada {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} dari Anda"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Kesalahan Menyimpan Informasi Debug"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Tidak bisa mendapatkan informasi cuaca"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Informasi Debug berhasil disimpan"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Disimpan ke {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2312,7 +2388,6 @@ msgid "Weather conditions"
 msgstr "Kondisi Cuaca"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Terjemahkan kondisi"
 
@@ -2625,6 +2700,17 @@ msgstr "Tampilkan arah angin sebagai teks"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Seperti SE, N bukan ikon arah."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/is.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/is.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2023-07-21 16:50+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic\n"
@@ -20,65 +20,65 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Villa"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Villa í þjónustu"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Rangur API-lykill"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Rangt snið á staðsetningu"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "API-lykill útilokaður"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Gat ekki fundið staðsetningu"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Enginn API-lykill"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Engin staðsetning"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Pakkar sem vantar"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Staðsetning ekki með"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Veðursmáforrit"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Smelltu til að opna"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Endurlesa"
 
@@ -88,8 +88,8 @@ msgstr "API-forritsviðmótið skilaði stöðukóða á milli 400 og 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Vistun staðsetninga"
 
@@ -101,14 +101,14 @@ msgstr "Því miður, ekki er hægt að vista staðsetningu sem fundin er sjálf
 msgid "Could not get weather information"
 msgstr "Gat ekki náð í veðurupplýsingar"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Óvænt villa kom upp við að uppfæra veðurupplýsingar, skoðaðu atvikaskrár í "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +124,7 @@ msgstr "Villa í netkerfi, skoðaðu atvikaskrár í Looking Glass"
 msgid "As of"
 msgstr "Miðað við"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Keyrt með"
 
@@ -132,52 +132,52 @@ msgstr "Keyrt með"
 msgid "from you"
 msgstr "frá þér"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "í"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "míl"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Hleð inn veðurlýsingu ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Hleð inn veðurspá ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Hleð inn ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Hitastig"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Rakastig"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Loftþrýstingur"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vindur"
 
@@ -187,18 +187,18 @@ msgstr ""
 "Gakktu úr skugga um að þú hafir sett inn staðsetningu eða sért að nota "
 "sjálfvirka staðsetningu"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Gat ekki fundið staðsetningu út frá heimilisfangi, athugaðu hvort það sé rétt"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Mistókst að fletta upp í API-viðmóti hnattstaðsetningar, skoðaðu atvikaskrár "
 "í Looking Glass til að sjá villur."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Aðvörun"
 
@@ -208,17 +208,17 @@ msgstr ""
 "Þú getur aðeins vistað réttar staðsetningar þegar smáforritið er ekki að "
 "endulesa upplýsingar"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Þú getur ekki vistað ranga staðsetningu"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Upplýsingar"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Staðsetning er þegar vistuð"
 
@@ -258,15 +258,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Með vindkælingu"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Tókst ekki að meðhöndla veðurupplýsingar"
 
@@ -279,7 +279,7 @@ msgstr ""
 "en náðu fyrst í einn slíkan á https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -287,7 +287,7 @@ msgstr ""
 "Gakktu úr skugga um að þú hafir\n"
 "sett API-lykilinn rétt inn og að notandaaðgangurinn þinn sé ekki læstur"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -298,252 +298,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Úrfelli"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Rigning"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Dálítil rigning"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Talsverð frostrigning"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Frostrigning"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Dálítil frostrigning"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Dálítil frostsúld"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Frostsúld"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Dálítil súld"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Mikil ískorn"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Ískorn"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Dálítil ískorn"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Mikil snjókoma"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Snjókoma"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Dálítil snjókoma"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Snjófjúk"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Þrumuveður"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Létt þoka"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Þoka"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Skýjað"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Alskýjað"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Hálfskýjað"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Mestmegnis bjart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Heiðskírt"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Sólskin"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Óþekkt"
 
@@ -567,7 +581,7 @@ msgstr ""
 "Settu inn API-lykil í stillingunum,\n"
 "en náðu fyrst í einn slíkan á https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -575,7 +589,7 @@ msgstr ""
 "Gakktu úr skugga um að þú hafir\n"
 "sett API-lykilinn frá DarkSky rétt inn"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Gat ekki fengið staðsetninguna"
 
@@ -585,122 +599,123 @@ msgid ""
 msgstr ""
 "Staðsetningarþjónusta svaraði með villum, skoðaðu atvikaskrár í Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Skýjahula"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Heiðskírt"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Bjartviðri"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Úrfelli og þrumur"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Talsverðir skúrir"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Talsverðir skúrir og þrumur"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Talsverð slydda"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Talsverð slydda og þrumur"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Talsverð slydduél"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Talsverð slydduél og þrumur"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Talsverð snjókoma og þrumur"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Talsverð snjóél"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Talsverð snjóél og þrumur"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Dálítið regn og þrumur"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Dálitlir skúrir"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Dálitlir skúrir og þrumur"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Dálítil slydda"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Dálítil slydda og þrumur"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Dálítil slydduél"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Dálítil slydduél og þrumur"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Dálítil snjókoma og þrumur"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Dálítil snjóél"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Dálítil snjóél og þrumur"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Regn og þrumur"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Skúrir"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Skúrir og þrumur"
 
@@ -709,45 +724,46 @@ msgstr "Skúrir og þrumur"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Slydda"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Slydda og þrumur"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Slydduél"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Slydduél og þrumur"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Snjókoma og þrumur"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Snjóél"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Snjór og þrumur"
 
@@ -756,20 +772,20 @@ msgstr "Snjór og þrumur"
 msgid "Unexpected response from API"
 msgstr "Óskiljanlegt svar frá API-viðmótinu"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Skyggni"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Tókst ekki að meðhöndla fyrirliggjandi veðurupplýsingar"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Tókst ekki að meðhöndla veðurspárupplýsingar"
 
@@ -798,92 +814,96 @@ msgid "Excellent - More than"
 msgstr "Frábært - meira en"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Mistur"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Alskýjað"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Dálitlar regnskúrir"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Súld"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Talsverðir regnskúrir"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Slydduél"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Haglél"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Haglél"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Dálítil snjóél"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Talsverð snjóél"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Þrumur"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Þrumuskúrir"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Gakktu úr skugga um að staðsetning sé á réttu sniði í stillingunum"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Gakktu úr skugga um að þú hafir sett inn réttan lykil í stillingunum"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -891,212 +911,228 @@ msgstr ""
 "Staðsetning fannst ekki, gakktu úr skugga um að staðsetning sé tiltæk og á "
 "réttu sniði"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Ef vandamálið er viðvarandi skaltu hafa samband við höfund smáforritsins"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Óþekkt villa, skoðaðu atvikaskrár í Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Þrumuveður með dálítilli rigningu"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Þrumuveður með rigningu"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Þrumuveður með talsverðri rigningu"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Dálítið þrumuveður"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Talsvert þrumuveður"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Þrumuveður á köflum"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Þrumuveður með dálítilli súld"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Þrumuveður með súld"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Þrumuveður með talsverðri súld"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Súldarslæðingur"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Talsverð súldarrigning"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Dálítil súldarrigning"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Súldarrigning"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Talsverð súldarrigning"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Skúraleiðingar og súld"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Talsverðar skúraleiðingar og súld"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Súldarskúrir"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Nokkur rigning"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Talsverð rigning"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Úrfelli"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Mikið úrfelli"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Dálitlar skúraleiðingar"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Skúrir"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Talsverðar skúraleiðingar"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Skúraleiðingar á köflum"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Slydduél"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Dálitlir regn/snjóskúrir"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Regn og snjókoma"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Dálítil snjóél"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Snjóél"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Talsverð snjóél"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Reykur"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Mistur"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Sand eða rykhvirflar"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Sandur"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Ryk"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Gosaska"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Vindhviður"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Hvirfilbylur"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Heiðskírt"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Skýjað"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Hálfskýjað"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Léttskýjað"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Skýjað með köflum"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Alskýjað"
 
@@ -1104,72 +1140,72 @@ msgstr "Alskýjað"
 msgid "Could not get forecast for your area"
 msgstr "Tókst ekki að fá spá fyrir svæðið þitt"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Staðsetning er utan BNA, notaðu aðra þjónustuveitu."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Tókst ekki að meðhöndla upplýsingar fyrir klukkustundaspá"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Bjartviðri og vindur"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Léttskýjað og vindur"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Hálfskýjað og vindasamt"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Alskýjað og vindasamt"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Alskýjað og vindur"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Snjókennd rigning"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Frostrigning og snjór"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Fellibylur"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Rok"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Hitabeltisstormur"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Heitt"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Kalt"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Snjóbylur"
 
@@ -1209,79 +1245,79 @@ msgstr "Föstudagur"
 msgid "Saturday"
 msgstr "Laugardagur"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Logn"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Andvari"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Kul"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Gola"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Stinningsgola"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Kaldi"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Stinningskaldi"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Allhvasst"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Hvassviðri"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Stormur"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Ofsaveður"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NA"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "A"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SA"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NV"
 
@@ -1333,7 +1369,7 @@ msgstr ""
 "Óþekkt villa við að fletta upp veðurupplýsingum,\n"
 " skoðaðu atvikaskrár í Looking Glass til að sjá villur"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Hitabeltisstormur"
 
@@ -1341,7 +1377,7 @@ msgstr "Hitabeltisstormur"
 msgid "Severe Thunderstorms"
 msgstr "Hvasst þrumuveður"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Þrumuveður"
 
@@ -1357,17 +1393,17 @@ msgstr "Ýmist rigning eða slydda"
 msgid "Mixed Snow and Sleet"
 msgstr "Ýmist snjókoma eða slydda"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Frostsúld"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Frostrigning"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Skúrir"
 
@@ -1379,11 +1415,11 @@ msgstr "Snjóhryðjur"
 msgid "Light Snow Showers"
 msgstr "Dálítil snjóél"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Snjóbylur"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Þokuveður"
 
@@ -1395,54 +1431,55 @@ msgstr "Reykjarkóf"
 msgid "Blustery"
 msgstr "Vindhviður"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Vindasamt"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Alskýjað"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Hálfskýjað"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Sólskin að mestu"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Ýmist rigning eða haglél"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Þrumuveður á köflum"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Þrumuveður á dreif"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Skúrir á dreif"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Úrfelli"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Snjóél á dreif"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Talsverð snjókoma"
 
@@ -1471,11 +1508,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "UK MET stofnunin"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1483,275 +1520,319 @@ msgstr ""
 "MET Office UK þjónustar einungis Bretland, gakktu úr skugga um að "
 "staðsetningin þín sé þar"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Engin gögn fundust fyrir staðsetningu"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Mjög lélegt"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "minna en {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Frábært"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "meira en {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Lélegt"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "milli {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Miðlungs"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Gott"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Mjög gott"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Vindhviður"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Dálítil snjóél"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET - Noregur"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Dálítill vindur"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Talsverður vindur"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Skafrenningur"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Mikil súld"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Talsverð súld/rigning"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Dálítil snjóél"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Dálítil súld/rigning"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Talsverð snjóél"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Rykstormur"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Snjókennd rigning"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Frostsúld/frostrigning"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Snjóél"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Talsverð frostsúld/frostrigning"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Dálítil frostsúld/frostrigning"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Frostþoka"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Dálítill vindur"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Talsverður vindur"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Skafrenningur"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Talsverð súld/rigning"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Dálítil súld/rigning"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Rykstormur"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Frostsúld/frostrigning"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Talsverð frostsúld/frostrigning"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Dálítil frostsúld/frostrigning"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Skýstrokkur"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Haglél"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Ís"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Eldingar án þruma"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Úrkoma í grennd"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Talsverð rigning eða snjókoma"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Dálítil rigning eða snjókoma"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Minnkandi skýjahula"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Vaxandi skýjahula"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Óbreytt skýjahula"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Reykur eða mistur"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Regn- eða snjóél"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Þrumuveður án úrkomu"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Ískristallar"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Hálfskýjað"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Gakktu úr skugga um að þú hafir sett API-lykilinn rétt inn "
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "FINNST EKKI"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Snjóbylur"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Örlítil snjókoma"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Nokkur rigning"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Nokkir skúrir"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Ýmist rigning eða snjókoma"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Talsverð rigning eða snjókoma"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Veldu aðra þjónustu eða staðsetningu"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "API-lykillinn sem þú gafst upp er ógildur."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Staðsetningin sem þú gafst upp fannst ekki."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Ofsarok"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Regn og snjókoma"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Rigning og slydda"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Snjóél"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Gjóla"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Svalt"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Að mestu leyti bjart"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Gakktu úr skugga um að þú hafir\n"
+"sett API-lykilinn frá Climacell rétt inn"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1759,46 +1840,41 @@ msgid ""
 msgstr ""
 "Staðsetningarþjónusta svaraði með villum, skoðaðu atvikaskrár í Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Mestmegnis bjart"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Snjókennd rigning"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Dálítil snjóél"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Talsverð snjóél"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Þrumuveður með dálítilli rigningu"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Þrumuveður með rigningu"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Með vindkælingu"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1806,7 +1882,7 @@ msgstr ""
 "Gat ekki náð í stillingaskrá, stillingaskrá fannst ekki á uppgefinni slóð\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1814,108 +1890,108 @@ msgstr ""
 "Gat ekki náð í efni stillingaskrár á uppgefinni slóð\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Gakktu úr skugga um að þú hafir sett inn staðsetningu eða sért að nota "
 "sjálfvirka staðsetningu"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 "Þessi þjónustuveita krefst lykils að API-viðmóti til að hægt sé að nota hana"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Daggarmark"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Úrkoma mun hætta eftir {precipStart} mínútur"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Úrkoma mun ekki hætta á næstu klukkustund"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Úrkoma mun hefjast eftir {precipStart} mínútur"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Túlkun veðurspár mistókst, skoðaðu atvikaskrár til að sjá frekari "
 "upplýsingar."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Miðað við {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} frá þér"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Heiti stöðvar: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Svæði: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Villa við að vista villuleitarupplýsingar"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Gat ekki náð í veðurupplýsingar"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Tókst að vista villuleitarupplýsingar"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Vistað í {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2316,7 +2392,6 @@ msgid "Weather conditions"
 msgstr "Veðurskilyrði"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Þýða veðurskilyrði"
 
@@ -2623,6 +2698,17 @@ msgstr "Birta vindátt sem texta"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Eins og SA, N í stað tákna fyrir stefnu."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/it.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2023-10-29 17:21+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -20,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Errore"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Errore di Servizio"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Chiave API errata"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Formato posizione errato"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Chiave bloccata"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Impossibile trovare la posizione"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Nessuna chiave API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Nessuna posizione"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Pacchetti Mancanti"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Località non coperta"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Applet Meteo"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Clicca per aprire"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Ricarica"
 
@@ -88,8 +88,8 @@ msgstr "Le API hanno restituito un codice di status tra 400 e 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Archivio Posizioni"
 
@@ -102,14 +102,14 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Impossibile ottenere informazioni meteo"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Errore imprevisto durante l'aggiornamento del tempo, consultare il log in "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -125,7 +125,7 @@ msgstr "Errore di rete, controlla i log in Looking Glass"
 msgid "As of"
 msgstr "Da"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Offerto da"
 
@@ -133,52 +133,52 @@ msgstr "Offerto da"
 msgid "from you"
 msgstr "da te"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Caricamento meteo in corso ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Caricamento meteo futuro ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Caricamento ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Umidità"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Pressione"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vento"
 
@@ -188,19 +188,19 @@ msgstr ""
 "Assicurati di aver inserito una posizione o utilizza invece la Posizione "
 "automatica"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Impossibile trovare la posizione in base all'indirizzo, controlla se è "
 "corretto"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Impossibile chiamare l'API di geolocalizzazione, vedere Looking Glass per "
 "gli errori."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Attenzione"
 
@@ -210,17 +210,17 @@ msgstr ""
 "È possibile salvare le posizioni corrette solo quando l'applet non si sta "
 "aggiornando"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Non è possibile salvare una posizione errata"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Posizione già salvata"
 
@@ -259,15 +259,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Percepita"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Elaborazione delle informazioni meteo non riuscita"
 
@@ -280,7 +280,7 @@ msgstr ""
 "o prendine una prima su https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -289,7 +289,7 @@ msgstr ""
 "di aver immesso correttamente la chiave API e che il tuo account non è "
 "bloccato"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -300,252 +300,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Pioggia molto forte"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Pioggia"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Lievi rovesci"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Forti rovesci con grandine"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Grandine"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Leggera pioggia gelata"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Lievi rovesci con grandine"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Pioggia fine ghiacciata"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Lievi rovesci"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Granuli di ghiaccio pesanti"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Granuli di ghiaccio"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Granuli di ghiaccio leggeri"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Forte nevicata"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Neve"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Neve leggera"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Raffiche"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Temporale"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Nebbia leggera"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Nebbia"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Nuvoloso"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Prevalentemente nuvoloso"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Parzialmente nuvoloso"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Prevalentemente soleggiato"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Sereno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Soleggiato"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -569,7 +583,7 @@ msgstr ""
 "Inserisci la chiave API nelle impostazioni,\n"
 "o prendine una prima su https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -577,7 +591,7 @@ msgstr ""
 "Per favore assicurati\n"
 "di aver immesso correttamente la chiave API forntia da DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Impossibile ottenere la posizione"
 
@@ -588,122 +602,123 @@ msgstr ""
 "Il servizio di localizzazione ha risposto con errori, consultare i registri "
 "in Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Nuvolosità"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Cielo sereno"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Sereno"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Forti rovesci e tuoni"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Forti rovesci di pioggia"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Forti rovesci e tuoni"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Forte nevicata"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Forte nevicata e tuoni"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Nevischio intenso"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Rovesci di nevischio e tuoni"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Nevicate abbondanti e tuoni"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Forte nevicata"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Forte nevicata e tuoni"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Lievi rovesci e tuoni"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Lievi rovesci"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Lievi rovesci e tuoni"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Nevischio leggero"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Nevischio leggero e tuoni"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Lieve nevicata"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Leggeri rovesci di nevischio e tuoni"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Neve leggera e tuoni"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Rovesci nevosi leggeri"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Leggeri rovesci di neve e tuoni"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Pioggia e tuoni"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Rovesci"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Rovesci e tuoni"
 
@@ -712,45 +727,46 @@ msgstr "Rovesci e tuoni"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Nevischio"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Nevischio e tuoni"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Lieve nevicata"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Rovesci di nevischio e tuoni"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Neve e tuoni"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Rovesci nevosi"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Rovesci di neve e tuoni"
 
@@ -759,20 +775,20 @@ msgstr "Rovesci di neve e tuoni"
 msgid "Unexpected response from API"
 msgstr "Risposta inattesa dalle API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Visibilità"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Elaborazione delle informazioni meteo correnti non riuscita"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Elaborazione delle informazioni di previsione non riuscita"
 
@@ -801,93 +817,97 @@ msgid "Excellent - More than"
 msgstr "Eccellente - Più di"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Nebbia"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Nuvoloso"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Lievi rovesci"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Lievi rovesci"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Pioggia pesante"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Nevischio"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Grandine"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Grandine"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Lieve nevicata"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Forte nevicata"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Tuoni"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Tuoni"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Assicurati che la Posizione sia nel formato corretto nelle Impostazioni"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Assicurati di aver inserito la chiave corretta nelle impostazioni"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -895,211 +915,227 @@ msgstr ""
 "Posizione non trovata, assicurarsi che la posizione sia disponibile o che "
 "sia nel formato corretto"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Se il problema persiste, contattare l'autore di questa applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Errore sconosciuto, consultare i registri in Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Temporale con pioggia leggera"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Temporale con pioggia"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Temporale con forti piogge"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Lieve temporale"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Forte temporale"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Temporale irregolare"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Temporale con leggera pioviggine"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Temporale con pioviggine"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Temporale con forti rovesci"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Lievi rovesci"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Forti rovesci"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Lievi rovesci"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Rovesci"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Forti rovesci"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Rovesci"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Forti rovesci"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Rovesci"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Rovesci moderati"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Forti rovesci"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Pioggia molto forte"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Rovesci estremi"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Pioggia a bassa intensità"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Pioggia"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Pioggia intensa"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Pioggia"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Nevischio"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Lievi rovesci e neve"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Pioggia e neve"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Lieve nevicata"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Neve"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Forte nevicata"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Fumo"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Foschia"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Sabbia, vortici di polvere"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Sabbia"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Polvere"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Cenere vulcanica"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Burrasche"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Cielo sereno"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Nuvoloso"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Poco nuvoloso"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Nubi sparse"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Nubi sparse"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Nuvoloso"
 
@@ -1107,73 +1143,73 @@ msgstr "Nuvoloso"
 msgid "Could not get forecast for your area"
 msgstr "Impossibile ottenere le previsioni per la tua zona"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "La posizione è al di fuori degli Stati Uniti, utilizzare un provider diverso."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Impossibile elaborare le informazioni sulla Previsione Oraria"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Sereno e ventoso"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Poco nuvoloso con vento"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Parzialmente nuvoloso con vento"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Prevalentemente nuvoloso e ventoso"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Nuvoloso e ventoso"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Pioggia nevosa"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Pioggia gelata e neve"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Uragano"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Tempesta"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tempesta tropicale"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Caldo"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Freddo"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Bufera di neve"
 
@@ -1213,79 +1249,79 @@ msgstr "Venerdì"
 msgid "Saturday"
 msgstr "Sabato"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Sereno"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Aria leggera"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Brezza leggera"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Brezza leggera"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Brezza moderata"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Brezza fresca"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Vento forte"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Quasi burrasca"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Burrasca"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Forte burrasca"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Tempesta violenta"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NO"
 
@@ -1337,7 +1373,7 @@ msgstr ""
 "Si è verificato un errore sconosciuto durante l'ottenimento del meteo, "
 "vedere i log di Looking Glass per ulteriori informazioni"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tempesta tropicale"
 
@@ -1345,7 +1381,7 @@ msgstr "Tempesta tropicale"
 msgid "Severe Thunderstorms"
 msgstr "Temporali di grande intensità"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Temporali"
 
@@ -1361,17 +1397,17 @@ msgstr "Pioggia e nevischio"
 msgid "Mixed Snow and Sleet"
 msgstr "Neve e nevischio"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Pioggia gelata"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Grandine"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Rovesci"
 
@@ -1383,11 +1419,11 @@ msgstr "Raffiche di neve"
 msgid "Light Snow Showers"
 msgstr "Lieve nevicata"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Bufera di neve"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Nebbia"
 
@@ -1399,54 +1435,55 @@ msgstr "Fumoso"
 msgid "Blustery"
 msgstr "Tempesta"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Ventoso"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Prevalentemente nuvoloso"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Parzialmente nuvoloso"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Prevalentemente soleggiato"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Pioggia mista a grandine"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Temporali isolati"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Temporali sparsi"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Temporali sparsi"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Pioggia Intensa"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Nevicate sparse"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Neve Intensa"
 
@@ -1476,11 +1513,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1488,277 +1525,321 @@ msgstr ""
 "MET Office UK copre solo il Regno Unito, assicurati che la tua posizione sia "
 "nel paese"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Non sono stati trovati dati per la posizione"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Molto povera"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Meno di {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Eccellente"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Più di {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Povera"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Tra {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Moderata"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Buona"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Molto buona"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Burrasche"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Lieve nevicata"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Vento lieve"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Vento forte"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Neve che soffia o cade"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Forti rovesci"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Forti rovesci"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Lieve nevicata"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Lievi rovesci"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Forte nevicata"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Tempesta di sabbia"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Pioggia nevosa"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Grandine"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Rovesci nevosi"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Forte Grandinata"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Lieve Grandinata"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Nebbia gelata"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Vento lieve"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Vento forte"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Neve che soffia o cade"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Forti rovesci"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Lievi rovesci"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Tempesta di sabbia"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Grandine"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Forte Grandinata"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Lieve Grandinata"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Nube a imbuto/Tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Rovesci di grandine"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Ghiaccio"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Fulmini senza tuoni"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Precipitazioni nelle vicinanze"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Forti piogge e neve"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Lievi rovesci e neve"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Copertura del cielo in diminuzione"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Copertura del cielo in aumento"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Cielo invariato"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Fumo o foschia"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Rovesci di neve e pioggia"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Temporale senza precipitazioni"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Polvere di diamante"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Parzialmente nuvoloso"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 "Per favore assicurati\n"
 "di aver immesso correttamente la chiave API"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NON TROVATO"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Bufera di neve"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Lieve nevicata"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Nevicata moderata"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Rovesci moderati"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Pioggia mista a neve"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Forti piogge miste e neve"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Seleziona un provider o una località diversi"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "Chiave API inserita non valida."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Località inserita non trovata."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Forte Tempesta"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Pioggia e Neve"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Pioggia e Nevischio"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Rovesci Nevosi"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Arioso"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Frigido"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Prevalentemente Sereno"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Per favore assicurati\n"
+"di aver immesso correttamente la chiave API fornita da Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1767,46 +1848,41 @@ msgstr ""
 "Il servizio di localizzazione ha risposto con errori, consultare i registri "
 "in Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Prevalentemente soleggiato"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Pioggia nevosa"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Lieve nevicata"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Forte nevicata"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Temporale con pioggia leggera"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Temporale con pioggia"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Percepita"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1815,7 +1891,7 @@ msgstr ""
 "percorso\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1823,106 +1899,106 @@ msgstr ""
 "Impossibile recuperare il contenuto del file di config nel percorso\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Assicurati di aver inserito una posizione o utilizza invece la Posizione "
 "automatica"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Questo provider richiedere una chiave API per operare"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Punto di rugiada"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Le precipitazioni termineranno tra {precipEnd} minuti"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Le precipitazioni non finiranno entro un'ora"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Le precipitazioni inizieranno entro {precipStart} minuti"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Analisi della previsione non riuscita, vedere i log per maggiori dettagli."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Alle {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} da te"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Nome Stazione: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Area: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Errore durante il salvataggio delle informazioni di debug"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Impossibile ottenere informazioni meteo"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Informazioni di debug salvate con successo"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Salvate in {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2327,7 +2403,6 @@ msgid "Weather conditions"
 msgstr "Condizioni meteo"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Condizioni di traduzione"
 
@@ -2642,6 +2717,17 @@ msgstr "Visualizza la direzione del vento come testo"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Come SE, N invece delle icone di direzione."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/ja.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ja.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: gnome-shell-extension-weather 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2022-12-03 22:47+0900\n"
 "Last-Translator: Takeshi AIHANA <takeshi.aihana@gmail.com>\n"
 "Language-Team: Japanese <takeshi.aihana@gmail.com>\n"
@@ -19,65 +19,65 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "サービスエラー"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "不正なAPIキー"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "不正な位置情報書式"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "APIキーがありません"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "位置情報がありません"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "サポート外の地点"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "天気アプレット"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "開く"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "更新"
 
@@ -87,8 +87,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -100,12 +100,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -119,7 +119,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "提供："
 
@@ -127,52 +127,52 @@ msgstr "提供："
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "現在の天気を読み込んでいます ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "天気予報を読み込んでいます ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "読み込み中 ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "気温"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "湿度"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "気圧"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "風向・風速"
 
@@ -180,15 +180,15 @@ msgstr "風向・風速"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "位置情報を入力するか位置の自動取得を有効にしてください"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr "住所による位置情報の取得に失敗しました。入力を確認してください"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -196,17 +196,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -242,15 +242,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "体感温度"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -261,13 +261,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -276,49 +276,53 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "大雨"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "雨"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "小雨"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "着氷性の雨"
@@ -326,166 +330,173 @@ msgstr "着氷性の雨"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "着氷性の雨"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "着氷性の雨"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "大雪"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "雪"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "小雪"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "にわか雪"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "激しい雷雨"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "霧"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "曇り"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "おおむね曇り"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "ところにより曇り"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "おおむね曇り"
@@ -493,42 +504,45 @@ msgstr "おおむね曇り"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "快晴"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "晴れ"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -550,13 +564,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -565,132 +579,133 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "雲量"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "快晴"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "晴れ"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "にわか雪"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "弱いにわか雨"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "弱いにわか雪"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "にわか雨"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -699,47 +714,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "みぞれ"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "ところにより激しい雷雨"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "ところによりにわか雨"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "にわか雪"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "にわか雪"
@@ -749,20 +765,20 @@ msgstr "にわか雪"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "視程"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -791,324 +807,344 @@ msgid "Excellent - More than"
 msgstr "絶好調 ― >"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "どんよりした空"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "弱いにわか雨"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "霧雨"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "大雪"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "ところによりにわか雨"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "雹"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "にわか雪"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "大雪"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "激しい雷雨"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "雷雨"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "激しい雷雨"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "激しい雷雨"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "非常に激しい雷雨"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "局地的な激しい雷雨"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "激しい雷雨"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "霧雨"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "雨と雹"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "大雨"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "着氷性の雨"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "弱いにわか雪"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "にわか雨"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "にわか雨"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "雨と雪"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "雨と雪"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "弱いにわか雪"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "にわか雨"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "大雪"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "けむり"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "もや"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "砂塵"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "竜巻"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "曇り"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "ちぎれ雲"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "ちぎれ雲"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "一面の曇り空"
 
@@ -1116,76 +1152,76 @@ msgstr "一面の曇り空"
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "ところにより曇り"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "おおむね曇り"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "にわか雪"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "着氷性の雨"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "風力12"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "風力10"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "熱帯暴風雨"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "温暖"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "寒冷"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "大吹雪"
 
@@ -1225,79 +1261,79 @@ msgstr "金曜日"
 msgid "Saturday"
 msgstr "土曜日"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "風力0"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "風力1"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "風力2"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "風力3"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "風力4"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "風力5"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "風力6"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "風力7"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "風力8"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "風力9"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "風力11"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "北"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "北東"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "東"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "南東"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "南"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "南西"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "西"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "北西"
 
@@ -1341,7 +1377,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "熱帯暴風雨"
@@ -1351,7 +1387,7 @@ msgstr "熱帯暴風雨"
 msgid "Severe Thunderstorms"
 msgstr "非常に激しい雷雨"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "激しい雷雨"
 
@@ -1370,19 +1406,19 @@ msgstr "雨とみぞれ"
 msgid "Mixed Snow and Sleet"
 msgstr "雪とみぞれ"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "着氷性の雨"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "にわか雨"
 
@@ -1395,11 +1431,11 @@ msgstr "にわか雪"
 msgid "Light Snow Showers"
 msgstr "弱いにわか雪"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "吹雪"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "霧"
 
@@ -1411,62 +1447,63 @@ msgstr "けむり"
 msgid "Blustery"
 msgstr "大荒れ"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "強風"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "おおむね曇り"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "ところにより曇り"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "おおむね曇り"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "雨と雹"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "局地的な激しい雷雨"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "ところにより激しい雷雨"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "ところによりにわか雨"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "大雨"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "ところによりにわか雪"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "大雪"
 
@@ -1493,455 +1530,491 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "弱いにわか雪"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "吹雪"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "砂嵐"
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "着氷性の霧雨"
+msgid "Light shower rain"
+msgstr "弱いにわか雪"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "大雪"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "にわか雪"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "にわか雪"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "着氷性の雨"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "吹雪"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "砂嵐"
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "着氷性の霧雨"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "にわか雪"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "にわか雪"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "ダイアモンドダスト"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "ところにより曇り"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "正しいAPIキーを入力してください"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "吹雪"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "吹雪"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "大雪"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "ところによりにわか雨"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "別のプロバイダまたは位置情報を選んでください"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "雨とみぞれ"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "にわか雪"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "おおむね曇り"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr "正しいAPIキーを入力してください"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "おおむね曇り"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "にわか雪"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "弱いにわか雪"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "大雪"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "激しい雷雨"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "激しい雷雨"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "体感温度"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr "位置情報を入力するか位置の自動取得を有効にしてください"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "このサービスプロバイダはAPIキーが必要です"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "露点"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "{lastUpdatedTime}現在"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "デバッグ情報が保存されました"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "保存先: {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2332,7 +2405,6 @@ msgid "Weather conditions"
 msgstr "天気の状態"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "状態を日本語で表示"
 
@@ -2609,6 +2681,17 @@ msgstr "風向を文字で表示"
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/ko.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ko.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl 1.13.7\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-05-01 17:58+0100\n"
 "Last-Translator: Hang Park <hangpark@kaist.ac.kr>\n"
 "Language-Team: Korean <hangpark@kaist.ac.kr>\n"
@@ -19,66 +19,66 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 #, fuzzy
 msgid "Weather Applet"
 msgstr "날씨"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "열기"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "새로고침"
 
@@ -88,8 +88,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -101,12 +101,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -120,7 +120,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -128,55 +128,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "현재 날씨를 가져오고 있습니다 ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "날씨 예보를 가져오고 있습니다 ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "가져오는 중 ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "기온:"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "습도:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "기압:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "풍속:"
@@ -185,15 +185,15 @@ msgstr "풍속:"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -201,17 +201,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -247,15 +247,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -266,13 +266,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -281,12 +281,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "폭설"
@@ -294,38 +295,41 @@ msgstr "폭설"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "착빙성 비"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "착빙성 비"
@@ -333,168 +337,175 @@ msgstr "착빙성 비"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "착빙성 비"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "착빙성 비"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "착빙성 이슬비"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "착빙성 이슬비"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "착빙성 이슬비"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "폭설"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "눈"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "약한 소낙눈"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "소낙눈"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "뇌우"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "안개"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "구름"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "구름 많음"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "구름 약간"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "구름 많음"
@@ -502,42 +513,45 @@ msgstr "구름 많음"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "맑음"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "화창"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -559,13 +573,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -574,136 +588,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "구름"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "맑음"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "맑음"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "폭설"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "폭설"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "폭설"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "폭설"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "소낙눈"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "약한 소낙눈"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "약한 소낙눈"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "약한 소낙눈"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "약한 소낙눈"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "약한 소낙눈"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "약한 소낙눈"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "약한 소낙눈"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "소낙눈"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -712,47 +727,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "진눈깨비"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "산재형 뇌우"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "산재형 소나기"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "소낙눈"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "소낙눈"
@@ -762,20 +778,20 @@ msgstr "소낙눈"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -804,330 +820,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "약한 소낙눈"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "이슬비"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "폭설"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "산재형 소나기"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "우박"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "소낙눈"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "약한 소낙눈"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "폭설"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "뇌우"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "천둥을 동반한 비"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "뇌우"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "뇌우"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "강한 뇌우"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "고립형 뇌우"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "뇌우"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "이슬비"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "비와 우박"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "착빙성 이슬비"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "착빙성 비"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "약한 소낙눈"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "소나기"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "소나기"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "비와 눈"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "비와 눈"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "약한 소낙눈"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "소나기"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "폭설"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "연기"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "아지랑이"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "먼지"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "토네이도"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "구름"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "산재형 소나기"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1135,76 +1171,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "구름 약간"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "구름 많음"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "소낙눈"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "착빙성 비"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "허리케인"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "열대 폭풍우"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "더움"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "추움"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1244,79 +1280,79 @@ msgstr "금요일"
 msgid "Saturday"
 msgstr "토요일"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "북풍"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "북동풍"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "동풍"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "남동풍"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "남풍"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "남서풍"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "서풍"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "북서풍"
 
@@ -1360,7 +1396,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "열대 폭풍우"
@@ -1370,7 +1406,7 @@ msgstr "열대 폭풍우"
 msgid "Severe Thunderstorms"
 msgstr "강한 뇌우"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "뇌우"
 
@@ -1389,19 +1425,19 @@ msgstr "비와 진눈깨비"
 msgid "Mixed Snow and Sleet"
 msgstr "눈과 진눈깨비"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "착빙성 이슬비"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "착빙성 비"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "소나기"
 
@@ -1415,12 +1451,12 @@ msgstr "소낙눈"
 msgid "Light Snow Showers"
 msgstr "약한 소낙눈"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "날린 눈"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "안개"
 
@@ -1432,63 +1468,64 @@ msgstr "연기"
 msgid "Blustery"
 msgstr "바람 거셈"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "바람 많음"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "구름 많음"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "구름 약간"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "구름 많음"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "비와 우박"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "고립형 뇌우"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "산재형 뇌우"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "산재형 소나기"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "폭설"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "산재형 소낙눈"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "폭설"
@@ -1516,457 +1553,492 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "약한 소낙눈"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 #, fuzzy
 msgid "OpenWeatherMap"
 msgstr "날씨"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 #, fuzzy
 msgid "WeatherBit"
 msgstr "날씨"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr ""
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-#, fuzzy
-msgid "US Weather"
-msgstr "날씨"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "날린 눈"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "착빙성 이슬비"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "착빙성 이슬비"
+msgid "Light shower rain"
+msgstr "약한 소낙눈"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "폭설"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "소낙눈"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "소낙눈"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "착빙성 비"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr ""
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+#, fuzzy
+msgid "US Weather"
+msgstr "날씨"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "날린 눈"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "착빙성 이슬비"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "소낙눈"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "비와 눈"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "비와 눈"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "소낙눈"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "구름 약간"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "날린 눈"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "날린 눈"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "폭설"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "산재형 소나기"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "비와 눈"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "비와 눈"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 #, fuzzy
 msgid "AccuWeather"
 msgstr "날씨"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "비와 눈"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "비와 진눈깨비"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "소낙눈"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "구름 많음"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "날씨"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "구름 많음"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "소낙눈"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "약한 소낙눈"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "폭설"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "뇌우"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "뇌우"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "날씨"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2364,7 +2436,6 @@ msgid "Weather conditions"
 msgstr "번역"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 #, fuzzy
 msgid "Translate conditions"
 msgstr "번역"
@@ -2643,6 +2714,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/lt.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/lt.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-04-08 16:49+0300\n"
 "Last-Translator: Ernestas Žaglinskas <virtualybe@gmail.com>\n"
 "Language-Team: \n"
@@ -22,65 +22,65 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Klaida"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Paslaugos Klaida"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Neteisingas API Raktas"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Neteisingas Vietos Formatas"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Raktas Užblokuotas"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Negalima rasti vietovės"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Nėra Api Rakto"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Nėra Vietovės"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Trūksta Paketų"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Vietovė neuždengta"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Orų Programa"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Spausti, kad atidaryti"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Atnaujinti"
 
@@ -90,8 +90,8 @@ msgstr "API grąžino būsenos kodą tarp 400 ir 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Vietovių saugykla"
 
@@ -103,14 +103,14 @@ msgstr "Atsiprašome, automatiškai gautos vietos išsaugoti negalite"
 msgid "Could not get weather information"
 msgstr "Negalima gauti informacijos apie orą"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Netikėta klaida atnaujinant orų prognozę, prašau peržiūrėti įrašus ties "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -126,7 +126,7 @@ msgstr "Tinklo klaida, prašau žiūrėti įrašus ties \"Looking Glass\""
 msgid "As of"
 msgstr "Atnaujinta"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Sukurta"
 
@@ -134,52 +134,52 @@ msgstr "Sukurta"
 msgid "from you"
 msgstr "nuo tavęs"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Įkeliami dabartiniai orai..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Įkeliami būsimi orai ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Įkeliama ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatūra"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Drėgmė"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Slėgis"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vėjas"
 
@@ -187,17 +187,17 @@ msgstr "Vėjas"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "Įsitikinkite, kad įvedėte vietą arba naudokite automatinę vietą"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr "Nepavyko rasti vietos pagal adresą, patikrinkite, ar tai teisinga"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nepavyko susisiekti su Geografinės padėties API , dėl klaidų žr. „Looking "
 "Glass“."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Įspėjimas"
 
@@ -205,17 +205,17 @@ msgstr "Įspėjimas"
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Tinkamas vietoves galite įrašyti tik tada, kai programa neatnaujinama"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Negalite išsaugoti neteisingos vietovės"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Informacija"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Vietovė jau yra išsaugota"
 
@@ -253,15 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Jutiminė"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Nepavyko apdoroti orų informacijos"
 
@@ -274,7 +274,7 @@ msgstr ""
 "arba pirmiausia gaukite jį adresu https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -282,7 +282,7 @@ msgstr ""
 "Prašome įsitikinti ar\n"
 "teisingai įvedėte API raktą ir Jūsų paskyra nėra užrakinta"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -293,252 +293,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Stiprus lietus"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Lietus"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Nestiprus lietus"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Stipri lijundra"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Lijundra"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Nestipri lijundra"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Nestipri šąlanti dulksna"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Šąlanti dulksna"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Nestipri dulksna"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Sunkios ledo granulės"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Ledo granulės"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Nestiprios ledo granulės"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Stipriai sninga"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Sninga"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Lengvai sninga"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Staigūs vėjo šuorai"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Perkūnija"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Lengvas rūkas"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Rūkas"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Debesuota"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Daugiausia debesuota"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Protarpiais debesuota"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Daugiausia saulėta"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Saulėta"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Saulėta"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Nežinoma"
 
@@ -562,7 +576,7 @@ msgstr ""
 "Nustatymuose įveskite API raktą,\n"
 "arba pirmiausia gaukite jį https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -570,7 +584,7 @@ msgstr ""
 "Prašome įsitikinti ar\n"
 "įvedėte API raktą, kurį turite iš DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Nepavyko nustatyti vietovės"
 
@@ -579,122 +593,123 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Vietos paslauga atsakė su klaidomis. Žr. žurnalus Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Debesuotumas"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Giedra"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Gražus oras"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Stiprus lietus ir perkūnija"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Stiprus lietus"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Stiprus lietus ir perkūnija"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Stipri šlapdriba"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Stipri šlapdriba ir perkūnija"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Stipri šlapdriba"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Stipri šlapdriba su perkūnija"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Stipriai sninga ir griaudi"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Stipriai sninga"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Stirpiai sninga ir griaudi"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Lengvas lietus su perkūnija"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Nestiprus lietus"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Lengvas lietus su perkūnija"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Nestirpi šlapdriba"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Lengva šlapdriba su perkūnija"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Lengva šlapdriba"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Lengva šlapdriba su perkūnija"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Lengvai sninga ir griaudi"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Lengvai snyguriuoja"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Lengvai snyguriuoja ir griaudi"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Lietus ir perkūnija"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Trumpi lietūs"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Trumpi lietūs ir perkūnija"
 
@@ -703,45 +718,46 @@ msgstr "Trumpi lietūs ir perkūnija"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Šlapdriba"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Šlapdriba ir perkūnija"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Šlapdriba"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Šlapdriba ir perkūnija"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Sninga ir griaudi"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Vietomis pasnigs"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Vietomis pasnigs su perkūnija"
 
@@ -750,20 +766,20 @@ msgstr "Vietomis pasnigs su perkūnija"
 msgid "Unexpected response from API"
 msgstr "Netikėtas atsakymas iš API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Matomumas"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Nepavyko apdoroti esamos orų informacijos"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Nepavyko apdoroti orų prognozės informacijos"
 
@@ -792,92 +808,96 @@ msgid "Excellent - More than"
 msgstr "Puikus – daugiau nei"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Rūkas"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Apsiniaukę"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Trumpalaikis lietus"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Lijundra"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Stiprus, trumpalaikis lietus"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Šlapdriba"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Kruša"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Trumpa kruša"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Protarpiais snyguriuoja"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Stipriai sninga"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Perkūnija"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Perkūnija"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Įsitikinkite, kad nustatymuose Vietovės formatas yra teisingas"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Įsitikinkite, kad nustatymuose įvedėte teisingą raktą"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -885,211 +905,227 @@ msgstr ""
 "Vietovė nerasta, įsitikinkite, kad vietovė pasiekiama arba jos formatas yra "
 "tinkamas"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Jei ši problema išlieka, susisiekite su šios programėlės autoriumi"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Nežinoma klaida, žr. žurnalus Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Perkūnija su nedideliu lietumi"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Perkūnija su lietumi"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Perkūnija su stipriu lietumi"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Nedidelė perkūnija"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Stipri perkūnija"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Smarki perkūnija"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Perkūnija su silpna dulksna"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Perkūnija su dulksna"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Perkūnija ir stipri dulksna"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Lengvo intensyvumo dulksna"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Stipraus intensyvumo dulksna"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Nestipri dulksna ir lietus"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Dulksna ir lietus"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Didelio intensyvumo lietus ir dulksna"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Trumpas lietus ir dulksna"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Stiprus lietus ir dulksna"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Dulksna"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Vidutinis lietus"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Stipraus intensyvumo lietus"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Liūtis"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Liūtis"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Lengvo intensyvumo lietus"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Purškiantis lietus"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Stiprus lietus"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Smulkus lietus"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Smulki šlapdriba"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Lengvas lietus ir sniegas"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Lietus ir sniegas"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Lengvai snyguriuoja"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Snyguriuoja"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Stipriai sninga"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Dūmai"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Migla"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Smėlio ir dulkių sūkuriai"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Smėlis"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Dulkės"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkaniniai pelenai"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Škvalas"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornadas"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Giedra"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Debesys"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Mažai debesuota"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Išblaškyti debesys"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Debesuota"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Debesuota"
 
@@ -1097,72 +1133,72 @@ msgstr "Debesuota"
 msgid "Could not get forecast for your area"
 msgstr "Nepavyko gauti jūsų vietovės orų prognozės"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Vietovė yra už JAV ribų, naudokite kitą teikėją."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Nepavyko apdoroti valandinės orų prognozės informacijos"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Giedra ir vėjuota"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Keli debesys ir vėjuota"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Protarpiais debesuota ir vėjuota"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Daugiausia debesuota ir vėjuota"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Debesuota ir vėjuota"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Sniegas ir lietus"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Šąlantis lietus ir sniegas"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Uraganas"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Audra"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropinė audra"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Karšta"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Šalta"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Pūga"
 
@@ -1202,79 +1238,79 @@ msgstr "Penktadienis"
 msgid "Saturday"
 msgstr "Šeštadienis"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Ramu"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Lengvas oras"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Lengvas vėjelis"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Švelnus vėjelis"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Vidutinis vėjas"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Gaivus vėjas"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Stiprus vėjas"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Netoliese audra"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Stiprus vėjas"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Labai stiprus vėjas"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Labai didelė audra"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "Š"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "ŠR"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "R"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "PR"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "P"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "PV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "ŠV"
 
@@ -1326,7 +1362,7 @@ msgstr ""
 "Įvyko nežinoma klaida, bandant gauti orų informaciją. Daugiau informacijos "
 "rasite Looking Glass žurnale"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropinė audra"
 
@@ -1334,7 +1370,7 @@ msgstr "Tropinė audra"
 msgid "Severe Thunderstorms"
 msgstr "Smarki audra su perkūnija"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Perkūnija (audringa)"
 
@@ -1350,17 +1386,17 @@ msgstr "Lietus bei šlapdriba"
 msgid "Mixed Snow and Sleet"
 msgstr "Sniegas bei šlapdriba"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Stingdanti dulksna (šlapdriba)"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Šąlantis lietus"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Purškiantis lietus"
 
@@ -1372,11 +1408,11 @@ msgstr "Sniego šuorai"
 msgid "Light Snow Showers"
 msgstr "Lengvai snyguriuoja"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Pustomas sniegas"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Migla"
 
@@ -1388,54 +1424,55 @@ msgstr "Dūmingas oras"
 msgid "Blustery"
 msgstr "Žvarbus oras"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Vėjuota"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Daugiausia debesuota"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Protarpiais debesuota"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Daugiausia saulėta"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Lietus bei kruša"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Izoliuotos perkūnijos"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Padrikos perkūnijos"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Padrikas lietus"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Sunkus lietus"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Vietomis sninga"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Sunkus sniegas"
 
@@ -1464,286 +1501,330 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office JK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 "MET Office UK apima tik JK, įsitikinkite, kad jūsų vietovė yra šioje šalyje"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Vietoovės duomenų nerasta"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Labai prastas"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Mažiau nei {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Puikus"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Daugiau nei {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Prastas"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Tarp {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Vidutinis"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Geras"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Labai geras"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Škvalas"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Lengvai snyguriuoja"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Nestiprus vėjas"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Stiprus vėjas"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Matomas kritimas"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Pustomas, slenkantis sniegas"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Stipri dulksna (šlapdriba)"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Stipri dulksna, lietus"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Lengvai snyguriuoja"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Lengva dulksna, lietus"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Stipriai sninga"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Dulkių audra"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Sniegas ir lietus"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Stingdanti šlapdriba/šąlantis lietus"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Vietomis pasnigs"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Stipri šlapdriba, dulksna / šąlantis lietus"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Lengva šlapdriba, dulksna / šąlantis lietus"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Šąlantis rūkas"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Nestiprus vėjas"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Stiprus vėjas"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Matomas kritimas"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Pustomas, slenkantis sniegas"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Stipri dulksna, lietus"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Lengva dulksna, lietus"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Dulkių audra"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Stingdanti šlapdriba/šąlantis lietus"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Stipri šlapdriba, dulksna / šąlantis lietus"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Lengva šlapdriba, dulksna / šąlantis lietus"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Piltuvo debesis, tornadas"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Krušos lietus"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Ledas"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Žaibas be griaustinio"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Krituliai apylinkėse"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Stiprus lietus ir sniegas"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Nestiprus lietus ir sniegas"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Dangaus aprėptis mažėja"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Dangaus aprėptis didėja"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Dangus nepakitęs"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Dūmai ar migla"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Protarpiais sniegas ir lietus"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Perkūnija be kritulių"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Deimantų dulkės"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Protaroiais debesuota"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Įsitikinkite, kad API raktą įvedėte teisingai"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Danija"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "Nerasta"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Pustomas sniegas"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Nedidelis sniegas"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Vidutinis sniegas"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Vidutinis lietaus dulksna"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Lietus ir sniegas"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Stiprus lietus su sniegu"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Pasirinkite kitą teikėją arba vietovę"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "Jūsų pateiktas API raktas neteisingas."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Jūsų nurodyta vietovė nerasta."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Stipri Audra"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Lietus ir Sniegas"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Lietus su Šlapdriba"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Smulkiai Sninga"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Vėsu"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Šalta"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Daugiausia Giedra"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Piratų Orai"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Prašome įsitikinti ar\n"
+"įvedėte API raktą, kurį turite iš Climacell"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1751,46 +1832,41 @@ msgstr ""
 "Vietos tarnybai nepavyko rasti jūsų vietovės. Žiūrėti įrašų žurnalą Looking "
 "Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Daugiausia saulėta"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Sniegas ir lietus"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Lengvai snyguriuoja"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Stipriai sninga"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Perkūnija su nedideliu lietumi"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Perkūnija su lietumi"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Jutiminė"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1798,7 +1874,7 @@ msgstr ""
 "Nepavyko gauti konfigūracijos, failas nerastas šioje vietoje\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1806,105 +1882,105 @@ msgstr ""
 "Nepavyko gauti konfigūracijos failo turinio šioje vietoje\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Įsitikinkite, kad įvedėte vietovę arba naudokite automatinį vietovės "
 "nustatymą."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Šiam teikėjui reikalingas API raktas, kad jis veiktų"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Rasos Taškas"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Krituliai baigsis po {precipEnd} min"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Krituliai nesibaigs per valandą"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Krituliai prasidės po {precipStart} min"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Orų prognozės analizė nepavyko, daugiau informacijos rasite žurnaluose."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Atnaujinta {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} nuo jūsų"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Stoties Pavadinimas: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Vietovė: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Klaida išsaugant derinimo informaciją"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Negalima gauti informacijos apie orą"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Derinimo Informacija išsaugota sėkmingai"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Išsaugota šioje vietoje {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2304,7 +2380,6 @@ msgid "Weather conditions"
 msgstr "Oro sąlygos"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Išversti sąlygas"
 
@@ -2613,6 +2688,17 @@ msgstr "Rodyti vėjo krypti tekstiniu formatu"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Kaip PR, Š vietoje krypties piktogramų."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/lv.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/lv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 3.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-02-16 11:25+0100\n"
 "Last-Translator: Reinis Danne <rei4dan@gmail.com>\n"
 "Language-Team: \n"
@@ -22,65 +22,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr ""
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr ""
 
@@ -90,8 +90,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -103,12 +103,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -122,7 +122,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -130,55 +130,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Ielādē pašreizējos laikapstākļus ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Ielādē gaidāmos laikapstākļus ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Ielādē ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "Temperatūra:"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "Mitrums:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "Spiediens:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "Vējš:"
@@ -187,15 +187,15 @@ msgstr "Vējš:"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -203,17 +203,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -249,15 +249,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -268,13 +268,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -283,12 +283,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "Spēcīgs sniegs"
@@ -296,38 +297,41 @@ msgstr "Spēcīgs sniegs"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "Sasalstošs lietus"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "Sasalstošs lietus"
@@ -335,168 +339,175 @@ msgstr "Sasalstošs lietus"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Sasalstošs lietus"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "Sasalstošs lietus"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "Sasalstoša smidzināšana"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Sasalstoša smidzināšana"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "Sasalstoša smidzināšana"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Spēcīgs sniegs"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Sniegs"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "Viegla snigšana"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "Sniegputenis"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "Pērkona negaiss"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "Miglains"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Apmācies"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Pārsvarā apmācies"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Daļēji apmācies"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "Pārsvarā apmācies"
@@ -504,42 +515,45 @@ msgstr "Pārsvarā apmācies"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Skaidrs"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Saulains"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -561,13 +575,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -576,136 +590,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "Apmācies"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "Skaidrs"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Skaidrs"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "Spēcīgs sniegs"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "Spēcīgs sniegs"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "Spēcīgs sniegs"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "Spēcīgs sniegs"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "Sniegs"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "Viegla snigšana"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "Viegla snigšana"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "Viegla snigšana"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "Viegla snigšana"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "Viegla snigšana"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Viegla snigšana"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "Viegla snigšana"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "Sniegs"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -714,47 +729,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Slapjš sniegs"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "Vietām pērkona negaiss"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "Vietām lietusgāzes"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Sniegs"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "Sniegs"
@@ -764,20 +780,20 @@ msgstr "Sniegs"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -806,330 +822,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "Viegla snigšana"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Smidzina"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "Spēcīgs sniegs"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "Vietām lietusgāzes"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Krusa"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "Sniegs"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "Viegla snigšana"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "Spēcīgs sniegs"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "Pērkona negaiss"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "Pērkona negaiss"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "Pērkona negaiss"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "Pērkona negaiss"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "Spēcīgs pērkona negaiss"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "Atsevišķi pērkona negaisi"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "Pērkona negaiss"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "Smidzina"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "Lietus un krusa"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "Sasalstoša smidzināšana"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "Sasalstošs lietus"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "Viegla snigšana"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "Lietusgāzes"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "Lietusgāzes"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "Lietus un sniegs"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "Lietus un sniegs"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "Viegla snigšana"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "Lietusgāzes"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "Spēcīgs sniegs"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "Dūmaka"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Dūmaka"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Putekļi"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "Apmācies"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "Vietām lietusgāzes"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1137,76 +1173,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "Daļēji apmācies"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "Pārsvarā apmācies"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "Sniegputenis"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "Sasalstošs lietus"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Viesuļvētra"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropiskā vētra"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Karsts"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Auksts"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1246,79 +1282,79 @@ msgstr "Piektdiena"
 msgid "Saturday"
 msgstr "Sestdiena"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "ZA"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "A"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "DA"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "D"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "DR"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "R"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "ZR"
 
@@ -1363,7 +1399,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "Tropiskā vētra"
@@ -1373,7 +1409,7 @@ msgstr "Tropiskā vētra"
 msgid "Severe Thunderstorms"
 msgstr "Spēcīgs pērkona negaiss"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Pērkona negaiss"
 
@@ -1392,19 +1428,19 @@ msgstr "Slapjdraņķis"
 msgid "Mixed Snow and Sleet"
 msgstr "Sniegs un slapjš sniegs"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "Sasalstoša smidzināšana"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "Sasalstošs lietus"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Lietusgāzes"
 
@@ -1418,12 +1454,12 @@ msgstr "Sniegputenis"
 msgid "Light Snow Showers"
 msgstr "Viegla snigšana"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "Sniega putenis"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Miglains"
 
@@ -1435,63 +1471,64 @@ msgstr "Dūmaka"
 msgid "Blustery"
 msgstr "Brāzmains"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Vējains"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "Pārsvarā apmācies"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "Daļēji apmācies"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "Pārsvarā apmācies"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "Lietus un krusa"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Atsevišķi pērkona negaisi"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Vietām pērkona negaiss"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Vietām lietusgāzes"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "Spēcīgs sniegs"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Vietām sniega putenis"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Spēcīgs sniegs"
@@ -1519,452 +1556,487 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Viegla snigšana"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "Rīt"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "Sniega putenis"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "Sasalstoša smidzināšana"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "Sasalstoša smidzināšana"
+msgid "Light shower rain"
+msgstr "Viegla snigšana"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Spēcīgs sniegs"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Sniegputenis"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Sniegs"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "Sasalstošs lietus"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Rīt"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Sniega putenis"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Sasalstoša smidzināšana"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "Sniegs"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "Lietus un sniegs"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "Lietus un sniegs"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "Sniegs"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "Daļēji apmācies"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Sniega putenis"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "Sniega putenis"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "Spēcīgs sniegs"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "Vietām lietusgāzes"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Lietus un sniegs"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "Lietus un sniegs"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Lietus un sniegs"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Slapjdraņķis"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Sniegs"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Pārsvarā apmācies"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Pārsvarā apmācies"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Sniegputenis"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Viegla snigšana"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Spēcīgs sniegs"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Pērkona negaiss"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Pērkona negaiss"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2356,7 +2428,6 @@ msgid "Weather conditions"
 msgstr ""
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr ""
 
@@ -2631,6 +2702,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/nb.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/nb.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2011-06-02 23:04+0200\n"
 "Last-Translator: Stian Ellingsen <stiell@stiell.org>\n"
 "Language-Team: \n"
@@ -18,65 +18,65 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "…"
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr ""
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr ""
 
@@ -86,8 +86,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -99,12 +99,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -118,7 +118,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -126,55 +126,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Laster værobservasjon …"
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Laster værvarsel …"
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Laster …"
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "Temperatur:"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "Fuktighet:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "Lufttrykk:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "Vind:"
@@ -183,15 +183,15 @@ msgstr "Vind:"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -199,17 +199,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -245,15 +245,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -264,13 +264,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -279,12 +279,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "Kraftig snøfall"
@@ -292,38 +293,41 @@ msgstr "Kraftig snøfall"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "Underkjølt regn"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "Underkjølt regn"
@@ -331,168 +335,175 @@ msgstr "Underkjølt regn"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Underkjølt regn"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "Underkjølt regn"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "Underkjølt yr"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Underkjølt yr"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "Underkjølt yr"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Kraftig snøfall"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Snø"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "Lette snøbyger"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "Lett snøfall"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "Tordenvær"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "Tåke"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Skyet"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Stort sett skyet"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Delvis skyet"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "Stort sett skyet"
@@ -500,42 +511,45 @@ msgstr "Stort sett skyet"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Klarvær"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Sol"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -557,13 +571,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -572,136 +586,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "Skyet"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "Klarvær"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Lettskyet"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "Kraftig snøfall"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "Kraftig snøfall"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "Kraftig snøfall"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "Kraftig snøfall"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "Snøbyger"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "Lette snøbyger"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "Lette snøbyger"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "Lette snøbyger"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "Lette snøbyger"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "Lette snøbyger"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Lette snøbyger"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "Lette snøbyger"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "Snøbyger"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -710,47 +725,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Sludd"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "Spredt tordenvær"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "Spredte regnbyger"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Snøbyger"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "Snøbyger"
@@ -760,20 +776,20 @@ msgstr "Snøbyger"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -802,330 +818,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "Lette snøbyger"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Yr"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "Kraftig snøfall"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "Spredte regnbyger"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Hagl"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "Snøbyger"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "Lette snøbyger"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "Kraftig snøfall"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "Tordenvær"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "Tordenbyger"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "Tordenvær"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "Tordenvær"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "Kraftig tordenvær"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "Lokalt tordenvær"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "Tordenvær"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "Yr"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "Regn og hagl"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "Underkjølt yr"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "Underkjølt regn"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "Lette snøbyger"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "Regnbyger"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "Regnbyger"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "Regn og snø"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "Regn og snø"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "Lette snøbyger"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "Regnbyger"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "Kraftig snøfall"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "Røyk"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Dis"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Støv"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "Skyet"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "Spredte regnbyger"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1133,76 +1169,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "Delvis skyet"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "Stort sett skyet"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "Lett snøfall"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "Underkjølt regn"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Orkan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropisk storm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Varmt"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Kaldt"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1242,79 +1278,79 @@ msgstr "fredag"
 msgid "Saturday"
 msgstr "lørdag"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr ""
 
@@ -1359,7 +1395,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "Tropisk storm"
@@ -1369,7 +1405,7 @@ msgstr "Tropisk storm"
 msgid "Severe Thunderstorms"
 msgstr "Kraftig tordenvær"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Tordenvær"
 
@@ -1388,19 +1424,19 @@ msgstr "Regn og sludd"
 msgid "Mixed Snow and Sleet"
 msgstr "Snø og sludd"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "Underkjølt yr"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "Underkjølt regn"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Regnbyger"
 
@@ -1414,12 +1450,12 @@ msgstr "Lett snøfall"
 msgid "Light Snow Showers"
 msgstr "Lette snøbyger"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "Snøføyke"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Tåke"
 
@@ -1431,63 +1467,64 @@ msgstr "Røyk"
 msgid "Blustery"
 msgstr "Vindbyger"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Vind"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "Stort sett skyet"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "Delvis skyet"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "Stort sett skyet"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "Regn og hagl"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Lokalt tordenvær"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Spredt tordenvær"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Spredte regnbyger"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "Kraftig snøfall"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Spredte snøbyger"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Kraftig snøfall"
@@ -1515,452 +1552,487 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Lette snøbyger"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "I morgen"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "Snøføyke"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "Underkjølt yr"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "Underkjølt yr"
+msgid "Light shower rain"
+msgstr "Lette snøbyger"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Kraftig snøfall"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Lett snøfall"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Snøbyger"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "Underkjølt regn"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "I morgen"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Snøføyke"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Underkjølt yr"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "Snøbyger"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "Regn og snø"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "Regn og snø"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "Snøbyger"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "Delvis skyet"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Snøføyke"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "Snøføyke"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "Kraftig snøfall"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "Spredte regnbyger"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Regn og snø"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "Regn og snø"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Regn og snø"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Regn og sludd"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Snøbyger"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Stort sett skyet"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Stort sett skyet"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Lett snøfall"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Lette snøbyger"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Kraftig snøfall"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Tordenvær"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Tordenvær"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2352,7 +2424,6 @@ msgid "Weather conditions"
 msgstr ""
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr ""
 
@@ -2627,6 +2698,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/nl.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/nl.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: cinnamon-weather (weather@mockturtl or Weather)\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-02-23 23:47+0100\n"
 "Last-Translator: Pjotr <pjotrvertaalt@gmail.com>\n"
 "Language-Team: Dutch\n"
@@ -21,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Fout"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Dienstfout"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Verkeerde API-sleutel"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Onjuiste locatie-opmaak"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Sleutel geblokkeerd"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Kan locatie niet vinden"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Geen API-sleutel"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Geen locatie"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Ontbrekende pakketten"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Locatie niet gedekt"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Werkbalkhulpje voor weer"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Klik om te openen"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Verversen"
 
@@ -89,8 +89,8 @@ msgstr "API retourneerde statuscode tussen 400 en 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Locatie-opslag"
 
@@ -102,13 +102,13 @@ msgstr "U kunt een automatisch verkregen locatie helaas niet opslaan"
 msgid "Could not get weather information"
 msgstr "Kon geen weersinformatie verkrijgen voor uw gebied"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Onverwachte fout tijdens verversen, zie a.u.b. logboek in Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +124,7 @@ msgstr "Netwerkfout, controleer a.u.b. de logboeken in Looking Glass"
 msgid "As of"
 msgstr "Met ingang van"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Mogelijk gemaakt door"
 
@@ -132,52 +132,52 @@ msgstr "Mogelijk gemaakt door"
 msgid "from you"
 msgstr "van u"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Huidig weer aan het laden..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Weersverwachting aan het laden..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Bezig met laden..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatuur"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Luchtvochtigheid"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Luchtdruk"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Wind"
 
@@ -187,16 +187,16 @@ msgstr ""
 "Zorg ervoor dat u een locatie hebt ingevoerd of gebruik in plaats daarvan "
 "Automatische locatie"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Kon geen locatie vinden op basis van adres, controleer a.u.b. of het juist is"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Geolocatie-API aanroepen is mislukt, zie Looking Glass voor fouten."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Waarschuwing"
 
@@ -206,17 +206,17 @@ msgstr ""
 "U kunt alleen correcte locaties opslaan wanneer het werkbalkhulpje niet "
 "wordt ververst"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "U kunt een foutieve locatie niet opslaan"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Informatie"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Locatie is reeds opgeslagen"
 
@@ -255,15 +255,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Voelt als"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Kon weersinformatie niet verwerken"
 
@@ -276,7 +276,7 @@ msgstr ""
 "of verkrijg er eerst een op https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -284,7 +284,7 @@ msgstr ""
 "Zorg er a.u.b. voor dat u\n"
 "de API-sleutel correct hebt ingevoerd en dat uw account niet is vergrendeld"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -295,252 +295,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Zware regenval"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Regen"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Lichte regenval"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Zware ijzel"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "IJzel"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Lichte ijzel"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Lichte motregenijzel"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Motregenijzel"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Lichte motregen"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Grote hagelstenen"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Hagelstenen"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Kleine hagelstenen"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Zware sneeuwval"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Sneeuw"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Lichte sneeuwval"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Stuifsneeuw"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Onweer"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Lichte mist"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Mist"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Bewolkt"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Overwegend bewolkt"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Deels bewolkt"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Overwegend helder"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Helder"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Zonnig"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -564,7 +578,7 @@ msgstr ""
 "Voer a.u.b. de API-sleutel in de instellingen in,\n"
 "of verkrijg er eerst een op https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -572,7 +586,7 @@ msgstr ""
 "Zorg er a.u.b. voor dat u\n"
 "de API-sleutel van DarkSky hebt ingevoerd"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Kon locatie niet verkrijgen"
 
@@ -582,122 +596,123 @@ msgid ""
 msgstr ""
 "Locatiedienst reageerde met fouten, zie a.u.b. de logboeken in Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Bewolking"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Heldere lucht"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Mooi"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Zware regenval en onweer"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Zware regenbuien"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Zware regenbuien en onweer"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Zware hagelbuien"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Zware hagelbuien met onweer"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Zware hagelbuien"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Zware hagelbuien en onweer"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Zware sneeuwval en onweer"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Zware sneeuwbuien"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Zware sneeuwbuien en onweer"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Lichte regen en onweer"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Lichte regenbuien"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Lichte regenbuien en onweer"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Lichte hagelbui"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Lichte hagelbui en onweer"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Lichte hagelbuien"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Lichte hagelbuien en onweer"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Lichte sneeuwval en onweer"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Lichte sneeuwbuien"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Lichte sneeuwbuien en onweer"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Regen en onweer"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Regenbuien"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Regenbuien en onweer"
 
@@ -706,45 +721,46 @@ msgstr "Regenbuien en onweer"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Hagel"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Hagel en onweer"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Hagelbuien"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Hagelbuien en onweer"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Sneeuw en onweer"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Sneeuwbuien"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Sneeuwbuien en onweer"
 
@@ -753,20 +769,20 @@ msgstr "Sneeuwbuien en onweer"
 msgid "Unexpected response from API"
 msgstr "Onverwachte respons van de API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Zicht"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Kon de huidige weerinformatie niet verwerken"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Kon voorspellingsinformatie niet verwerken"
 
@@ -795,92 +811,96 @@ msgid "Excellent - More than"
 msgstr "Uitstekend - Meer dan"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Mist"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Zwaar bewolkt"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Lichte regenbui"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Motregen"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Zware regenbui"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Natte-sneeuwbui"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Hagel"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Hagelbui"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Lichte sneeuwbui"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Zware sneeuwbui"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Onweer"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Onweersbui"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Zorg a.u.b. voor de juiste locatie-opmaak in de instellingen"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Zorg a.u.b. voor de juiste sleutel in de instellingen"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -888,213 +908,229 @@ msgstr ""
 "Locatie niet gevonden, zorg ervoor dat de locatie beschikbaar is en in de "
 "juiste opmaak is ingevoerd"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Als dit probleem aanhoudt, neem dan a.u.b. contact op met de maker van dit "
 "werkbalkhulpje"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Onbekende fout, zie a.u.b. de logboeken in Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Onweersbui met lichte regen"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Onweersbui met regen"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Onweersbui met zware regenval"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Lichte onweersbui"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Zware onweersbui"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Plaatselijke onweersbui"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Onweersbui met lichte motregen"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Onweersbui met motregen"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Onweersbui met zware motregen"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Motregen met lichte intensiteit"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Motregen met zware intensiteit"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Motregen met lichte intensiteit"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Motregen"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Motregen met zware intensiteit"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Regen- en motregenbuien"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Zware regen- en motregenbuien"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Motregenbuien"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Matige regenval"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Zware regenval"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Zeer zware regenval"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Extreme regenval"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Lichte regenbuien"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Regenbuien"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Zware regenbuien"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Verspreide regenbuien"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Hagelbuien"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Lichte regen- en sneeuwval"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Regen en sneeuw"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Lichte sneeuwbuien"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Sneeuwbuien"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Zware sneeuwbuien"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Rook"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Nevel"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Zand- en stofwervelwinden"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Zand"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Stof"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkanische as"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Windstoten"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Wervelwind"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Lucht is helder"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Wolken"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Weinig bewolking"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Verspreide bewolking"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Wisselend bewolkt"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Laaghangende bewolking"
 
@@ -1102,72 +1138,72 @@ msgstr "Laaghangende bewolking"
 msgid "Could not get forecast for your area"
 msgstr "Kon geen voorspelling krijgen voor uw gebied"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Locatie is buiten de VS, maak a.u.b. gebruik van een andere aanbieder."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Kon uurlijkse voorspellingsinformatie niet verwerken"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Helder en winderig"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Weinig bewolking en winderig"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Deels bewolkt en winderig"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Overwegend bewolkt en winderig"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Zwaar bewolkt en winderig"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Natte sneeuw"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "IJzel en sneeuw"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Orkaan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Storm"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropische storm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Zeer warm"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Koud"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Sneeuwstorm"
 
@@ -1207,79 +1243,79 @@ msgstr "Vrijdag"
 msgid "Saturday"
 msgstr "Zaterdag"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Rustig"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Zeer licht briesje"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Licht briesje"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Zacht briesje"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Gematigd briesje"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Fris briesje"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Sterk briesje"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Bijna storm"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Storm"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Harde storm"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Heftige storm"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "ZO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "ZW"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "W"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NW"
 
@@ -1331,7 +1367,7 @@ msgstr ""
 "Onbekende fout trad op tijdens het verkrijgen van het weer, zie Looking "
 "Glass-logboeken voor meer informatie"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropische storm"
 
@@ -1339,7 +1375,7 @@ msgstr "Tropische storm"
 msgid "Severe Thunderstorms"
 msgstr "Zware onweersbuien"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Onweersbuien"
 
@@ -1355,17 +1391,17 @@ msgstr "Mengsel van regen en hagel"
 msgid "Mixed Snow and Sleet"
 msgstr "Mengsel van sneeuw en hagel"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Motregenijzel"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "IJzel"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Buien"
 
@@ -1377,11 +1413,11 @@ msgstr "Sneeuwvlagen"
 msgid "Light Snow Showers"
 msgstr "Lichte sneeuwbuien"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Stuifsneeuw"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Mistig"
 
@@ -1393,54 +1429,55 @@ msgstr "Rokerig"
 msgid "Blustery"
 msgstr "Onstuimig"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Winderig"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Overwegend bewolkt"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Deels bewolkt"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Overwegend zonnig"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Mengsel van regen en hagel"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Plaatselijke onweersbuien"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Verspreide onweersbuien"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Verspreide buien"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Zware regenval"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Verspreide sneeuwbuien"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Zware sneeuwval"
 
@@ -1469,11 +1506,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1481,275 +1518,319 @@ msgstr ""
 "MET Office UK beslaat alleen het Verenigd Koninkrijk, dus deze keuze heeft "
 "alleen zin wanneer u zich in Groot-Brittannië bevindt"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Geen gegevens gevonden voor locatie"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Zeer slecht"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Minder dan {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Uitstekend"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Meer dan {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Slecht"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Tussen {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Matig"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Goed"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Zeer goed"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Windstoten"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Lichte sneeuwbuien"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Zwakke wind"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Harde wind"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Rondwaaiende of stuivende sneeuw"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Zware motregen"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Zware motregen/regen"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Lichte sneeuwbuien"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Lichte motregen/regen"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Zware sneeuwbuien"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Stofstorm"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Natte sneeuw"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Motregenijzel/ijzel"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Sneeuwbuien"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Zware motregenijzel/ijzel"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Lichte motregenijzel/ijzel"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Aanvriezende mist"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Zwakke wind"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Harde wind"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Rondwaaiende of stuivende sneeuw"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Zware motregen/regen"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Lichte motregen/regen"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Stofstorm"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Motregenijzel/ijzel"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Zware motregenijzel/ijzel"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Lichte motregenijzel/ijzel"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Trechtervormige wolk/tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Hagelbuien"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "IJs"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Bliksem zonder donder"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Neerslag in de omgeving"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Zware regen- en sneeuwval"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Lichte regen- en sneeuwval"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Bewolking neemt af"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Bewolking neemt toe"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Bewolking ongewijzigd"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Rook of nevel"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Sneeuw- en regenbuien"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Onweer zonder neerslag"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "IJsstof"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Deels bewolkt"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Zorg er a.u.b. voor dat u de API-sleutel correct hebt ingevoerd"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "Niet gevonden"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Stuifsneeuw"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Lichte sneeuwval"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Matige sneeuw"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Matige regenbuien"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Mengsel van regen en sneeuw"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Zware mengeling van regen en sneeuw"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Kies a.u.b. een andere aanbieder of locatie"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "De API-sleutel die u opgaf is ongeldig."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "De locatie die u opgaf was onvindbaar."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Flinke storm"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Regen en sneeuw"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Regen en natte sneeuw of hagel"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Sneeuwbuien"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Winderig"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Koud"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Overwegend helder"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Zorg er a.u.b. voor dat u\n"
+"de API-sleutel van Climacell hebt ingevoerd"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1757,46 +1838,41 @@ msgstr ""
 "Locatiedienst kon uw locatie niet vinden, zie a.u.b. de logboeken in Looking "
 "Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Overwegend helder"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Natte sneeuw"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Lichte sneeuwbuien"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Zware sneeuwbuien"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Onweersbui met lichte regen"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Onweersbui met regen"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Voelt als"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1804,7 +1880,7 @@ msgstr ""
 "Kon instellingen niet ophalen, bestand niet gevonden onder paden\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1812,105 +1888,105 @@ msgstr ""
 "Kon inhoud van instellingenbestand niet verkrijgen onder pad\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Zorg ervoor dat u een locatie hebt ingevoerd of gebruik in plaats daarvan "
 "Automatische locatie."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Deze aanbieder heeft een API-sleutel nodig om te kunnen werken"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Dauwpunt"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Neerslag zal ophouden over {precipEnd} minuten"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Neerslag zal niet binnen een uur ophouden"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Neerslag zal beginnen over {precipStart} minuten"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Lezen van voorspelling mislukt, zie logboeken voor meer bijzonderheden."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Met ingang van {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} van u vandaan"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Stationsnaam: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Gebied: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Fout bij opslaan van foutopsporingsinformatie"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Kon geen weersinformatie verkrijgen voor uw gebied"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Foutopsporingsinformatie met succes opgeslagen"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Opgeslagen naar {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2313,7 +2389,6 @@ msgid "Weather conditions"
 msgstr "Weersomstandigheden"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Weersomstandigheden vertalen"
 
@@ -2626,6 +2701,17 @@ msgstr "Toon windrichting als tekst"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Als ZO, N in plaats van richtingpictogrammen."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/pl.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/pl.po
@@ -9,7 +9,7 @@ msgstr ""
 "weather@mockturtl\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-08-23 18:23+0200\n"
 "Last-Translator: \n"
 "Language-Team: lukaszdabrowski80@gmail.com\n"
@@ -22,65 +22,65 @@ msgstr ""
 "|| n%100>14) ? 1 : 2);\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Błąd"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Błąd usługi"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Nieprawidłowy klucz API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Nieprawidłowy format lokalizacji"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Klucz zablokowany"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Nie mogę znaleźć lokalizacji"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Brak klucza API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Brak lokalizacji"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Brakujące pakiety"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Lokalizacja nie jest objęta"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Aplet Pogoda"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Kliknij, aby otworzyć"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Odśwież"
 
@@ -90,8 +90,8 @@ msgstr "API zwróciło kod statusu między 400 a 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Lokalizacja sklepu"
 
@@ -103,14 +103,14 @@ msgstr "Nie możesz zapisać lokalizacji uzyskanej automatycznie, przepraszam"
 msgid "Could not get weather information"
 msgstr "Nie udało się uzyskać informacji o pogodzie"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Nieoczekiwany błąd podczas odświeżania pogody, zobacz logowanie w Looking "
 "Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -126,7 +126,7 @@ msgstr "Błąd sieci, sprawdź logi w Looking Glass"
 msgid "As of"
 msgstr "Od"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Obsługiwane przez"
 
@@ -134,52 +134,52 @@ msgstr "Obsługiwane przez"
 msgid "from you"
 msgstr "od Ciebie"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mile"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Ładowanie aktualnej pogody ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Ładowanie przyszłej pogody ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Ładowanie ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Wilgotność"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Ciśnienie"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Wiatr"
 
@@ -189,18 +189,18 @@ msgstr ""
 "Upewnij się, że wprowadzono lokalizację lub zamiast tego użyj funkcji "
 "Lokalizacja automatyczna"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Nie można znaleźć lokalizacji na podstawie adresu, sprawdź, czy jest poprawna"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nie udało się wywołać interfejsu API geolokalizacji, zobacz Looking Glass "
 "dla błędów."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
@@ -210,17 +210,17 @@ msgstr ""
 "Poprawne lokalizacje można zapisywać tylko wtedy, gdy aplet nie jest "
 "odświeżany"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Nie możesz zapisać nieprawidłowej lokalizacji"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Informacja"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Lokalizacja jest już zapisana"
 
@@ -258,15 +258,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Odczuwalna"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Nie udało się przetworzyć informacji o pogodzie"
 
@@ -279,7 +279,7 @@ msgstr ""
 "lub uzyskaj go najpierw na stronie https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -287,7 +287,7 @@ msgstr ""
 "Upewnij się, że\n"
 "wprowadziłeś klucz API poprawnie, a Twoje konto nie jest zablokowane"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -298,252 +298,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Ulewny deszcz"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Deszcz"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Lekki deszcz"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Silne opady marznącego deszczu"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Marznący deszcz"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Lekki marznący deszcz"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Lekka marznąca mżawka"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Mrożąca mżawka"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Lekka mżawka"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Duże granulki lodu"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Granulki lodu"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Lekkie granulki lodu"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Obfite opady śniegu"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Śnieg"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Lekki śnieg"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Śnieżyca"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Burza z piorunami"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Lekka mgła"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Mgła"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Chmury"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Przeważnie pochmurno"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Częściowe zachmurzenie"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Przeważnie bezchmurnie"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Przejrzyście"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Słonecznie"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Nieznane"
 
@@ -567,7 +581,7 @@ msgstr ""
 "Proszę wprowadzić klucz API w ustawieniach.\n"
 "lub uzyskaj go najpierw na stronie https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -575,7 +589,7 @@ msgstr ""
 "Upewnij się, że\n"
 "wprowadziłeś klucz API, który masz od DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Nie udało się uzyskać lokalizacji"
 
@@ -586,122 +600,123 @@ msgstr ""
 "Usługa lokalizacji odpowiedziała z błędami, proszę zobaczyć logi w Looking "
 "Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Zachmurzenie"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Bezchmurne niebo"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Raczej"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Ulewny deszcz i burze"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Ulewne deszcze"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Duże opady deszczu i burze"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Duże opady śniegu"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Duże opady śniegu i burze"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Silne opady śniegu"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Silne opady deszczu i burze"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Obfite opady śniegu i burze"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Silne opady śniegu"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Silne opady śniegu i burze"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Lekki deszcz i burze"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Lekkie opady deszczu"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Lekkie opady deszczu i burze"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Lekki śnieg"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Lekki śnieg i burze"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Lekkie opady śniegu"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Lekkie opady śniegu i burze"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Lekki śnieg i burze"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Lekkie opady śniegu"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Lekkie opady śniegu i burze"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Deszcz i pioruny"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Przelotne deszcze"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Przelotne deszcze i burze"
 
@@ -710,45 +725,46 @@ msgstr "Przelotne deszcze i burze"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Śnieg z deszczem"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Deszcz ze śniegiem i burze"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Przelotny śnieg"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Przelotny śnieg i burze"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Śnieg i burze"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Opady śniegu"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Opady śniegu i burze"
 
@@ -757,20 +773,20 @@ msgstr "Opady śniegu i burze"
 msgid "Unexpected response from API"
 msgstr "Niespodziewana odpowiedź z API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Widoczność"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Nie udało się przetworzyć aktualnych informacji o pogodzie"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Nie udało się przetworzyć informacji o prognozie"
 
@@ -799,92 +815,96 @@ msgid "Excellent - More than"
 msgstr "Doskonały - Więcej niż"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Mgła"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Zachmurzenie"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Lekki deszczyk"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Mżawka"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Ulewny deszcz"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Deszcz ze śniegiem"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Grad"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Deszcz gradowy"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Lekki śnieg z deszczem"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Silny śnieg z deszczem"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Zagrzmi"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Przelotnie zagrzmi"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Upewnij się, że Lokalizacja jest w prawidłowym formacie w Ustawieniach"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Upewnij się, że wprowadziłeś prawidłowy klucz w ustawieniach"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -892,211 +912,227 @@ msgstr ""
 "Nie znaleziono lokalizacji, upewnij się, że lokalizacja jest dostępna lub "
 "jest w prawidłowym formacie"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Jeśli problem nadal występuje, prosimy o kontakt z autorem tego apletu"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Nieznany błąd, proszę zobaczyć logi w Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Burza z lekkim deszczem"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Burza z deszczem"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Burza z ulewnym deszczem"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Lekka burza"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Silna burza"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Gwałtowna burza z piorunami"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Burza z lekką mżawką"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Burza z mżawką"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Burza z silną mżawką"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Lekkie opady mżawki"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Silne opady mżawki"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Lekka mżawka deszcz"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Mżawka deszcz"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Intensywna mżawka deszcz"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Deszcz i mżawka"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Ulewny deszcz i mżawka"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Przelotna mżawka"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Umiarkowany deszcz"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Intensywny deszcz"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Bardzo silny deszcz"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Ekstremalny deszcz"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Przelotny deszcz o lekkiej intensywności"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Przelotny deszcz"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Intensywny przelotny deszcz"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Poszarpany przelotny deszcz"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Deszcz ze śniegiem"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Lekki deszcz i śnieg"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Deszcz i śnieg"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Lekki przelotny śnieg"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Przelotny śnieg"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Silny przelotny śnieg"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Zadymiony"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Mgła"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Piasek, wiry pyłowe"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Piasek"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Pył"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Popiół wulkaniczny"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Szkwał"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Niebo jest czyste"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Chmury"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Nieliczne chmury"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Rozproszone chmury"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Rozbite chmury"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Pochmurno"
 
@@ -1104,72 +1140,72 @@ msgstr "Pochmurno"
 msgid "Could not get forecast for your area"
 msgstr "Nie można uzyskać prognozy dla Twojego obszaru"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokalizacja jest poza USA, proszę użyć innego dostawcy."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Nie udało się przetworzyć informacji o prognozie godzinowej"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Bezchmurnie i wietrznie"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Niewiele chmur i wietrznie"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Nieliczne chmury i wietrznie"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Przeważnie pochmurno i wietrznie"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Pochmurno i wietrznie"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Śnieżno deszczowo"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Marznący deszcz i śnieg"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Huragan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Burza"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropical storm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Gorąco"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Zimno"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Blizzard"
 
@@ -1209,79 +1245,79 @@ msgstr "Piątek"
 msgid "Saturday"
 msgstr "Sobota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Spokój"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Lekki powiew"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Lekki powiew"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Delikatny powiew"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Umiarkowany wiatr"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Świeży powiew"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Silny wiatr"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "W pobliżu wichury"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Wichura"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Silna wichura"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Gwałtowna burza"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SW"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "W"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NW"
 
@@ -1335,7 +1371,7 @@ msgstr ""
 "Wystąpił nieznany błąd podczas uzyskiwania pogody, zobacz logi Looking Glass "
 "aby uzyskać więcej informacji"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropikalna burza"
 
@@ -1343,7 +1379,7 @@ msgstr "Tropikalna burza"
 msgid "Severe Thunderstorms"
 msgstr "Silne burze"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Burze"
 
@@ -1359,17 +1395,17 @@ msgstr "Trochę deszczu i deszczu ze śniegiem"
 msgid "Mixed Snow and Sleet"
 msgstr "Śnieg i deszcz ze śniegiem"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Marznąca mżawka"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Marznący deszcz"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Przelotny deszcz"
 
@@ -1381,11 +1417,11 @@ msgstr "Zamiecie śnieżne"
 msgid "Light Snow Showers"
 msgstr "Lekkie opady śniegu"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Zamiecie śnieżne"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Mglisto"
 
@@ -1397,54 +1433,55 @@ msgstr "Zadyniony"
 msgid "Blustery"
 msgstr "Burzowo"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Wietrzny"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Przeważnie pochmurno"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Częściowe zachmurzenie"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Przeważnie słonecznie"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Deszcz i grad"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Pojedyncze burze"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Rozproszone burze"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Przelotne opady"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Ulewa"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Rozległe opady śniegu"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Duże opady śniegu"
 
@@ -1469,297 +1506,341 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Urząd Meteorologiczny UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Nie znaleziono danych dla lokalizacji"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Bardzo słabe"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Mniej niż {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Doskonała"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Więcej niż {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Słaba"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Pomiędzy {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Umiarkowane"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Dobra"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Bardzo dobra"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Szkwał"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Lekki przelotny śnieg"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
+msgid "Heavy drizzle"
+msgstr "Silna mżawka"
+
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Lekki przelotny śnieg"
+
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Silny przelotny śnieg"
+
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Śnieżno deszczowo"
+
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Opady śniegu"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
+msgid "Freezing fog"
+msgstr "Zamarzająca mgła"
+
+#: 3.8/weather-applet.js:13091
 #, fuzzy
 msgid "Tomorrow.io"
 msgstr "Jutro"
 
-#: 3.8/weather-applet.js:13058
+#: 3.8/weather-applet.js:13300
 msgid "Light wind"
 msgstr "Lekki wiatr"
 
-#: 3.8/weather-applet.js:13072
+#: 3.8/weather-applet.js:13314
 msgid "Strong wind"
 msgstr "Silny wiatr"
 
-#: 3.8/weather-applet.js:13422
+#: 3.8/weather-applet.js:13664
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:13997
+#: 3.8/weather-applet.js:14239
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:14191
+#: 3.8/weather-applet.js:14433
 msgid "Blowing or drifting snow"
 msgstr "Nawiewy lub zaspy śnieżne"
 
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
-msgid "Heavy drizzle"
-msgstr "Silna mżawka"
-
-#: 3.8/weather-applet.js:14199
+#: 3.8/weather-applet.js:14441
 msgid "Heavy drizzle/rain"
 msgstr "Silna mżawka/deszcz"
 
-#: 3.8/weather-applet.js:14201
+#: 3.8/weather-applet.js:14443
 msgid "Light drizzle/rain"
 msgstr "Lekka mżawka/deszcz"
 
-#: 3.8/weather-applet.js:14203
+#: 3.8/weather-applet.js:14445
 #, fuzzy
 msgid "Dust Storm"
 msgstr "Burza pyłowa"
 
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:14449
 msgid "Freezing drizzle/freezing rain"
 msgstr "Marznąca mżawka/ marznący deszcz"
 
-#: 3.8/weather-applet.js:14209
+#: 3.8/weather-applet.js:14451
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Silna marznąca mżawka/ marznący deszcz"
 
-#: 3.8/weather-applet.js:14211
+#: 3.8/weather-applet.js:14453
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Lekka marznąca mżawka/ marznący deszcz"
 
-#: 3.8/weather-applet.js:14213
-msgid "Freezing fog"
-msgstr "Zamarzająca mgła"
-
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Chmura lejkowata/tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Gradobicie"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Lód"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Błyskawica bez grzmotu"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Opady w okolicy"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Ulewny deszcz i śnieg"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Lekki deszcz i śnieg"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 #, fuzzy
 msgid "Sky coverage decreasing"
 msgstr "Coraz mniejszy zasięg nieba"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 #, fuzzy
 msgid "Sky coverage increasing"
 msgstr "Zwiększający się zasięg nieba"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Niebo bez zmian"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Dym lub mgła"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Opady śniegu i deszczu"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Burza bez opadów"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Diamentowy pył"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Częściowe zachmurzenie"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Upewnij się, że wprowadziłeś klucz API poprawnie"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NIE ZNALEZIONO"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Zawieje śnieg"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Lekki śnieg"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Umiarkowany śnieg"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Umiarkowany deszcz"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Deszcz ze śniegiem"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Silny deszcz ze śniegiem"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 #, fuzzy
 msgid "AccuWeather"
 msgstr "Pogoda"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 #, fuzzy
 msgid "Weather Underground"
 msgstr "Warunki pogodowe"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 #, fuzzy
 msgid "Strong Storm"
 msgstr "Silny wiatr"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Deszcz i śnieg"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Trochę deszczu i deszczu ze śniegiem"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Opady śniegu"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Przeważnie bezchmurnie"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Upewnij się, że\n"
+"wprowadziłeś klucz API, który otrzymałeś od Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1768,157 +1849,152 @@ msgstr ""
 "Usługa lokalizacji odpowiedziała z błędami, proszę zobaczyć logi w Looking "
 "Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Przeważnie bezchmurnie"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Śnieżno deszczowo"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Lekki przelotny śnieg"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Silny przelotny śnieg"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Burza z lekkim deszczem"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Burza z deszczem"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Odczuwalna"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Upewnij się, że wprowadzono lokalizację lub zamiast tego użyj funkcji "
 "Lokalizacja automatyczna"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Ten dostawca wymaga klucza API do działania"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Opady zakończą się za {precipEnd} minut"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Opady nie ustaną w ciągu godziny"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Opady rozpoczną się w ciągu {precipStart} minut"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Od {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 #, fuzzy
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} od ciebie"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Nie udało się uzyskać informacji o pogodzie"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2318,7 +2394,6 @@ msgid "Weather conditions"
 msgstr "Warunki pogodowe"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Przetłumacz warunki pogodowe"
 
@@ -2632,6 +2707,17 @@ msgstr "Wyświetlanie kierunku wiatru jako tekst"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Jak SE, N zamiast ikon kierunków."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/pt.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 3.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-02-01 16:18-0100\n"
 "Last-Translator: \n"
 "Language-Team: Português ; Daniel Miranda <dmiranda@gmail.com>, Luiz Rodrigo "
@@ -21,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Erro"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Erro de Serviço"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Chave Incorreta da API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Formatação Incorreta de Local"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Chave Bloquiada"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Não foi possível encontrar a localização"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Sem Chave da Api"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Sem Localização"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Pacotes em Falta"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Localização não Coberta"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Applet de Clima"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Clique para abrir"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Recarregar"
 
@@ -89,8 +89,8 @@ msgstr "API retornou código de estado entre 400 e 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Armazém de Localização"
 
@@ -102,14 +102,14 @@ msgstr "Não pode guardar uma localização obtida automaticamente, desculpe"
 msgid "Could not get weather information"
 msgstr "Não foi possível obter informação do clima"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Erro inesperado enquanto recarregando o Clima, por favor verifique o registo "
 "no Looking Glass (Aparência Vidrada)"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -127,7 +127,7 @@ msgstr ""
 msgid "As of"
 msgstr "Às"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Fornecido por"
 
@@ -135,52 +135,52 @@ msgstr "Fornecido por"
 msgid "from you"
 msgstr "de ti"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Carregando as condições meteorológicas atuais ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Carregando as condições meteorológicas futuras ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Carregando ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Humidade"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Pressão"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vento"
 
@@ -190,19 +190,19 @@ msgstr ""
 "Confira que já introduziste um localização ou então use uma localização "
 "automática"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Não foi possível encontrar localizações baseadas no endereço, por favor "
 "verifique se está correto"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Não foi possível chamar a API de geolocalização, verifique o Looking Glass "
 "(Aparência Vidrada) por erros."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Aviso"
 
@@ -212,17 +212,17 @@ msgstr ""
 "Pode guardar as localizações corretas apenas quando o applet não está "
 "recarregando"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Não pode guardar uma localização incorreta"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Informação"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "A localização já está guardada"
 
@@ -260,15 +260,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Sensação térmica"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Não foi possível processar a informação do clima"
 
@@ -281,7 +281,7 @@ msgstr ""
 "ou antes obtenha uma em https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -289,7 +289,7 @@ msgstr ""
 "Por favor confirme que\n"
 "já introduziste a chave da API corretamente e a sua conta não está bloquiada"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -300,254 +300,268 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Chuva forte"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Chuva"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Chuva leve"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Chuva pesada congelante"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Chuva congelante"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Chuva congelante"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "Geada"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Geada"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "Geada"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Granizo pesado"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Granizo de gelo"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Granizo leve de gelo"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Forte nevada"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Neve"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Neve fraca"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Flocos de neve"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Tempestade"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Neblina leve"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Neblina"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Nublado"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Muito nublado"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Maioritariamente limpo"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Limpo"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Ensolarado"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -571,7 +585,7 @@ msgstr ""
 "Por favor insira a chave da API nas definições,\n"
 "ou primeiro obtenha uma em https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -579,7 +593,7 @@ msgstr ""
 "Por favor confirme que já,\n"
 "introduziste a chave da API que já tens do DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Não foi possível obter a localização"
 
@@ -590,122 +604,123 @@ msgstr ""
 "Serviço de localização respondido com erros, por favor verifique os registos "
 "no Looking Glass (Aparência Vidrada)"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Nublado"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Limpo"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Limpo"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Chuva pesada com trovões"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Fortes pancadas de chuva"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Fortes pancadas de chuva com trovões"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Granizo forte"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Granizo"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Fortes pancadas de granizo"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Fortes pancadas de granizo com trovões"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Neve com trovadas"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Fortes pancadas de neve"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Fortes pancadas de neve com trovões"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Chuva leve com trovoadas"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Pancada de chuva fraca"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Pancada de chuva fraca com trovões"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Granizo leve"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Granizo leve com trovoadas"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Pancadas de granizo leve"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Pancadas de granizo leve com trovões"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Nevada leve com trovoada"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Pancadas leves de neve"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Pancadas leves de neve com trovões"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Chuva e trovões"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Pancadas de chuva"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Pancadas de chuva com trovoadas"
 
@@ -714,45 +729,46 @@ msgstr "Pancadas de chuva com trovoadas"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Granizo"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Granizo e trovão"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Pancadas de granizo"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Pancadas de granizo com trovões"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Neve e trovões"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Pancadas de neve"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Pancadas de neve e trovões"
 
@@ -761,20 +777,20 @@ msgstr "Pancadas de neve e trovões"
 msgid "Unexpected response from API"
 msgstr "Resposta inesperada da API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Visibilidade"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Falha no processamento da informação atual do clima"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Falha no processamento da informação das previsões"
 
@@ -803,94 +819,98 @@ msgid "Excellent - More than"
 msgstr "Excelente - Mais que"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Névoa"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Nublado"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Pancadas leve de chuva"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Chuvisco"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Fortes pancadas de chuva"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Chuvas de granizo"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Granizo"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Nevadas"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Neve fraca"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Forte nevada"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Tempestade"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Tempestades"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Certifique-se de que a localização esteja no formato correto nas "
 "configurações"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Certifique-se de inserir a chave correta nas configurações"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -898,212 +918,228 @@ msgstr ""
 "Local não encontrado, verifique se o local está disponível ou no formato "
 "correto"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Se o problema persistir, entre em contato com o autor deste applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 "Erro desconhecido, consulte os registos no Looking Glass (Aparência Vidrada)"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Trovoada com chuva fraca"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Tempestade com chuva"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Trovoada com chuva forte"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Tempestade leve"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Tempestade severa"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Tempestades isoladas"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Trovoada com chuvisco leve"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Tempestade com chuvisco"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Trovoada com chuvisco forte"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Chuvisco de intensidade leve"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Chuvisco de intensidade forte"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Chuva chuvisca de intensidade leve"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Chuvisco"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Chuva chuvisca de intensidade forte"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Pancadas de chuva e chuvisco"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Pancadas fortes de chuva e chuvisco"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Chuvisco"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Chuva moderada"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Chuva pesada"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Chuva muito pesada"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Chuva extrema"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Chuva de intensidade leve"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Chuva"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Chuva de alta intensidade"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Chuva irregular"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Chuva de granizo"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Chuva leve com neve"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Chuva e neve"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Neve fraca"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Neve"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Forte nevada"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Fumaça"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Neblina"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Areia, redemoinhos de poeira"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Areia"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Neblina"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Cinza vulcanica"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Rajadas"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "O céu está limp"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Nublado"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Poucas núvens"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Nuvens dispersas"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Nuvens quebradas"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Nuvens nublados"
 
@@ -1111,72 +1147,72 @@ msgstr "Nuvens nublados"
 msgid "Could not get forecast for your area"
 msgstr "Não foi possível obter a previsão para sua área"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "A localização é fora dos EUA. Use um provedor diferente."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Falha ao processar informações de previsão por hora"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Claro e ventoso"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Ventoso e com poucas nuvens"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Parcialmente nublado e ventoso"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Muito nublado e ventoso"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Nublado e ventoso"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Flocos de neve"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Chuva congelada"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Furacão"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Tempestade"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tempestade tropical"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Quente"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Frio"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Nevasca"
 
@@ -1216,79 +1252,79 @@ msgstr "Sexta-feira"
 msgid "Saturday"
 msgstr "Sábado"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Calmo"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Ar leve"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Brisa leve"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Brisa gentil"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Brisa moderada"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Brisa fresca"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Brisa forte"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Quase ventania"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Ventania"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Ventania forte"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Tempestade violenta"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr ""
 
@@ -1340,7 +1376,7 @@ msgstr ""
 "Ocorreu um erro desconhecido ao obter o clima, consulte os registos do "
 "Looking Glass (Aparência Vidrada) para obter mais informações"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tempestade tropical"
 
@@ -1348,7 +1384,7 @@ msgstr "Tempestade tropical"
 msgid "Severe Thunderstorms"
 msgstr "Tempestade severa"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Tempestade"
 
@@ -1364,17 +1400,17 @@ msgstr "Granizo e chuva"
 msgid "Mixed Snow and Sleet"
 msgstr "Granizo e neve"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Geada"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Chuva congelada"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Chuva"
 
@@ -1386,11 +1422,11 @@ msgstr "Flocos de neve"
 msgid "Light Snow Showers"
 msgstr "Neve fraca"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Nevasca"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Neblina"
 
@@ -1402,62 +1438,63 @@ msgstr "Niebla"
 msgid "Blustery"
 msgstr "Rajadas de vento"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Ventoso"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Muito nublado"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "Muito nublado"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "Chuva e granizo"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Tempestades isoladas"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Tempestades isoladas"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Chuvas Isoladas"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "Forte nevada"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Nevadas isoladas"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Forte nevada"
@@ -1488,11 +1525,11 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1500,276 +1537,320 @@ msgstr ""
 "MET Office UK cobre apenas o Reino Unido, certifique-se de que sua "
 "localização esteja neste país"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Não foram encontrados dados para localização"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Muito fraco"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Menos que {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Excelente"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mais que {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Fraco"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Entre {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Moderado"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Bom"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Muito bom"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Rajadas"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Neve fraca"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr ""
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Vento leve"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Vento forte"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Atravessamento visual"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Nevasca"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Geada pesada"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Geada pesada/chuva"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Neve fraca"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Chuvisco pesado/chuva"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Forte nevada"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Tempestade de poeira"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Flocos de neve"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Geada congelante/chuva congelante"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Pancadas de neve"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Geada forte congelante/chuva congelante"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Geada leve congelante/chuva congelante"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Névoa congelante"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr ""
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Vento leve"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Vento forte"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Atravessamento visual"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Nevasca"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Geada pesada/chuva"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Chuvisco pesado/chuva"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Tempestade de poeira"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Geada congelante/chuva congelante"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Geada forte congelante/chuva congelante"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Geada leve congelante/chuva congelante"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Nuvem funil/tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Chuvas de granizo"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Gelo"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Relâmpago sem trovão"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Precipitação nas proximidades"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Chuva pesada e neve"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Chuva leve e neve"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Cobertura do céu diminuindo"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Cobertura do céu aumentando"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Céu inalterado"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Fumaça ou neblina"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Pancadas de neve e chuva"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Trovoada sem precipitação"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Pó de diamante"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Certifique-se de inserir a chave API corretamente"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NÂO ENCONTRADO"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Nevasca"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "Nevasca"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Nevada moderada"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Pancadas moderadas de chuva"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Chuva e neve"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Chuva e neve fortes"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Selecione um provedor ou local diferente"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Clima subterrâneo"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "A chave de API que você forneceu é inválida."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "O local que você forneceu não foi encontrado."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Tempestade forte"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Chuva e neve"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Granizo e chuva"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Nevadas"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Brisado"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Gelado"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Muito claro"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Por favor confirme que\n"
+"já introduziste a chave da API que tens do Climacell"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1777,46 +1858,41 @@ msgstr ""
 "O Serviço de localização não conseguiu encontrar sua localização. Consulte "
 "os registros no Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Maioritariamente limpo"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Flocos de neve"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Neve fraca"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Forte nevada"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Trovoada com chuva fraca"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Tempestade com chuva"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Sensação térmica"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1825,7 +1901,7 @@ msgstr ""
 "caminhos\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1833,103 +1909,103 @@ msgstr ""
 "Não foi possível obter o conteúdo do arquivo de configuração no caminho\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr "Certifique-se de inserir um local ou use a localização automática."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Este provedor requer uma chave de API para operar"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Ponto de condensação da água"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "A precipitação terminará em {precipEnd} minutos"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "A precipitação não terminará dentro de uma hora"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "A precipitação começará dentro de {precipStart} minutos"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Falha na análise da previsão. Consulte os registos para obter mais detalhes."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Às {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} de ti"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Nome da estação: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Área: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Erro ao salvar informações de depuração"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Não foi possível obter informação do clima"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Erro ao salvar informações de depuração"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Guardado em {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "Clima"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2330,7 +2406,6 @@ msgid "Weather conditions"
 msgstr "Condições do clima"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Traduzir condições"
 
@@ -2644,6 +2719,17 @@ msgstr "Exibir a direção do vento como texto"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Como SE, N em vez de ícones de direção."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/pt_BR.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/pt_BR.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl 2.6.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2023-04-14 18:10-0300\n"
 "Last-Translator: Fúlvio Alves <fga.fulvio@gmail.com>\n"
 "Language-Team: Português <jorgebadad@gmail.com>\n"
@@ -21,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Erro"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Erro de serviço"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Chave API Incorreta"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Formato de local incorreto"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Chave bloqueada"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Não pode encontrar o local"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Sem chave API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Sem local"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Pacotes ausentes"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Local não coberto"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Miniaplicativo Meteorológico"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Clique para abrir"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -89,8 +89,8 @@ msgstr "A API retornou o código de status entre 400 e 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Loja de Locais"
 
@@ -102,13 +102,13 @@ msgstr "Você não pode salvar um local obtido automaticamente, desculpe"
 msgid "Could not get weather information"
 msgstr "Não foi possível obter informações meteorológicas"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Erro inesperado ao atualizar o tempo. Consulte o registro em Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +124,7 @@ msgstr "Erro de rede. Verifique o registro em Looking Glass"
 msgid "As of"
 msgstr "A partir de"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Distribuído por"
 
@@ -132,52 +132,52 @@ msgstr "Distribuído por"
 msgid "from you"
 msgstr "de você"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "pol"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Carregando as condições meteorológicas atuais ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Carregando as condições meteorológicas futuras ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Carregando ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Umidade"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Pressão"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vento"
 
@@ -185,18 +185,18 @@ msgstr "Vento"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "Verifique se você inseriu um local ou use a localização automática"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Não foi possível encontrar o local com base no endereço. Verifique se está "
 "correto"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Falha ao chamar a API de geolocalização. Consulte Looking Glass para erros."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Aviso"
 
@@ -205,17 +205,17 @@ msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Você só pode salvar locais corretos quando o applet não estiver atualizando"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Você não pode salvar um local incorreto"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Informação"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "O local já está salvo"
 
@@ -253,15 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Sensação Térmica"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Falha ao processar informações meteorológicas"
 
@@ -274,7 +274,7 @@ msgstr ""
 "ou obtenha uma primeiro em https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -282,7 +282,7 @@ msgstr ""
 "Tenha certeza de que você \n"
 "informou a chave API correta e que sua conta não está bloqueada"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -293,252 +293,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Chuva forte"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Chuva"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Chuva leve"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Chuva congelante forte"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Chuva congelante"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Chuva congelante fraca"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Garoa congelante leve"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Garoa congelante"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Garoa leve"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Granizo forte"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Granizo"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Granizo leve"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Neve forte"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Neve"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Neve leve"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Rajadas"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Tempestade"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Nevoeiro leve"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Névoa"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Nublado"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Predominantemente nublado"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Predominantemente limpo"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Limpo"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Ensolarado"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -562,7 +576,7 @@ msgstr ""
 "Favor insira a chave API nas configurações, \n"
 "ou obtenha uma primeiro em https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -570,7 +584,7 @@ msgstr ""
 "Tenha certeza de que você \n"
 "inseriu a chave API que você tem de DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Não foi possível obter o local"
 
@@ -581,122 +595,123 @@ msgstr ""
 "O Serviço de Localização respondeu com erros. Consulte os registros em "
 "Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Nebulosidade"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Céu limpo"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Tempo calmo e claro"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Chuva forte e trovões"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Chuvas fortes isoladas"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Chuvas fortes isoladas e trovões"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Granizo forte"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Granizo forte e trovões"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Granizo forte isolado"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Granizo forte isolado e trovões"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Neve intensa e trovões"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Neve intensa e isolada"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Neve intensa, isolada e trovões"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Chuva leve e trovões"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Chuva leve isolada"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Chuva leve isolada e trovões"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Granizo fraco"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Granizo fraco e trovões"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Granizo fraco isolado"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Granizo fraco isolado e trovões"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Neve fraca e trovões"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Neve fraca isolada"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Neve fraca isolada e trovões"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Chuva e trovões"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Chuvas isoladas"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Chuva isoladas e trovões"
 
@@ -705,45 +720,46 @@ msgstr "Chuva isoladas e trovões"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Granizo"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Granizo e trovões"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Granizo isolado"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Granizo isolado e trovões"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Neve e trovões"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Neve isolada"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Neve isolada e trovões"
 
@@ -752,20 +768,20 @@ msgstr "Neve isolada e trovões"
 msgid "Unexpected response from API"
 msgstr "Resposta inesperada de API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Visibilidade"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Falha ao processar informações meteorológicas atuais"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Falha ao processar informações de previsão"
 
@@ -794,92 +810,96 @@ msgid "Excellent - More than"
 msgstr "Excelente - Mais de"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Névoa"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Muito nublado"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Chuva leve isolada"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Garoa"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Chuva intensa isolada"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Granizo isolado"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Bolas de granizo"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Bolas de granizo isoladas"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Neve leve isolada"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Neve intensa isolada"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Trovões"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Trovões isolados"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Tenha certeza de que o local está no formato correto nas Configurações"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Tenha certeza de que você introduziu a chave correta nas configurações"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -887,211 +907,227 @@ msgstr ""
 "Local não encontrado. Tenha certeza que seu local está disponível ou que "
 "está no formato correto"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Se este problema persistir, contate o Autor deste applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Erro desconhecido. Consulte o registro em Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Tempestade com chuva leve"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Tempestade com chuva"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Tempestade com chuva forte"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Tempestade leve"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Tempestade forte"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Tempestade irregular"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Tempestade com garoa leve"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Tempestade com garoa"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Tempestade com garoa forte"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Garoa leve"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Garoa forte"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Chuva com garoa de intensidade leve"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Chuva com garoa"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Chuva com garoa de intensidade forte"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Chuva isolada e garoa"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Chuva isolada forte e garoa"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Garoa isolada"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Chuva moderada"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Chuva forte"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Chuva muito forte"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Chuva extrema"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Chuva isolada leve"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Chuva isolada"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Chuva isolada forte"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Chuva isolada irregular"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Granizo isolado"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Chuva leve e neve"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Chuva e neve"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Neve leve isolada"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Neve isolada"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Neve isolada intensa"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Fumaça"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Neblina"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Areia, redemoinhos de poeira"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Areia"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Poeira"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Cinza vulcânica"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Rajadas"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "O céu está limpo"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Nuvens"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Poucas nuvens"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Nuvens dispersas"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Nuvens quebradas"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Muito nublado"
 
@@ -1099,72 +1135,72 @@ msgstr "Muito nublado"
 msgid "Could not get forecast for your area"
 msgstr "Não foi possível obter a previsão para sua área"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "O local fica fora dos EUA. Utilize um provedor diferente."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Falha ao processar informações de previsão por hora"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Limpo e ventoso"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Poucas nuvens e ventoso"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Parcialmente nublado e ventoso"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Maiormente nublado e ventoso"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Muito nublado e ventoso"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Chuva com neve"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Chuva Congelante e neve"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Furacão"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Tempestade"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tempestade tropical"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Quente"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Frio"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Nevasca"
 
@@ -1204,79 +1240,79 @@ msgstr "Sexta-feira"
 msgid "Saturday"
 msgstr "Sábado"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Calmo"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Ar leve"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Brisa leve"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Brisa suave"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Brisa moderada"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Brisa fresca"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Brisa forte"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Perto de vendaval"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Vendaval"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Vendaval forte"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Tempestade violenta"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "L"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NO"
 
@@ -1328,7 +1364,7 @@ msgstr ""
 "Ocorreu um erro desconhecido ao obter o clima. Consulte os registros no "
 "Looking Glass para mais informações"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tempestade tropical"
 
@@ -1336,7 +1372,7 @@ msgstr "Tempestade tropical"
 msgid "Severe Thunderstorms"
 msgstr "Tempestades severas"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Tempestades"
 
@@ -1352,17 +1388,17 @@ msgstr "Chuva e granizo misturados"
 msgid "Mixed Snow and Sleet"
 msgstr "Neve e granizo misturados"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Garoa gelada"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Chuva gelada"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Chuvas isoladas"
 
@@ -1374,11 +1410,11 @@ msgstr "Flocos de neve"
 msgid "Light Snow Showers"
 msgstr "Neve leve isolada"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Neve com vento"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Nebuloso"
 
@@ -1390,54 +1426,55 @@ msgstr "Esfumaçado"
 msgid "Blustery"
 msgstr "Tempestuoso"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Ventoso"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Predominantemente nublado"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Predominantemente ensolarado"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Chuva e granizo misturados"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Tempestades isoladas"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Tempestades dispersas"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Chuvas isoladas dispersas"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Chuva forte"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Neve dispersa isolada"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Neve intensa"
 
@@ -1467,295 +1504,339 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Não foram encontrados dados para o local"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Muito pouca"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Menos que {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Excelente"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mais de {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Pouca"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Entre {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Moderada"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Bom"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Muito boa"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Rajadas"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Neve leve isolada"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET da Noruega"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Vento leve"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Vendaval forte"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "USWeather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Soprando ou arrastando neve"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Garoa forte"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Garoa forte/chuva"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Neve leve isolada"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Garoa leve/chuva"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Neve isolada intensa"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Tempestade de areia"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Chuva com neve"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Garoa gelada/chuva gelada"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Neve isolada"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Garoa gelada forte/chuva gelada"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Garoa gelada leve/chuva gelada"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Névoa gelada"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Vento leve"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Vendaval forte"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "USWeather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Soprando ou arrastando neve"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Garoa forte/chuva"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Garoa leve/chuva"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Tempestade de areia"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Garoa gelada/chuva gelada"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Garoa gelada forte/chuva gelada"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Garoa gelada leve/chuva gelada"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Nuvem em funil/tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Granizo"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Gelo"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Relâmpagos sem trovão"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Precipitação na vizinhança"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Chuva forte e trovões"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Chuva leve e neve"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Cobertura do céu diminuindo"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Cobertura do céu aumentando"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Céu inalterado"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Fumaça ou neblina"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Pancadas de neve e chuva"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Tempestade sem precipitação"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Cristais de gelo"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 "Favor tenha certeza que você \n"
 "inseriu a chave API corretamente"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NÃO ENCONTRADO"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Neve com vento"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Neve leve"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Neve moderada"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Pancadas de chuva moderada"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Chuva e neve misturadas"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Chuva e neve misturadas fortemente"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 #, fuzzy
 msgid "AccuWeather"
 msgstr "Clima"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 #, fuzzy
 msgid "Weather Underground"
 msgstr "Condições meteorológicas"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 #, fuzzy
 msgid "The location you provided was not found."
 msgstr "Nenhum local fornecido"
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 #, fuzzy
 msgid "Strong Storm"
 msgstr "Brisa forte"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Chuva e neve"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Chuva e granizo misturados"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Neve Isolada"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Predominantemente limpo"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "USWeather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Tenha certeza de que você \n"
+"inseriu a chave API que você tem de Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1764,46 +1845,41 @@ msgstr ""
 "O Serviço de Localização respondeu com erros. Consulte os registros em "
 "Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Predominantemente limpo"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Chuva com neve"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Neve leve isolada"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Neve isolada intensa"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Tempestade com chuva leve"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Tempestade com chuva"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Sensação Térmica"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 #, fuzzy
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
@@ -1813,7 +1889,7 @@ msgstr ""
 "caminho\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1821,104 +1897,104 @@ msgstr ""
 "Não foi possível obter o conteúdo do arquivo de configuração no caminho\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr "Verifique se você inseriu um local ou use a localização automática"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Este provedor requer uma chave API para operar"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Ponto de orvalho"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "A precipitação terminará em {precipEnd} minutos"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "A precipitação não terminará dentro de uma hora"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "A precipitação começará dentro de {precipStart} minutos"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Falha na análise da previsão. Consulte os registros para obter mais detalhes."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "A partir de {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} de você"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Erro ao salvar informações de depuração"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Não foi possível obter informações meteorológicas"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Informações de depuração salvas com sucesso"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Salvo em {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "USWeather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2321,7 +2397,6 @@ msgid "Weather conditions"
 msgstr "Condições meteorológicas"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Traduzir condições"
 
@@ -2636,6 +2711,17 @@ msgstr "Exibir a direção do vento como texto"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Como SE,N em vez de ícones de direção."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/ro.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ro.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: simon04-gnome-shell-extension-weather\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-02-16 11:25+0100\n"
 "Last-Translator: Marian Vasile <marianvasile@upcmail.ro> și Dorian Baciu\n"
 "Language-Team: \n"
@@ -22,65 +22,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Clic pentru a deschide"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr ""
 
@@ -90,8 +90,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -103,12 +103,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -122,7 +122,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -130,55 +130,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Se încarcă vremea curentă..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Se încarcă prognoza..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Se încarcă"
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "Temperatură:"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "Umiditate:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "Presiune:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "Vânt:"
@@ -187,15 +187,15 @@ msgstr "Vânt:"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -203,17 +203,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -249,15 +249,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -268,13 +268,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -283,12 +283,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "Ninsoare abundentă"
@@ -296,38 +297,41 @@ msgstr "Ninsoare abundentă"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "Ploaie rece"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "Ploaie rece"
@@ -335,168 +339,175 @@ msgstr "Ploaie rece"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Ploaie rece"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "Ploaie rece"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "Burniță rece"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Burniță rece"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "Burniță rece"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Ninsoare abundentă"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Ninsoare"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "Ninsoare ușoară"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "Furtuni"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "Ceață"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Înnorat"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Majoritar înnorat"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Parțial înnorat"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "Majoritar înnorat"
@@ -504,42 +515,45 @@ msgstr "Majoritar înnorat"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Senin"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Însorit"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -561,13 +575,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -576,136 +590,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "Înnorat"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "Senin"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Vreme bună"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "Ninsoare abundentă"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "Ninsoare abundentă"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "Ninsoare abundentă"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "Ninsoare abundentă"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "Ninsori în averse"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "Ninsoare ușoară în averse"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "Ninsori în averse"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -714,47 +729,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Lapoviță"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "Furtuni răzlețe"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "Averse răzlețe"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Ninsori în averse"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "Ninsori în averse"
@@ -764,20 +780,20 @@ msgstr "Ninsori în averse"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -806,330 +822,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "Ninsoare ușoară în averse"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Burniță"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "Ninsoare abundentă"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "Averse răzlețe"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Grindină"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "Ninsori în averse"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "Ninsoare abundentă"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "Furtuni"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "Ploi abundente în averse"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "Furtuni"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "Furtuni"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "Furtuni severe"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "Furtuni izolate"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "Furtuni"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "Burniță"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "Ploaie cu grindină"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "Burniță rece"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "Ploaie rece"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "Averse"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "Averse"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "Lapoviță"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "Lapoviță"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "Averse"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "Ninsoare abundentă"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "Întunecat"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Ceață ușoară"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Praf"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornadă"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "Înnorat"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "Averse răzlețe"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1137,76 +1173,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "Parțial înnorat"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "Majoritar înnorat"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "Ninsoare ușoară"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "Ploaie rece"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Uragan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Furtună tropicală"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Foarte cald"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Rece"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1246,79 +1282,79 @@ msgstr "Vineri"
 msgid "Saturday"
 msgstr "Sâmbătă"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NV"
 
@@ -1363,7 +1399,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "Furtună tropicală"
@@ -1373,7 +1409,7 @@ msgstr "Furtună tropicală"
 msgid "Severe Thunderstorms"
 msgstr "Furtuni severe"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Furtuni"
 
@@ -1392,19 +1428,19 @@ msgstr "Măzăriche"
 msgid "Mixed Snow and Sleet"
 msgstr "Măzăriche"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "Burniță rece"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "Ploaie rece"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Averse"
 
@@ -1418,12 +1454,12 @@ msgstr "Ninsoare ușoară"
 msgid "Light Snow Showers"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "Ninsoare viscolită"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Ceață"
 
@@ -1435,63 +1471,64 @@ msgstr "Întunecat"
 msgid "Blustery"
 msgstr "Zgomotos"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Rafale de vânt"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "Majoritar înnorat"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "Parțial înnorat"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "Majoritar înnorat"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "Ploaie cu grindină"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Furtuni izolate"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Furtuni răzlețe"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Averse răzlețe"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "Ninsoare abundentă"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Ninsori răzlețe"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Ninsoare abundentă"
@@ -1519,452 +1556,487 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Ninsoare ușoară în averse"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "Mâine"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "Ninsoare viscolită"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "Burniță rece"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "Burniță rece"
+msgid "Light shower rain"
+msgstr "Ninsoare ușoară în averse"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Ninsoare abundentă"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Ninsoare ușoară"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Ninsori în averse"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "Ploaie rece"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Mâine"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Ninsoare viscolită"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Burniță rece"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "Ninsori în averse"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "Lapoviță"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "Lapoviță"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "Ninsori în averse"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "Parțial înnorat"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Ninsoare viscolită"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "Ninsoare viscolită"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "Ninsoare abundentă"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "Averse răzlețe"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Lapoviță"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "Lapoviță"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Lapoviță"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Măzăriche"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Ninsori în averse"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Majoritar înnorat"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Majoritar înnorat"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Ninsoare ușoară"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Ninsoare ușoară în averse"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Ninsoare abundentă"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Furtuni"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Furtuni"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2361,7 +2433,6 @@ msgid "Weather conditions"
 msgstr ""
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr ""
 
@@ -2638,6 +2709,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/ru.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ru.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-07-20 14:32+0600\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -23,65 +23,65 @@ msgstr ""
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Ошибка"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Ошибка сервиса"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Неверный ключа API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Неверный формат местоположения"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Ключ заблокирован"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Невозможно найти местоположение"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Нет ключа API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Нет местоположения"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Отсутствуют пакеты"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Местоположение не поддерживается"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Погода"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Нажмите дял открытия"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Обновить"
 
@@ -91,8 +91,8 @@ msgstr "API вернул код статуса между 400 и 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Хранение местоположения"
 
@@ -105,13 +105,13 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Невозможно получить информацию о погоде"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Неожиданная ошибка во время обновления погоды, см. логи в Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -127,7 +127,7 @@ msgstr "Ошибка сети, см. логи в Looking Glass"
 msgid "As of"
 msgstr "По состоянию на"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "При помощи"
 
@@ -135,52 +135,52 @@ msgstr "При помощи"
 msgid "from you"
 msgstr "от вас"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "мм"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "миль"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "км"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Загрузка текущей погоды ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Загрузка прогноза погоды ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Загрузка ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Температура"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Влажность"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Давление"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Ветер"
 
@@ -190,17 +190,17 @@ msgstr ""
 "Убедитесь, что вы ввели местоположение или используйте автоматическое "
 "местоположение"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Невозможно найти местоположение по адресу, пожалуйста убедитесь, что данные "
 "верны"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Не удалось вызвать Geolocation API, см. логи в Looking Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Предупреждение"
 
@@ -210,17 +210,17 @@ msgstr ""
 "Вы можете сохранить правильное местопооложение только когда аплет не "
 "обновляется"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Вы не можете сохранить неверное местоположение"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Инфомрация"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Местоположение уже сохранено"
 
@@ -258,15 +258,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Ощущается как"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Не удалось обработать информацию о погоде"
 
@@ -279,7 +279,7 @@ msgstr ""
 "или сначала получите его на https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -287,7 +287,7 @@ msgstr ""
 "Пожалуйста убедитесь, что\n"
 "введённый ключ API правильный и ваш аккаунт не заблокирован"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -298,252 +298,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Сильный дождь"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Дождь"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Небольшой дождь"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Сильный ледяной дождь"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Ледяной дождь"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Небольшой ледяной дождь"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Лёгкая изморось"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Изморось"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Лёгкая морось"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Сильный град"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Град"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Небольшой град"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Сильный снегопад"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Снегопад"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Лёгкий снегопад"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Кратковременные снегопады"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Гроза"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Лёгкий туман"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Туман"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Облачно"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Облачно с прояснениями"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Переменная облачность"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Преимущественно ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Солнечно"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Неизвестно"
 
@@ -567,7 +581,7 @@ msgstr ""
 "Пожалуйста введите ключ API в настройках,\n"
 "или сначала получите на https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -575,7 +589,7 @@ msgstr ""
 "Пожалуйста убедитесь, что\n"
 "введённый ключ API совпадает с ключем от DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Не удалось получить местоположение"
 
@@ -584,122 +598,123 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Сервис местоположения ответил с ошибками, см. логи в Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Облачно"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Ясно"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Ясно"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Сильный дождь с грозой"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Проливные дожди"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Проливные дожди с грозой"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Сильный мокрый снегопад"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Сильный мокрый снегопад с грозой"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Сильный дождь с мокрым снегом"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Сильный дождь с мокрым снегом и грозой"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Сильный снегопад с грозой"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Сильный снегопад"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Сильный снегопад с грозой"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Небольшой дожль с грозой"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Врменами небольшой дождь"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Небольшой дождь с грозой"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Небольшой мокрый снегопад"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Небольшой мокрый снегопад с грозой"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Небольшой мокрый снегопад"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Небольшой мокрый снегопад с грозой"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Небольшой снегопад с грозой"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Небольшой снегопад"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Небольшой снегопад с грозой"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Дождь с грозой"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Временами дожди"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Временами дожди с грозой"
 
@@ -708,45 +723,46 @@ msgstr "Временами дожди с грозой"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Мокрый снег"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Мокрый снег с грозой"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Мокрый снегопад"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Мокрый снегопад с грозой"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Снег с грозой"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Снег"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Снег с грозой"
 
@@ -755,20 +771,20 @@ msgstr "Снег с грозой"
 msgid "Unexpected response from API"
 msgstr "Неожиданный ответ от API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Видимость"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Не удалось обработать текущую информацию о погоде"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Не удалось обработать прогноз погоды"
 
@@ -797,302 +813,322 @@ msgid "Excellent - More than"
 msgstr "Отличная - более чем"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Туман"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Пасмурно"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Небольшие дожди"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Морось"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Сильные дожди"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Дождь со снегом"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Град"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Временами град"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Лёгкие снегопады"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Сильные снегопады"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Гроза"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Дождь с грозой"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Пожалуйста, убедитесь, что формат местоположения в настройках верный"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Убедитесь, что введённый в настройках ключ верный"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr "Местоположение не найдено, убедитесь, что оно доступно и формат верный"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Если это проблема повторяетс, пожалуйста, обратитесь к автору апплета"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Неожиданная ошибка, см. логи в Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Гроза, небольшой дождь"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Гроза, дождь"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Гроза, сильный дождь"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Лёгкая гроза"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Сильная гроза"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Рваная гроза"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Гроза с мелким дождём"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Гроза с моросью"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Гроза с сильным моросящим дождём"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Мороящий дождь"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Сильный дождь"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Лёгкий интетсивный моросящий дождь"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Моросящий дождь"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Сильный интетсивный моросящий дождь"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Ливень и морось"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Сильный ливень и морось"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Моросящий дождь"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Умеренный дождь"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Сильный дождь"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Сильный ливень"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Экстремальный ливень"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Лёгкий ливень"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Ливень"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Сильный ливень"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Местами дождь"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Мокрый снег"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Лёгкий снег с дождём"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Дождь со снегом"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Лёгкий снег"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Снег"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Сильный снегопад"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Дым"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Туман"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Песок, пыльные вихри"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Песок"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Пыль"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Вулканический пепел"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Шквал"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Смерч"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Ясное небо"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Облачно"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Местами облачно"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Рассыпчатые обака"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Прерывистые облака"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Тучи"
 
@@ -1100,72 +1136,72 @@ msgstr "Тучи"
 msgid "Could not get forecast for your area"
 msgstr "Не удалось получить прогноз для вашей местности"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Местоположение вне США, используйте другой сервис."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Не удалось обработать почасовой прогноз"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Ясно и ветренно"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Местами облака и ветренно"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Прерывистые облака и ветренно"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Преимущественно облачн о и ветренно"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Пасмурно и ветренно"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Снег с дождём"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Моросящий дождь со снегом"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Ураган"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Шторм"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Тропический шторм"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Жарко"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Холодно"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Метель"
 
@@ -1205,79 +1241,79 @@ msgstr "Пятница"
 msgid "Saturday"
 msgstr "Суббота"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Штиль"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Лёгкий ветерок"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Лёгкий ветер"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Слабый ветер"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Умеренный ветер"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Свежий ветер"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Сильный ветер"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Почти шторм"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Шторм"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Сильный шторм"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Очень сильный шторм"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "С"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "СВ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "В"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "ЮВ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "Ю"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "ЮЗ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "З"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "СЗ"
 
@@ -1328,7 +1364,7 @@ msgid ""
 msgstr ""
 "Неожиданная ошибка во время обновления погоды, см. логи в Looking Glass"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Тропический шторм"
 
@@ -1336,7 +1372,7 @@ msgstr "Тропический шторм"
 msgid "Severe Thunderstorms"
 msgstr "Сильный грозы"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Грозы"
 
@@ -1352,17 +1388,17 @@ msgstr "Дождь со снегом"
 msgid "Mixed Snow and Sleet"
 msgstr "Снег/мокрый снег"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Изморось"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Холодный дождь"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Ливень"
 
@@ -1374,11 +1410,11 @@ msgstr "Порывы снега"
 msgid "Light Snow Showers"
 msgstr "Небольшой снегопад"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Метель"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Туман"
 
@@ -1390,54 +1426,55 @@ msgstr "Дымно"
 msgid "Blustery"
 msgstr "Порывистый ветер"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Ветренно"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Преимущественная облачность"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Переменная облачность"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Преимущественно ясно"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Дождь с градом"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Отдельные грозы"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Местами грозы"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Местами дожди"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Сильный дождь"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Местами дожди со снегом"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Сильный снегопад"
 
@@ -1462,452 +1499,491 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Данные для местоположения не найдены"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Очень плохая"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Менее чем {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Отличная"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Более чем {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Плохая"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Между {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Умереннная"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Хорошая"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Очень хорошая"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Шквал"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Лёгкий снег"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
+msgid "Heavy drizzle"
+msgstr "Сильный дождь"
+
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Лёгкий снег"
+
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Сильный снегопад"
+
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Снег с дождём"
+
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Снег"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
+msgid "Freezing fog"
+msgstr "Морозный туман"
+
+#: 3.8/weather-applet.js:13091
 #, fuzzy
 msgid "Tomorrow.io"
 msgstr "Завтра"
 
-#: 3.8/weather-applet.js:13058
+#: 3.8/weather-applet.js:13300
 msgid "Light wind"
 msgstr "Небольшой ветер"
 
-#: 3.8/weather-applet.js:13072
+#: 3.8/weather-applet.js:13314
 msgid "Strong wind"
 msgstr "Сильный ветер"
 
-#: 3.8/weather-applet.js:13422
+#: 3.8/weather-applet.js:13664
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:13997
+#: 3.8/weather-applet.js:14239
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:14191
+#: 3.8/weather-applet.js:14433
 msgid "Blowing or drifting snow"
 msgstr "Метель"
 
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
-msgid "Heavy drizzle"
-msgstr "Сильный дождь"
-
-#: 3.8/weather-applet.js:14199
+#: 3.8/weather-applet.js:14441
 msgid "Heavy drizzle/rain"
 msgstr "Сильный моросящий дождь"
 
-#: 3.8/weather-applet.js:14201
+#: 3.8/weather-applet.js:14443
 msgid "Light drizzle/rain"
 msgstr "Лёгкая морось"
 
-#: 3.8/weather-applet.js:14203
+#: 3.8/weather-applet.js:14445
 #, fuzzy
 msgid "Dust Storm"
 msgstr "Пыльная буря"
 
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:14449
 msgid "Freezing drizzle/freezing rain"
 msgstr "Изморось"
 
-#: 3.8/weather-applet.js:14209
+#: 3.8/weather-applet.js:14451
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Сильный ледяной дождь"
 
-#: 3.8/weather-applet.js:14211
+#: 3.8/weather-applet.js:14453
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Лёгкая изморось"
 
-#: 3.8/weather-applet.js:14213
-msgid "Freezing fog"
-msgstr "Морозный туман"
-
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Смерч"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Ливень с градом"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Лёд"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Молнии без грома"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Осадки поблизости"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Сильный дождь со снегом"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Лёгкий снег с дождём"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Небо проясняется"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Небо темнеет"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Небо без изменений"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Дым или дымка"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Снегопад с ледяным дождём"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Гроза без осадков"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Алмазная пыль"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Переменная облачность"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Пожалуйста убедитесь, что введённый ключ API верный"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "Не найдено"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Позёмки"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Лёгкий снегопад"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Умеренный снегопад"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Умеренный дождь"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Дождь со снегом"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Сильный дождь со снегом"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 #, fuzzy
 msgid "AccuWeather"
 msgstr "Погода"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 #, fuzzy
 msgid "Weather Underground"
 msgstr "Погодные условия"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 #, fuzzy
 msgid "Strong Storm"
 msgstr "Сильный ветер"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Дождь со снегом"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Дождь со снегом"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Снег"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Преимущественно ясно"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Пожалуйста убедитесь, что\n"
+"введённый ключ API совпадает с ключем от Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr "Сервис местоположения ответил с ошибками, см. логи в Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Преимущественно ясно"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Снег с дождём"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Лёгкий снег"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Сильный снегопад"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Гроза, небольшой дождь"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Гроза, дождь"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Ощущается как"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Убедитесь, что вы ввели местоположение или используйте автоматическое "
 "местоположение"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Этот сервис требует ключ API для работы"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Осадки закончатся в течение {precipEnd} минут"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Осадки не закончатся в течение часа"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Осадки начнутся в течение {precipStart} минут"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "По состоянию на {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 #, fuzzy
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} от вас"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Невозможно получить информацию о погоде"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2306,7 +2382,6 @@ msgid "Weather conditions"
 msgstr "Погодные условия"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Переводить погодные условия"
 
@@ -2618,6 +2693,17 @@ msgstr "Отображать направление ветра как текст
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Например ЮВ, С вместо иконок направления"
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/sk.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/sk.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: 3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-08-08 22:01+0200\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: slovenčina <>\n"
@@ -21,65 +21,65 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 1 : (n>=2 && n<=4) ? 2 : 0;\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Chyba"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Chyba služby"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Nesprávny kľúč rozhrania API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Nesprávny formát umiestnenia"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Kľúč je zablokovaný"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Nie je možné nájsť polohu"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Žiadny kľúč API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Žiadna lokácia"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Chýbajúce balíky"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Oblať nie je pokrytá"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Applet Počasie"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Kliknite pre otvorenie"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Obnoviť"
 
@@ -89,8 +89,8 @@ msgstr "Rozhranie API vrátilo stavový kód medzi 400 a 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Ukladací priestor polohy"
 
@@ -102,13 +102,13 @@ msgstr "Polohu získanú automaticky nie je možné uložiť, ľutujeme"
 msgid "Could not get weather information"
 msgstr "Nepodarilo sa získať informácie o počasí"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Neočakávaná chyba pri aktualizácii počasia, pozrite sa do logu Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +124,7 @@ msgstr "Chyba siete, skontrolujte denníky v programe Looking Glass"
 msgid "As of"
 msgstr "Aktualizácia z"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Údaje z"
 
@@ -132,52 +132,52 @@ msgstr "Údaje z"
 msgid "from you"
 msgstr "od Vás"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Načítava sa aktuálne počasie ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Načítava sa predpoveď počasia ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Načítava sa ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Teplota"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Vlhkosť"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Tlak"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vietor"
 
@@ -187,17 +187,17 @@ msgstr ""
 "Uistite sa, že ste zadali miesto, alebo použite namiesto toho automatické "
 "určovanie polohy"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Na základe adresy sa nepodarilo nájsť polohu. Skontrolujte, či je správna"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nepodarilo sa zavolať Geolocation API, chyby nájdete v časti Looking Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Varovanie"
 
@@ -205,17 +205,17 @@ msgstr "Varovanie"
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Správne umiestnenia môžete uložiť iba vtedy, ak sa aplet neobnovuje"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Nemôžete uložiť nesprávnu polohu"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Poloha už je uložená"
 
@@ -252,15 +252,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Pocitovo"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Informácie o počasí sa nepodarilo spracovať"
 
@@ -273,7 +273,7 @@ msgstr ""
 "alebo si kľúč najskôr zaobstarajte na https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -281,7 +281,7 @@ msgstr ""
 "Uistite sa prosím\n"
 "že ste zadali správny kľúč API a že Váš účet nie je uzamknutý"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -292,252 +292,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Silný dážď"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Dážď"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Slabý dážď"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Silný mrznúci dážď"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Mrznúci dážď"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Slabý mrznúci dážď"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Slabé mrznúce mrholenie"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Mráz a mrholenie"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Mierne mrholenie"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Silný ľadovec"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Ľadovec"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Mierny ľadovec"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Husté sneženie"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Sneženie"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Slabé sneženie"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Príval dažďa"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Búrka"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Mierna hmla"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Hmlisto"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Oblačno"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Zamračené"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Polojasno"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Takmer jadno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Slnečno"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Neznáme"
 
@@ -561,7 +575,7 @@ msgstr ""
 "V nastaveniach zadajte kľúč API,\n"
 "alebo si ho najskôr zaobstarajte na https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -569,7 +583,7 @@ msgstr ""
 "Uistite sa prosím,\n"
 "že ste zadali kľúč API, ktorý máte od DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Lokalitu nie je možné nájsť"
 
@@ -580,122 +594,123 @@ msgstr ""
 "Služba určovania polohy odpovedala chybami. Pozrite si denníky v službe "
 "Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Oblačno"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Jasno"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Pekne"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Búrka so silným dažďom"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Silné dažďové prehánky"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Silné dažďové prehánky s búrkou"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Silný dážď"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Silný dážď a búrka"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Silné dažďové prehánky"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Silné dažďové prehánky s búrkou"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Husté sneženie a búrka"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Silné snehové prehánky"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Silné snehové prehánky a búrka"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Slabý dážď a búrka"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Slabé dažďové prehánky"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Slabé dažďové prehánky s búrkou"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Ľahký dážď so snehom"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Ľahký dážď so snehom a búrka"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Ľahký dážď so snehom"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Ľahký dážď so snehom a búrka"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Slabé sneženie a búrka"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Mierne snehové prehánky"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Slabé snehové prehánky a búrka"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Dážď a hrmavica"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Snehové prehánky"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Dažďové prehánky a hrmavica"
 
@@ -704,45 +719,46 @@ msgstr "Dažďové prehánky a hrmavica"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Poľadovica"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Búrka a poľadovica"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Mrznúce prehánky"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Mrznúce prehánky a hrmavica"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Sneženie a hrmavica"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Snehové prehánky"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Snehové prehánky a hrmavica"
 
@@ -751,20 +767,20 @@ msgstr "Snehové prehánky a hrmavica"
 msgid "Unexpected response from API"
 msgstr "Neočakávaná odpoveď z API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Dohľadnosť"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Informácie o aktuálnom počasí sa nepodarilo spracovať"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Informácie o predpovedi sa nepodarilo spracovať"
 
@@ -793,92 +809,96 @@ msgid "Excellent - More than"
 msgstr "Vynikajúce - viac ako"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Hmla"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Zatiahnuté"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Slabé dažďové prehánky"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Mrholenie"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Silná prehánka"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Mrznúca prehánka"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Krúpy"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Prehánky s krúpami"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Mierne snehové prehánky"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Silné snehové prehánky"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Búrky"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Búrky s prehánkami"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "V nastaveniach prosím skontrolujte, či je Poloha v správnom formáte"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Uistite sa, že ste v nastaveniach zadali správny kľúč"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -886,211 +906,227 @@ msgstr ""
 "Poloha sa nenašla, uistite sa, že je k dispozícii, resp. že je v správnom "
 "formáte"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Ak tento problém pretrváva, kontaktujte autora tohto apletu"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Neznáma chyba, pozrite si denníky v programe Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Slabý dážď a búrka"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Búrka s dažďom"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Búrka so silným dažďom"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Slabá búrka"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Silná búrka"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Ojedinelé búrky"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Búrka a mierne mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Búrka a mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Búrka a silné mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Slabé mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Silné mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Slabé mrznúce mrholenie/dážď"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Mrholenie"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Silné mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Mrznúce dažďové prehánky"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Výdatné mrznúce dažďové prehánky"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Mrznúce preánky"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Stredne silný dážď"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Silný dážď"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Veľmi silný dážď"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Extrémny dážď"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Slabé dažďové prehánky"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Prehánky"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Silné dažďové prehánky"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Ojedinelé prehánky"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Prehánky so snehom"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Slabý dážď so snehom"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Dážď so snehom"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Mierne snehové prehánky"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Prehánky"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Silné snehové prehánky"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Dymno"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Hmla"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Prašno"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Prašno"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Prašno"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkanický prach"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Víchor"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornádo"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Jasno"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Oblačno"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Miestami oblačno"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Miestami oblačno"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Miestami oblačno"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Zatiahnuté"
 
@@ -1098,72 +1134,72 @@ msgstr "Zatiahnuté"
 msgid "Could not get forecast for your area"
 msgstr "Predpoveď pre vašu oblasť sa nepodarilo získať"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Poloha sa nachádza mimo USA, použite iného poskytovateľa."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Informácie o hodinovej predpovedi sa nepodarilo spracovať"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Jasno a veterno"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Miestami oblačno a veterno"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Polojasno a veterno"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Takmer zamračené a veterno"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Zatiahnuté a veterno"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Dážď so snehom"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Mrznúci dážď a sneh"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Hurikán"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Búrka"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropická búrka"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Horúco"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Chladno"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Metelica"
 
@@ -1203,79 +1239,79 @@ msgstr "Piatok"
 msgid "Saturday"
 msgstr "Sobota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Bezvetrie"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Svieži vzduch"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Slabý vánok"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Jemný vánok"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Mierny vánok"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Čerstvý vánok"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Silný vánok"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Takmer víchrica"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Víchrica"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Silná víchrica"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Prudká búrka"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "JV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "J"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "JZ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "SZ"
 
@@ -1327,7 +1363,7 @@ msgstr ""
 "Pri získavaní počasia sa vyskytla neznáma chyba, ďalšie informácie nájdete v "
 "denníkoch programu Looking Glass"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropická búrka"
 
@@ -1335,7 +1371,7 @@ msgstr "Tropická búrka"
 msgid "Severe Thunderstorms"
 msgstr "Časté búrky"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Búrky"
 
@@ -1351,17 +1387,17 @@ msgstr "Dážď a poľadovica"
 msgid "Mixed Snow and Sleet"
 msgstr "Sneh a poľadovica"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Mráz a mrholenie"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Mrznúci dážď"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Prehánky"
 
@@ -1373,11 +1409,11 @@ msgstr "Snehové záveje"
 msgid "Light Snow Showers"
 msgstr "Mierne snehové prehánky"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Fujavica"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Hmlisto"
 
@@ -1389,54 +1425,55 @@ msgstr "Dymno"
 msgid "Blustery"
 msgstr "Búrlivo"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Veterno"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Prevažne zamračené"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Miestami oblačno"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Prevažne slnečno"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Dážď s krúpami"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Ojedinelé búrky"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Občasné búrky"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Občasné prehánky"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Hustý dážď"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Občasné snehové prehánky"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Husté sneženie"
 
@@ -1461,295 +1498,339 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "MET Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Údaje o polohe sa nenašli"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Veľmi zlé"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Menej ako {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Vynikajúce"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Viac ako {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Slabé"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Medzi {lessDistance}-{greaterDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Uspokojivé"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Dobré"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Veľmi dobré"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Víchor"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Mierne snehové prehánky"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
+msgid "Heavy drizzle"
+msgstr "Silné mrznúce mrholenie"
+
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Mierne snehové prehánky"
+
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Silné snehové prehánky"
+
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Dážď so snehom"
+
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Snehové prehánky"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
+msgid "Freezing fog"
+msgstr "Mrznúca hmla"
+
+#: 3.8/weather-applet.js:13091
 #, fuzzy
 msgid "Tomorrow.io"
 msgstr "Zajtra"
 
-#: 3.8/weather-applet.js:13058
+#: 3.8/weather-applet.js:13300
 msgid "Light wind"
 msgstr "Slabý vietor"
 
-#: 3.8/weather-applet.js:13072
+#: 3.8/weather-applet.js:13314
 msgid "Strong wind"
 msgstr "Silný vietor"
 
-#: 3.8/weather-applet.js:13422
+#: 3.8/weather-applet.js:13664
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:13997
+#: 3.8/weather-applet.js:14239
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:14191
+#: 3.8/weather-applet.js:14433
 msgid "Blowing or drifting snow"
 msgstr "Fujavica a snehové víry"
 
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
-msgid "Heavy drizzle"
-msgstr "Silné mrznúce mrholenie"
-
-#: 3.8/weather-applet.js:14199
+#: 3.8/weather-applet.js:14441
 msgid "Heavy drizzle/rain"
 msgstr "Silné mrznúce mrholenie/dážď"
 
-#: 3.8/weather-applet.js:14201
+#: 3.8/weather-applet.js:14443
 msgid "Light drizzle/rain"
 msgstr "Slabé mrznúce mrholenie/dážď"
 
-#: 3.8/weather-applet.js:14203
+#: 3.8/weather-applet.js:14445
 #, fuzzy
 msgid "Dust Storm"
 msgstr "Prachová búrka"
 
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:14449
 msgid "Freezing drizzle/freezing rain"
 msgstr "Mráz a mrholenie/dážď"
 
-#: 3.8/weather-applet.js:14209
+#: 3.8/weather-applet.js:14451
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Silné mrznúce mrholenie/dážď"
 
-#: 3.8/weather-applet.js:14211
+#: 3.8/weather-applet.js:14453
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Slabé mrznúce mrholenie/dážď"
 
-#: 3.8/weather-applet.js:14213
-msgid "Freezing fog"
-msgstr "Mrznúca hmla"
-
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Tromba/tornádo"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Krúpové prehánky"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Ľad"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Blýskavica"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Zrážky v okolí"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Výdatný dážď so snehom"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Slabý dážď so snehom"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Ubúdajúca oblačnosť"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Pribúdajúca oblačnosť"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Oblačnosť bez zmeny"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Dymno alebo opar"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Snehové prehánky s dažďom"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Hrmavica"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Diamantový prach"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Miestami oblačno"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Uistite sa, že ste kľúč API zadali správne"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NENÁJDENÉ"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Fujavica"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Slabé sneženie"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Stredne silné sneženie"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Stredne silné prehánky"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Dážď so snehom"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Výdatný dážď so snehom"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 #, fuzzy
 msgid "AccuWeather"
 msgstr "Počasie"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 #, fuzzy
 msgid "Weather Underground"
 msgstr "Poveternostné podmienky"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 #, fuzzy
 msgid "Strong Storm"
 msgstr "Silný vánok"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Dážď so snehom"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Dážď a poľadovica"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Snehové prehánky"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Takmer jadno"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Uistite sa prosím, \n"
+"že sta zadali kľúč API, ktorý máte od Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1758,157 +1839,152 @@ msgstr ""
 "Služba určovania polohy odpovedala chybami. Pozrite si denníky v službe "
 "Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Takmer jadno"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Dážď so snehom"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Mierne snehové prehánky"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Silné snehové prehánky"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Slabý dážď a búrka"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Búrka s dažďom"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Pocitovo"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Uistite sa, že ste zadali miesto, alebo použite namiesto toho automatické "
 "určovanie polohy"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Tento poskytovateľ vyžaduje na svoju činnosť kľúč API"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Zrážky sa skončia o {precipEnd} minúty"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Zrážky sa do hodiny neskončia"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Zrážky začnú do {precipStart} minút"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Aktualizácia z {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 #, fuzzy
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} od vás"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Nepodarilo sa získať informácie o počasí"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2307,7 +2383,6 @@ msgid "Weather conditions"
 msgstr "Poveternostné podmienky"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Preložiť podmienky"
 
@@ -2619,6 +2694,17 @@ msgstr "Zobraziť smer vetra ako text"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Napríklad ako JV, S, namiesto ikonky smeru."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/sl.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/sl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl 3.1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-08-04 14:34+0200\n"
 "Last-Translator: dkrat7 <dkrat7 @github.com>\n"
 "Language-Team: \n"
@@ -19,65 +19,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Napaka"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Napaka storitve"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Napačen ključ za API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Napačna oblika lokacije"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Ključ blokiran"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Ne najdem lokacije"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Manjka ključ za API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Manjka lokacija"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Manjkajo paketi"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Lokacija ni pokrita"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Aplikacija Vreme"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Odpri s klikom"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Osveži"
 
@@ -87,8 +87,8 @@ msgstr "API je vrnil kodo statusa med 400 in 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Shramba lokacij"
 
@@ -100,14 +100,14 @@ msgstr "Samodejno pridobljene lokacije ne morete shraniti"
 msgid "Could not get weather information"
 msgstr "Vremenske informacije ni mogoče pridobiti"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Nepričakovana napaka pri osveževanju Vremena, preverite dnevniški zapis v "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +123,7 @@ msgstr "Napaka mreže, preverite dnevniške zapise (Looking Glass)"
 msgid "As of"
 msgstr "Ob"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Vir podatkov"
 
@@ -131,52 +131,52 @@ msgstr "Vir podatkov"
 msgid "from you"
 msgstr "od vas"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Pridobivam trenutno vreme..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Pridobivam vremensko napoved ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Pridobivam ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Vlažnost"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Zračni tlak"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Veter"
 
@@ -184,18 +184,18 @@ msgstr "Veter"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "Preverite, da ste vnesli lokacijo ali pa uporabite samodejno lokacijo"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Ni bilo mogoče pridobiti lokacije na podlagi naslova, preverite, če je "
 "pravilen"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Neuspešno klicanje geolokacijskega API-ja, preverite Looking Glass za napake."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Opozorilo"
 
@@ -203,17 +203,17 @@ msgstr "Opozorilo"
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Lokacijo lahko shranite samo, ko se aplikacija ne osvežuje"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Nepravilne lokacije ne morete shraniti"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Informacije"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Lokacija je že shranjena"
 
@@ -251,15 +251,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Občuti se kot"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Neuspešna obdelava vremenskih informacij"
 
@@ -272,7 +272,7 @@ msgstr ""
 "ali pa ga pridobite na https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -280,7 +280,7 @@ msgstr ""
 "Preverite, da ste vnesli\n"
 "pravilen ključ za API in vaš račun ni zaklenjen"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -291,252 +291,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Močan dež"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Dež"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Rahel dež"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Močan zmrznjen dež"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Zmrznjen dež"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Rahel zmrznjen dež"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Rahlo zmrznjeno pršenje"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Zmrznjeno pršenje"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Rahlo pršenje"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Močna sodra"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Sodra"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Rahla sodra"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Močno sneženje"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Sneg"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Rahlo sneženje"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Pršenje"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Nevihta"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Rahla megla"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Megla"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Oblačno"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Pretežno oblačno"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Delno oblačno"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Pretežno jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Sončno"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Neznano"
 
@@ -560,7 +574,7 @@ msgstr ""
 "Vnesite ključ za API v nastavitve,\n"
 "ali pa ga pridobite na https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -568,7 +582,7 @@ msgstr ""
 "Preverite, da ste vnesli\n"
 "ključ za API, ki ste ga dobili od DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Lokacije ni mogoče pridobiti"
 
@@ -579,122 +593,123 @@ msgstr ""
 "Lokacijska storitev je sporočila napako, preverite dnevniški zapis v Looking "
 "Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Oblačnost"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Jasno nebo"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Pretežno jasno"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Močan dež in grmenje"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Močne dežne plohe"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Močne dežne plohe in grmenje"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Močna sodra"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Močna sodra in grmenje"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Močne plohe s sodro"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Močne plohe s sodro in grmenjem"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Močno sneženje in grmenje"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Močne snežne plohe"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Močne snežne plohe in grmenje"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Rahel dež in grmenje"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Rahle dežne plohe"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Rahle dežne plohe in grmenje"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Rahla sodra"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Rahla sodra in grmenje"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Manjše plohe s sodro"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Manjše plohe s sodro in grmenje"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Rahlo sneženje in grmenje"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Manjše snežne plohe"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Manjše snežne plohe in grmenje"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Dež in grmenje"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Dežne plohe"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Dežne plohe in grmenje"
 
@@ -703,45 +718,46 @@ msgstr "Dežne plohe in grmenje"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Sodra"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Sodra in grmenje"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Plohe s sodro"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Plohe s sodro in grmenje"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Sneženje in grmenje"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Snežne plohe"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Snežne plohe in grmenje"
 
@@ -750,20 +766,20 @@ msgstr "Snežne plohe in grmenje"
 msgid "Unexpected response from API"
 msgstr "Nepričakovan odziv s strani API-ja"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Vidnost"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Neuspešna obdelava trenutnih vremenskih informacij"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Neuspešna obdelava vremenske napovedi"
 
@@ -792,304 +808,324 @@ msgid "Excellent - More than"
 msgstr "Odlično - Več kot"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Meglica"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Pretežno oblačno"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Manjše dežne plohe"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Pršenje"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Močne dežne plohe"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Plohe s sodro"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Toča"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Ploha s točo"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Manjša snežna ploha"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Močna snežna ploha"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Grmenje"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Nevihta s ploho"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Preverite, da ima v nastavitvah lokacija pravilno obliko"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Preverite, da ste v nastavitvah vnesli pravilen ključ"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 "Lokacija ni najdena, preverite, da lokacija obstaja in da ima pravilno obliko"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Če težava ostane, kontaktirajte avtorja aplikacije"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Neznana napaka, preverite dnevniške zapise v Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Nevihta z rahlim dežjem"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Nevihta z dežjem"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Nevihta z močnim dežjem"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Manjša nevihta"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Močna nevihta"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Nevihta s prekinitvami"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Nevihta z rahlim pršenjem"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Nevihta s pršenjem"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Nevihta z močnim pršenjem"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Rahlo pršenje"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Močno pršenje"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Rahlo pršenje"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Pršenje"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Močno pršenje"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Dežna ploha in pršenje"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Močna dežna ploha in pršenje"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Ploha s pršenjem"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Zmeren dež"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Močan dež"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Zelo močan dež"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Ekstremen dež"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Rahla dežna ploha"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Dežna ploha"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Močna dežna ploha"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Dežna ploha s prekinitvami"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Plohe s sodro"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Rahel dež s snegom"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "Dež s snegom"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Manjša snežna ploha"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Snežna ploha"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Močno snežna ploha"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Dim"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Meglica"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Peščeni, prašni vrtinci"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Pesek"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Prah"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkanski pepel"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Sunki vetra"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Jasno nebo"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Oblaki"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Nekaj oblakov"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Raztreseni oblaki"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Razpršeni oblaki"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Pretežno oblačno"
 
@@ -1097,72 +1133,72 @@ msgstr "Pretežno oblačno"
 msgid "Could not get forecast for your area"
 msgstr "Za vaše področje ni mogoče pridobiti napovedi"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokacija je zunaj ZDA, uporabite drugo storitev."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Neuspešna obdelava urne napovedi"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Jasno in vetrovno"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Nekaj oblakov in vetrovno"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Delno oblačno in vetrovno"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Pretežno oblačno in vetrovno"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Pretežno oblačno in vetrovno"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Dež s snegom"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Zmrznjen dež in sneg"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Orkan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Nevihta"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropska nevihta"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Vroče"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Mrzlo"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Snežni metež"
 
@@ -1202,79 +1238,79 @@ msgstr "Petek"
 msgid "Saturday"
 msgstr "Sobota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Mirno"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Rahel piš"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Rahla sapa"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Nežen vetrič"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Zmeren vetrič"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Svež vetrič"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Močan vetrič"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Manjši sunki vetra"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Sunki vetra"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Močni sunki vetra"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Silovito neurje"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "JV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "J"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "JZ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "SZ"
 
@@ -1326,7 +1362,7 @@ msgstr ""
 "Pri pridobivanju vremena se je zgodila neznana napaka, preverite Looking "
 "Glass za več informacij"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "Tropska nevihta"
@@ -1335,7 +1371,7 @@ msgstr "Tropska nevihta"
 msgid "Severe Thunderstorms"
 msgstr "Hude nevihte"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Nevihte"
 
@@ -1353,19 +1389,19 @@ msgstr "Dež s sodro"
 msgid "Mixed Snow and Sleet"
 msgstr "Sneg s sodro"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "Zmrznjeno pršenje"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "Zmrznjen dež"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Plohe"
 
@@ -1378,11 +1414,11 @@ msgstr "Naletavanje snega"
 msgid "Light Snow Showers"
 msgstr "Manjše snežne plohe"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Snežni vihar"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Megleno"
 
@@ -1394,61 +1430,62 @@ msgstr "Zadimljeno"
 msgid "Blustery"
 msgstr "Viharno"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Vetrovno"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "Pretežno oblačno"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "Delno oblačno"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Pretežno jasno"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "Dež s točo"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Posamezne nevihte"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Razpršene nevihte"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Razpršene plohe"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Močan dež"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Razpršene snežne plohe"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Močno sneženje"
@@ -1476,297 +1513,341 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Za lokacijo ni najdenih podatkov"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Zelo slabo"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Manj kot {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Odlično"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Več kot {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Slabo"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Med {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Srednje"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Dobro"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Zelo dobro"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Sunki vetra"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Manjša snežna ploha"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
+msgid "Heavy drizzle"
+msgstr "Močno pršenje"
+
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Manjša snežna ploha"
+
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Močno snežna ploha"
+
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Dež s snegom"
+
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Snežne plohe"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
+msgid "Freezing fog"
+msgstr "Zmrznjena megla"
+
+#: 3.8/weather-applet.js:13091
 #, fuzzy
 msgid "Tomorrow.io"
 msgstr "Jutri"
 
-#: 3.8/weather-applet.js:13058
+#: 3.8/weather-applet.js:13300
 msgid "Light wind"
 msgstr "Šibek veter"
 
-#: 3.8/weather-applet.js:13072
+#: 3.8/weather-applet.js:13314
 msgid "Strong wind"
 msgstr "Močan veter"
 
-#: 3.8/weather-applet.js:13422
+#: 3.8/weather-applet.js:13664
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:13997
+#: 3.8/weather-applet.js:14239
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:14191
+#: 3.8/weather-applet.js:14433
 #, fuzzy
 msgid "Blowing or drifting snow"
 msgstr "Snežni vihar"
 
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
-msgid "Heavy drizzle"
-msgstr "Močno pršenje"
-
-#: 3.8/weather-applet.js:14199
+#: 3.8/weather-applet.js:14441
 msgid "Heavy drizzle/rain"
 msgstr "Močno pršenje/dež"
 
-#: 3.8/weather-applet.js:14201
+#: 3.8/weather-applet.js:14443
 msgid "Light drizzle/rain"
 msgstr "Rahlo pršenje/dež"
 
-#: 3.8/weather-applet.js:14203
+#: 3.8/weather-applet.js:14445
 #, fuzzy
 msgid "Dust Storm"
 msgstr "Prašna nevihta"
 
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:14449
 msgid "Freezing drizzle/freezing rain"
 msgstr "Zmrznjeno pršenje/dež"
 
-#: 3.8/weather-applet.js:14209
+#: 3.8/weather-applet.js:14451
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Močno zmrznjeno pršenje/dež"
 
-#: 3.8/weather-applet.js:14211
+#: 3.8/weather-applet.js:14453
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Rahlo zmrznjeno pršenje/dež"
 
-#: 3.8/weather-applet.js:14213
-msgid "Freezing fog"
-msgstr "Zmrznjena megla"
-
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Lijakasti oblak/tornado"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Plohe s točo"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Led"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Bliskanje brez grmenja"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Padavine v bližini"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Močan dež in sneg"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Rahel dež in sneg"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Pokritost neba se zmanjšuje"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Pokritost neba se povečuje"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Nebo je nespremenjeno"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Dim ali meglica"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Snežne in dežne plohe"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Nevihta brez padavin"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Ledene iglice"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "Delno oblačno"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Preverite, da ste vnesli pravilen ključ za API"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "NI NAJDENO"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Snežni vihar"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Rahlo sneženje"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Zmerno sneženje"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Zmerne snežne plohe"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Dež s snegom"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Močan dež s snegom"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 #, fuzzy
 msgid "AccuWeather"
 msgstr "Vreme"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 #, fuzzy
 msgid "Weather Underground"
 msgstr "Vremenske razmere"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 #, fuzzy
 msgid "Strong Storm"
 msgstr "Močan vetrič"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Dež s snegom"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Dež s sodro"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Snežne plohe"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Pretežno jasno"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Preverite, da ste vnesli\n"
+"ključ za API, ki ste ga dobili od Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1775,155 +1856,150 @@ msgstr ""
 "Lokacijska storitev je sporočila napako, preverite dnevniški zapis v Looking "
 "Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Pretežno jasno"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Dež s snegom"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Manjša snežna ploha"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Močno snežna ploha"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Nevihta z rahlim dežjem"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Nevihta z dežjem"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Občuti se kot"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr "Preverite, da ste vnesli lokacijo ali pa uporabite samodejno lokacijo"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Storitev za delovanje zahteva ključ za API"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Padavine bodo ponehale v {precipEnd} minutah"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Padavine ne bodo ponehale v eni uri"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Padavine bodo pričele v {precipStart} minutah"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Ob {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 #, fuzzy
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} od vas"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Vremenske informacije ni mogoče pridobiti"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2323,7 +2399,6 @@ msgid "Weather conditions"
 msgstr "Vremenske razmere"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Prevedi razmere"
 
@@ -2633,6 +2708,17 @@ msgstr "Prikaži smer vetra kot besedilo"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Kot npr. SV, S namesto ikon za smer."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/sr.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/sr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2021-02-16 11:25+0100\n"
 "Last-Translator: Knez <vladimirknezev@gmail.com>\n"
 "Language-Team: Serbia <LL@li.org>\n"
@@ -19,67 +19,67 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Грешка"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Грешка услуге"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Нетачан АПИ кључ"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Нетачан формат локације"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Кључ је блокиран"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Није могуће пронаћи локацију"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Нема Апи кључа"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Нема локације"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 #, fuzzy
 msgid "Location not covered"
 msgstr "Нема постављене локације"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 #, fuzzy
 msgid "Weather Applet"
 msgstr "Време"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Кликни за отварање"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Освежи"
 
@@ -89,8 +89,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 #, fuzzy
 msgid "Location Store"
 msgstr "Локација"
@@ -104,14 +104,14 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Није могуће добити локацију"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Неочекивана грешка током освежавања времена, погледајте записнике у прозорче "
 "огледала"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -127,7 +127,7 @@ msgstr "Мрежна грешка, погледајте записнике у п
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -135,55 +135,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "у"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Учитавање тренутне прогнозе..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Учитавање будуће прогнозе..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Учитавање..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "Температура"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "Влажност:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "Притисак:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "Ветар:"
@@ -194,15 +194,15 @@ msgstr ""
 "Проверите да ли сте унели локацију или уместо ње користите Аутоматску "
 "локацију"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -210,17 +210,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -257,16 +257,16 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 #, fuzzy
 msgid "Feels Like"
 msgstr "Као да је"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Обрада информација о времену није успела"
 
@@ -280,7 +280,7 @@ msgstr ""
 "или узмите прво један са https://darksky.net/dev/register"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 #, fuzzy
 msgid ""
 "Please Make sure you\n"
@@ -289,7 +289,7 @@ msgstr ""
 "Проверите да ли сте\n"
 "правилно унели АПИ кључ"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 #, fuzzy
 msgid ""
 "Please Make sure you\n"
@@ -301,12 +301,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "Веома јака киша"
@@ -314,37 +315,40 @@ msgstr "Веома јака киша"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Слаба киша"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "Ледена киша"
@@ -352,113 +356,117 @@ msgstr "Ледена киша"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Ледена киша"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "Ледена киша"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "Слабо ромињање"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 #, fuzzy
 msgid "Freezing drizzle"
 msgstr "Ледена киша"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "Слабо ромињање"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Јак снег"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Снег"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Слаб снег"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr ""
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Олуја с грмљавином"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 #, fuzzy
 msgid "Light fog"
 msgstr "Слаб снег"
@@ -466,95 +474,101 @@ msgstr "Слаб снег"
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Магла"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 #, fuzzy
 msgid "Cloudy"
 msgstr "Облачност"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr ""
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr ""
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr ""
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Ведро"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr ""
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -578,7 +592,7 @@ msgstr ""
 "Молимо вас да унесете АПИ кључ у подешавањима,\n"
 "или узмите прво један са https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 #, fuzzy
 msgid ""
 "Please Make sure you\n"
@@ -587,7 +601,7 @@ msgstr ""
 "Проверите да ли сте\n"
 "правилно унели АПИ кључ"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Није могуће добити локацију"
 
@@ -598,143 +612,144 @@ msgstr ""
 "Локацијска служба одговорила је на грешке, погледајте записнике у прозорче "
 "огледала"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Облачност"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Ведро"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr ""
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 #, fuzzy
 msgid "Heavy rain and thunder"
 msgstr "Јаки пљускови и ромињање"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "Јак мећаве"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 #, fuzzy
 msgid "Heavy rain showers and thunder"
 msgstr "Јаки пљускови и ромињање"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "Јак снег"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 #, fuzzy
 msgid "Heavy sleet and thunder"
 msgstr "Јака олуја с грмљавином"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "Јак мећаве"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 #, fuzzy
 msgid "Heavy sleet showers and thunder"
 msgstr "Јаки пљускови и ромињање"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "Јака олуја с грмљавином"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "Јак мећаве"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 #, fuzzy
 msgid "Heavy snow showers and thunder"
 msgstr "Јаки пљускови и ромињање"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 #, fuzzy
 msgid "Light rain and thunder"
 msgstr "Слба киша и снег"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "Слба киша и снег"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "Слба киша и снег"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 #, fuzzy
 msgid "Light sleet"
 msgstr "Слаб снег"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 #, fuzzy
 msgid "Light sleet and thunder"
 msgstr "Слаба олуја с грмљавином"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "Блага падавина снега"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "Слаби краткотрајни пљусак"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "Слаба олуја с грмљавином"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 #, fuzzy
 msgid "Light snow showers"
 msgstr "Блага падавина снега"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 #, fuzzy
 msgid "Rain and thunder"
 msgstr "Киша и снег"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "Киша и снег"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -743,47 +758,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Суснежица"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "Блага падавина снега"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 #, fuzzy
 msgid "Snow showers"
 msgstr "Мећава"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr ""
 
@@ -792,20 +808,20 @@ msgstr ""
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Обрада тренутних информација о времену није успела"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Информације о прогнози нису успеле"
 
@@ -835,100 +851,104 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Сумаглица"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 #, fuzzy
 msgid "Overcast"
 msgstr "Тмурно"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "Слба киша и снег"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Ромињање"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "Јак мећаве"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr ""
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr ""
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "Јак мећаве"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "Блага падавина снега"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "Јак мећаве"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "Олуја с грмљавином"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "Олуја с грмљавином"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Проверите да ли је локација у исправном формату у подешавањима"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Проверите да ли сте унели исправан кључ у подешавању"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -936,212 +956,228 @@ msgstr ""
 "Локација није пронађена, проверите да ли је локација доступна или је "
 "исправнаформат"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Ако овај проблем и даље постоји, обратите се аутору овог програмчета"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Непозната грешка, погледајте записнике у прозорче огледала"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Грмљавина са слабом кишом"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Грмљавина са кишом"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Грмљавина са јаком кишом"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Слаба олуја с грмљавином"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Јака олуја с грмљавином"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Изузетно јака грмљавина"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Грмљавина са слабим ромињањем кише"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Грмљавина са ромињањем"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Грмљавина са јаким ромињањем"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Слабо ромињање"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Јако ромињање"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Слабо ромињање кише"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Ромињање кише"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Јако ромињање кише"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Пљускови и ромињање"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Јаки пљускови и ромињање"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Ромињање"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Умерена киша"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Јака киша"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Веома јака киша"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Екстремна киша"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Слаби краткотрајни пљусак"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Пљусак"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Јак краткотрајни пљусак"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Изузетно јак пљусак"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Јака суснежица"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Слба киша и снег"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Киша и снег"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Блага падавина снега"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Мећава"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Јак мећаве"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Дим"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Измаглица"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Песак, ковитлаци прашине"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Песак"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Прашина"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Вулкански пепео"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Бура"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Торнадо"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Ведро"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "Облачност"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Мало облака"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Распирени облаци"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Испрекидани облаци"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Тмурно"
 
@@ -1149,77 +1185,77 @@ msgstr "Тмурно"
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 #, fuzzy
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Информације о прогнози нису успеле"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 #, fuzzy
 msgid "Few clouds and windy"
 msgstr "Мало облака"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 #, fuzzy
 msgid "Overcast and windy"
 msgstr "Тмурно"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "Пљусак"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "Слба киша и снег"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr ""
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr ""
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr ""
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr ""
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1259,82 +1295,82 @@ msgstr "Петак"
 msgid "Saturday"
 msgstr "Субота"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 #, fuzzy
 msgid "Light air"
 msgstr "Слаба киша"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 #, fuzzy
 msgid "Light breeze"
 msgstr "Слаба киша"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 #, fuzzy
 msgid "Moderate breeze"
 msgstr "Умерена киша"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "С"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "СИ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "И"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "ЈИ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "Ј"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "ЈЗ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "З"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "СЗ"
 
@@ -1381,7 +1417,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr ""
 
@@ -1390,7 +1426,7 @@ msgstr ""
 msgid "Severe Thunderstorms"
 msgstr "Олуја с грмљавином"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 #, fuzzy
 msgid "Thunderstorms"
 msgstr "Олуја с грмљавином"
@@ -1408,19 +1444,19 @@ msgstr ""
 msgid "Mixed Snow and Sleet"
 msgstr ""
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "Ледена киша"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "Ледена киша"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 #, fuzzy
 msgid "Showers"
 msgstr "Мећава"
@@ -1434,11 +1470,11 @@ msgstr ""
 msgid "Light Snow Showers"
 msgstr "Блага падавина снега"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr ""
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr ""
 
@@ -1451,60 +1487,61 @@ msgstr "Дим"
 msgid "Blustery"
 msgstr ""
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 #, fuzzy
 msgid "Windy"
 msgstr "Ветар:"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr ""
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr ""
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr ""
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr ""
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Изузетно јака грмљавина"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Изузетно јака грмљавина"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Распирени облаци"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "Јак снег"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Распирени облаци"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Јак снег"
@@ -1531,209 +1568,244 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 #, fuzzy
 msgid "Data was not found for location"
 msgstr "Није могуће пронаћи локацију"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 #, fuzzy
 msgid "Moderate"
 msgstr "Умерена киша"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Бура"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Блага падавина снега"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 #, fuzzy
 msgid "WeatherBit"
 msgstr "Време"
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "Сутра"
-
-#: 3.8/weather-applet.js:13058
-#, fuzzy
-msgid "Light wind"
-msgstr "Слаба киша"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-#, fuzzy
-msgid "US Weather"
-msgstr "Време"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr ""
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "Јако ромињање"
 
-#: 3.8/weather-applet.js:14199
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Heavy drizzle/rain"
-msgstr "Јако ромињање кише"
+msgid "Light shower rain"
+msgstr "Блага падавина снега"
 
-#: 3.8/weather-applet.js:14201
+#: 3.8/weather-applet.js:12854
 #, fuzzy
-msgid "Light drizzle/rain"
-msgstr "Слабо ромињање кише"
+msgid "Heavy shower rain"
+msgstr "Јак мећаве"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12862
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "Ледена киша"
+msgid "Mix snow/rain"
+msgstr "Пљусак"
 
-#: 3.8/weather-applet.js:14209
+#: 3.8/weather-applet.js:12864
 #, fuzzy
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Јако ромињање кише"
+msgid "Snow shower"
+msgstr "Мећава"
 
-#: 3.8/weather-applet.js:14211
-#, fuzzy
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Слабо ромињање кише"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "Ледена киша"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Сутра"
+
+#: 3.8/weather-applet.js:13300
+#, fuzzy
+msgid "Light wind"
+msgstr "Слаба киша"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+#, fuzzy
+msgid "US Weather"
+msgstr "Време"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr ""
+
+#: 3.8/weather-applet.js:14441
+#, fuzzy
+msgid "Heavy drizzle/rain"
+msgstr "Јако ромињање кише"
+
+#: 3.8/weather-applet.js:14443
+#, fuzzy
+msgid "Light drizzle/rain"
+msgstr "Слабо ромињање кише"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Ледена киша"
+
+#: 3.8/weather-applet.js:14451
+#, fuzzy
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Јако ромињање кише"
+
+#: 3.8/weather-applet.js:14453
+#, fuzzy
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Слабо ромињање кише"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "Јак мећаве"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 #, fuzzy
 msgid "Lightning without thunder"
 msgstr "Слаба олуја с грмљавином"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "Киша и снег"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "Слба киша и снег"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 #, fuzzy
 msgid "Thunderstorm without precipitation"
 msgstr "Грмљавина са кишом"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr ""
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 #, fuzzy
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
@@ -1741,108 +1813,117 @@ msgstr ""
 "правилно унели АПИ кључ"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 #, fuzzy
 msgid "Blowing snow"
 msgstr "Слаб снег"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "Слаб снег"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "Умерена киша"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "Умерена киша"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 #, fuzzy
 msgid "Mixed rain and snow"
 msgstr "Слба киша и снег"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "Слба киша и снег"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 #, fuzzy
 msgid "AccuWeather"
 msgstr "Време"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 #, fuzzy
 msgid "The location you provided was not found."
 msgstr "Нема постављене локације"
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Киша и снег"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Киша и снег"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Мећава"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr ""
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "Време"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Проверите да ли сте\n"
+"правилно унели АПИ кључ"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1851,155 +1932,151 @@ msgstr ""
 "Локацијска служба одговорила је на грешке, погледајте записнике у прозорче "
 "огледала"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-msgid "Mainly clear"
-msgstr ""
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Пљусак"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Блага падавина снега"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Јак мећаве"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Грмљавина са слабом кишом"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Грмљавина са кишом"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Као да је"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Проверите да ли сте унели локацију или уместо ње користите Аутоматску "
 "локацију"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Није могуће добити локацију"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "Време"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2403,7 +2480,6 @@ msgid "Weather conditions"
 msgstr "Преведи временска стања"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Преведи временска стања"
 
@@ -2687,6 +2763,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/sv.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/sv.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: weather@mockturtl 3.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2024-02-01 22:38+0100\n"
 "Last-Translator: jorgenqv <jorgenqv@yahoo.com>\n"
 "Language-Team: \n"
@@ -20,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.4.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Fel"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Tjänst-fel"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Felaktig API nyckel"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Felaktigt Plats format"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Nyckel blockerad"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Kan inte hitta plats"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Ingen Api-nyckel"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Ingen plats"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Saknar paket"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Platsen täcks inte"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Väder-panelprogram"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Klicka för att öppna"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Uppdatera"
 
@@ -88,8 +88,8 @@ msgstr "API returnerade statuskod mellan 400 och 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Spara plats"
 
@@ -101,13 +101,13 @@ msgstr "Du kan inte spara en plats som hämtats automatiskt, tyvärr"
 msgid "Could not get weather information"
 msgstr "Kunde inte hämta väderinformation"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Oväntat fel medan uppdatering av väder, vänligen se logg i Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +123,7 @@ msgstr "Nätverksfel, vänligen checka loggar i Looking Glass"
 msgid "As of"
 msgstr "Fr.o.m"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Drivs av"
 
@@ -131,52 +131,52 @@ msgstr "Drivs av"
 msgid "from you"
 msgstr "från dig"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "i"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Läser in aktuellt väder..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Läser in kommande väder..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Läser in..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Luftfuktighet"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Lufttryck"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Vind"
 
@@ -185,16 +185,16 @@ msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Kontrollera att du angett en plats eller använd Automatisk plats istället"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Kunde inte hitta plats baserad på adress, vänligen kontrollera om det är rätt"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Misslyckades att anropa Geolocation API, se Looking Glass för fel."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Varning"
 
@@ -202,17 +202,17 @@ msgstr "Varning"
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Du kan bara spara korrekt plats när panelprogrammet inte uppdateras"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Du kan inte spara en inkorrekt plats"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Plats är redan sparad"
 
@@ -250,15 +250,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Känns som"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Misslyckades att behandla väderinformation"
 
@@ -271,7 +271,7 @@ msgstr ""
 "eller hämta en först på https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -279,7 +279,7 @@ msgstr ""
 "Vänligen var säker på att du\n"
 "angett API-nyckeln korrekt och att ditt konto inte är låst"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -290,252 +290,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Kraftigt regn"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Regn"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Lättare regn"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Kraftigt underkylt regn"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Underkylt regn"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Lätt underkylt regn"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Lätt underkylt duggregn"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Underkylt dyggregn"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Lätt duggregn"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Kraftigt hagel"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Småhagel"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Lätt småhagel"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Tung snö"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Snö"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Lätt snöfall"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Kastbyar"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Åska"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Lätt dimma"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Dimma"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Molnigt"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Mestadels molnigt"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Delvis molnigt"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Mestadels klart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Klart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Soligt"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Okänt"
 
@@ -559,7 +573,7 @@ msgstr ""
 "Vänligen ange API nyckel i inställningar,\n"
 "eller hämta en först https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -567,7 +581,7 @@ msgstr ""
 "Vänligen var säker på att du\n"
 "angett den API-nyckeln du har hos DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Kunde inte hämta plats"
 
@@ -577,122 +591,123 @@ msgid ""
 msgstr ""
 "Plats-tjänsten svarade med felmeddelanden, vänligen se logg i Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Molnighet"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Klar himmel"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Klart"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Kraftigt regn med åska"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Kraftiga regnskurar"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Kraftiga regnskurar med åska"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Kraftigt slask"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Kraftigt slask med åska"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Kraftiga slaskskurar"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Kraftiga slaskskurar och åska"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Kraftigt snöfall och åska"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Kraftiga snöbyar"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Kraftiga snöbyar och åska"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Lätt regn med åska"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Lätta regnskurar"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Lätta regnskurar och åska"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Lätt slask"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Lätt slask med åska"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Lätta slaskskurar"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Lätta slaskskurar och åska"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Lätt snöfall och åska"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Lätta snöbyar"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Lätta snöbyar och åska"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Regn och åska"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Regnskurar"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Regnskurar och åska"
 
@@ -701,45 +716,46 @@ msgstr "Regnskurar och åska"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Slask"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Slask och åska"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Slaskskurar"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Slaskskurar och åska"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Snö och åska"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Snöbyar"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Snöbyar och åska"
 
@@ -748,20 +764,20 @@ msgstr "Snöbyar och åska"
 msgid "Unexpected response from API"
 msgstr "Oväntad respons från API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Sikt"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Misslyckades med att behandla aktuell Väder-info"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Misslyckades att behandla prognos-info"
 
@@ -790,304 +806,324 @@ msgid "Excellent - More than"
 msgstr "Utmärkt - Mer än"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Disigt"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Mulet"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Lätta regnskurar"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Smådugg"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Tunga regnskurar"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Slaskskurar"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Hagel"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Hagelbyar"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Lätta snöbyar"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Tunga snöbyar"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Åska"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Åskskurar"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Vänligen var noga med plats är i korrekt format i inställningarna"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Se till att du angett korrekt nyckel i inställningarna"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 "Plats hittades inte, var säker på att den är tillgänglig och är i rätt format"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Om detta problem fortsätter, vänligen kontakta detta panelprograms utvecklare"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Okänt fel, vänligen se loggar i Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Åska med lättare regn"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Åska med regn"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Åska med kraftigt regn"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Lättare Åska"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Kraftig åska"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Ojämna åskbyar"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Åska med lättare duggregn"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Åska med duggregn"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Åska med kraftigt duggregn"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Lättare smådugg"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Kraftigt smådugg"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Lättare duggregn"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Duggregn"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Kraftigt duggregn"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Regnskurar och duggregn"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Kraftiga skurar och duggregn"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Duschregn"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Måttligt regn"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Kraftigt intensivt regn"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Mycket kraftigt regn"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Extremt regn"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Lätta intensiva regnskurar"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Regnskurar"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Kraftiga intensiva regnskurar"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Störtskurar"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Slaskskurar"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Lätt regn och snö"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Regn och snö"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Lätta snöbyar"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Snöbyar"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Kraftiga snöbyar"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Rök"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Disigt"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Sand, dammvirvlar"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Sand"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Damm"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Vulkanisk aska"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Vindbyar"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Tromb"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Himmelen är klar"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Moln"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Enstaka moln"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Spridda moln"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Växlande molnighet"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Mulet"
 
@@ -1095,72 +1131,72 @@ msgstr "Mulet"
 msgid "Could not get forecast for your area"
 msgstr "Kunde inte hämta prognos för ditt område"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Platsen är utanför USA, vänligen använd en annan väderlekstjänst."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Det gick inte att behandla prognosinformation per timme"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Klart och blåsigt"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Få moln och blåsigt"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Delvis molnigt och blåsigt"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Mest molnigt och blåsigt"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Mulet och blåsigt"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Snöigt regn"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Frysande regn och snö"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Orkan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Storm"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropisk storm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Hett"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Kallt"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Häftig snöstorm"
 
@@ -1200,79 +1236,79 @@ msgstr "Fredag"
 msgid "Saturday"
 msgstr "Lördag"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Stiljte"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Nästan stiltje"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Lätt bris"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "God bris"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Måttlig bris"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Frisk bris"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Styv bris"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Styv kuling"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Hård kuling"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Halv storm"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Svår storm"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "NO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "Ö"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "NV"
 
@@ -1324,7 +1360,7 @@ msgstr ""
 "Okänt fel hände medan hämtning av väder, se Looking Glass loggar för mer "
 "infromation"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropisk storm"
 
@@ -1332,7 +1368,7 @@ msgstr "Tropisk storm"
 msgid "Severe Thunderstorms"
 msgstr "Kraftigt åskväder"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Åskväder"
 
@@ -1348,17 +1384,17 @@ msgstr "Blandat regnslask"
 msgid "Mixed Snow and Sleet"
 msgstr "Blandat snö och slask"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Fryst duggregn"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Frysande regn"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Skurar"
 
@@ -1370,11 +1406,11 @@ msgstr "Snöbyar"
 msgid "Light Snow Showers"
 msgstr "Lätta snöbyar"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Snöblåst"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Dimmigt"
 
@@ -1386,54 +1422,55 @@ msgstr "Rökigt"
 msgid "Blustery"
 msgstr "Häftig blåst"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Blåsigt"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Mestadels molnigt"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Delvis molnigt"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Mestadels soligt"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Blandat regn och hagel"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Enstaka åskaväder"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Utbrett åskväder"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Spridda skurar"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Kraftigt regn"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Spridda snöbyar"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Blötsnö"
 
@@ -1462,332 +1499,371 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 "MET Office UK täcker endast UK, vänligen säkerställ att din plats är i landet"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Ingen data hittades för plats"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Mycket dåligt"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Mindre än {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Utmärkt"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mer än {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Dåligt"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Mellan {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Måttligt"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "God"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Mycket god"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Vindbyar"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Lätta snöbyar"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norge"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Lätt vind"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Stark vind"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Blåsande eller drivande snö"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Kraftigt smådugg"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Kraftigt dugg/regn"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Lätta snöbyar"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Lätt dugg/regn"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Kraftiga snöbyar"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Sandstorm"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Snöigt regn"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Underkylt dugg/underkylt regn"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Snöbyar"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Kraftigt underkylt dugg/underkylt regn"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Lätt underkylt dugg/underkylt regn"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Frysande dimma"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Lätt vind"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Stark vind"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Blåsande eller drivande snö"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Kraftigt dugg/regn"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Lätt dugg/regn"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Sandstorm"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Underkylt dugg/underkylt regn"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Kraftigt underkylt dugg/underkylt regn"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Lätt underkylt dugg/underkylt regn"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Trattmoln/tromb"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Hagelskurar"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Is"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Blixtar utan åska"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Nederbörd i närheten"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Kraftigt regn och snö"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Lätt regn och snö"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Minskande himmelstäckning"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Ökande himmelstäckning"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Oförändrad himmel"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Rök eller dis"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Snö och regnskurar"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Åska utan nederbörd"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Isnål-snö"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Delvis molnigt"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Vänligen kolla att du angett API-nyckel korrekt"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Danmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "HITTADES INTE"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Snöblåst"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Lätt snöfall"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Måttligt snöfall"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Måttliga regnskurar"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Snöblandat regn"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Kraftigt snöblandat regn"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Vänligen välj en annan tjänst eller plats"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "API-nyckeln du angav är ogiltig."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Platsen du angav hittades inte."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Kraftig storm"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Regn och snö"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Blandat regnslask"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Snöbyar"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Blåsigt"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Kylig"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Mestadels klart"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Vänligen var säker på att du\n"
+"angett den API-nyckeln du har hos Climacell"
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 "Plats-tjänsten kunde inte hitta din plats, vänligen se logg i Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Mestadels klart"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Snöigt regn"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Lätta snöbyar"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Kraftiga snöbyar"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Åska med lättare regn"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Åska med regn"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Känns som"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1795,7 +1871,7 @@ msgstr ""
 "Kunde inte hämta inställningar, fil hittades inte i sökväg\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1803,103 +1879,103 @@ msgstr ""
 "Kunde inte hämta innehåll för inställningsfil i sökväg\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Kontrollera att du angett en plats eller använd Automatisk plats istället."
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Denna väderlekstjänst kräver en API-nyckel för att fungera"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Daggpunkt"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Nederbörd kommer att upphöra inom {precipEnd} minuter"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Nederbörd kommer inte att upphöra inom en timme"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Nederbörd kommer att börja inom {precipStart} minuter"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Prognos tolkning misslyckades, se loggar för mer information."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Fr.o.m. {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} från dig"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Stationsnamn: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Område: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Fel vid sparande av felsökningsinformation"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Kunde inte hämta väderinformation"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Felsökningsinformationen har sparats"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Sparad i {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2300,7 +2376,6 @@ msgid "Weather conditions"
 msgstr "Väderförhållanden"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Översätt väderförhållanden"
 
@@ -2611,6 +2686,17 @@ msgstr "Visa vindriktning som text"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Såsom SO, N istället för riktnings-ikon."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/tr.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/tr.po
@@ -15,7 +15,7 @@ msgstr ""
 "Project-Id-Version: 3.2.8\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2023-02-03 09:59+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
@@ -27,65 +27,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Hata"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Servis Hatası"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Hatalı API Anahtarı"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Yanlış Konum Biçimi"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Anahtar Engellendi"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Konum bulunamadı"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Api Anahtarı Yok"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Konum Yok"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Eksik Paketler"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Konum kapsanmamış"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Hava Durumu Uygulaması"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Açmak için tıklayın"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Yenile"
 
@@ -95,8 +95,8 @@ msgstr "API, 400 ile 500 arasında durum kodu döndürdü"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Konum Deposu"
 
@@ -108,13 +108,13 @@ msgstr "Otomatik olarak elde edilen bir konumu kaydedemezsiniz, üzgünüm"
 msgid "Could not get weather information"
 msgstr "Hava durumu bilgisi alınamadı"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Hava Yenileme Sırasında Beklenmeyen Hata, lütfen Hata günlüklerine bakın"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -130,7 +130,7 @@ msgstr "Ağ Hatası, lütfen Hata günlüklerini kontrol edin"
 msgid "As of"
 msgstr "İtibarıyla"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "Veri sağlayıcı"
 
@@ -138,52 +138,52 @@ msgstr "Veri sağlayıcı"
 msgid "from you"
 msgstr "sizden"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Mevcut hava durumu yükleniyor ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Gelecekteki hava durumu yükleniyor ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Yükleniyor ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Sıcaklık"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Nem"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Basınç"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Rüzgar"
 
@@ -192,16 +192,16 @@ msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Bir konum girdiğinizden emin olun veya bunun yerine Otomatik konum kullanın"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Adrese göre konum bulunamadı, lütfen doğru olup olmadığını kontrol edin"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Geolocation API çağrılamadı, hatalar için Hata Günlüklerine bakın."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "Uyarı"
 
@@ -209,17 +209,17 @@ msgstr "Uyarı"
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Doğru konumları yalnızca uygulama yenilenmediğinde kaydedebilirsiniz"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Yanlış bir konumu kaydedemezsiniz"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Bilgi"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Konum zaten kaydedildi"
 
@@ -257,15 +257,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Hissedilen"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Hava Durumu Bilgisi İşlenemedi"
 
@@ -278,7 +278,7 @@ msgstr ""
 "veya https://developer.climacell.co/sign-up adresinden bir tane edinin"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -286,7 +286,7 @@ msgstr ""
 "Lütfen API anahtarını doğru girdiğinizden emin olun\n"
 "hesabınız kilitli değil"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -297,252 +297,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Şiddetli yağmur"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Yağmur"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Hafif yağmur"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Şiddetli dondurucu yağmur"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Dolu yağışlı"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Hafif donan yağmur"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Hafif dondurucu çiseleme"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Dondurucu çiseleme"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Hafif çiseleme"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Yoğun buz topakları"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Buz topakları"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Hafif buz topakları"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Ağır kar yağışı"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Kar"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Hafif kar"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Sağanak yağış"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Gökgürültülü Fırtınalı"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Hafif Sis"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Sisli"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Bulutlu"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Çok Bulutlu"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Parçalı Bulutlu"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Çoğunlukla Açık"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Açık"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Güneşli"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
@@ -566,7 +580,7 @@ msgstr ""
 "Lütfen ayarlara API anahtarını girin,\n"
 "veya https://darksky.net/dev/register adresinden bir tane edinin"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -574,7 +588,7 @@ msgstr ""
 "Lütfen emin ol\n"
 "DarkSky'den sahip olduğunuz API anahtarını girdiniz"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Konum alınamadı"
 
@@ -583,122 +597,123 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Konum Hizmeti hatalarla yanıt verdi, lütfen hata günlüklerine bakın"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Bulanıklık"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Hava açık"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Açık"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Şiddetli yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Şiddetli sağnak yağmur"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Şiddetli sağnak yağmur ve gök gürültüsü"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Yoğun sulu kar"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Yoğun sulu kar ve gök gürültüsü"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Şiddetl isağnak sulu kar"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Şiddetli sağnak sulu kar ve gök gürültüsü"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Yoğun kar ve gök gürültüsü"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Şiddetli sağnak kar yağışı"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Şiddetli sağnak kar yağışı ve gök gürültüsü"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Hafif yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Hafif sağanak yağmur"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Hafif sağanak yağmur ve gök gürültüsü"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Hafif Sulu kar"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Hafif karla karışık yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Hafif sağnak karla karışık yağmur"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Hafif sağnak karla karışık yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Hafif kar yağışı ve gök gürültüsü"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Hafif sağanak kar yağışı"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Hafif sağnak kar yağışı ve gök gürültüsü"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Yağmur ve gök gürültüsü"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Sağanak yağmur"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Sağanak yağmur ve gök gürültüsü"
 
@@ -707,45 +722,46 @@ msgstr "Sağanak yağmur ve gök gürültüsü"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Karla karışık yağmur"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Karla karışık yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Karla karışık yağmur"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Karla karışık sağanak yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Kar ve gök gürültüsü"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Sağanak kar"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Sağanak kar ve gök gürültüsü"
 
@@ -754,20 +770,20 @@ msgstr "Sağanak kar ve gök gürültüsü"
 msgid "Unexpected response from API"
 msgstr "API'den beklenmeyen yanıt"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Görüş mesafesi"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Mevcut Hava Durumu Bilgisi İşlenemedi"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Tahmin Bilgileri İşlenemedi"
 
@@ -796,92 +812,96 @@ msgid "Excellent - More than"
 msgstr "Mükemmel - Şundan fazla"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Buğulu"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Bulutlu"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Hafif sağanak yağmur"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Çiseleme"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Şiddetli sağnak yağmur"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Karla karışık yağmur"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Dolu"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Sağanak dolu"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Hafif sağanak kar yağışı"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Şiddetli sağnak kar yağışı"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Gökgürültülü"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Gökgürültülü sağnak"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Lütfen Ayarda Konumun doğru biçimde olduğundan emin olun"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Ayarlara doğru anahtarı girdiğinizden emin olun"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -889,211 +909,227 @@ msgstr ""
 "Konum bulunamadı, konumun kullanılabilir olduğundan veya doğru biçimde "
 "olduğundan emin olun"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Bu sorun devam ederse, lütfen bu uygulamanın Yazarına başvurun"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Bilinmeyen Hata, lütfen Hata günlüklere bakın"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Hafif yağmur ve gök gürültülü sağanak yağış"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Fırtına ve yağmur"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Fırtına şiddetli yağmur"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Hafif gök gürültülü fırtına"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Yoğun gök gürültülü fırtına"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Düzensiz fırtına"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Gök gürültülü hafif çiseleme"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Çiseleyen yağmur fırtınası"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Fırtına ağır çiseleyen yağmur ile"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Hafif yoğun çiseleme"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Ağır yoğun çiseleme"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Hafif yoğun yağmurlu"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Çiseleyen yağmur"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Şiddetli yoğun yağmur"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Çiseleme ve ahmak ıslatan"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Şiddetli çiseleme ve ahmak ıslatan"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Çiseleme ahmak ıslatan"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Ilımlı yağmur"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Yüksek yoğun yağmur"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Çok şiddetli yağmur"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Aşırı yağmur"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Hafif şiddetli yağmur"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Şiddetli yağmur"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Sağanak yağmur"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Düzensiz sağanak yağmur"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Ahmak ıslatan"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Hafif kar ve yağmur"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Yağmur ve kar"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Hafif şiddetli kar yağışı"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Şiddetli kar"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Ağır şiddetli kar"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Dumanlı"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Puslu"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Kum, toz fırtınası"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Kum"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Tozlu"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Volkanik kül"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Bağrışma"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Bora"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Gökyüzü açık"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Bulutlu"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Az bulutlu"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Dağınık bulutlu"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Parçalı bulutlu"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Kapalı bulanık"
 
@@ -1101,72 +1137,72 @@ msgstr "Kapalı bulanık"
 msgid "Could not get forecast for your area"
 msgstr "Bölgeniz için hava tahmini alınamadı"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "Konum ABD dışında, lütfen farklı bir sağlayıcı kullanın."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Saatlik Tahmin Bilgileri İşlenemedi"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Açık ve rüzgarlı"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Az bulutluAz bulutlu ve rüzgarlı"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Parçalı ve rüzgarlı"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Çoğunlukla bulutlu ve rüzgarlı"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Bulutlu ve rüzgarlı"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Karlı yağmur"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Dondurucu Yağmur ve kar"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Kasırga"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Fırtına"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Tropik Fırtına"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Sıcak"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Soğuk"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Kar fırtınası"
 
@@ -1206,79 +1242,79 @@ msgstr "Cuma"
 msgid "Saturday"
 msgstr "Cumartesi"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Sakin"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Hafif hava"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Hafif bir esinti"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Hafif esinti"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Ilıman esinti"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Taze esinti"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Güçlü esinti"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Yakın bora"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Bora"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Şiddetli bora"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Şiddetli fırtına"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "K"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "KD"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "D"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "GD"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "G"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "GB"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "B"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "KB"
 
@@ -1330,7 +1366,7 @@ msgstr ""
 "Hava durumu alınırken bilinmeyen bir hata oluştu, daha fazla bilgi için Hata "
 "günlüklerine bakın"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Tropikal Fırtına"
 
@@ -1338,7 +1374,7 @@ msgstr "Tropikal Fırtına"
 msgid "Severe Thunderstorms"
 msgstr "Şiddetli Fırtınalar"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Gök gürültülü"
 
@@ -1354,17 +1390,17 @@ msgstr "Sulu Kar"
 msgid "Mixed Snow and Sleet"
 msgstr "Sulu Kar"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Dondurucu Çiseleme"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Dondurucu yağmur"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Sağanak"
 
@@ -1376,11 +1412,11 @@ msgstr "Kar Fırtınası"
 msgid "Light Snow Showers"
 msgstr "Hafif Kar Yağışı"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Tipi"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Sisli"
 
@@ -1392,54 +1428,55 @@ msgstr "Dumanlı"
 msgid "Blustery"
 msgstr "Fırtınalı"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Rüzgarlı"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Çok Bulutlu"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Parçalı Bulutlu"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Çoğunlukla Güneşli"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Karışık Yağmur ve Dolu"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "İzole Fırtınalar"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Aralıklı sağanak"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Sağanak Yağış"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Şiddetli Yağmur"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Dağınık Kar Yağışı"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Şiddetli Kar"
 
@@ -1468,11 +1505,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1480,322 +1517,361 @@ msgstr ""
 "MET Office UK yalnızca Birleşik Krallık'ı kapsar, lütfen konumunuzun ülke "
 "içinde olduğundan emin olun"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Konum için veri bulunamadı"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Çok zayıf"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "{distance} {distanceUnit} 'den az"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Mükemmel"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "{distance} {distanceUnit} 'den fazla"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Zayıf"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "{smallerDistance}-{biggerDistance} {distanceUnit} arasında"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Ilımlı"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "İyi"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Çok iyi"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Bağrışma"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Hafif şiddetli kar yağışı"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norveç"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Hafif Rüzgar"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Şiddetli Rüzgar"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "ABD Hava Durumu"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Görsel Geçiş"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Üfleyen veya sürüklenen kar"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Yoğun çiseleme"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Şiddetli çiseleme/yağmur"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Hafif şiddetli kar yağışı"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Hafif çiseleme/yağmur"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Ağır şiddetli kar"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Toz Fırtınası"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Karlı yağmur"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Dondurucu çiseleme/dondurucu yağmur"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Sağanak kar"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Şiddetli donan çiseleme/dondurucu yağmur"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Hafif donan çiseleme/dondurucu yağmur"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Dondurucu sis"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Hafif Rüzgar"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Şiddetli Rüzgar"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "ABD Hava Durumu"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Görsel Geçiş"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Üfleyen veya sürüklenen kar"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Şiddetli çiseleme/yağmur"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Hafif çiseleme/yağmur"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Toz Fırtınası"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Dondurucu çiseleme/dondurucu yağmur"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Şiddetli donan çiseleme/dondurucu yağmur"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Hafif donan çiseleme/dondurucu yağmur"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Huni bulutu/kasırga"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Dolu sağanakları"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Buz"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Gök gürültüsü olmayan şimşek"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Yakın çevrede yağış"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Şiddetli yağmur ve kar"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Hafif yağmur ve kar"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Gökyüzü kapsama alanı azalıyor"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Gökyüzü kapsama alanı artıyor"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Gökyüzü değişmedi"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Duman veya pus"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Kar ve yağmur sağanakları"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Yağışsız fırtına"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Elmas tozu"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Parçalı bulutlu"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Lütfen API anahtarını doğru girdiğinizden emin olun"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Danimarka"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "BULUNAMADI"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Tipi"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Hafif kar"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Orta şiddette kar"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Orta şiddetli sağanak yağmur"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Karla karışık yağmur"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Şiddetli karla karışık yağmur"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Alman Hava Servisi"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Lütfen farklı bir sağlayıcı veya konum seçin"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "Sağladığınız API anahtarı geçersiz."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Sağladığınız konum bulunamadı."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Güçlü Fırtına"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Yağmur ve Kar"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Yağmur ve Sulu Kar"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Sağanak Kar"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Esintili"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "Soğuk"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Çoğunlukla Açık"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "ABD Hava Durumu"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Lütfen emin ol\n"
+"Climacell'den sahip olduğunuz API anahtarını girdiniz"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr "Konum Hizmeti hatalarla yanıt verdi, lütfen hata günlüklerine bakın"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Çoğunlukla Açık"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Karlı yağmur"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Hafif şiddetli kar yağışı"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Ağır şiddetli kar"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Hafif yağmur ve gök gürültülü sağanak yağış"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Fırtına ve yağmur"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Hissedilen"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1803,7 +1879,7 @@ msgstr ""
 "Yapılandırma alınamadı, dosya yol altında bulunamadı\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1811,105 +1887,105 @@ msgstr ""
 "Yol altında yapılandırma dosyasının içeriği alınamadı\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Bir konum girdiğinizden emin olun veya bunun yerine Otomatik konum kullanın"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Bu sağlayıcının çalışması için bir API anahtarı gerekiyor"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Çiy Noktası"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Yağış {precipEnd} dakika içinde sona erecek"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Yağış bir saat içinde bitmeyecek"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Yağış {precipStart} dakika içinde başlayacak"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Tahmin ayrıştırma başarısız oldu, daha fazla ayrıntı için günlüklere bakın."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "{lastUpdatedTime} itibarıyla"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "Sizden {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "İstasyon Adı: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Alan: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Hata Ayıklama Bilgileri Kaydedilirken Hata"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Hava durumu bilgisi alınamadı"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Hata Ayıklama Bilgileri başarıyla kaydedildi"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "{filePath} klasörüne kaydedildi"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "ABD Hava Durumu"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2308,7 +2384,6 @@ msgid "Weather conditions"
 msgstr "Hava durumu"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Dilinize çevirin"
 
@@ -2616,6 +2691,17 @@ msgstr "Rüzgar yönünü metin olarak göster"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Yön simgeleri yerine GD, K gibi."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/uk.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/uk.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: 1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Denys Komar <id52@pm.me>\n"
 "Language-Team: \n"
@@ -14,65 +14,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "Помилка"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "Помилка сервісу"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "Невірний ключ API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "Невірний формат місцеположення"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "Ключ заблоковано"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "Неможливо виявити місцеположення"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "Немає ключа API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "Немає місцеположення"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "Відсутні пакети"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "Місцеположення не обслуговується"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "Weather Applet"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "Натисніть, щоб відкрити"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "Оновити"
 
@@ -82,8 +82,8 @@ msgstr "API повернув код статусу між 400 і 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "Постачальник місцерозташування"
 
@@ -95,14 +95,14 @@ msgstr "На жаль, ви не можете зберегти місцезна�
 msgid "Could not get weather information"
 msgstr "Не вдалося отримати інформацію про погоду"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Неочікувана помилка під час оновлення прогнозу погоди, перегляньте вхід у "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -118,7 +118,7 @@ msgstr "Помилка мережі, перевірте журнали в Lookin
 msgid "As of"
 msgstr "Станом на"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "На основі"
 
@@ -126,52 +126,52 @@ msgstr "На основі"
 msgid "from you"
 msgstr "від вас"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "мм"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "в"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "миль"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "км"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Завантаження поточної погоди..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Завантаження прогнозу погоди..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Завантаження ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "Температура"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "Вологість"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "Тиск"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "Вітер"
 
@@ -181,18 +181,18 @@ msgstr ""
 "Переконайтеся, що ви ввели місцезнаходження, або замість цього скористайтеся "
 "автоматичним визначенням місцезнаходження"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Не вдалося знайти місцезнаходження за адресою, будь ласка, перевірте, чи це "
 "правильно"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Не вдалося викликати Geolocation API. Перегляньте помилки в Looking Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "УВАГА"
 
@@ -201,17 +201,17 @@ msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Правильні розташування можна зберегти лише тоді, коли аплет не оновлюється"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "Ви не можете зберегти неправильне розташування"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Інформація"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "Розташування вже збережено"
 
@@ -249,15 +249,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "Відчувається як"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "Помилка отримання інформації про погоду"
 
@@ -270,7 +270,7 @@ msgstr ""
 "або спочатку отримайте його на https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -278,7 +278,7 @@ msgstr ""
 "Будь ласка, переконайтеся, що ви\n"
 "ввели ключ API правильно, і ваш обліковий запис не заблоковано"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -289,252 +289,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "Сильний дощ"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "Дощ"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "Легкий дощ"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "Сильний крижаний дощ"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Крижаний дощ"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "Легкий крижаний дощ"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "Легка крижана мряка"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Крижана мряка"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "Легка мряка"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "Сильний мокрий сніг"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "Мокрий сніг"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "Легкий мокрий сніг"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Сильний сніг"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Сніг"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "Легкий сніг"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "Шквали"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "Гроза"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "Легкий туман"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "Туман"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Хмарно"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Переважно хмарно"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Мінлива хмарність"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "Переважно ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Сонячно"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "Невідомо"
 
@@ -558,7 +572,7 @@ msgstr ""
 "Будь ласка, введіть ключ API в налаштуваннях,\n"
 "або спочатку отримайте його на https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -566,7 +580,7 @@ msgstr ""
 "Будь ласка, переконайтеся, що ви\n"
 "ввів ключ API, який ви маєте від DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "Не вдалося отримати місцезнаходження"
 
@@ -576,122 +590,123 @@ msgid ""
 msgstr ""
 "Служба локації відповіла помилками, перегляньте журнали в Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "Хмарність"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "Чисте небо"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Ясно"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "Сильний дощ з громом"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "Сильний дощ"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "Сильний дощ з громом"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "Сильний мокрий сніг"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "Сильний мокрий сніг з громом"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "Сильний мокрий сніг"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "Сильний мокрий сніг з громом"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "Сильний сніг"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "Сильні снігопади"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "Сильні снігопади з громом"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "Легкий дощ з громом"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "Невеликий дощ"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "Невеликий дощ з громом"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "Невеликий мокрий сніг"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "Невеликий мокрий сніг з громом"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "Невеликий дощ з мокрим снігом"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "Невеликий дощ з мокрим снігом, гром"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "Невеликий сніг з громом"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Невеликий сніг"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "Невеликий сніг з громом"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "Дощ з громом"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "Дощ"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "Дощ з громом"
 
@@ -700,45 +715,46 @@ msgstr "Дощ з громом"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Мокрий сніг"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "Мокрий сніг з громом"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "Мокрий сніг"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "Мокрий сніг з громом"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "Сніг та грім"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Сніг"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "Сніг та грім"
 
@@ -747,20 +763,20 @@ msgstr "Сніг та грім"
 msgid "Unexpected response from API"
 msgstr "Неочікувана відповідь від API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "Видимі"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "Помилка отримання поточної погоди"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "Помилка отримання прогнозу на майбутнє"
 
@@ -789,94 +805,98 @@ msgid "Excellent - More than"
 msgstr "Чудово"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "Димка"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "Похмуро"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "Легкий дощ"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Мряка"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "Сильний дощ"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "Мокрий сніг"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Град"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "Злива з градом"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "Невеликий сніг"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "Сильний сніг"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "Грім"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "Гроза"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Переконайтеся, що місцеположення вказано у правильному форматі в "
 "налаштуваннях"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "Переконайтеся, що ви ввели правильний ключ у налаштуваннях"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -884,211 +904,227 @@ msgstr ""
 "Розташування не знайдено. Переконайтеся, що місцеположення доступне або має "
 "правильний формат"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Якщо проблема не зникає, зверніться до автора цього аплету"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Невідома помилка, дивіться в логах"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "Гроза, невеликий дощ"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "Гроза, дощ"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "Гроза, сильний дощ"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "Невелика гроза"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "Сильна гроза"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "Можливі грози"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "Гроза з мрякою"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "Гроза з мрякою"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Гроза з сильною мрякою"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "Мряка"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "Сильна мряка"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "Легка мряка"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "Дощ, мряка"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "Сильний дощ, мряка"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "Дощ, мряка"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "Сильний дощ з мрякою"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "Мряка"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "Помірний дощ"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "Сильний дощ"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "Злива"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "Злива"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "Дощ"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "Дощ"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "Рясний дощ"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "Можливий дощ"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "Мокрий сніг"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "Легкий сніг з дощем"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "Сніг з дощем"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "Легкий сніг"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "Сніг"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "Силний сніг"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "Смог"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Мгла"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "Пісок, пил"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "Пісок"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Пил"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "Вулканічний попіл"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "Шквали"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Торнадо"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "Чисте небо"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "Хмарно"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "Невелика хмарність"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "Розсіяна хмарність"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "Розірвані хмари"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "Похмурі хмари"
 
@@ -1096,74 +1132,74 @@ msgstr "Похмурі хмари"
 msgid "Could not get forecast for your area"
 msgstr "Не вдалося отримати прогноз для вашої області"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "Місцезнаходження знаходиться за межами США, використовуйте іншого "
 "постачальника."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Не вдалося обробити інформацію про погодинний прогноз"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "Ясно та вітряно"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "Малохмарно та вітряно"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "Мінлива хмарність та вітер"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "Переважно хмарно та вітряно"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "Похмуро і вітряно"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "Сніг з дожщем"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "Крижаний дощ і сніг"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Ураган"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "Шторм"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Тропічний шторм"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Спека"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Холодно"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "Завірюха"
 
@@ -1203,79 +1239,79 @@ msgstr "П'ятниця"
 msgid "Saturday"
 msgstr "Сублта"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "Штиль"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "Легке повітря"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "Легкий вітерець"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "Легкий бриз"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "Помірний вітер"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "Свіжий вітерець"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "Сильний вітер"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "Майже шторм"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "Шторм"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "Сильний шторм"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "Сильний шторм"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "П"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "Пн-Сх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "Сх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "Пд-Сх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "Пд"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "Пд-Зх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "Зх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "Пн-Зх"
 
@@ -1327,7 +1363,7 @@ msgstr ""
 "Під час отримання погоди сталася невідома помилка. Для отримання додаткової "
 "інформації перегляньте журнали логів"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "Тропічний шторм"
 
@@ -1335,7 +1371,7 @@ msgstr "Тропічний шторм"
 msgid "Severe Thunderstorms"
 msgstr "Сильні грози"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Грози"
 
@@ -1351,17 +1387,17 @@ msgstr "Дощ із мокрим снігом"
 msgid "Mixed Snow and Sleet"
 msgstr "Сніг та мокрий сніг"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "Крижана мряка"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "Крижаний дощ"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Дощик"
 
@@ -1373,11 +1409,11 @@ msgstr "Снігові шквали"
 msgid "Light Snow Showers"
 msgstr "Невеликий сніг"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "Заметіль"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Туманно"
 
@@ -1389,54 +1425,55 @@ msgstr "Димчасто"
 msgid "Blustery"
 msgstr "Вітряно"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Вітряно"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "Переважно хмарно"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "Мінлива хмарність"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "Переважно сонячно"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "Змішаний дощ і град"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "Ізольовані грози"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "Місцями грози"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "Короткочасні дощі"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "Сильний дощ"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "Подекуди снігопади"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "Сильний сніг"
 
@@ -1465,11 +1502,11 @@ msgstr ""
 "  {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1477,276 +1514,320 @@ msgstr ""
 "MET Office UK поширюється лише на Великобританію, переконайтеся, що ви "
 "перебуваєте в цій країні"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "Не знайдено даних для розташування"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "Дуже погано"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Менше ніж {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "Відмінно"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "Більше ніж {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "Погано"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Між {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "Нормально"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "Добре"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "Дуже добре"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "Шквали"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Легкий сніг"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "Легкий вітер"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "Сильний вітер"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "Задування або замети снігу"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "Сильна мряка"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "Сильний дощ/мряка"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "Легкий сніг"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "Мряка/дощ"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Силний сніг"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "Пилова буря"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Сніг з дожщем"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "Крижаний дощ"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Сніг"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Сильний крижаний дощ"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Мряка/крижаний дощ"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "Крижаний туман"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "Легкий вітер"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "Сильний вітер"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "Задування або замети снігу"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "Сильний дощ/мряка"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "Мряка/дощ"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "Пилова буря"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "Крижаний дощ"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Сильний крижаний дощ"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Мряка/крижаний дощ"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "Воронкова хмара/торнадо"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "Град"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "Лід"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "Блискавка без грому"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "Опади поблизу"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "Сильний дощ зі снігом"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "Легкий сніг з дощем"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "Покриття неба зменшується"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "Покриття неба збільшується"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "Небо без змін"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "Дим або імла"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "Сніг з дощем"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "Гроза без опадів"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "Алмазний пил"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "Мінлива хмарність"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "Переконайтеся, що ви правильно ввели ключ API"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "Не знайдено"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Заметіль"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "Невеликий сніг"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "Помірний сніг"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "Помірний дощ"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Дощ зі снігом"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "Сильний дощ зі снігом"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "Будь ласка, виберіть іншого постачальника або місцезнаходження"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "Наданий вами ключ API недійсний."
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "Вказане вами місце не знайдено."
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "Сильний шторм"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "Сніг з дощем"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "Дощ із мокрим снігом"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "Сніг"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "Вітряно"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "Переважно ясно"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 #, fuzzy
 msgid "Pirate Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"Будь ласка, переконайтеся, що ви\n"
+"ввели ключ API, який ви отримали від Climacell"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
@@ -1754,46 +1835,41 @@ msgid ""
 msgstr ""
 "Служба локації відповіла помилками, перегляньте журнали в Looking Glass"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Переважно ясно"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Сніг з дожщем"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Легкий сніг"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Силний сніг"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Гроза, невеликий дощ"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Гроза, дощ"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Відчувається як"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1801,112 +1877,112 @@ msgstr ""
 "Не вдалося отримати конфігурацію, файл не знайдено за шляхами \n"
 "{configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 "Не вдалося отримати вміст конфігураційного файлу за шляхом {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Переконайтеся, що ви ввели місцезнаходження, або замість цього скористайтеся "
 "автоматичним визначенням місцезнаходження"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "Для роботи цього постачальника потрібен ключ API"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "Точка роси"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Опади припиняться через {precipEnd} хв"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "Опади не припиняться протягом години"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Опади почнуться через {precipStart} хв"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Помилка аналізу прогнозу, подробиці дивіться в журналах."
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "Станом на {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} від вас"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "Назва станції: {stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "Район: {stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "Помилка збереження інформації про налагодження"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Не вдалося отримати інформацію про погоду"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "Інформацію про налагодження успішно збережено"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "Збережено в {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2309,7 +2385,6 @@ msgid "Weather conditions"
 msgstr "Метеорологічні умови"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "Переклад"
 
@@ -2620,6 +2695,17 @@ msgstr "Відображення напрямку вітру як текст"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "Як Пд-Сх, П замість піктограм напрямків."
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/vi.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2012-06-17 17:04+0700\n"
 "Last-Translator: Ngô Trung <ndtrung4419@gmail.com>\n"
 "Language-Team: \n"
@@ -19,65 +19,65 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr ""
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr ""
 
@@ -87,8 +87,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -101,12 +101,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Tải lại dữ liệu thời tiết"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -120,7 +120,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -128,55 +128,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "Đang tải dữ liệu thời tiết hiện tại..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "Đang tải dữ liệu dự báo thời tiết..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "Đang tải..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "Đơn vị đo nhiệt độ:"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "Độ ẩm:"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "Áp suất:"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "Gió:"
@@ -185,15 +185,15 @@ msgstr "Gió:"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -201,17 +201,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -247,16 +247,16 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 #, fuzzy
 msgid "Feels Like"
 msgstr "Cảm giác ngoài trời:"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -267,13 +267,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -282,12 +282,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "Tuyết mạnh"
@@ -295,38 +296,41 @@ msgstr "Tuyết mạnh"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "Mưa rét"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "Mưa rét"
@@ -334,168 +338,175 @@ msgstr "Mưa rét"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "Mưa rét"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "Mưa rét"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "Mưa phùn rét"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "Mưa phùn rét"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "Mưa phùn rét"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "Tuyết mạnh"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "Tuyết"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "Tuyết bất chợt"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "Giông"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "Sương mù"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "Mây mù"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "Nhiều mây"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "Ít mây"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "Nhiều mây"
@@ -503,42 +514,45 @@ msgstr "Nhiều mây"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "Trời trong"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "Nắng"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -560,13 +574,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -575,136 +589,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "Mây mù"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "Trời trong"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "Bình thường"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "Tuyết mạnh"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "Tuyết mạnh"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "Tuyết mạnh"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "Tuyết mạnh"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "Mưa tuyết rào"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "Tuyết rào nhẹ"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "Mưa tuyết rào"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -713,47 +728,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "Mưa tuyết"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "Giông rải rác"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "Mưa rào rải rác"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "Mưa tuyết rào"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "Mưa tuyết rào"
@@ -763,20 +779,20 @@ msgstr "Mưa tuyết rào"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -805,330 +821,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "Tuyết rào nhẹ"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "Mưa phùn"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "Tuyết mạnh"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "Mưa rào rải rác"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "Mưa đá"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "Mưa tuyết rào"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "Tuyết mạnh"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "Giông"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "Mưa rào có sấm"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "Giông"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "Giông"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "Giông nguy hiểm"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "Giông diện hẹp"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "Giông"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "Mưa phùn"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "Mưa và mưa đá"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "Mưa phùn rét"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "Mưa rét"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "Mưa rào"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "Mưa rào"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "Mưa và tuyết"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "Mưa và tuyết"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "Mưa rào"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "Tuyết mạnh"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "Khói mù"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "Bụi mù"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "Bụi mù"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "Lốc xoáy"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "Mây mù"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "Mưa rào rải rác"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1136,76 +1172,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "Ít mây"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "Nhiều mây"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "Tuyết bất chợt"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "Mưa rét"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "Cuồng phong"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "Bão nhiệt đới"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "Nóng"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "Lạnh"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1245,79 +1281,79 @@ msgstr "Thứ sáu"
 msgid "Saturday"
 msgstr "Thứ bảy"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "B"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "ĐB"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "Đ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "ĐN"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "TN"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "T"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "TB"
 
@@ -1362,7 +1398,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "Bão nhiệt đới"
@@ -1372,7 +1408,7 @@ msgstr "Bão nhiệt đới"
 msgid "Severe Thunderstorms"
 msgstr "Giông nguy hiểm"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "Giông"
 
@@ -1391,19 +1427,19 @@ msgstr "Mưa và mưa tuyết"
 msgid "Mixed Snow and Sleet"
 msgstr "Tuyết và mưa tuyết"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "Mưa phùn rét"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "Mưa rét"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "Mưa rào"
 
@@ -1417,12 +1453,12 @@ msgstr "Tuyết bất chợt"
 msgid "Light Snow Showers"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "Gió tuyết"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "Sương mù"
 
@@ -1434,63 +1470,64 @@ msgstr "Khói mù"
 msgid "Blustery"
 msgstr "Gió dữ dội"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "Gió"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "Nhiều mây"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "Ít mây"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "Nhiều mây"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "Mưa và mưa đá"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "Giông diện hẹp"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "Giông rải rác"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "Mưa rào rải rác"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "Tuyết mạnh"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "Mưa tuyết rải rác"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "Tuyết mạnh"
@@ -1518,454 +1555,489 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "Tuyết rào nhẹ"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "Ngày mai"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "Gió tuyết"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "Mưa phùn rét"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "Mưa phùn rét"
+msgid "Light shower rain"
+msgstr "Tuyết rào nhẹ"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "Tuyết mạnh"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "Tuyết bất chợt"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "Mưa tuyết rào"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "Mưa rét"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Ngày mai"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Gió tuyết"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Mưa phùn rét"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "Mưa tuyết rào"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "Mưa và tuyết"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "Mưa và tuyết"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "Mưa tuyết rào"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "Ít mây"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "Gió tuyết"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "Gió tuyết"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "Tuyết mạnh"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "Mưa rào rải rác"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "Mưa và tuyết"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "Mưa và tuyết"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "Mưa và tuyết"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "Mưa và mưa tuyết"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "Mưa tuyết rào"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "Nhiều mây"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "Nhiều mây"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "Tuyết bất chợt"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "Tuyết rào nhẹ"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "Tuyết mạnh"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "Giông"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "Giông"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "Cảm giác ngoài trời:"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "Tải lại dữ liệu thời tiết"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2361,7 +2433,6 @@ msgid "Weather conditions"
 msgstr "Dịch tình hình thời tiết"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 #, fuzzy
 msgid "Translate conditions"
 msgstr "Dịch tình hình thời tiết"
@@ -2638,6 +2709,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/weather@mockturtl.pot
+++ b/weather@mockturtl/files/weather@mockturtl/po/weather@mockturtl.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: weather@mockturtl 3.6.0\n"
+"Project-Id-Version: weather@mockturtl 3.6.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,65 +18,65 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr ""
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr ""
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr ""
 
@@ -86,8 +86,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -99,12 +99,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -118,7 +118,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -126,52 +126,52 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr ""
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr ""
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr ""
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr ""
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr ""
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr ""
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr ""
 
@@ -179,15 +179,15 @@ msgstr ""
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -195,17 +195,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -241,15 +241,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -260,13 +260,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -275,252 +275,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr ""
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr ""
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr ""
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr ""
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr ""
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr ""
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr ""
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr ""
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr ""
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr ""
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr ""
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr ""
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr ""
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr ""
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr ""
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr ""
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr ""
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr ""
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr ""
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr ""
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -542,13 +556,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -557,122 +571,123 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr ""
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr ""
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr ""
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr ""
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr ""
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr ""
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr ""
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr ""
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr ""
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr ""
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -681,45 +696,46 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr ""
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr ""
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr ""
 
@@ -728,20 +744,20 @@ msgstr ""
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -770,302 +786,322 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr ""
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr ""
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr ""
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr ""
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr ""
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr ""
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr ""
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr ""
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr ""
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1073,72 +1109,72 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr ""
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr ""
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr ""
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr ""
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr ""
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr ""
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1178,79 +1214,79 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr ""
 
@@ -1294,7 +1330,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr ""
 
@@ -1302,7 +1338,7 @@ msgstr ""
 msgid "Severe Thunderstorms"
 msgstr ""
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr ""
 
@@ -1318,17 +1354,17 @@ msgstr ""
 msgid "Mixed Snow and Sleet"
 msgstr ""
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr ""
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr ""
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr ""
 
@@ -1340,11 +1376,11 @@ msgstr ""
 msgid "Light Snow Showers"
 msgstr ""
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr ""
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr ""
 
@@ -1356,54 +1392,55 @@ msgstr ""
 msgid "Blustery"
 msgstr ""
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr ""
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr ""
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr ""
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr ""
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr ""
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr ""
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr ""
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr ""
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr ""
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr ""
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr ""
 
@@ -1428,428 +1465,459 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
+msgstr ""
+
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+msgid "Light shower sleet"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr ""
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr ""
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr ""
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
+#: 3.8/weather-applet.js:12850
+msgid "Light shower rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
+#: 3.8/weather-applet.js:12854
+msgid "Heavy shower rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
+#: 3.8/weather-applet.js:12862
+msgid "Mix snow/rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
+#: 3.8/weather-applet.js:12864
+msgid "Snow shower"
 msgstr ""
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr ""
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr ""
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr ""
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr ""
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr ""
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr ""
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-msgid "Mainly clear"
-msgstr ""
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 msgid "Snow grains"
 msgstr ""
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 msgid "Light showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 msgid "Heavy showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 msgid "Thunderstorm with slight hail"
 msgstr ""
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 msgid "Thunderstorm with hail"
 msgstr ""
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2239,7 +2307,6 @@ msgid "Weather conditions"
 msgstr ""
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr ""
 
@@ -2513,6 +2580,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/files/weather@mockturtl/po/zh_CN.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/zh_CN.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: 3.2.12\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2023-05-31 19:39+0800\n"
 "Last-Translator: Slinet6056 <slinet6056@gmail.com>\n"
 "Language-Team: Chinese (simplified)\n"
@@ -23,65 +23,65 @@ msgstr ""
 "X-Generator: Poedit 3.3.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr "错误"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr "服务错误"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr "不正确的 API 密钥"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr "不正确的位置格式"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr "密钥已被封禁"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr "找不到位置"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr "没有 API 密钥"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr "没有位置信息"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr "缺失的软件包"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr "地点未被覆盖"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr "天气小程序"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "点击打开"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr "刷新"
 
@@ -91,8 +91,8 @@ msgstr "API 返回在 400 与 500 之间的状态码"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr "保存位置"
 
@@ -104,12 +104,12 @@ msgstr "抱歉，您不能保存一个自动获得的位置"
 msgid "Could not get weather information"
 msgstr "无法获取天气信息"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr "刷新天气时出现意外错误，请查看 Looking Glass 中的日志"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -125,7 +125,7 @@ msgstr "网络错误，请检查 Looking Glass 中的日志"
 msgid "As of"
 msgstr "更新于"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr "数据来源"
 
@@ -133,52 +133,52 @@ msgstr "数据来源"
 msgid "from you"
 msgstr "外"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr "毫米"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr "英寸"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr "英里"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr "千米"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "正在加载当前天气…"
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "正在加载未来天气…"
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "正在加载…"
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 msgid "Temperature"
 msgstr "气温"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 msgid "Humidity"
 msgstr "湿度"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 msgid "Pressure"
 msgstr "压力"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 msgid "Wind"
 msgstr "风速"
 
@@ -186,15 +186,15 @@ msgstr "风速"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "确保您输入了一个位置或使用自动定位代替"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr "无法根据地址找到位置，请检查是否正确"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "调用 Geolocation API 失败，请参阅 Looking Glass 中的错误。"
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr "警告"
 
@@ -202,17 +202,17 @@ msgstr "警告"
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "只有在小程序不刷新的情况下，您才能正确保存位置"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr "您不能保存一个不正确的位置"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr "位置已被保存"
 
@@ -248,15 +248,15 @@ msgstr "从位置存储中加载数据失败，请查看日志以了解更多信
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr "体感"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr "处理天气信息失败"
 
@@ -269,7 +269,7 @@ msgstr ""
 "或先在 https://developer.climacell.co/sign-up 上获取一个"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -277,7 +277,7 @@ msgstr ""
 "请确保您\n"
 "输入正确的 API 密钥，并且您的账户没有被封禁"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -288,252 +288,266 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 msgid "Heavy rain"
 msgstr "大雨"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr "雨"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 msgid "Light rain"
 msgstr "小雨"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 msgid "Heavy freezing rain"
 msgstr "大冻雨"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "冻雨"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 msgid "Light freezing rain"
 msgstr "小冻雨"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 msgid "Light freezing drizzle"
 msgstr "小冻毛雨"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "冻毛雨"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 msgid "Light drizzle"
 msgstr "小毛雨"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr "大冰丸"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr "冰丸"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr "小冰丸"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "大雪"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "雪"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 msgid "Light snow"
 msgstr "小雪"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 msgid "Flurries"
 msgstr "零星小雪"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 msgid "Thunderstorm"
 msgstr "雷暴"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr "轻雾"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 msgid "Fog"
 msgstr "雾"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "多云"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "多云"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "少云"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 msgid "Mostly clear"
 msgstr "少云"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "晴"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "晴"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr "未知"
 
@@ -557,7 +571,7 @@ msgstr ""
 "请在设置中输入 API 密钥，\n"
 "或先在 https://darksky.net/dev/register 上获取一个"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -565,7 +579,7 @@ msgstr ""
 "请确保您\n"
 "输入从 DarkSky 获取的 API 密钥"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr "无法获取位置"
 
@@ -574,122 +588,123 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "定位服务响应错误，请查看 Looking Glass 中的日志"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 msgid "Cloudiness"
 msgstr "云量"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 msgid "Clear sky"
 msgstr "晴"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "晴"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr "强雷雨"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 msgid "Heavy rain showers"
 msgstr "强阵雨"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr "强雷阵雨"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 msgid "Heavy sleet"
 msgstr "大雨夹雪"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr "大雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 msgid "Heavy sleet showers"
 msgstr "短时大雨夹雪"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr "短时大雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 msgid "Heavy snow and thunder"
 msgstr "强雷雪"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 msgid "Heavy snow showers"
 msgstr "强阵雪"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr "强雷阵雪"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr "小雷雨"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 msgid "Light rain showers"
 msgstr "小阵雨"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 msgid "Light rain showers and thunder"
 msgstr "小雷阵雨"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr "小雨夹雪"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr "小雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 msgid "Light sleet showers"
 msgstr "短时小雨夹雪"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 msgid "Light sleet showers and thunder"
 msgstr "短时小雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 msgid "Light snow and thunder"
 msgstr "小雷雪"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "小阵雪"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 msgid "Light snow showers and thunder"
 msgstr "小雷阵雪"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr "雷雨"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 msgid "Rain showers"
 msgstr "阵雨"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr "雷阵雨"
 
@@ -698,45 +713,46 @@ msgstr "雷阵雨"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "雨夹雪"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 msgid "Sleet and thunder"
 msgstr "雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 msgid "Sleet showers"
 msgstr "短时雨夹雪"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr "短时雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr "雷雪"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "阵雪"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 msgid "Snow showers and thunder"
 msgstr "雷阵雪"
 
@@ -745,20 +761,20 @@ msgstr "雷阵雪"
 msgid "Unexpected response from API"
 msgstr "来自 API 的意外响应"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr "能见度"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr "处理当前天气信息失败"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr "处理未来天气信息失败"
 
@@ -787,302 +803,322 @@ msgid "Excellent - More than"
 msgstr "极佳 - 高于"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr "雾"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr "阴"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 msgid "Light rain shower"
 msgstr "小阵雨"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "毛毛雨"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 msgid "Heavy rain shower"
 msgstr "强阵雨"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 msgid "Sleet shower"
 msgstr "短时雨夹雪"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "冰雹"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 msgid "Hail shower"
 msgstr "短时冰雹"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 msgid "Light snow shower"
 msgstr "小阵雪"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 msgid "Heavy snow shower"
 msgstr "强阵雪"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 msgid "Thunder"
 msgstr "雷"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 msgid "Thunder shower"
 msgstr "阵雷"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "请确保设置中的位置格式正确"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr "确保您在设置中输入了正确的密钥"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr "未找到位置，请确保位置可用或格式正确"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "如果这个问题持续存在，请联系本小程序的作者"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "未知的错误，请查看 Looking Glass 中的日志"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr "雷暴，伴有小雨"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 msgid "Thunderstorm with rain"
 msgstr "雷暴，伴有雨"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr "雷暴，伴有大雨"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 msgid "Light thunderstorm"
 msgstr "小雷暴"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 msgid "Heavy thunderstorm"
 msgstr "强雷暴"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 msgid "Ragged thunderstorm"
 msgstr "局部雷暴"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr "雷暴，伴有小毛雨"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 msgid "Thunderstorm with drizzle"
 msgstr "雷暴，伴有毛毛雨"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr "雷暴，伴有强毛雨"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr "小毛雨"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr "强毛雨"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr "毛毛细雨"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 msgid "Drizzle rain"
 msgstr "细雨"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr "强细雨"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 msgid "Shower rain and drizzle"
 msgstr "毛毛雨，时有阵雨"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr "毛毛雨，时有强阵雨"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 msgid "Shower drizzle"
 msgstr "短时毛毛雨"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr "中雨"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr "大雨"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr "暴雨"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 msgid "Extreme rain"
 msgstr "大暴雨"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 msgid "Light intensity shower rain"
 msgstr "小阵雨"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 msgid "Shower rain"
 msgstr "阵雨"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr "强阵雨"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr "局部阵雨"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 msgid "Shower sleet"
 msgstr "短时雨夹雪"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 msgid "Light rain and snow"
 msgstr "小雨夹雪"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 msgid "Rain and snow"
 msgstr "雨夹雪"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 msgid "Light shower snow"
 msgstr "小阵雪"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 msgid "Shower snow"
 msgstr "阵雪"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 msgid "Heavy shower snow"
 msgstr "强阵雪"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 msgid "Smoke"
 msgstr "烟"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "霾"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr "沙尘暴"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr "扬沙"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "浮尘"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr "火山灰"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr "飑"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "龙卷风"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr "晴"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 msgid "Clouds"
 msgstr "云"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr "少云"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 msgid "Scattered clouds"
 msgstr "疏云"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr "碎云"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr "阴"
 
@@ -1090,72 +1126,72 @@ msgstr "阴"
 msgid "Could not get forecast for your area"
 msgstr "无法获取您所在地区的预报"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr "您的位置在美国以外，请使用其他数据源。"
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "处理每小时预测信息失败"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr "晴朗，有风"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr "少云，有风"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 msgid "Partly cloudy and windy"
 msgstr "疏云，有风"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 msgid "Mostly cloudy and windy"
 msgstr "多云，有风"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr "阴，有风"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 msgid "Snowy rain"
 msgstr "雨夹雪"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 msgid "Freezing rain and snow"
 msgstr "冻雨夹雪"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "飓风"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr "风暴"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "热带风暴"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "热"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "冷"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr "暴风雪"
 
@@ -1195,79 +1231,79 @@ msgstr "星期五"
 msgid "Saturday"
 msgstr "星期六"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr "无风"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr "软风"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr "轻风"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr "微风"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr "和风"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr "劲风"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr "强风"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr "疾风"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr "大风"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr "烈风"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr "狂风"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr "北"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr "东北"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr "东"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr "东南"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr "南"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr "西南"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr "西"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr "西北"
 
@@ -1317,7 +1353,7 @@ msgid ""
 "more information"
 msgstr "在获取天气时发生了未知的错误，更多信息请参见 Looking Glass 日志"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 msgid "Tropical Storm"
 msgstr "热带风暴"
 
@@ -1325,7 +1361,7 @@ msgstr "热带风暴"
 msgid "Severe Thunderstorms"
 msgstr "强雷暴"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "雷暴"
 
@@ -1341,17 +1377,17 @@ msgstr "雨夹雪"
 msgid "Mixed Snow and Sleet"
 msgstr "雨夹雪"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 msgid "Freezing Drizzle"
 msgstr "冻毛雨"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 msgid "Freezing Rain"
 msgstr "冻雨"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "阵雨"
 
@@ -1363,11 +1399,11 @@ msgstr "小雪"
 msgid "Light Snow Showers"
 msgstr "小阵雪"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 msgid "Blowing Snow"
 msgstr "吹雪"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "雾"
 
@@ -1379,54 +1415,55 @@ msgstr "烟"
 msgid "Blustery"
 msgstr "大风"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "有风"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 msgid "Mostly Cloudy"
 msgstr "多云"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 msgid "Partly Cloudy"
 msgstr "疏云"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 msgid "Mostly Sunny"
 msgstr "少云"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 msgid "Mixed Rain and Hail"
 msgstr "雨和冰雹"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 msgid "Isolated Thunderstorms"
 msgstr "孤立雷暴"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 msgid "Scattered Thunderstorms"
 msgstr "零星雷暴"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 msgid "Scattered Showers"
 msgstr "零星阵雨"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 msgid "Heavy Rain"
 msgstr "大雨"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 msgid "Scattered Snow Showers"
 msgstr "零星阵雪"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 msgid "Heavy Snow"
 msgstr "大雪"
 
@@ -1455,331 +1492,370 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr "英国气象局"
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr "英国气象局数据服务仅覆盖英国，请确认您的位置"
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr "没有找到当前位置的数据"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr "很差"
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr "小于 {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr "极好"
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr "大于 {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr "差"
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "在 {smallerDistance}~{biggerDistance} {distanceUnit} 之间"
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr "一般"
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr "好"
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr "很好"
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Squall"
+msgstr "飑"
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "小阵雪"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr "挪威气象研究所"
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12849
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr "小风"
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr "大风"
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr "美国国家气象局"
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/weather-applet.js:14191
-msgid "Blowing or drifting snow"
-msgstr "吹雪或飘雪"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 msgid "Heavy drizzle"
 msgstr "强毛雨"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr "强毛雨或雨"
+#: 3.8/weather-applet.js:12850
+#, fuzzy
+msgid "Light shower rain"
+msgstr "小阵雪"
 
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr "小毛雨或雨"
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "强阵雪"
 
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr "沙尘暴"
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "雨夹雪"
 
-#: 3.8/weather-applet.js:14207
-msgid "Freezing drizzle/freezing rain"
-msgstr "冻毛雨或冻雨"
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "阵雪"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "强冻毛雨或冻雨"
-
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr "小冻毛雨或冻雨"
-
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 msgid "Freezing fog"
 msgstr "冻雾"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr "小风"
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr "大风"
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr "美国国家气象局"
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:14433
+msgid "Blowing or drifting snow"
+msgstr "吹雪或飘雪"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr "强毛雨或雨"
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr "小毛雨或雨"
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr "沙尘暴"
+
+#: 3.8/weather-applet.js:14449
+msgid "Freezing drizzle/freezing rain"
+msgstr "冻毛雨或冻雨"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "强冻毛雨或冻雨"
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr "小冻毛雨或冻雨"
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr "漏斗云或龙卷风"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 msgid "Hail showers"
 msgstr "短时冰雹"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr "冰"
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr "没有雷声的闪电"
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr "附近有降水"
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 msgid "Heavy rain and snow"
 msgstr "大雨夹雪"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 msgid "Light rain And snow"
 msgstr "小雨夹雪"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr "天空覆盖率下降"
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr "天空覆盖率增加"
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr "天空没有变化"
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr "烟或霾"
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 msgid "Snow and rain showers"
 msgstr "雪和阵雨"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr "无降水的雷暴"
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr "钻石尘"
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 msgid "Partially cloudy"
 msgstr "疏云"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr "请确保您输入了正确的 API 密钥"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr "丹麦气象研究所"
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr "找不到"
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "吹雪"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 msgid "Slight snow"
 msgstr "小雪"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 msgid "Moderate snow"
 msgstr "中雪"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 msgid "Moderate rain showers"
 msgstr "中等规模的阵雨"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "雨夹雪"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 msgid "Heavy mixed rain and snow"
 msgstr "强雨夹雪"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr "德国气象局"
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr "请选择一个不同的数据源或地点"
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr "您提供的 API 密钥无效。"
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr "没有找到您提供的位置。"
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr "强风暴"
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 msgid "Rain and Snow"
 msgstr "雨夹雪"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 msgid "Rain and Sleet"
 msgstr "雨夹雪"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 msgid "Snow Showers"
 msgstr "阵雪"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr "微风"
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr "寒冷"
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 msgid "Mostly Clear"
 msgstr "少云"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+"请确保您\n"
+"输入从 Climacell 获取的 API 密钥"
+
+#: 3.8/weather-applet.js:16724
 #, fuzzy
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr "定位服务响应错误，请查看 Looking Glass 中的日志"
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "少云"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "雨夹雪"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "小阵雪"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "强阵雪"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "雷暴，伴有小雨"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "雷暴，伴有雨"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 #, fuzzy
 msgid "Feels like"
 msgstr "体感"
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1787,7 +1863,7 @@ msgstr ""
 "无法检索配置，在以下路径找不到文件\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1795,103 +1871,103 @@ msgstr ""
 "无法获取以下路径配置文件的内容\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 #, fuzzy
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr "确保您输入了一个位置或使用自动定位代替"
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr "该数据源需要一个 API 密钥来操作"
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr "露点"
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "降水将在 {precipEnd} 分钟内结束"
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr "降水在一小时内不会结束"
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "降水将在 {precipStart} 分钟内开始"
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "天气预测解析失败，详情请查看日志。"
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr "更新于 {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr "距您 {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr "气象站名称：{stationName}"
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr "地区：{stationArea}"
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr "保存调试信息时出错"
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 #, fuzzy
 msgid "Could not open file {filePath} for writing"
 msgstr "无法获取天气信息"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr "调试信息保存成功"
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr "已保存到 {filePath}"
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 #, fuzzy
 msgid "No Weather Data"
 msgstr "美国国家气象局"
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2286,7 +2362,6 @@ msgid "Weather conditions"
 msgstr "天气状况"
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr "翻译天气状况"
 
@@ -2582,6 +2657,17 @@ msgstr "以文本形式显示风向"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "例如 “东南”、“北”，而不是方向图标。"
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
+msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"

--- a/weather@mockturtl/files/weather@mockturtl/po/zh_TW.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/zh_TW.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: simon 04-gnome-shell-extension-weather-452bcfe\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-30 09:33+0100\n"
+"POT-Creation-Date: 2024-06-03 08:04+0100\n"
 "PO-Revision-Date: 2011-12-02 14:44+0800\n"
 "Last-Translator: Wenjie Huang\n"
 "Language-Team: Chinese (Traditional)\n"
@@ -19,65 +19,65 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:19289
+#: 3.8/weather-applet.js:19563
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:19290 3.8/weather-applet.js:19292
-#: 3.8/weather-applet.js:19294 3.8/weather-applet.js:19297
-#: 3.8/weather-applet.js:19300 3.8/weather-applet.js:19301
-#: 3.8/weather-applet.js:19302 3.8/weather-applet.js:19303
+#: 3.8/weather-applet.js:19564 3.8/weather-applet.js:19566
+#: 3.8/weather-applet.js:19568 3.8/weather-applet.js:19571
+#: 3.8/weather-applet.js:19574 3.8/weather-applet.js:19575
+#: 3.8/weather-applet.js:19576 3.8/weather-applet.js:19577
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:19291
+#: 3.0/applet.js:168 3.8/weather-applet.js:19565
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:19293
+#: 3.0/applet.js:170 3.8/weather-applet.js:19567
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:19295
+#: 3.0/applet.js:172 3.8/weather-applet.js:19569
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:19296
+#: 3.0/applet.js:173 3.8/weather-applet.js:19570
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:19298
+#: 3.0/applet.js:175 3.8/weather-applet.js:19572
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:19299
+#: 3.0/applet.js:176 3.8/weather-applet.js:19573
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:19304
+#: 3.0/applet.js:181 3.8/weather-applet.js:19578
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:19305
+#: 3.0/applet.js:182 3.8/weather-applet.js:19579
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9940
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9937
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:19565
+#: 3.0/applet.js:217 3.8/weather-applet.js:19839
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:19566
+#: 3.0/applet.js:218 3.8/weather-applet.js:19840
 msgid "Click to open"
 msgstr "開啟"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18013
-#: 3.8/weather-applet.js:19569
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:18287
+#: 3.8/weather-applet.js:19843
 msgid "Refresh"
 msgstr ""
 
@@ -87,8 +87,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:10096
+#: 3.8/weather-applet.js:10100
 msgid "Location Store"
 msgstr ""
 
@@ -100,12 +100,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:19397
+#: 3.0/applet.js:624 3.8/weather-applet.js:19671
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:19648
+#: 3.0/applet.js:670 3.8/weather-applet.js:19922
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -119,7 +119,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:18826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:19100
 msgid "Powered by"
 msgstr ""
 
@@ -127,55 +127,55 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.8/weather-applet.js:19000
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:18726
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:19000
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10888
-#: 3.8/weather-applet.js:18943
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10885
+#: 3.8/weather-applet.js:19217
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10889
-#: 3.8/weather-applet.js:18944
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10886
+#: 3.8/weather-applet.js:19218
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:19147
+#: 3.0/applet.js:1227 3.8/weather-applet.js:19421
 msgid "Loading current weather ..."
 msgstr "正在載入目前天氣 ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:19150
+#: 3.0/applet.js:1230 3.8/weather-applet.js:19424
 msgid "Loading future weather ..."
 msgstr "正在載入天氣預報 ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:17945
+#: 3.0/applet.js:1280 3.8/weather-applet.js:18219
 msgid "Loading ..."
 msgstr "正在載入 ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:17964
+#: 3.0/applet.js:1329 3.8/weather-applet.js:18238
 #, fuzzy
 msgid "Temperature"
 msgstr "溫度："
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:17969
+#: 3.0/applet.js:1330 3.8/weather-applet.js:18243
 #, fuzzy
 msgid "Humidity"
 msgstr "濕度："
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:17974
+#: 3.0/applet.js:1331 3.8/weather-applet.js:18248
 #, fuzzy
 msgid "Pressure"
 msgstr "氣壓："
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:13057 3.8/weather-applet.js:13064
-#: 3.8/weather-applet.js:13065 3.8/weather-applet.js:13071
-#: 3.8/weather-applet.js:15411 3.8/weather-applet.js:15412
-#: 3.8/weather-applet.js:17807
+#: 3.0/applet.js:1332 3.8/weather-applet.js:13299 3.8/weather-applet.js:13306
+#: 3.8/weather-applet.js:13307 3.8/weather-applet.js:13313
+#: 3.8/weather-applet.js:15652 3.8/weather-applet.js:15653
+#: 3.8/weather-applet.js:16308 3.8/weather-applet.js:18081
 #, fuzzy
 msgid "Wind"
 msgstr "風力："
@@ -184,15 +184,15 @@ msgstr "風力："
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:10514
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10511
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10535
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10532
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "Warning"
 msgstr ""
 
@@ -200,17 +200,17 @@ msgstr ""
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:10099
+#: 3.0/applet.js:2036 3.8/weather-applet.js:10096
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:10103
+#: 3.8/weather-applet.js:10100
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:10103
+#: 3.0/applet.js:2040 3.8/weather-applet.js:10100
 msgid "Location is already saved"
 msgstr ""
 
@@ -246,15 +246,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11438 3.8/weather-applet.js:12460
-#: 3.8/weather-applet.js:12958 3.8/weather-applet.js:13693
-#: 3.8/weather-applet.js:14061 3.8/weather-applet.js:15593
-#: 3.8/weather-applet.js:16143
+#: 3.8/weather-applet.js:11533 3.8/weather-applet.js:12555
+#: 3.8/weather-applet.js:13200 3.8/weather-applet.js:13935
+#: 3.8/weather-applet.js:14303 3.8/weather-applet.js:15834
+#: 3.8/weather-applet.js:16412
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:16218
+#: 3.8/weather-applet.js:16487
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -265,13 +265,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12644 3.8/weather-applet.js:16078
+#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:16347
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12921
+#: 3.0/climacell.js:248 3.8/weather-applet.js:13163
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -280,12 +280,13 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:11092 3.8/weather-applet.js:11099
-#: 3.8/weather-applet.js:11106 3.8/weather-applet.js:11107
-#: 3.8/weather-applet.js:12102 3.8/weather-applet.js:12103
-#: 3.8/weather-applet.js:12109 3.8/weather-applet.js:12116
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:13100
-#: 3.8/weather-applet.js:14239 3.8/weather-applet.js:16576
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:11089 3.8/weather-applet.js:11096
+#: 3.8/weather-applet.js:11103 3.8/weather-applet.js:11104
+#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
+#: 3.8/weather-applet.js:12204 3.8/weather-applet.js:12211
+#: 3.8/weather-applet.js:12218 3.8/weather-applet.js:12846
+#: 3.8/weather-applet.js:13342 3.8/weather-applet.js:14481
+#: 3.8/weather-applet.js:16845
 #, fuzzy
 msgid "Heavy rain"
 msgstr "大雪"
@@ -293,38 +294,41 @@ msgstr "大雪"
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12277 3.8/weather-applet.js:12278
-#: 3.8/weather-applet.js:12284 3.8/weather-applet.js:13085
-#: 3.8/weather-applet.js:13086 3.8/weather-applet.js:13092
-#: 3.8/weather-applet.js:13099 3.8/weather-applet.js:13141
-#: 3.8/weather-applet.js:13148 3.8/weather-applet.js:13155
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:13892
-#: 3.8/weather-applet.js:14231 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14553
-#: 3.8/weather-applet.js:15383 3.8/weather-applet.js:15384
-#: 3.8/weather-applet.js:15761 3.8/weather-applet.js:15762
-#: 3.8/weather-applet.js:16561 3.8/weather-applet.js:16568
-#: 3.8/weather-applet.js:16569 3.8/weather-applet.js:16575
-#: 3.8/weather-applet.js:16582 3.8/weather-applet.js:16589
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11267 3.8/weather-applet.js:12372
+#: 3.8/weather-applet.js:12373 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12781 3.8/weather-applet.js:13327
+#: 3.8/weather-applet.js:13328 3.8/weather-applet.js:13334
+#: 3.8/weather-applet.js:13341 3.8/weather-applet.js:13383
+#: 3.8/weather-applet.js:13390 3.8/weather-applet.js:13397
+#: 3.8/weather-applet.js:14077 3.8/weather-applet.js:14126
+#: 3.8/weather-applet.js:14127 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:14473 3.8/weather-applet.js:14753
+#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:14795
+#: 3.8/weather-applet.js:15624 3.8/weather-applet.js:15625
+#: 3.8/weather-applet.js:16002 3.8/weather-applet.js:16003
+#: 3.8/weather-applet.js:16302 3.8/weather-applet.js:16830
+#: 3.8/weather-applet.js:16837 3.8/weather-applet.js:16838
+#: 3.8/weather-applet.js:16844 3.8/weather-applet.js:16851
+#: 3.8/weather-applet.js:16858
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11064
-#: 3.8/weather-applet.js:11071 3.8/weather-applet.js:11085
-#: 3.8/weather-applet.js:11086 3.8/weather-applet.js:11279
-#: 3.8/weather-applet.js:12186 3.8/weather-applet.js:12187
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:13093
-#: 3.8/weather-applet.js:14241 3.8/weather-applet.js:16562
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:11061
+#: 3.8/weather-applet.js:11068 3.8/weather-applet.js:11082
+#: 3.8/weather-applet.js:11083 3.8/weather-applet.js:11338
+#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12282
+#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12295
+#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12842
+#: 3.8/weather-applet.js:13335 3.8/weather-applet.js:14483
+#: 3.8/weather-applet.js:16831
 #, fuzzy
 msgid "Light rain"
 msgstr "凍雨"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:13156 3.8/weather-applet.js:14215
+#: 3.0/climacell.js:280 3.8/weather-applet.js:13398 3.8/weather-applet.js:14457
 #, fuzzy
 msgid "Heavy freezing rain"
 msgstr "凍雨"
@@ -332,168 +336,175 @@ msgstr "凍雨"
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11284
-#: 3.8/weather-applet.js:13142 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13857 3.8/weather-applet.js:13863
-#: 3.8/weather-applet.js:13864 3.8/weather-applet.js:13870
-#: 3.8/weather-applet.js:16590
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11348
+#: 3.8/weather-applet.js:12848 3.8/weather-applet.js:13384
+#: 3.8/weather-applet.js:14098 3.8/weather-applet.js:14099
+#: 3.8/weather-applet.js:14105 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:14112 3.8/weather-applet.js:16859
 msgid "Freezing rain"
 msgstr "凍雨"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:13149 3.8/weather-applet.js:14217
-#: 3.8/weather-applet.js:16583
+#: 3.0/climacell.js:294 3.8/weather-applet.js:13391 3.8/weather-applet.js:14459
+#: 3.8/weather-applet.js:16852
 #, fuzzy
 msgid "Light freezing rain"
 msgstr "凍雨"
 
-#: 3.0/climacell.js:301 3.8/weather-applet.js:16548
+#: 3.0/climacell.js:301 3.8/weather-applet.js:16817
 #, fuzzy
 msgid "Light freezing drizzle"
 msgstr "凍毛毛雨"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:13135 3.8/weather-applet.js:16555
+#: 3.0/climacell.js:302 3.8/weather-applet.js:13377 3.8/weather-applet.js:16824
 msgid "Freezing drizzle"
 msgstr "凍毛毛雨"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14197
-#: 3.8/weather-applet.js:16527
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12836
+#: 3.8/weather-applet.js:14439 3.8/weather-applet.js:16796
 #, fuzzy
 msgid "Light drizzle"
 msgstr "凍毛毛雨"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:13170
+#: 3.0/climacell.js:315 3.8/weather-applet.js:13412
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:13162 3.8/weather-applet.js:13163
-#: 3.8/weather-applet.js:13169 3.8/weather-applet.js:13176
+#: 3.0/climacell.js:330 3.8/weather-applet.js:13404 3.8/weather-applet.js:13405
+#: 3.8/weather-applet.js:13411 3.8/weather-applet.js:13418
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:13177
+#: 3.0/climacell.js:329 3.8/weather-applet.js:13419
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11176
-#: 3.8/weather-applet.js:11183 3.8/weather-applet.js:11190
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11291
-#: 3.8/weather-applet.js:12158 3.8/weather-applet.js:12159
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12172
-#: 3.8/weather-applet.js:12179 3.8/weather-applet.js:13128
-#: 3.8/weather-applet.js:14257 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:16611
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:11173
+#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11187
+#: 3.8/weather-applet.js:11188 3.8/weather-applet.js:11362
+#: 3.8/weather-applet.js:12253 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12260 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:12860
+#: 3.8/weather-applet.js:13370 3.8/weather-applet.js:14499
+#: 3.8/weather-applet.js:14830 3.8/weather-applet.js:16880
 msgid "Heavy snow"
 msgstr "大雪"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11290 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12340
-#: 3.8/weather-applet.js:13106 3.8/weather-applet.js:13107
-#: 3.8/weather-applet.js:13120 3.8/weather-applet.js:13127
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
-#: 3.8/weather-applet.js:14251 3.8/weather-applet.js:14497
-#: 3.8/weather-applet.js:14581 3.8/weather-applet.js:15397
-#: 3.8/weather-applet.js:15398 3.8/weather-applet.js:15789
-#: 3.8/weather-applet.js:15790 3.8/weather-applet.js:16596
-#: 3.8/weather-applet.js:16603 3.8/weather-applet.js:16604
-#: 3.8/weather-applet.js:16610 3.8/weather-applet.js:16617
+#: 3.8/weather-applet.js:11269 3.8/weather-applet.js:11360
+#: 3.8/weather-applet.js:12428 3.8/weather-applet.js:12429
+#: 3.8/weather-applet.js:12435 3.8/weather-applet.js:12789
+#: 3.8/weather-applet.js:12858 3.8/weather-applet.js:13348
+#: 3.8/weather-applet.js:13349 3.8/weather-applet.js:13362
+#: 3.8/weather-applet.js:13369 3.8/weather-applet.js:14070
+#: 3.8/weather-applet.js:14071 3.8/weather-applet.js:14493
+#: 3.8/weather-applet.js:14739 3.8/weather-applet.js:14823
+#: 3.8/weather-applet.js:15638 3.8/weather-applet.js:15639
+#: 3.8/weather-applet.js:16030 3.8/weather-applet.js:16031
+#: 3.8/weather-applet.js:16306 3.8/weather-applet.js:16865
+#: 3.8/weather-applet.js:16872 3.8/weather-applet.js:16873
+#: 3.8/weather-applet.js:16879 3.8/weather-applet.js:16886
 msgid "Snow"
 msgstr "雪"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11155
-#: 3.8/weather-applet.js:11162 3.8/weather-applet.js:11169
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11289
-#: 3.8/weather-applet.js:12242 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:13121
-#: 3.8/weather-applet.js:14259 3.8/weather-applet.js:16597
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:11152
+#: 3.8/weather-applet.js:11159 3.8/weather-applet.js:11166
+#: 3.8/weather-applet.js:11167 3.8/weather-applet.js:11358
+#: 3.8/weather-applet.js:12337 3.8/weather-applet.js:12338
+#: 3.8/weather-applet.js:12344 3.8/weather-applet.js:12351
+#: 3.8/weather-applet.js:12358 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13363 3.8/weather-applet.js:14501
+#: 3.8/weather-applet.js:16866
 #, fuzzy
 msgid "Light snow"
 msgstr "小雪"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:13113
-#: 3.8/weather-applet.js:13114 3.8/weather-applet.js:15768
-#: 3.8/weather-applet.js:15769
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12868
+#: 3.8/weather-applet.js:13355 3.8/weather-applet.js:13356
+#: 3.8/weather-applet.js:16009 3.8/weather-applet.js:16010
 #, fuzzy
 msgid "Flurries"
 msgstr "飄雪"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11264
-#: 3.8/weather-applet.js:13183 3.8/weather-applet.js:13184
-#: 3.8/weather-applet.js:13901 3.8/weather-applet.js:13902
-#: 3.8/weather-applet.js:14263 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596 3.8/weather-applet.js:15404
-#: 3.8/weather-applet.js:15405 3.8/weather-applet.js:16659
-#: 3.8/weather-applet.js:16660 3.8/weather-applet.js:16666
-#: 3.8/weather-applet.js:16673
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11263
+#: 3.8/weather-applet.js:11308 3.8/weather-applet.js:12769
+#: 3.8/weather-applet.js:12834 3.8/weather-applet.js:13425
+#: 3.8/weather-applet.js:13426 3.8/weather-applet.js:14143
+#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14505
+#: 3.8/weather-applet.js:14837 3.8/weather-applet.js:14838
+#: 3.8/weather-applet.js:15645 3.8/weather-applet.js:15646
+#: 3.8/weather-applet.js:16928 3.8/weather-applet.js:16929
+#: 3.8/weather-applet.js:16935 3.8/weather-applet.js:16942
 #, fuzzy
 msgid "Thunderstorm"
 msgstr "雷雨"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13051
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:13293
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:11043 3.8/weather-applet.js:11044
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12095
-#: 3.8/weather-applet.js:12096 3.8/weather-applet.js:13043
-#: 3.8/weather-applet.js:13044 3.8/weather-applet.js:13050
-#: 3.8/weather-applet.js:13971 3.8/weather-applet.js:13972
-#: 3.8/weather-applet.js:14205 3.8/weather-applet.js:15355
-#: 3.8/weather-applet.js:15356 3.8/weather-applet.js:15817
-#: 3.8/weather-applet.js:15818 3.8/weather-applet.js:16519
-#: 3.8/weather-applet.js:16520
+#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11041
+#: 3.8/weather-applet.js:11283 3.8/weather-applet.js:11388
+#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12191
+#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12882
+#: 3.8/weather-applet.js:13285 3.8/weather-applet.js:13286
+#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:14214 3.8/weather-applet.js:14447
+#: 3.8/weather-applet.js:15596 3.8/weather-applet.js:15597
+#: 3.8/weather-applet.js:16058 3.8/weather-applet.js:16059
+#: 3.8/weather-applet.js:16310 3.8/weather-applet.js:16788
+#: 3.8/weather-applet.js:16789
 #, fuzzy
 msgid "Fog"
 msgstr "霧"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:11050 3.8/weather-applet.js:11051
-#: 3.8/weather-applet.js:12081 3.8/weather-applet.js:12082
-#: 3.8/weather-applet.js:13015 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:15348 3.8/weather-applet.js:15349
-#: 3.8/weather-applet.js:15859 3.8/weather-applet.js:15860
+#: 3.8/weather-applet.js:11047 3.8/weather-applet.js:11048
+#: 3.8/weather-applet.js:12176 3.8/weather-applet.js:12177
+#: 3.8/weather-applet.js:13257 3.8/weather-applet.js:13258
+#: 3.8/weather-applet.js:14732 3.8/weather-applet.js:14733
+#: 3.8/weather-applet.js:15589 3.8/weather-applet.js:15590
+#: 3.8/weather-applet.js:16100 3.8/weather-applet.js:16101
+#: 3.8/weather-applet.js:16304
 msgid "Cloudy"
 msgstr "有雲"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13037 3.8/weather-applet.js:13779
-#: 3.8/weather-applet.js:13780 3.8/weather-applet.js:13814
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:13278
+#: 3.8/weather-applet.js:13279 3.8/weather-applet.js:14021
+#: 3.8/weather-applet.js:14022 3.8/weather-applet.js:14056
 msgid "Mostly cloudy"
 msgstr "多雲"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:11015
-#: 3.8/weather-applet.js:11016 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11023 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:13029
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13772
-#: 3.8/weather-applet.js:13773 3.8/weather-applet.js:13807
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14484
-#: 3.8/weather-applet.js:16504 3.8/weather-applet.js:16505
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:11012
+#: 3.8/weather-applet.js:11013 3.8/weather-applet.js:11019
+#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:12365
+#: 3.8/weather-applet.js:12366 3.8/weather-applet.js:13271
+#: 3.8/weather-applet.js:13272 3.8/weather-applet.js:14014
+#: 3.8/weather-applet.js:14015 3.8/weather-applet.js:14049
+#: 3.8/weather-applet.js:14725 3.8/weather-applet.js:14726
+#: 3.8/weather-applet.js:16773 3.8/weather-applet.js:16774
 msgid "Partly cloudy"
 msgstr "晴時多雲"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13022
-#: 3.8/weather-applet.js:13023
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:13264
+#: 3.8/weather-applet.js:13265
 #, fuzzy
 msgid "Mostly clear"
 msgstr "多雲"
@@ -501,42 +512,45 @@ msgstr "多雲"
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:11002
-#: 3.8/weather-applet.js:11309 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13758
-#: 3.8/weather-applet.js:13759 3.8/weather-applet.js:13793
-#: 3.8/weather-applet.js:14275 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14477 3.8/weather-applet.js:15334
-#: 3.8/weather-applet.js:15335 3.8/weather-applet.js:15341
-#: 3.8/weather-applet.js:15342 3.8/weather-applet.js:15894
-#: 3.8/weather-applet.js:15895 3.8/weather-applet.js:16490
+#: 3.8/weather-applet.js:10998 3.8/weather-applet.js:10999
+#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:12805
+#: 3.8/weather-applet.js:12886 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:14000
+#: 3.8/weather-applet.js:14001 3.8/weather-applet.js:14035
+#: 3.8/weather-applet.js:14517 3.8/weather-applet.js:14718
+#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:15575
+#: 3.8/weather-applet.js:15576 3.8/weather-applet.js:15582
+#: 3.8/weather-applet.js:15583 3.8/weather-applet.js:16135
+#: 3.8/weather-applet.js:16136 3.8/weather-applet.js:16298
+#: 3.8/weather-applet.js:16759
 msgid "Clear"
 msgstr "明朗"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11008
-#: 3.8/weather-applet.js:11009 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:15901
-#: 3.8/weather-applet.js:15902
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:11005
+#: 3.8/weather-applet.js:11006 3.8/weather-applet.js:13250
+#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:16142
+#: 3.8/weather-applet.js:16143
 msgid "Sunny"
 msgstr "晴"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:10995 3.8/weather-applet.js:11029
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:11218
-#: 3.8/weather-applet.js:11219 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:12065 3.8/weather-applet.js:12362
-#: 3.8/weather-applet.js:12363 3.8/weather-applet.js:13000
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13749
-#: 3.8/weather-applet.js:13750 3.8/weather-applet.js:13978
-#: 3.8/weather-applet.js:13979 3.8/weather-applet.js:15267
-#: 3.8/weather-applet.js:15268 3.8/weather-applet.js:15418
-#: 3.8/weather-applet.js:15419 3.8/weather-applet.js:16005
-#: 3.8/weather-applet.js:16007 3.8/weather-applet.js:16680
-#: 3.8/weather-applet.js:16681
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10991
+#: 3.8/weather-applet.js:10992 3.8/weather-applet.js:11026
+#: 3.8/weather-applet.js:11027 3.8/weather-applet.js:11215
+#: 3.8/weather-applet.js:11216 3.8/weather-applet.js:12159
+#: 3.8/weather-applet.js:12160 3.8/weather-applet.js:12457
+#: 3.8/weather-applet.js:12458 3.8/weather-applet.js:12816
+#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:13242
+#: 3.8/weather-applet.js:13243 3.8/weather-applet.js:13991
+#: 3.8/weather-applet.js:13992 3.8/weather-applet.js:14220
+#: 3.8/weather-applet.js:14221 3.8/weather-applet.js:15508
+#: 3.8/weather-applet.js:15509 3.8/weather-applet.js:15659
+#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:16246
+#: 3.8/weather-applet.js:16248 3.8/weather-applet.js:16949
+#: 3.8/weather-applet.js:16950
 msgid "Unknown"
 msgstr ""
 
@@ -558,13 +572,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:16088
+#: 3.0/darkSky.js:238
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:16475
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:16744
 msgid "Could not obtain location"
 msgstr ""
 
@@ -573,136 +587,137 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11926
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:12021
 #, fuzzy
 msgid "Cloudiness"
 msgstr "有雲"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:12074
-#: 3.8/weather-applet.js:12075 3.8/weather-applet.js:16491
+#: 3.8/weather-applet.js:11401 3.8/weather-applet.js:12169
+#: 3.8/weather-applet.js:12170 3.8/weather-applet.js:16760
 #, fuzzy
 msgid "Clear sky"
 msgstr "明朗"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:12088 3.8/weather-applet.js:12089
+#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12184
 msgid "Fair"
 msgstr "晴"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:12110
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:12205
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:12117
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:12212
 #, fuzzy
 msgid "Heavy rain showers"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:12124
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:12219
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12130
-#: 3.8/weather-applet.js:12131 3.8/weather-applet.js:12137
-#: 3.8/weather-applet.js:12144 3.8/weather-applet.js:12151
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:12225
+#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
+#: 3.8/weather-applet.js:12872
 #, fuzzy
 msgid "Heavy sleet"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:12138
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:12233
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:12145
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:12240
 #, fuzzy
 msgid "Heavy sleet showers"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:12152
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:12247
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:12166
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:12261
 #, fuzzy
 msgid "Heavy snow and thunder"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:12173
-#: 3.8/weather-applet.js:14589
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:12268
+#: 3.8/weather-applet.js:14831
 #, fuzzy
 msgid "Heavy snow showers"
 msgstr "陣雪"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:12180
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:12275
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:12194
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:12289
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:12201
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:12296
 #, fuzzy
 msgid "Light rain showers"
 msgstr "小雪"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:12208
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:12303
 #, fuzzy
 msgid "Light rain showers and thunder"
 msgstr "小雪"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12235
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:12309
+#: 3.8/weather-applet.js:12310 3.8/weather-applet.js:12316
+#: 3.8/weather-applet.js:12323 3.8/weather-applet.js:12330
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:12222
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:12317
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:12229
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:12324
 #, fuzzy
 msgid "Light sleet showers"
 msgstr "小雪"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:12236
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:12331
 #, fuzzy
 msgid "Light sleet showers and thunder"
 msgstr "小雪"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:12250
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:12345
 #, fuzzy
 msgid "Light snow and thunder"
 msgstr "小雪"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:12257
-#: 3.8/weather-applet.js:16646
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:12352
+#: 3.8/weather-applet.js:16915
 msgid "Light snow showers"
 msgstr "小雪"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:12264
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:12359
 #, fuzzy
 msgid "Light snow showers and thunder"
 msgstr "小雪"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:12285
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:12380
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12291
-#: 3.8/weather-applet.js:12292 3.8/weather-applet.js:12298
-#: 3.8/weather-applet.js:13893 3.8/weather-applet.js:14237
-#: 3.8/weather-applet.js:14554 3.8/weather-applet.js:14560
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:12386
+#: 3.8/weather-applet.js:12387 3.8/weather-applet.js:12393
+#: 3.8/weather-applet.js:14135 3.8/weather-applet.js:14479
+#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14802
 #, fuzzy
 msgid "Rain showers"
 msgstr "陣雪"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:12299
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:12394
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -711,47 +726,48 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11113
-#: 3.8/weather-applet.js:11120 3.8/weather-applet.js:11127
-#: 3.8/weather-applet.js:11128 3.8/weather-applet.js:11292
-#: 3.8/weather-applet.js:12305 3.8/weather-applet.js:12306
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12326 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
-#: 3.8/weather-applet.js:13850 3.8/weather-applet.js:13877
-#: 3.8/weather-applet.js:13878 3.8/weather-applet.js:15390
-#: 3.8/weather-applet.js:15391 3.8/weather-applet.js:15803
-#: 3.8/weather-applet.js:15804
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11117 3.8/weather-applet.js:11124
+#: 3.8/weather-applet.js:11125 3.8/weather-applet.js:11364
+#: 3.8/weather-applet.js:12400 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12407 3.8/weather-applet.js:12414
+#: 3.8/weather-applet.js:12421 3.8/weather-applet.js:12792
+#: 3.8/weather-applet.js:12870 3.8/weather-applet.js:14084
+#: 3.8/weather-applet.js:14085 3.8/weather-applet.js:14091
+#: 3.8/weather-applet.js:14092 3.8/weather-applet.js:14119
+#: 3.8/weather-applet.js:14120 3.8/weather-applet.js:15631
+#: 3.8/weather-applet.js:15632 3.8/weather-applet.js:16044
+#: 3.8/weather-applet.js:16045 3.8/weather-applet.js:16312
 msgid "Sleet"
 msgstr "霰"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:12313
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:12408
 #, fuzzy
 msgid "Sleet and thunder"
 msgstr "零星雷暴"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:12320
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:12415
 #, fuzzy
 msgid "Sleet showers"
 msgstr "零星陣雨"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:12327
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:12422
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:12341
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:12436
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:12347 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:12354 3.8/weather-applet.js:14255
-#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:16645
-#: 3.8/weather-applet.js:16652 3.8/weather-applet.js:16653
+#: 3.8/weather-applet.js:12442 3.8/weather-applet.js:12443
+#: 3.8/weather-applet.js:12449 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14824 3.8/weather-applet.js:16914
+#: 3.8/weather-applet.js:16921 3.8/weather-applet.js:16922
 msgid "Snow showers"
 msgstr "陣雪"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:12355
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:12450
 #, fuzzy
 msgid "Snow showers and thunder"
 msgstr "陣雪"
@@ -761,20 +777,20 @@ msgstr "陣雪"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10813
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10810
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10841
-#: 3.8/weather-applet.js:12471 3.8/weather-applet.js:13706
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:12566 3.8/weather-applet.js:13948
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10656 3.8/weather-applet.js:12497
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:13485
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10619
+#: 3.8/weather-applet.js:10653 3.8/weather-applet.js:12592
+#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:13727
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -803,330 +819,350 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:11299 3.8/weather-applet.js:14227
+#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11034
+#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11380
+#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12874
+#: 3.8/weather-applet.js:14469
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11057
-#: 3.8/weather-applet.js:11058 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13787 3.8/weather-applet.js:13821
-#: 3.8/weather-applet.js:14271 3.8/weather-applet.js:16511
-#: 3.8/weather-applet.js:16512
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:11054
+#: 3.8/weather-applet.js:11055 3.8/weather-applet.js:12813
+#: 3.8/weather-applet.js:12894 3.8/weather-applet.js:14028
+#: 3.8/weather-applet.js:14029 3.8/weather-applet.js:14063
+#: 3.8/weather-applet.js:14513 3.8/weather-applet.js:16780
+#: 3.8/weather-applet.js:16781
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11065
-#: 3.8/weather-applet.js:11072
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:11062
+#: 3.8/weather-applet.js:11069
 #, fuzzy
 msgid "Light rain shower"
 msgstr "小雪"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:11078 3.8/weather-applet.js:11079
-#: 3.8/weather-applet.js:11271 3.8/weather-applet.js:13078
-#: 3.8/weather-applet.js:13079 3.8/weather-applet.js:13134
-#: 3.8/weather-applet.js:14193 3.8/weather-applet.js:15740
-#: 3.8/weather-applet.js:15741 3.8/weather-applet.js:16526
-#: 3.8/weather-applet.js:16533 3.8/weather-applet.js:16534
-#: 3.8/weather-applet.js:16540 3.8/weather-applet.js:16547
-#: 3.8/weather-applet.js:16554
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:11075 3.8/weather-applet.js:11076
+#: 3.8/weather-applet.js:11265 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:12773 3.8/weather-applet.js:12838
+#: 3.8/weather-applet.js:13320 3.8/weather-applet.js:13321
+#: 3.8/weather-applet.js:13376 3.8/weather-applet.js:14435
+#: 3.8/weather-applet.js:15981 3.8/weather-applet.js:15982
+#: 3.8/weather-applet.js:16795 3.8/weather-applet.js:16802
+#: 3.8/weather-applet.js:16803 3.8/weather-applet.js:16809
+#: 3.8/weather-applet.js:16816 3.8/weather-applet.js:16823
 msgid "Drizzle"
 msgstr "小雨"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11093
-#: 3.8/weather-applet.js:11100
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:11090
+#: 3.8/weather-applet.js:11097
 #, fuzzy
 msgid "Heavy rain shower"
 msgstr "大雪"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11114
-#: 3.8/weather-applet.js:11121
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:11111
+#: 3.8/weather-applet.js:11118
 #, fuzzy
 msgid "Sleet shower"
 msgstr "零星陣雨"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:11134 3.8/weather-applet.js:11141
-#: 3.8/weather-applet.js:11148 3.8/weather-applet.js:11149
-#: 3.8/weather-applet.js:14269 3.8/weather-applet.js:15362
-#: 3.8/weather-applet.js:15363 3.8/weather-applet.js:15796
-#: 3.8/weather-applet.js:15797
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:11131 3.8/weather-applet.js:11138
+#: 3.8/weather-applet.js:11145 3.8/weather-applet.js:11146
+#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:15603
+#: 3.8/weather-applet.js:15604 3.8/weather-applet.js:16037
+#: 3.8/weather-applet.js:16038
 msgid "Hail"
 msgstr "冰雹"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11135
-#: 3.8/weather-applet.js:11142
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:11132
+#: 3.8/weather-applet.js:11139
 #, fuzzy
 msgid "Hail shower"
 msgstr "陣雪"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11163
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:11153
+#: 3.8/weather-applet.js:11160
 #, fuzzy
 msgid "Light snow shower"
 msgstr "小雪"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11184
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11181 3.8/weather-applet.js:12866
 #, fuzzy
 msgid "Heavy snow shower"
 msgstr "大雪"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:11197 3.8/weather-applet.js:11204
-#: 3.8/weather-applet.js:11211 3.8/weather-applet.js:11212
+#: 3.8/weather-applet.js:11194 3.8/weather-applet.js:11201
+#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11209
 #, fuzzy
 msgid "Thunder"
 msgstr "雷雨"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:11195
+#: 3.8/weather-applet.js:11202
 #, fuzzy
 msgid "Thunder shower"
 msgstr "雷陣雨"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11554
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11649
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11558
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11653
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11562
+#: 3.8/weather-applet.js:11657
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11566
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11661
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11570
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11665
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11260
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11300
+#: 3.8/weather-applet.js:12822
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11261
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11302
+#: 3.8/weather-applet.js:12824
 #, fuzzy
 msgid "Thunderstorm with rain"
 msgstr "雷雨"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11262
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:12826
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11263
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11306
 #, fuzzy
 msgid "Light thunderstorm"
 msgstr "雷雨"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11265
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11310
 #, fuzzy
 msgid "Heavy thunderstorm"
 msgstr "強雷暴雨"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11266
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11312
 #, fuzzy
 msgid "Ragged thunderstorm"
 msgstr "局部地區有雷暴"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11267
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11314
+#: 3.8/weather-applet.js:12828
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11268
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11316
+#: 3.8/weather-applet.js:12830
 #, fuzzy
 msgid "Thunderstorm with drizzle"
 msgstr "雷雨"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11269
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11318
+#: 3.8/weather-applet.js:12832
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11270
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11320
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11272
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11324
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11273
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11326
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11274
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11328
 #, fuzzy
 msgid "Drizzle rain"
 msgstr "小雨"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11275
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11330
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11276
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11332
 #, fuzzy
 msgid "Shower rain and drizzle"
 msgstr "冰雹"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11277
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11334
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11278
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11336
 #, fuzzy
 msgid "Shower drizzle"
 msgstr "凍毛毛雨"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11280
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11340
+#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14760
+#: 3.8/weather-applet.js:14761
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11281
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11342
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11282
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11344
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11283
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11346
 #, fuzzy
 msgid "Extreme rain"
 msgstr "凍雨"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11285
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11350
 #, fuzzy
 msgid "Light intensity shower rain"
 msgstr "小雪"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11286
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:12852
 #, fuzzy
 msgid "Shower rain"
 msgstr "陣雨"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11287
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11354
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11288
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11356
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11293
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11368
 #, fuzzy
 msgid "Shower sleet"
 msgstr "陣雨"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11294
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11370
 #, fuzzy
 msgid "Light rain and snow"
 msgstr "雨雪交加"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11295
-#: 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
-#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14567
-#: 3.8/weather-applet.js:14574
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11372
+#: 3.8/weather-applet.js:14767 3.8/weather-applet.js:14768
+#: 3.8/weather-applet.js:14774 3.8/weather-applet.js:14809
+#: 3.8/weather-applet.js:14816
 #, fuzzy
 msgid "Rain and snow"
 msgstr "雨雪交加"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11296
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11374
 #, fuzzy
 msgid "Light shower snow"
 msgstr "小雪"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11297
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11376
 #, fuzzy
 msgid "Shower snow"
 msgstr "陣雨"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11298
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11378
 #, fuzzy
 msgid "Heavy shower snow"
 msgstr "大雪"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11300 3.8/weather-applet.js:13936
-#: 3.8/weather-applet.js:13937 3.8/weather-applet.js:15831
-#: 3.8/weather-applet.js:15832
+#: 3.8/weather-applet.js:11277 3.8/weather-applet.js:11382
+#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12876
+#: 3.8/weather-applet.js:14178 3.8/weather-applet.js:14179
+#: 3.8/weather-applet.js:16072 3.8/weather-applet.js:16073
 #, fuzzy
 msgid "Smoke"
 msgstr "煙霧"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11301 3.8/weather-applet.js:13943
-#: 3.8/weather-applet.js:13944 3.8/weather-applet.js:15824
-#: 3.8/weather-applet.js:15825
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11279 3.8/weather-applet.js:11384
+#: 3.8/weather-applet.js:12798 3.8/weather-applet.js:12878
+#: 3.8/weather-applet.js:14185 3.8/weather-applet.js:14186
+#: 3.8/weather-applet.js:16065 3.8/weather-applet.js:16066
 msgid "Haze"
 msgstr "陰霾"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11302
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11386
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11304
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11285
+#: 3.8/weather-applet.js:11390
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11305 3.8/weather-applet.js:13929
-#: 3.8/weather-applet.js:13930 3.8/weather-applet.js:15810
-#: 3.8/weather-applet.js:15811
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11281 3.8/weather-applet.js:11392
+#: 3.8/weather-applet.js:12800 3.8/weather-applet.js:12880
+#: 3.8/weather-applet.js:14171 3.8/weather-applet.js:14172
+#: 3.8/weather-applet.js:16051 3.8/weather-applet.js:16052
 msgid "Dust"
 msgstr "灰塵"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11306
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11394
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11307
-#: 3.8/weather-applet.js:14261
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11396
+#: 3.8/weather-applet.js:14503
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11308 3.8/weather-applet.js:13908
-#: 3.8/weather-applet.js:13909 3.8/weather-applet.js:15683
-#: 3.8/weather-applet.js:15684
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11291 3.8/weather-applet.js:11398
+#: 3.8/weather-applet.js:14150 3.8/weather-applet.js:14151
+#: 3.8/weather-applet.js:15924 3.8/weather-applet.js:15925
 msgid "Tornado"
 msgstr "龍捲風"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11311
+#: 3.0/openWeatherMap.js:413
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11312
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11273
 #, fuzzy
 msgid "Clouds"
 msgstr "有雲"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:13765 3.8/weather-applet.js:13766
-#: 3.8/weather-applet.js:13800
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11403
+#: 3.8/weather-applet.js:12807 3.8/weather-applet.js:12888
+#: 3.8/weather-applet.js:14007 3.8/weather-applet.js:14008
+#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:16766
+#: 3.8/weather-applet.js:16767
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11314
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11405
+#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12890
 #, fuzzy
 msgid "Scattered clouds"
 msgstr "零星陣雨"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11315
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11407
+#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:12892
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11316
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11409
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1134,76 +1170,76 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:13442
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:13684
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:13506
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:13748
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13794
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:14036
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13801
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:14043
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13808
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:14050
 #, fuzzy
 msgid "Partly cloudy and windy"
 msgstr "晴時多雲"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13815
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:14057
 #, fuzzy
 msgid "Mostly cloudy and windy"
 msgstr "多雲"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13822
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:14064
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13836
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:14078
 #, fuzzy
 msgid "Snowy rain"
 msgstr "飄雪"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13871
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:14113
 #, fuzzy
 msgid "Freezing rain and snow"
 msgstr "凍雨"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9555 3.8/weather-applet.js:13915
-#: 3.8/weather-applet.js:13916 3.8/weather-applet.js:15697
-#: 3.8/weather-applet.js:15698
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9552 3.8/weather-applet.js:14157
+#: 3.8/weather-applet.js:14158 3.8/weather-applet.js:15938
+#: 3.8/weather-applet.js:15939
 msgid "Hurricane"
 msgstr "颶風"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9550
-#: 3.8/weather-applet.js:13922
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9547
+#: 3.8/weather-applet.js:14164
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13923
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:14165
 msgid "Tropical storm"
 msgstr "熱帶風暴"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13950 3.8/weather-applet.js:13951
-#: 3.8/weather-applet.js:15929 3.8/weather-applet.js:15930
+#: 3.8/weather-applet.js:14192 3.8/weather-applet.js:14193
+#: 3.8/weather-applet.js:16170 3.8/weather-applet.js:16171
 msgid "Hot"
 msgstr "炎熱"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13957 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14199 3.8/weather-applet.js:14200
 msgid "Cold"
 msgstr "冷"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13964 3.8/weather-applet.js:13965
-#: 3.8/weather-applet.js:15978 3.8/weather-applet.js:15979
+#: 3.8/weather-applet.js:14206 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:16219 3.8/weather-applet.js:16220
 msgid "Blizzard"
 msgstr ""
 
@@ -1243,79 +1279,79 @@ msgstr "星期五"
 msgid "Saturday"
 msgstr "星期六"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9520
+#: 3.0/utils.js:301 3.8/weather-applet.js:9517
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9523
+#: 3.0/utils.js:304 3.8/weather-applet.js:9520
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9526
+#: 3.0/utils.js:307 3.8/weather-applet.js:9523
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9529
+#: 3.0/utils.js:310 3.8/weather-applet.js:9526
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9532
+#: 3.0/utils.js:313 3.8/weather-applet.js:9529
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9535
+#: 3.0/utils.js:316 3.8/weather-applet.js:9532
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9538
+#: 3.0/utils.js:319 3.8/weather-applet.js:9535
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9541
+#: 3.0/utils.js:322 3.8/weather-applet.js:9538
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9544
+#: 3.0/utils.js:325 3.8/weather-applet.js:9541
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9547
+#: 3.0/utils.js:328 3.8/weather-applet.js:9544
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9553
+#: 3.0/utils.js:334 3.8/weather-applet.js:9550
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "N"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "E"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "S"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "SW"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "W"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9703
+#: 3.0/utils.js:429 3.8/weather-applet.js:9700
 msgid "NW"
 msgstr ""
 
@@ -1360,7 +1396,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:15690 3.8/weather-applet.js:15691
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:15931 3.8/weather-applet.js:15932
 #, fuzzy
 msgid "Tropical Storm"
 msgstr "熱帶風暴"
@@ -1370,7 +1406,7 @@ msgstr "熱帶風暴"
 msgid "Severe Thunderstorms"
 msgstr "強雷暴雨"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:15711 3.8/weather-applet.js:15712
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:15952 3.8/weather-applet.js:15953
 msgid "Thunderstorms"
 msgstr "雷雨"
 
@@ -1389,19 +1425,19 @@ msgstr "雨霰交加"
 msgid "Mixed Snow and Sleet"
 msgstr "雪霰交加"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:15733 3.8/weather-applet.js:15734
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:15974 3.8/weather-applet.js:15975
 #, fuzzy
 msgid "Freezing Drizzle"
 msgstr "凍毛毛雨"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:15747 3.8/weather-applet.js:15748
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:15988 3.8/weather-applet.js:15989
 #, fuzzy
 msgid "Freezing Rain"
 msgstr "凍雨"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:15754 3.8/weather-applet.js:15755
-#: 3.8/weather-applet.js:16624 3.8/weather-applet.js:16631
-#: 3.8/weather-applet.js:16632 3.8/weather-applet.js:16638
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:15995 3.8/weather-applet.js:15996
+#: 3.8/weather-applet.js:16893 3.8/weather-applet.js:16900
+#: 3.8/weather-applet.js:16901 3.8/weather-applet.js:16907
 msgid "Showers"
 msgstr "陣雨"
 
@@ -1415,12 +1451,12 @@ msgstr "飄雪"
 msgid "Light Snow Showers"
 msgstr "小雪"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:15782 3.8/weather-applet.js:15783
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:16023 3.8/weather-applet.js:16024
 #, fuzzy
 msgid "Blowing Snow"
 msgstr "暴雪"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14504 3.8/weather-applet.js:14505
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:14746 3.8/weather-applet.js:14747
 msgid "Foggy"
 msgstr "霧"
 
@@ -1432,63 +1468,64 @@ msgstr "煙霧"
 msgid "Blustery"
 msgstr "大風"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:15845 3.8/weather-applet.js:15846
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:16086 3.8/weather-applet.js:16087
 msgid "Windy"
 msgstr "有風"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15866 3.8/weather-applet.js:15867
-#: 3.8/weather-applet.js:15873 3.8/weather-applet.js:15874
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:16107 3.8/weather-applet.js:16108
+#: 3.8/weather-applet.js:16114 3.8/weather-applet.js:16115
 #, fuzzy
 msgid "Mostly Cloudy"
 msgstr "多雲"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:15369 3.8/weather-applet.js:15370
-#: 3.8/weather-applet.js:15376 3.8/weather-applet.js:15377
-#: 3.8/weather-applet.js:15880 3.8/weather-applet.js:15881
-#: 3.8/weather-applet.js:15887 3.8/weather-applet.js:15888
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:15610 3.8/weather-applet.js:15611
+#: 3.8/weather-applet.js:15617 3.8/weather-applet.js:15618
+#: 3.8/weather-applet.js:16121 3.8/weather-applet.js:16122
+#: 3.8/weather-applet.js:16128 3.8/weather-applet.js:16129
+#: 3.8/weather-applet.js:16300
 #, fuzzy
 msgid "Partly Cloudy"
 msgstr "晴時多雲"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15915 3.8/weather-applet.js:15916
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:16156 3.8/weather-applet.js:16157
 #, fuzzy
 msgid "Mostly Sunny"
 msgstr "多雲"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15922 3.8/weather-applet.js:15923
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:16163 3.8/weather-applet.js:16164
 #, fuzzy
 msgid "Mixed Rain and Hail"
 msgstr "冰雹"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15936 3.8/weather-applet.js:15937
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:16177 3.8/weather-applet.js:16178
 #, fuzzy
 msgid "Isolated Thunderstorms"
 msgstr "局部地區有雷暴"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15943 3.8/weather-applet.js:15944
-#: 3.8/weather-applet.js:15999 3.8/weather-applet.js:16000
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:16184 3.8/weather-applet.js:16185
+#: 3.8/weather-applet.js:16240 3.8/weather-applet.js:16241
 #, fuzzy
 msgid "Scattered Thunderstorms"
 msgstr "零星雷暴"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15950 3.8/weather-applet.js:15951
-#: 3.8/weather-applet.js:15985 3.8/weather-applet.js:15986
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:16191 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16226 3.8/weather-applet.js:16227
 #, fuzzy
 msgid "Scattered Showers"
 msgstr "零星陣雨"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15957 3.8/weather-applet.js:15958
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:16198 3.8/weather-applet.js:16199
 #, fuzzy
 msgid "Heavy Rain"
 msgstr "大雪"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15964 3.8/weather-applet.js:15965
-#: 3.8/weather-applet.js:15992 3.8/weather-applet.js:15993
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:16205 3.8/weather-applet.js:16206
+#: 3.8/weather-applet.js:16233 3.8/weather-applet.js:16234
 #, fuzzy
 msgid "Scattered Snow Showers"
 msgstr "零星陣雪"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15971 3.8/weather-applet.js:15972
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:16212 3.8/weather-applet.js:16213
 #, fuzzy
 msgid "Heavy Snow"
 msgstr "大雪"
@@ -1516,452 +1553,487 @@ msgid ""
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10580
+#: 3.8/weather-applet.js:10577
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10685
+#: 3.8/weather-applet.js:10682
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10773
+#: 3.8/weather-applet.js:10770
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10854
+#: 3.8/weather-applet.js:10851
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10855
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863
+#: 3.8/weather-applet.js:10860
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10863 3.8/weather-applet.js:10868
-#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:10878
-#: 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10860 3.8/weather-applet.js:10865
+#: 3.8/weather-applet.js:10870 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10880
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10868
+#: 3.8/weather-applet.js:10865
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10873
+#: 3.8/weather-applet.js:10870
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10878 3.8/weather-applet.js:10883
+#: 3.8/weather-applet.js:10875 3.8/weather-applet.js:10880
 msgid "Very good"
 msgstr ""
 
+#: 3.8/weather-applet.js:11287
+msgid "Ash"
+msgstr ""
+
+#: 3.8/weather-applet.js:11289
+msgid "Squall"
+msgstr ""
+
+#: 3.8/weather-applet.js:11366
+#, fuzzy
+msgid "Light shower sleet"
+msgstr "小雪"
+
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11531 3.8/weather-applet.js:16877
+#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:17146
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11817
+#: 3.8/weather-applet.js:11912
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:12379
+#: 3.8/weather-applet.js:12474
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12849
-#, fuzzy
-msgid "Tomorrow.io"
-msgstr "明天"
-
-#: 3.8/weather-applet.js:13058
-msgid "Light wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13072
-msgid "Strong wind"
-msgstr ""
-
-#: 3.8/weather-applet.js:13422
-msgid "US Weather"
-msgstr ""
-
-#: 3.8/weather-applet.js:13997
-msgid "Visual Crossing"
-msgstr ""
-
-#: 3.8/weather-applet.js:14191
-#, fuzzy
-msgid "Blowing or drifting snow"
-msgstr "暴雪"
-
-#: 3.8/weather-applet.js:14195 3.8/weather-applet.js:16541
+#: 3.8/weather-applet.js:12840 3.8/weather-applet.js:14437
+#: 3.8/weather-applet.js:16810
 #, fuzzy
 msgid "Heavy drizzle"
 msgstr "凍毛毛雨"
 
-#: 3.8/weather-applet.js:14199
-msgid "Heavy drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14201
-msgid "Light drizzle/rain"
-msgstr ""
-
-#: 3.8/weather-applet.js:14203
-msgid "Dust Storm"
-msgstr ""
-
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:12850
 #, fuzzy
-msgid "Freezing drizzle/freezing rain"
-msgstr "凍毛毛雨"
+msgid "Light shower rain"
+msgstr "小雪"
 
-#: 3.8/weather-applet.js:14209
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12854
+#, fuzzy
+msgid "Heavy shower rain"
+msgstr "大雪"
 
-#: 3.8/weather-applet.js:14211
-msgid "Light freezing drizzle/freezing rain"
-msgstr ""
+#: 3.8/weather-applet.js:12862
+#, fuzzy
+msgid "Mix snow/rain"
+msgstr "飄雪"
 
-#: 3.8/weather-applet.js:14213
+#: 3.8/weather-applet.js:12864
+#, fuzzy
+msgid "Snow shower"
+msgstr "陣雪"
+
+#: 3.8/weather-applet.js:12884 3.8/weather-applet.js:14455
 #, fuzzy
 msgid "Freezing fog"
 msgstr "凍雨"
 
-#: 3.8/weather-applet.js:14219
+#: 3.8/weather-applet.js:13091
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "明天"
+
+#: 3.8/weather-applet.js:13300
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13314
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:13664
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14239
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:14433
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "暴雪"
+
+#: 3.8/weather-applet.js:14441
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14443
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14445
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14449
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "凍毛毛雨"
+
+#: 3.8/weather-applet.js:14451
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14453
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:14461
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:14463
 #, fuzzy
 msgid "Hail showers"
 msgstr "陣雪"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:14465
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:14225
+#: 3.8/weather-applet.js:14467
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:14229
+#: 3.8/weather-applet.js:14471
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:14233 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:14475 3.8/weather-applet.js:14775
 #, fuzzy
 msgid "Heavy rain and snow"
 msgstr "雨雪交加"
 
-#: 3.8/weather-applet.js:14235
+#: 3.8/weather-applet.js:14477
 #, fuzzy
 msgid "Light rain And snow"
 msgstr "雨雪交加"
 
-#: 3.8/weather-applet.js:14243
+#: 3.8/weather-applet.js:14485
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14245
+#: 3.8/weather-applet.js:14487
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:14247
+#: 3.8/weather-applet.js:14489
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:14249
+#: 3.8/weather-applet.js:14491
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:14253
+#: 3.8/weather-applet.js:14495
 #, fuzzy
 msgid "Snow and rain showers"
 msgstr "陣雪"
 
-#: 3.8/weather-applet.js:14265
+#: 3.8/weather-applet.js:14507
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:14267
+#: 3.8/weather-applet.js:14509
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:14273
+#: 3.8/weather-applet.js:14515
 #, fuzzy
 msgid "Partially cloudy"
 msgstr "晴時多雲"
 
-#: 3.8/weather-applet.js:14295
+#: 3.8/weather-applet.js:14537
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14312
+#: 3.8/weather-applet.js:14554
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:14465 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14602 3.8/weather-applet.js:14603
+#: 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.8/weather-applet.js:14844 3.8/weather-applet.js:14845
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:14498
+#: 3.8/weather-applet.js:14740
 msgid "Blowing snow"
 msgstr "暴雪"
 
-#: 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.8/weather-applet.js:14781 3.8/weather-applet.js:14782
 #, fuzzy
 msgid "Slight snow"
 msgstr "暴雪"
 
-#: 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.8/weather-applet.js:14788 3.8/weather-applet.js:14789
 #, fuzzy
 msgid "Moderate snow"
 msgstr "大雪"
 
-#: 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:14803
 #, fuzzy
 msgid "Moderate rain showers"
 msgstr "零星陣雨"
 
-#: 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14810
 msgid "Mixed rain and snow"
 msgstr "雨雪交加"
 
-#: 3.8/weather-applet.js:14575
+#: 3.8/weather-applet.js:14817
 #, fuzzy
 msgid "Heavy mixed rain and snow"
 msgstr "雨雪交加"
 
-#: 3.8/weather-applet.js:14743
+#: 3.8/weather-applet.js:14984
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15370
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:15142
+#: 3.8/weather-applet.js:15383
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:15458
+#: 3.8/weather-applet.js:15699
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:15661
+#: 3.8/weather-applet.js:15902
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:15668
+#: 3.8/weather-applet.js:15909
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:15704 3.8/weather-applet.js:15705
+#: 3.8/weather-applet.js:15945 3.8/weather-applet.js:15946
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:15719 3.8/weather-applet.js:15720
+#: 3.8/weather-applet.js:15960 3.8/weather-applet.js:15961
 #, fuzzy
 msgid "Rain and Snow"
 msgstr "雨雪交加"
 
-#: 3.8/weather-applet.js:15726 3.8/weather-applet.js:15727
+#: 3.8/weather-applet.js:15967 3.8/weather-applet.js:15968
 #, fuzzy
 msgid "Rain and Sleet"
 msgstr "雨霰交加"
 
-#: 3.8/weather-applet.js:15775 3.8/weather-applet.js:15776
+#: 3.8/weather-applet.js:16016 3.8/weather-applet.js:16017
 #, fuzzy
 msgid "Snow Showers"
 msgstr "陣雪"
 
-#: 3.8/weather-applet.js:15838 3.8/weather-applet.js:15839
+#: 3.8/weather-applet.js:16079 3.8/weather-applet.js:16080
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:15852 3.8/weather-applet.js:15853
+#: 3.8/weather-applet.js:16093 3.8/weather-applet.js:16094
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15908 3.8/weather-applet.js:15909
+#: 3.8/weather-applet.js:16149 3.8/weather-applet.js:16150
 #, fuzzy
 msgid "Mostly Clear"
 msgstr "多雲"
 
-#: 3.8/weather-applet.js:16061
+#: 3.8/weather-applet.js:16330
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:16455
+#: 3.8/weather-applet.js:16357
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:16724
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:16497 3.8/weather-applet.js:16498
-#, fuzzy
-msgid "Mainly clear"
-msgstr "多雲"
-
-#: 3.8/weather-applet.js:16618
+#: 3.8/weather-applet.js:16887
 #, fuzzy
 msgid "Snow grains"
 msgstr "飄雪"
 
-#: 3.8/weather-applet.js:16625
+#: 3.8/weather-applet.js:16894
 #, fuzzy
 msgid "Light showers"
 msgstr "小雪"
 
-#: 3.8/weather-applet.js:16639
+#: 3.8/weather-applet.js:16908
 #, fuzzy
 msgid "Heavy showers"
 msgstr "大雪"
 
-#: 3.8/weather-applet.js:16667
+#: 3.8/weather-applet.js:16936
 #, fuzzy
 msgid "Thunderstorm with slight hail"
 msgstr "雷雨"
 
-#: 3.8/weather-applet.js:16674
+#: 3.8/weather-applet.js:16943
 #, fuzzy
 msgid "Thunderstorm with hail"
 msgstr "雷雨"
 
-#: 3.8/weather-applet.js:16701 3.8/weather-applet.js:16860
+#: 3.8/weather-applet.js:16970 3.8/weather-applet.js:17129
 msgid "Feels like"
 msgstr ""
 
-#: 3.8/weather-applet.js:16769
+#: 3.8/weather-applet.js:17038
 msgid "Open Meteo"
 msgstr ""
 
-#: 3.8/weather-applet.js:17274
+#: 3.8/weather-applet.js:17544
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17281
+#: 3.8/weather-applet.js:17551
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17557
+#: 3.8/weather-applet.js:17827
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:17575
+#: 3.8/weather-applet.js:17845
 msgid "This provider requires an API key to operate"
 msgstr ""
 
-#: 3.8/weather-applet.js:17979
+#: 3.8/weather-applet.js:18253
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:18062
+#: 3.8/weather-applet.js:18336
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18064
+#: 3.8/weather-applet.js:18338
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:18067
+#: 3.8/weather-applet.js:18341
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:18270
+#: 3.8/weather-applet.js:18544
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:18833 3.8/weather-applet.js:19441
+#: 3.8/weather-applet.js:19107 3.8/weather-applet.js:19715
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18839
+#: 3.8/weather-applet.js:19113
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:18843
+#: 3.8/weather-applet.js:19117
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18846
+#: 3.8/weather-applet.js:19120
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:18856
+#: 3.8/weather-applet.js:19130
 msgid "{count} weather alert(s)"
 msgstr ""
 
-#: 3.8/weather-applet.js:19251 3.8/weather-applet.js:19261
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19525 3.8/weather-applet.js:19535
+#: 3.8/weather-applet.js:19542
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:19268
+#: 3.8/weather-applet.js:19542
 msgid "Could not open file {filePath} for writing"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19277
+#: 3.8/weather-applet.js:19551
 msgid "Saved to {filePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "No Script Provided"
 msgstr ""
 
-#: 3.8/weather-applet.js:19481
+#: 3.8/weather-applet.js:19755
 msgid "You need to add a script first."
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No Weather Data"
 msgstr ""
 
-#: 3.8/weather-applet.js:19485
+#: 3.8/weather-applet.js:19759
 msgid "No weather data to run script with"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Script Executed Successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:19493
+#: 3.8/weather-applet.js:19767
 msgid "Your script has been executed successfully."
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Error Running Script"
 msgstr ""
 
-#: 3.8/weather-applet.js:19496
+#: 3.8/weather-applet.js:19770
 msgid "Script returned error, see logs for more information"
 msgstr ""
 
@@ -2353,7 +2425,6 @@ msgid "Weather conditions"
 msgstr ""
 
 #. 3.0->settings-schema.json->translateCondition->description
-#. 3.8->settings-schema.json->translateCondition->description
 msgid "Translate conditions"
 msgstr ""
 
@@ -2628,6 +2699,17 @@ msgstr ""
 
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Provider should translate conditions if available"
+msgstr ""
+
+#. 3.8->settings-schema.json->translateCondition->tooltip
+msgid ""
+"Should your provider translate the conditions to your language if your "
+"locale is supported by the provider. Otherwise the applet will use it's own "
+"translation system."
 msgstr ""
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip

--- a/weather@mockturtl/src/3_0/weatherbit.ts
+++ b/weather@mockturtl/src/3_0/weatherbit.ts
@@ -72,8 +72,8 @@ class Weatherbit implements WeatherProvider {
     // A function as a function parameter 2 levels deep does not know
     // about the top level object information, has to pass it in as a parameter
     /**
-     * 
-     * @param baseUrl 
+     *
+     * @param baseUrl
      * @param ParseFunction returns WeatherData or ForecastData Object
      */
     private async GetData(baseUrl: string, loc: Location, ParseFunction: (json: any, context: any) => WeatherData | ForecastData[] | HourlyForecastData[]) {
@@ -257,7 +257,7 @@ class Weatherbit implements WeatherProvider {
      * Weatherbit does not consider Daylight saving time when returning Dates
      * in string format, but we can check if unix timestamp and date string has mismatch
      * to figure out if it's an incorrect Date.
-     * 
+     *
      * @param ts unix timestamp initialized as Date from payload
      * @param last_ob_time last refresh time in string format
      * @returns the hour difference of incorrect time from correct time
@@ -287,7 +287,7 @@ class Weatherbit implements WeatherProvider {
     private ConstructQuery(query: string, loc: Location): string {
         let key = this.app.config._apiKey.replace(" ", "");
         if (this.app.config.noApiKey()) {
-            this.app.log.Error("DarkSky: No API Key given");
+            this.app.log.Error("Weatherbit: No API Key given");
             this.app.HandleError({
                 type: "hard",
                 userError: true,
@@ -306,7 +306,7 @@ class Weatherbit implements WeatherProvider {
     };
 
     /**
-    * 
+    *
     * @param message Soup Message object
     * @returns null if custom error checking does not find anything
     */

--- a/weather@mockturtl/src/3_8/config.ts
+++ b/weather@mockturtl/src/3_8/config.ts
@@ -105,6 +105,9 @@ export class Config {
 	public readonly _refreshInterval!: number;
 	public readonly _manualLocation!: boolean;
 	public readonly _dataService!: Services;
+	/**
+	 * Should the __API__ translate the condition
+	 */
 	public readonly _translateCondition!: boolean;
 	public readonly _pressureUnit!: WeatherPressureUnits;
 	public readonly _show24Hours!: boolean;

--- a/weather@mockturtl/src/3_8/config.ts
+++ b/weather@mockturtl/src/3_8/config.ts
@@ -56,7 +56,7 @@ export type DistanceUnits = 'automatic' | 'metric' | 'imperial';
 
 /** Change settings-schema if you change this */
 export type Services =
-	"OpenWeatherMap" |
+	"OpenWeatherMap_Open" |
 	"MetNorway" |
 	"Weatherbit" |
 	"Tomorrow.io" |
@@ -72,7 +72,7 @@ export type Services =
 	"OpenWeatherMap_OneCall";
 
 export const ServiceClassMapping: ServiceClassMappingType = {
-	"OpenWeatherMap": (app) => new OpenWeatherMapOpen(app),
+	"OpenWeatherMap_Open": (app) => new OpenWeatherMapOpen(app),
 	"OpenWeatherMap_OneCall": (app) => new OpenWeatherMapOneCall(app),
 	"MetNorway": (app) => new MetNorway(app),
 	"Weatherbit": (app) => new Weatherbit(app),

--- a/weather@mockturtl/src/3_8/loop.ts
+++ b/weather@mockturtl/src/3_8/loop.ts
@@ -100,6 +100,10 @@ export class WeatherLoop {
 	public async Start(): Promise<void> {
 		Logger.Info("Main Loop started.")
 		while (true) {
+			if (this.IsStray()) {
+				Logger.Info("Applet removed, stopping loop.")
+				return;
+			}
 			await this.DoCheck({immediate: false});
 			await delay(this.LoopInterval());
 		}

--- a/weather@mockturtl/src/3_8/main.ts
+++ b/weather@mockturtl/src/3_8/main.ts
@@ -574,19 +574,19 @@ The contents of the file saved from the applet help page goes here
 		if (weatherInfo.hourlyForecasts == null) weatherInfo.hourlyForecasts = [];
 
 		// Translate conditions if set
-		weatherInfo.condition.main = ProcessCondition(weatherInfo.condition.main, this.config._translateCondition);
-		weatherInfo.condition.description = ProcessCondition(weatherInfo.condition.description, this.config._translateCondition);
+		weatherInfo.condition.main = ProcessCondition(weatherInfo.condition.main);
+		weatherInfo.condition.description = ProcessCondition(weatherInfo.condition.description);
 
 		for (const forecast of weatherInfo.forecasts) {
 			const condition = forecast.condition;
-			condition.main = ProcessCondition(condition.main, this.config._translateCondition);
-			condition.description = ProcessCondition(condition.description, this.config._translateCondition);
+			condition.main = ProcessCondition(condition.main);
+			condition.description = ProcessCondition(condition.description);
 		}
 
 		for (const forecast of weatherInfo.hourlyForecasts) {
 			const condition = forecast.condition;
-			condition.main = ProcessCondition(condition.main, this.config._translateCondition);
-			condition.description = ProcessCondition(condition.description, this.config._translateCondition);
+			condition.main = ProcessCondition(condition.main);
+			condition.description = ProcessCondition(condition.description);
 		}
 
 		return weatherInfo;

--- a/weather@mockturtl/src/3_8/providers/accuWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/accuWeather.ts
@@ -60,8 +60,7 @@ export class AccuWeather extends BaseProvider {
 
     public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
         const locationID = `${loc.lat},${loc.lon}`;
-        const userLocale = this.app.config.currentLocale?.toLowerCase() ?? "en-us";
-        const locale = this.app.config._translateCondition ? userLocale : "en-us";
+        const locale = this.app.config._translateCondition ? this.app.config.currentLocale?.toLowerCase() ?? "en-us" : "en-us";
 
         let location: LocationPayload | null;
         if (this.locationCache[locationID] != null) {
@@ -71,7 +70,7 @@ export class AccuWeather extends BaseProvider {
             location = await HttpLib.Instance.LoadJsonSimple<LocationPayload>({
 				url: this.locSearchUrl,
 				cancellable,
-				params: { q: locationID, details: true, language: userLocale, apikey: this.app.config.ApiKey },
+				params: { q: locationID, details: true, language: locale, apikey: this.app.config.ApiKey },
 				HandleError: this.HandleErrors
 			});
 		}
@@ -159,6 +158,8 @@ export class AccuWeather extends BaseProvider {
             },
             condition: {
                 ...this.ResolveIcons(current.WeatherIcon, current.IsDayTime),
+				// TODO: decide if the text is not translated we should use the icon phrase or keep it as is.
+				// The weathertext unique and useful.
                 main: current.WeatherText,
                 description: current.WeatherText
             },

--- a/weather@mockturtl/src/3_8/providers/open-meteo/payload/common.ts
+++ b/weather@mockturtl/src/3_8/providers/open-meteo/payload/common.ts
@@ -14,8 +14,8 @@ export function OpenMeteoWeatherCodeToCondition(code: number, isDay: boolean): C
 			return {
 				icons: !isDay ? ["weather-few-clouds-night"] : ["weather-few-clouds"],
 				customIcon: !isDay ? "night-alt-cloudy-symbolic" : "day-cloudy-symbolic",
-				main: _("Mainly clear"),
-				description: _("Mainly clear")
+				main: _("Few clouds"),
+				description: _("Few clouds")
 			}
 		case 2:
 			return {

--- a/weather@mockturtl/src/3_8/providers/open-meteo/payload/current.ts
+++ b/weather@mockturtl/src/3_8/providers/open-meteo/payload/current.ts
@@ -18,6 +18,10 @@ export interface OpenMeteoCurrentWeather {
 	 */
 	temperature_2m: number;
 	/**
+	 * °C
+	 */
+	dewpoint_2m: number;
+	/**
 	 * %
 	 */
 	relative_humidity_2m: number;
@@ -89,7 +93,7 @@ export function OpenMeteoCurrentWeatherToData(data: OpenMeteoCurrentWeather): Cu
 			speed: KPHtoMPS(data.wind_speed_10m),
 			degree: data.wind_direction_10m,
 		},
-		dewPoint: null,
+		dewPoint: CelsiusToKelvin(data.dewpoint_2m),
 		extra_field: {
 			name: _("Feels like"),
 			value: CelsiusToKelvin(data.apparent_temperature),

--- a/weather@mockturtl/src/3_8/providers/open-meteo/provider.ts
+++ b/weather@mockturtl/src/3_8/providers/open-meteo/provider.ts
@@ -31,7 +31,7 @@ export class OpenMeteo extends BaseProvider {
 			params: {
 				latitude: loc.lat,
 				longitude: loc.lon,
-				current: "temperature_2m,relative_humidity_2m,apparent_temperature,is_day,precipitation,rain,showers,snowfall,weather_code,surface_pressure,wind_speed_10m,wind_direction_10m,wind_gusts_10m",
+				current: "temperature_2m,dewpoint_2m,relative_humidity_2m,apparent_temperature,is_day,precipitation,rain,showers,snowfall,weather_code,surface_pressure,wind_speed_10m,wind_direction_10m,wind_gusts_10m",
 				hourly: "temperature_2m,precipitation_probability,precipitation,rain,showers,snowfall,snow_depth,weather_code,wind_speed_10m,wind_direction_10m,is_day",
 				daily: "weather_code,temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,sunrise,sunset",
 				timezone: "auto",

--- a/weather@mockturtl/src/3_8/providers/openweathermap/payload/common.ts
+++ b/weather@mockturtl/src/3_8/providers/openweathermap/payload/common.ts
@@ -1,4 +1,4 @@
-import { _ } from "../../../utils";
+import type { OWMWeatherConditionDescription, OWMWeatherConditionMain } from "./condition";
 
 export interface OpenWeatherMapError {
 	cod: number;
@@ -9,14 +9,15 @@ export interface OWMWeatherCondition {
 	/** [Weather condition id](https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2) */
 	id: number;
 	/** Group of weather parameters (Rain, Snow, Extreme etc.) */
-	main: string;
+	main: OWMWeatherConditionMain;
 	/**  Weather condition within the group ([full list of weather conditions](https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2)).*/
-	description: string;
+	description: OWMWeatherConditionDescription;
 	/** Weather icon id */
 	icon: string;
 }
 
-export const OWM_SUPPORTED_LANGS = ["af", "al", "ar", "az", "bg", "ca", "cz", "da", "de", "el", "en", "eu", "fa", "fi",
+export const OWM_SUPPORTED_LANGS = [
+	"af", "al", "ar", "az", "bg", "ca", "cz", "da", "de", "el", "en", "eu", "fa", "fi",
 	"fr", "gl", "he", "hi", "hr", "hu", "id", "it", "ja", "kr", "la", "lt", "mk", "no", "nl", "pl",
 	"pt", "pt_br", "ro", "ru", "se", "sk", "sl", "sp", "es", "sr", "th", "tr", "ua", "uk", "vi", "zh_cn", "zh_tw", "zu"
 ];
@@ -44,75 +45,3 @@ export function ConvertLocaleToOWMLang(systemLocale: string | null): string {
 	}
 	return lang;
 }
-
-
-
-
-// This is here so they are translated.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const openWeatherMapConditionLibrary = [
-	// Group 2xx: Thunderstorm
-	_("Thunderstorm with light rain"),
-	_("Thunderstorm with rain"),
-	_("Thunderstorm with heavy rain"),
-	_("Light thunderstorm"),
-	_("Thunderstorm"),
-	_("Heavy thunderstorm"),
-	_("Ragged thunderstorm"),
-	_("Thunderstorm with light drizzle"),
-	_("Thunderstorm with drizzle"),
-	_("Thunderstorm with heavy drizzle"),
-	// Group 3xx: Drizzle
-	_("Light intensity drizzle"),
-	_("Drizzle"),
-	_("Heavy intensity drizzle"),
-	_("Light intensity drizzle rain"),
-	_("Drizzle rain"),
-	_("Heavy intensity drizzle rain"),
-	_("Shower rain and drizzle"),
-	_("Heavy shower rain and drizzle"),
-	_("Shower drizzle"),
-	// Group 5xx: Rain
-	_("Light rain"),
-	_("Moderate rain"),
-	_("Heavy intensity rain"),
-	_("Very heavy rain"),
-	_("Extreme rain"),
-	_("Freezing rain"),
-	_("Light intensity shower rain"),
-	_("Shower rain"),
-	_("Heavy intensity shower rain"),
-	_("Ragged shower rain"),
-	// Group 6xx: Snow
-	_("Light snow"),
-	_("Snow"),
-	_("Heavy snow"),
-	_("Sleet"),
-	_("Shower sleet"),
-	_("Light rain and snow"),
-	_("Rain and snow"),
-	_("Light shower snow"),
-	_("Shower snow"),
-	_("Heavy shower snow"),
-	// Group 7xx: Atmosphere
-	_("Mist"),
-	_("Smoke"),
-	_("Haze"),
-	_("Sand, dust whirls"),
-	_("Fog"),
-	_("Sand"),
-	_("Dust"),
-	_("Volcanic ash"),
-	_("Squalls"),
-	_("Tornado"),
-	// Group 800: Clear
-	_("Clear"),
-	_("Clear sky"),
-	_("Sky is clear"),
-	// Group 80x: Clouds
-	_("Clouds"),
-	_("Few clouds"),
-	_("Scattered clouds"),
-	_("Broken clouds"),
-	_("Overcast clouds")
-];

--- a/weather@mockturtl/src/3_8/providers/openweathermap/payload/condition.ts
+++ b/weather@mockturtl/src/3_8/providers/openweathermap/payload/condition.ts
@@ -1,4 +1,253 @@
+import { Logger } from "../../../lib/services/logger";
+import { _ } from "../../../utils";
 import type { BuiltinIcons, CustomIcons } from "../../../weather-data"
+
+export type OWMWeatherConditionMain =
+	"Thunderstorm" |
+	"Drizzle" |
+	"Rain" |
+	"Snow" |
+	"Clear" |
+	"Clouds" |
+	"Mist" |
+	"Smoke" |
+	"Haze" |
+	"Dust" |
+	"Fog" |
+	"Sand" |
+	"Ash" |
+	"Squall" |
+	"Tornado"
+;
+
+/**
+ * Better to be explicit about the values so that we can catch any new values that are added to the API,
+ * and the translation system can pick up all the strings.
+ * @param condition
+ * @returns
+ */
+export function OWMMainToTranslated(condition: OWMWeatherConditionMain): string {
+	switch (condition) {
+		case "Thunderstorm":
+			return _("Thunderstorm")
+		case "Drizzle":
+			return _("Drizzle")
+		case "Rain":
+			return _("Rain")
+		case "Snow":
+			return _("Snow")
+		case "Clear":
+			return _("Clear")
+		case "Clouds":
+			return _("Clouds")
+		case "Mist":
+			return _("Mist")
+		case "Smoke":
+			return _("Smoke")
+		case "Haze":
+			return _("Haze")
+		case "Dust":
+			return _("Dust")
+		case "Fog":
+			return _("Fog")
+		case "Sand":
+			return _("Sand")
+		case "Ash":
+			return _("Ash")
+		case "Squall":
+			return _("Squall")
+		case "Tornado":
+			return _("Tornado")
+		default:
+			Logger.Error("Unknown weather condition main: " + (condition as string));
+			return condition;
+	}
+}
+
+export type OWMWeatherConditionDescription =
+	"thunderstorm with light rain" |
+	"thunderstorm with rain" |
+	"thunderstorm with heavy rain" |
+	"light thunderstorm" |
+	"thunderstorm" |
+	"heavy thunderstorm" |
+	"ragged thunderstorm" |
+	"thunderstorm with light drizzle" |
+	"thunderstorm with drizzle" |
+	"thunderstorm with heavy drizzle" |
+	"light intensity drizzle" |
+	"drizzle" |
+	"heavy intensity drizzle" |
+	"light intensity drizzle rain" |
+	"drizzle rain" |
+	"heavy intensity drizzle rain" |
+	"shower rain and drizzle" |
+	"heavy shower rain and drizzle" |
+	"shower drizzle" |
+	"light rain" |
+	"moderate rain" |
+	"heavy intensity rain" |
+	"very heavy rain" |
+	"extreme rain" |
+	"freezing rain" |
+	"light intensity shower rain" |
+	"shower rain" |
+	"heavy intensity shower rain" |
+	"ragged shower rain" |
+	"light snow" |
+	"snow" |
+	"heavy snow" |
+	"sleet" |
+	"light shower sleet" |
+	"shower sleet" |
+	"light rain and snow" |
+	"rain and snow" |
+	"light shower snow" |
+	"shower snow" |
+	"heavy shower snow" |
+	"mist" |
+	"smoke" |
+	"haze" |
+	"sand/dust whirls" |
+	"fog" |
+	"sand" |
+	"dust" |
+	"volcanic ash" |
+	"squalls" |
+	"tornado" |
+	"clear sky" |
+	"sky is clear" |
+	"few clouds" |
+	"scattered clouds" |
+	"broken clouds" |
+	"overcast clouds"
+;
+
+/**
+ * /**
+ * Better to be explicit about the values so that we can catch any new values that are added to the API,
+ * and the translation system can pick up all the strings.
+ * @param condition
+ * @returns
+ */
+export function OWMDescToTranslated(description: OWMWeatherConditionDescription): string {
+	switch (description) {
+		case "thunderstorm with light rain":
+			return _("Thunderstorm with light rain")
+		case "thunderstorm with rain":
+			return _("Thunderstorm with rain")
+		case "thunderstorm with heavy rain":
+			return _("Thunderstorm with heavy rain")
+		case "light thunderstorm":
+			return _("Light thunderstorm")
+		case "thunderstorm":
+			return _("Thunderstorm")
+		case "heavy thunderstorm":
+			return _("Heavy thunderstorm")
+		case "ragged thunderstorm":
+			return _("Ragged thunderstorm")
+		case "thunderstorm with light drizzle":
+			return _("Thunderstorm with light drizzle")
+		case "thunderstorm with drizzle":
+			return _("Thunderstorm with drizzle")
+		case "thunderstorm with heavy drizzle":
+			return _("Thunderstorm with heavy drizzle")
+		case "light intensity drizzle":
+			return _("Light intensity drizzle")
+		case "drizzle":
+			return _("Drizzle")
+		case "heavy intensity drizzle":
+			return _("Heavy intensity drizzle")
+		case "light intensity drizzle rain":
+			return _("Light intensity drizzle rain")
+		case "drizzle rain":
+			return _("Drizzle rain")
+		case "heavy intensity drizzle rain":
+			return _("Heavy intensity drizzle rain")
+		case "shower rain and drizzle":
+			return _("Shower rain and drizzle")
+		case "heavy shower rain and drizzle":
+			return _("Heavy shower rain and drizzle")
+		case "shower drizzle":
+			return _("Shower drizzle")
+		case "light rain":
+			return _("Light rain")
+		case "moderate rain":
+			return _("Moderate rain")
+		case "heavy intensity rain":
+			return _("Heavy intensity rain")
+		case "very heavy rain":
+			return _("Very heavy rain")
+		case "extreme rain":
+			return _("Extreme rain")
+		case "freezing rain":
+			return _("Freezing rain")
+		case "light intensity shower rain":
+			return _("Light intensity shower rain")
+		case "shower rain":
+			return _("Shower rain")
+		case "heavy intensity shower rain":
+			return _("Heavy intensity shower rain")
+		case "ragged shower rain":
+			return _("Ragged shower rain")
+		case "light snow":
+			return _("Light snow")
+		case "snow":
+			return _("Snow")
+		case "heavy snow":
+			return _("Heavy snow")
+		case "sleet":
+			return _("Sleet")
+		case "light shower sleet":
+			return _("Light shower sleet")
+		case "shower sleet":
+			return _("Shower sleet")
+		case "light rain and snow":
+			return _("Light rain and snow")
+		case "rain and snow":
+			return _("Rain and snow")
+		case "light shower snow":
+			return _("Light shower snow")
+		case "shower snow":
+			return _("Shower snow")
+		case "heavy shower snow":
+			return _("Heavy shower snow")
+		case "mist":
+			return _("Mist")
+		case "smoke":
+			return _("Smoke")
+		case "haze":
+			return _("Haze")
+		case "sand/dust whirls":
+			return _("Sand, dust whirls")
+		case "fog":
+			return _("Fog")
+		case "sand":
+			return _("Sand")
+		case "dust":
+			return _("Dust")
+		case "volcanic ash":
+			return _("Volcanic ash")
+		case "squalls":
+			return _("Squalls")
+		case "tornado":
+			return _("Tornado")
+		case "clear sky":
+		case "sky is clear":
+			return _("Clear sky")
+		case "few clouds":
+			return _("Few clouds")
+		case "scattered clouds":
+			return _("Scattered clouds")
+		case "broken clouds":
+			return _("Broken clouds")
+		case "overcast clouds":
+			return _("Overcast clouds")
+		default:
+			Logger.Error("Unknown weather condition description: " + (description as string));
+			return description;
+	}
+}
 
 export function OWMIconToBuiltInIcons(icon: string): BuiltinIcons[] {
 	// https://openweathermap.org/weather-conditions

--- a/weather@mockturtl/src/3_8/providers/openweathermap/payload/forecast_daily.ts
+++ b/weather@mockturtl/src/3_8/providers/openweathermap/payload/forecast_daily.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import type { OWMWeatherCondition } from "./common";
-import { OWMIconToBuiltInIcons, OWMIconToCustomIcon } from "./condition";
+import { OWMDescToTranslated, OWMIconToBuiltInIcons, OWMIconToCustomIcon, OWMMainToTranslated } from "./condition";
 import type { ForecastData } from "../../../weather-data";
 
 export interface OWMDailyForecastResponse {
@@ -87,7 +87,7 @@ export interface OWMDailyForecast {
 	snow?: number;
 }
 
-export function OWMDailyForecastsToData(forecast: OWMDailyForecast[], timezone: string | undefined = "local"): ForecastData[] {
+export function OWMDailyForecastsToData(forecast: OWMDailyForecast[], conditionsTranslated: boolean, timezone: string | undefined = "local"): ForecastData[] {
 	const result: ForecastData[] = [];
 	for (const day of forecast) {
 		const data: ForecastData = {
@@ -95,8 +95,8 @@ export function OWMDailyForecastsToData(forecast: OWMDailyForecast[], timezone: 
 			temp_max: day.temp.max,
 			temp_min: day.temp.min,
 			condition: {
-				main: day.weather?.[0]?.main,
-				description: day.weather?.[0]?.description,
+				main: conditionsTranslated ? day.weather?.[0]?.main : OWMMainToTranslated(day.weather?.[0]?.main),
+				description: conditionsTranslated ? day.weather?.[0]?.description : OWMDescToTranslated(day.weather?.[0]?.description),
 				icons: OWMIconToBuiltInIcons(day.weather?.[0]?.icon),
 				customIcon: OWMIconToCustomIcon(day.weather?.[0]?.icon)
 			}

--- a/weather@mockturtl/src/3_8/providers/openweathermap/payload/onecall.ts
+++ b/weather@mockturtl/src/3_8/providers/openweathermap/payload/onecall.ts
@@ -1,10 +1,10 @@
 import { DateTime } from "luxon";
 import type { OWMWeatherCondition } from "./common";
-import { OWMIconToBuiltInIcons, OWMIconToCustomIcon } from "./condition";
+import { OWMDescToTranslated, OWMIconToBuiltInIcons, OWMIconToCustomIcon, OWMMainToTranslated } from "./condition";
 import { _ } from "../../../utils";
 import type { AlertData, ForecastData, HourlyForecastData, ImmediatePrecipitation, WeatherData } from "../../../weather-data";
 
-export function OWMOneCallToWeatherData(json: OWMOneCallPayload): WeatherData {
+export function OWMOneCallToWeatherData(json: OWMOneCallPayload, conditionsTranslated: boolean): WeatherData {
 	const weather: WeatherData = {
 		coord: {
 			lat: json.lat,
@@ -26,8 +26,8 @@ export function OWMOneCallToWeatherData(json: OWMOneCallPayload): WeatherData {
 		humidity: json.current.humidity,
 		dewPoint: json.current.dew_point,
 		condition: {
-			main: json?.current?.weather?.[0]?.main,
-			description: json?.current?.weather?.[0]?.description,
+			main: conditionsTranslated ? json?.current?.weather?.[0]?.main : OWMMainToTranslated(json?.current?.weather?.[0]?.main),
+			description: conditionsTranslated ? json?.current?.weather?.[0]?.description : OWMDescToTranslated(json?.current?.weather?.[0]?.description),
 			icons: OWMIconToBuiltInIcons(json?.current?.weather?.[0]?.icon),
 			customIcon: OWMIconToCustomIcon(json?.current?.weather?.[0]?.icon)
 		},
@@ -66,8 +66,8 @@ export function OWMOneCallToWeatherData(json: OWMOneCallPayload): WeatherData {
 			temp_min: day.temp.min,
 			temp_max: day.temp.max,
 			condition: {
-				main: day.weather[0].main,
-				description: day.weather[0].description,
+				main: conditionsTranslated ? day.weather[0].main : OWMMainToTranslated(day.weather[0].main),
+				description: conditionsTranslated ? day.weather[0].description : OWMDescToTranslated(day.weather[0].description),
 				icons: OWMIconToBuiltInIcons(day.weather[0].icon),
 				customIcon: OWMIconToCustomIcon(day.weather[0].icon)
 			},
@@ -82,8 +82,8 @@ export function OWMOneCallToWeatherData(json: OWMOneCallPayload): WeatherData {
 			date: DateTime.fromSeconds(hour.dt, { zone: json.timezone }),
 			temp: hour.temp,
 			condition: {
-				main: hour.weather[0].main,
-				description: hour.weather[0].description,
+				main: conditionsTranslated ? hour.weather[0].main : OWMMainToTranslated(hour.weather[0].main),
+				description: conditionsTranslated ? hour.weather[0].description : OWMDescToTranslated(hour.weather[0].description),
 				icons: OWMIconToBuiltInIcons(hour.weather[0].icon),
 				customIcon: OWMIconToCustomIcon(hour.weather[0].icon)
 			},

--- a/weather@mockturtl/src/3_8/providers/openweathermap/payload/weather.ts
+++ b/weather@mockturtl/src/3_8/providers/openweathermap/payload/weather.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import type { OWMWeatherCondition } from "./common";
-import { OWMIconToBuiltInIcons, OWMIconToCustomIcon } from "./condition";
+import { OWMDescToTranslated, OWMIconToBuiltInIcons, OWMIconToCustomIcon, OWMMainToTranslated } from "./condition";
 import { _ } from "../../../utils";
 import type { WeatherData } from "../../../weather-data";
 
@@ -90,7 +90,7 @@ export interface OWMWeatherResponse {
 	}
 }
 
-export function OWMWeatherToWeatherData(weather: OWMWeatherResponse, timezone: string | undefined = "local"): Omit<WeatherData, "forecasts" | "immediatePrecipitation" | "hourlyForecasts" | "alerts"> {
+export function OWMWeatherToWeatherData(weather: OWMWeatherResponse, conditionsTranslated: boolean, timezone: string | undefined = "local"): Omit<WeatherData, "forecasts" | "immediatePrecipitation" | "hourlyForecasts" | "alerts"> {
 	return {
 		date: DateTime.fromSeconds(weather.dt, { zone: timezone }),
 		sunrise: DateTime.fromSeconds(weather.sys.sunrise, {zone: timezone}),
@@ -102,8 +102,8 @@ export function OWMWeatherToWeatherData(weather: OWMWeatherResponse, timezone: s
 			url: `https://openweathermap.org/city/${weather.id}`
 		},
 		condition: {
-			main: weather.weather?.[0].main,
-			description: weather.weather?.[0].description,
+			main: conditionsTranslated ? weather.weather?.[0].main : OWMMainToTranslated(weather.weather?.[0].main),
+			description: conditionsTranslated ? weather.weather?.[0].description : OWMDescToTranslated(weather.weather?.[0].description),
 			icons: OWMIconToBuiltInIcons(weather.weather?.[0].icon),
 			customIcon: OWMIconToCustomIcon(weather.weather?.[0].icon)
 		},

--- a/weather@mockturtl/src/3_8/providers/openweathermap/provider-closed.ts
+++ b/weather@mockturtl/src/3_8/providers/openweathermap/provider-closed.ts
@@ -70,7 +70,7 @@ export class OpenWeatherMapOneCall extends BaseProvider {
 
 		// Put id to the parsable object, even if it ends up undefined
 		json.id = cachedID ?? idPayload?.id;
-		return OWMOneCallToWeatherData(json);
+		return OWMOneCallToWeatherData(json, !!params.lang);
 	};
 
 	private ConstructParams(loc: LocationData, key: string): HTTPParams {

--- a/weather@mockturtl/src/3_8/providers/openweathermap/provider-open.ts
+++ b/weather@mockturtl/src/3_8/providers/openweathermap/provider-open.ts
@@ -24,15 +24,16 @@ export class OpenWeatherMapOpen extends BaseProvider {
 
 
 	public override async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable, config: Config): Promise<WeatherData | null> {
+		const params: HTTPParams = this.ConstructParams(loc);
 		const current = await HttpLib.Instance.LoadJsonSimple<OWMWeatherResponse>({
 			url: "https://api.openweathermap.org/data/2.5/weather",
 			cancellable,
-			params: this.ConstructParams(loc)
+			params: params
 		});
 		const daily = await HttpLib.Instance.LoadJsonSimple<OWMDailyForecastResponse>({
 			url: "https://api.openweathermap.org/data/2.5/forecast/daily",
 			cancellable,
-			params: this.ConstructParams(loc)
+			params: params
 		});
 
 		if (!current || !daily) {
@@ -40,8 +41,8 @@ export class OpenWeatherMapOpen extends BaseProvider {
 		}
 
 		return {
-			...OWMWeatherToWeatherData(current, config.Timezone),
-			forecasts: OWMDailyForecastsToData(daily.list, config.Timezone)
+			...OWMWeatherToWeatherData(current, !!params.lang, config.Timezone),
+			forecasts: OWMDailyForecastsToData(daily.list, !!params.lang, config.Timezone)
 		};
 	}
 

--- a/weather@mockturtl/src/3_8/providers/openweathermap/provider-open.ts
+++ b/weather@mockturtl/src/3_8/providers/openweathermap/provider-open.ts
@@ -14,7 +14,7 @@ import { OWMWeatherToWeatherData } from "./payload/weather";
 export class OpenWeatherMapOpen extends BaseProvider {
 	public override needsApiKey = false;
 	public override prettyName = _("OpenWeatherMap");
-	public override name: Services = "OpenWeatherMap";
+	public override name: Services = "OpenWeatherMap_Open";
 	public override maxForecastSupport = 7;
 	public override maxHourlyForecastSupport = 0;
 	public override website = "https://openweathermap.org/";

--- a/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
@@ -5,7 +5,7 @@ import type { WeatherData, ForecastData, HourlyForecastData, PrecipitationType, 
 import { _, IsNight, FahrenheitToKelvin, CelsiusToKelvin, MPHtoMPS } from "../../utils";
 import { DateTime } from "luxon";
 import { BaseProvider } from "../BaseProvider";
-import type { PirateWeatherIcon, PirateWeatherPayload, PirateWeatherQueryUnits } from "./types/common";
+import { PirateWeatherSummaryToTranslated, type PirateWeatherIcon, type PirateWeatherPayload, type PirateWeatherQueryUnits } from "./types/common";
 import { ALERT_LEVEL_ORDER } from "../../consts";
 import type { LocationData, SunTime } from "../../types";
 
@@ -79,8 +79,8 @@ export class PirateWeather extends BaseProvider {
 				humidity: json.currently.humidity * 100,
 				dewPoint: this.ToKelvin(json.currently.dewPoint, unit),
 				condition: {
-					main: json.currently.summary,
-					description: json.currently.summary,
+					main: PirateWeatherSummaryToTranslated(json.currently.summary),
+					description: PirateWeatherSummaryToTranslated(json.currently.summary),
 					icons: this.ResolveIcon(json.currently.icon, { sunrise: sunrise, sunset: sunset }),
 					customIcon: this.ResolveCustomIcon(json.currently.icon)
 				},
@@ -100,8 +100,8 @@ export class PirateWeather extends BaseProvider {
 					temp_min: this.ToKelvin(day.temperatureLow, unit),
 					temp_max: this.ToKelvin(day.temperatureHigh, unit),
 					condition: {
-						main: day.summary,
-						description: day.summary,
+						main: PirateWeatherSummaryToTranslated(day.summary),
+						description: PirateWeatherSummaryToTranslated(day.summary),
 						icons: this.ResolveIcon(day.icon),
 						customIcon: this.ResolveCustomIcon(day.icon)
 					},
@@ -120,8 +120,8 @@ export class PirateWeather extends BaseProvider {
 					date: DateTime.fromSeconds(hour.time, { zone: json.timezone }),
 					temp: this.ToKelvin(hour.temperature, unit),
 					condition: {
-						main: hour.summary,
-						description: hour.summary,
+						main: PirateWeatherSummaryToTranslated(hour.summary),
+						description: PirateWeatherSummaryToTranslated(hour.summary),
 						icons: this.ResolveIcon(hour.icon, { sunrise: sunrise, sunset: sunset }, DateTime.fromSeconds(hour.time, { zone: json.timezone })),
 						customIcon: this.ResolveCustomIcon(hour.icon)
 					},
@@ -217,7 +217,7 @@ export class PirateWeather extends BaseProvider {
 				userError: true,
 				detail: "no key",
 				service: "pirate_weather",
-				message: _("Please Make sure you\nentered the API key that you have from DarkSky")
+				message: _("Please Make sure you\nentered the API key that you have from Pirate Weather")
 			});
 			return false;
 		}

--- a/weather@mockturtl/src/3_8/providers/pirate_weather/types/common.ts
+++ b/weather@mockturtl/src/3_8/providers/pirate_weather/types/common.ts
@@ -1,3 +1,5 @@
+import { Logger } from "../../../lib/services/logger";
+import { _ } from "../../../utils";
 import type { PirateWeatherAlert } from "./alerts";
 import type { PirateWeatherDailyPayload } from "./daily";
 import type { PirateWeatherHourlyPayload } from "./hourly";
@@ -20,7 +22,7 @@ export interface PirateWeatherPayload {
 	currently: {
 		/** Unix timestamp in seconds */
 		time: number;
-		summary: string;
+		summary: PirateWeatherSummary;
 		icon: PirateWeatherIcon;
 		nearestStormDistance: number;
 		nearestStormBearing: number;
@@ -40,23 +42,64 @@ export interface PirateWeatherPayload {
 		ozone: number;
 	},
 	minutely: {
-		summary: string;
+		summary: PirateWeatherSummary;
 		icon: PirateWeatherIcon;
 		data: PirateWeatherMinutelyPayload[];
 	}
 	hourly: {
-		summary: string;
+		summary: PirateWeatherSummary;
 		icon: PirateWeatherIcon;
 		data: PirateWeatherHourlyPayload[];
 	}
 	daily: {
-		summary: string;
+		summary: PirateWeatherSummary;
 		icon: PirateWeatherIcon;
 		data: PirateWeatherDailyPayload[]
 	}
 	alerts?: PirateWeatherAlert[];
 }
 
+/**
+ * As of 2024-06-01 PirateWeather API only supports the following weather summaries.
+ */
+export type PirateWeatherSummary =
+	"Clear" |
+	"Partly Cloudy" |
+	"Rain" |
+	"Cloudy" |
+	"Snow" |
+	"Wind" |
+	"Fog" |
+	"Sleet"
+;
+
+export function PirateWeatherSummaryToTranslated(summary: PirateWeatherSummary): string {
+	switch (summary) {
+		case "Clear":
+			return _("Clear");
+		case "Partly Cloudy":
+			return _("Partly Cloudy");
+		case "Rain":
+			return _("Rain");
+		case "Cloudy":
+			return _("Cloudy");
+		case "Snow":
+			return _("Snow");
+		case "Wind":
+			return _("Wind");
+		case "Fog":
+			return _("Fog");
+		case "Sleet":
+			return _("Sleet");
+		default:
+			Logger.Error(`Unknown PirateWeatherSummary: ${summary as string}`);
+			return summary;
+	}
+}
+
+/**
+ * https://github.com/Pirate-Weather/pirateweather/blob/0b3823f8bf45de303e77affbabb358a243cda0f6/docs/API.md#icon
+ */
 export type PirateWeatherIcon =
 	"clear-day" |
 	"clear-night" |

--- a/weather@mockturtl/src/3_8/providers/pirate_weather/types/daily.ts
+++ b/weather@mockturtl/src/3_8/providers/pirate_weather/types/daily.ts
@@ -1,8 +1,8 @@
-import type { PirateWeatherIcon } from "./common";
+import type { PirateWeatherIcon, PirateWeatherSummary } from "./common";
 
 export interface PirateWeatherDailyPayload {
 	time: number;
-	summary: string;
+	summary: PirateWeatherSummary;
 	icon: PirateWeatherIcon;
 	sunriseTime: number;
 	sunsetTime: number;

--- a/weather@mockturtl/src/3_8/providers/pirate_weather/types/hourly.ts
+++ b/weather@mockturtl/src/3_8/providers/pirate_weather/types/hourly.ts
@@ -1,8 +1,8 @@
-import type { PirateWeatherIcon } from "./common";
+import type { PirateWeatherIcon, PirateWeatherSummary } from "./common";
 
 export interface PirateWeatherHourlyPayload {
 	time: number;
-	summary: string;
+	summary: PirateWeatherSummary;
 	icon: PirateWeatherIcon;
 	precipIntensity: number;
 	precipProbability: number;

--- a/weather@mockturtl/src/3_8/providers/pirate_weather/types/minutely.ts
+++ b/weather@mockturtl/src/3_8/providers/pirate_weather/types/minutely.ts
@@ -1,9 +1,9 @@
-import type { PirateWeatherIcon } from "./common";
+import type { PirateWeatherIcon, PirateWeatherSummary } from "./common";
 
 export interface PirateWeatherMinutelyPayload {
 	time: number;
 	icon: PirateWeatherIcon;
-	summary: string;
+	summary: PirateWeatherSummary;
 	precipIntensity: number;
 	precipProbability: number;
 	precipIntensityError: number;

--- a/weather@mockturtl/src/3_8/providers/visualcrossing/provider.ts
+++ b/weather@mockturtl/src/3_8/providers/visualcrossing/provider.ts
@@ -143,9 +143,6 @@ export class VisualCrossing extends BaseProvider {
 							chance: hour.precipprob,
 							volume: hour.precip
 						}
-
-						/*if (item.precipitation.type == "snow")
-						item.precipitation.volume = hour.snow;*/
 					}
 
 					result.push(item);

--- a/weather@mockturtl/src/3_8/utils.ts
+++ b/weather@mockturtl/src/3_8/utils.ts
@@ -258,11 +258,8 @@ export function ValidTimezone(tz: string): boolean {
 // To UserConfig converters
 
 /** Capitalizes first letter and translates if needed */
-export function ProcessCondition(condition: string, shouldTranslate: boolean): string {
-	condition = CapitalizeFirstLetter(condition);
-	if (shouldTranslate)
-		condition = _(condition);
-	return condition;
+export function ProcessCondition(condition: string): string {
+	return CapitalizeFirstLetter(condition);
 }
 
 export function LocalizedColon(locale: string | null): string {

--- a/weather@mockturtl/src/3_8/weather-data.ts
+++ b/weather@mockturtl/src/3_8/weather-data.ts
@@ -115,9 +115,9 @@ export interface Precipitation {
 }
 
 export interface Condition {
-	/** Short description */
+	/** Short description, must already be translated. */
 	main: string,
-	/** Long Description */
+	/** Long Description, must already be translated. */
 	description: string,
 	/** GTK icon name, descending from most fit to least fit.
 	 * needs multiple in case one/some of them are not available


### PR DESCRIPTION
* Make translating conditions more consistent across all providers and clarify purpose of "Translate conditions"  settings toggle
* Stop applet loop when applet is removed
* Add missing dewpoint from Open-Meteo
* Fix https://github.com/linuxmint/cinnamon-spices-applets/issues/6048, Fix https://github.com/linuxmint/cinnamon-spices-applets/issues/6046 -  Rename OpenWeatherMap name internally so people fall back to the default Open-Meteo so no user-action is needed.