### PR TITLE
[SpiceSpy@claudiux] v2.0.0

### DIFF
--- a/SpiceSpy@claudiux/files/SpiceSpy@claudiux/CHANGELOG.md
+++ b/SpiceSpy@claudiux/files/SpiceSpy@claudiux/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v2.0.0~20240623
+
+* From now on, for each Spice row:
+    * clicking on the Spice name (or UUID) or on its icon or on its score opens its web page, at the top of this page.
+    * clicking on the Spice comments opens its web page, at the comments section.
+    * clicking on the Spice translations opens the web page showing the status of translations.
+* Several bugfixes.
+
 ### v1.2.0~20240621
 
 * Added the ability to display the number of available translations for each spice in the menu.

--- a/SpiceSpy@claudiux/files/SpiceSpy@claudiux/README.md
+++ b/SpiceSpy@claudiux/files/SpiceSpy@claudiux/README.md
@@ -35,7 +35,11 @@ The menu of the SpiceSpy applet contains:
     * its number of available translations (optional).
 * A button "Configure..."
 
-Clicking on a Spice opens its web page.
+Please note:
+
+* clicking on the Spice *name* (or *UUID*) or on its *icon* or on its *score* opens its web page, at the *top* of this page.
+* clicking on the Spice *comments* opens its web page, at the *comments section*.
+* clicking on the Spice *translations* opens the web page showing the *status of translations*.
 
 ## Translations
 

--- a/SpiceSpy@claudiux/files/SpiceSpy@claudiux/metadata.json
+++ b/SpiceSpy@claudiux/files/SpiceSpy@claudiux/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "SpiceSpy@claudiux",
   "name": "SpiceSpy",
   "description": "Notifies you when there's a change to your favorite Spices on the website.",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "max-instances": 1,
   "author": "claudiux"
 }


### PR DESCRIPTION
* From now on, for each Spice row:
    * clicking on the Spice name (or UUID) or on its icon or on its score opens its web page, at the top of this page.
    * clicking on the Spice comments opens its web page, at the comments section.
    * clicking on the Spice translations opens the web page showing the status of translations.
* Several bugfixes.