### PR TITLE
Weather, Add line break {br} for Override label and Override tooltip

### DIFF
--- a/weather@mockturtl/README.md
+++ b/weather@mockturtl/README.md
@@ -184,6 +184,7 @@ The setting allows you to make the applet display basically anything in the form
 | `{country}`       | Country name shown in the popup                           |
 | `{search_entry}`  | Search entry text in manual location (or location store)  |
 | `{last_updated}`  | Formatted last updated time                               |
+| `{br}`            | Line Break		                                            |
 
 ## Run script when the weather data changes
 

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -9360,7 +9360,8 @@ function InjectValues(text, weather, config, inCommand = false) {
             .replace(/{{city}}/g, Literal(city))
             .replace(/{{country}}/g, Literal(country))
             .replace(/{{search_entry}}/g, Literal(searchEntry))
-            .replace(/{{last_updated}}/g, Literal(lastUpdatedTime));
+            .replace(/{{last_updated}}/g, Literal(lastUpdatedTime))
+            .replace(/{{br}}/g, Literal("\n"));
     }
     return text.replace(/{t}/g, temp)
         .replace(/{u}/g, tempUnit)
@@ -9377,7 +9378,8 @@ function InjectValues(text, weather, config, inCommand = false) {
         .replace(/{city}/g, city)
         .replace(/{country}/g, country)
         .replace(/{search_entry}/g, searchEntry)
-        .replace(/{last_updated}/g, lastUpdatedTime);
+        .replace(/{last_updated}/g, lastUpdatedTime)
+        .replace(/{br}/g, "\n");
 }
 function CapitalizeFirstLetter(description) {
     if ((description == undefined || description == null)) {

--- a/weather@mockturtl/src/3_8/utils.ts
+++ b/weather@mockturtl/src/3_8/utils.ts
@@ -96,7 +96,8 @@ export function InjectValues(text: string, weather: WeatherData, config: Config,
 					.replace(/{{city}}/g, Literal(city))
 					.replace(/{{country}}/g, Literal(country))
 					.replace(/{{search_entry}}/g, Literal(searchEntry))
-					.replace(/{{last_updated}}/g, Literal(lastUpdatedTime));
+					.replace(/{{last_updated}}/g, Literal(lastUpdatedTime))
+					.replace(/{{br}}/g, Literal("\n"));
 	}
 
 	return  text.replace(/{t}/g, temp)
@@ -114,7 +115,8 @@ export function InjectValues(text: string, weather: WeatherData, config: Config,
 				.replace(/{city}/g, city)
 				.replace(/{country}/g, country)
 				.replace(/{search_entry}/g, searchEntry)
-				.replace(/{last_updated}/g, lastUpdatedTime);
+				.replace(/{last_updated}/g, lastUpdatedTime)
+				.replace(/{br}/g, "\n");
 }
 
 export function CapitalizeFirstLetter(description: string): string {


### PR DESCRIPTION
Fixes \n, \\\\n or %n not inserting a line break in the Override label and Override tooltip.
![Screenshot from 2024-06-20 14-52-40](https://github.com/linuxmint/cinnamon-spices-applets/assets/1768005/28f52414-37cc-4d6b-9b2c-9e4b2becf2d8)
