### PR TITLE
bletooth-battery@zamszowy: headset and icons

### DIFF
--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
@@ -288,6 +288,7 @@ BtBattery.prototype = {
                 && dev.kind != UPower.DeviceKind.GAMING_INPUT
                 && dev.kind != UPower.DeviceKind.PHONE
                 && dev.kind != UPower.DeviceKind.HEADPHONES
+                && dev.kind != UPower.DeviceKind.HEADSET
                 && dev.kind != UPower.DeviceKind.MEDIA_PLAYER) {
 
                 // blacklist by default non mouse/kb/phone/gaming input/mediaplayer/headphones devices
@@ -348,8 +349,8 @@ BtBattery.prototype = {
 
             if ((type == UPower.DeviceKind.KEYBOARD && !this.enable_keyboards)
                 || (type == UPower.DeviceKind.MOUSE && !this.enable_mice)
-                || (type == UPower.DeviceKind.HEADPHONES && !this.enable_headphones)
-                || (type != UPower.DeviceKind.KEYBOARD && type != UPower.DeviceKind.MOUSE && type != UPower.DeviceKind.HEADPHONES && !this.enable_others))
+                || ((type == UPower.DeviceKind.HEADPHONES || type == UPower.DeviceKind.HEADSET) && !this.enable_headphones)
+                || (type != UPower.DeviceKind.KEYBOARD && type != UPower.DeviceKind.MOUSE && type != UPower.DeviceKind.HEADPHONES && type != UPower.DeviceKind.HEADSET && !this.enable_others))
             {
                 continue;
             }
@@ -428,7 +429,7 @@ BtBattery.prototype = {
             return "keyboard-" + this.perc_to_3_digit_str(this.perc_round_to_10(batt));
         } else if (type == UPower.DeviceKind.MOUSE) {
             return "mouse-" + this.perc_to_3_digit_str(this.perc_round_to_10(batt));
-        } else if (type == UPower.DeviceKind.HEADPHONES) {
+        } else if (type == UPower.DeviceKind.HEADPHONES || type == UPower.DeviceKind.HEADSET) {
             return "headphones-" + this.perc_to_3_digit_str(this.perc_round_to_10(batt));
         } else {
             return "battery-" + this.perc_to_3_digit_str(this.perc_round_to_10(batt));

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
@@ -456,7 +456,7 @@ BtBattery.prototype = {
     },
 
     perc_round_to_10: function(perc) {
-        return Math.round(perc / 10) * 10;
+        return Math.floor(perc / 10) * 10;
     },
 
     perc_to_3_digit_str: function(perc) {

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/headphones-000.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/headphones-000.svg
@@ -5,7 +5,7 @@
    version="1.1"
    id="svg17"
    sodipodi:docname="headphones-000.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -19,15 +19,17 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="34.954545"
-     inkscape:cx="10.985696"
-     inkscape:cy="10.985696"
+     inkscape:zoom="45.254834"
+     inkscape:cx="8.0543882"
+     inkscape:cy="11.45734"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg17" />
+     inkscape:current-layer="svg17"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs11">
     <style
@@ -50,4 +52,9 @@
      style="fill:#dfdfdf;fill-opacity:1;stroke-width:0.717355"
      d="M 11.833944,13.105511 V 19 h 1.833334 v -5.894489 z m 5.5,0 V 19 h 1.833334 v -5.894489 z"
      id="path542" />
+  <path
+     style="color:#f44336;fill:currentColor"
+     class="ColorScheme-NegativeText"
+     d="m 6.5,10 v 4 l 0.25,2 h 1.5 L 8.5,14 v -4 z m 0,7 v 2 h 2 v -2 z"
+     id="path3" />
 </svg>

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/headphones-020.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/headphones-020.svg
@@ -5,7 +5,7 @@
    version="1.1"
    id="svg60"
    sodipodi:docname="headphones-020.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,14 +20,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="34.954545"
-     inkscape:cx="5.5214565"
-     inkscape:cy="10.356307"
+     inkscape:cx="5.5357608"
+     inkscape:cy="10.342003"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g58" />
+     inkscape:current-layer="g58"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs50">
     <style
@@ -41,15 +43,15 @@
      id="g58">
     <path
        opacity="0.35"
-       style="color:#f44336;fill:currentColor"
-       class="ColorScheme-NegativeText"
-       d="m 60.50002,722.36 c -0.277,0 -0.5,0.223 -0.5,0.5 v 0.5 l -2,-0.002 v -2.6e-4 l -2e-5,14.502 c 0,0.277 0.223,0.5 0.5,0.5 h 6 c 0.277,0 0.5,-0.223 0.5,-0.5 v -14.501 l -0.50002,0.002 h -1.5 v -0.5 c 0,-0.277 -0.223,-0.50001 -0.5,-0.50001 z"
-       id="path5" />
+       style="color:#ff9800;fill:currentColor"
+       class="ColorScheme-NeutralText"
+       d="m 60.50001,722.36 c -0.27701,0 -0.5,0.22301 -0.5,0.50001 v 0.5 l -2,-0.002 v -2.6e-4 l -1e-5,14.502 c 0,0.277 0.22299,0.5 0.5,0.5 h 6 c 0.27699,0 0.5,-0.223 0.5,-0.5 l 1e-5,-14.501 -0.50001,0.002 H 63 v -0.5 c 0,-0.277 -0.22301,-0.50001 -0.5,-0.50001 z"
+       id="path18" />
     <path
-       style="color:#f44336;fill:currentColor;stroke-width:0.999996"
-       class="ColorScheme-NegativeText"
-       d="m 58.00002,735.36 v 2.5 c 0,0.277 0.223,0.5 0.5,0.5 h 6 c 0.277,0 0.5,-0.223 0.5,-0.5 v -2.5 z"
-       id="path7" />
+       style="color:#ff9800;fill:currentColor;stroke-width:0.707009"
+       class="ColorScheme-NeutralText"
+       d="M 58.00001,735.36 58,738.11007 c -1e-5,0.13846 0.22299,0.24993 0.5,0.24993 h 6 c 0.27699,0 0.5,-0.11147 0.5,-0.24993 l 1e-5,-2.75007 z"
+       id="path20" />
     <path
        style="fill:#dfdfdf;fill-opacity:1;stroke-width:0.717355"
        d="m 72.5,722.36067 c -3.047,0 -5.5,3.38091 -5.5,7.58074 v 5.05368 c 0,0 0,2.52684 1.833333,2.52684 h 6.11e-4 v -6.31721 h -6.11e-4 v -1.26344 c 0,-2.79976 1.635334,-5.05368 3.666667,-5.05368 2.031333,0 3.666667,2.25397 3.666667,5.05368 v 0.83815 h 6.11e-4 v 6.74246 C 76.170678,737.52105 78,737.51889 78,734.99441 v -5.05368 C 78,725.74091 75.547,722.36 72.5,722.36 Z"

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/headphones-030.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/headphones-030.svg
@@ -5,12 +5,12 @@
    version="1.1"
    id="svg60"
    sodipodi:docname="headphones-030.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   xml:space="preserve"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
      id="namedview62"
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -20,43 +20,39 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="34.954545"
-     inkscape:cx="5.5214565"
-     inkscape:cy="9.5552667"
+     inkscape:cx="5.5357608"
+     inkscape:cy="9.5409624"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g58" />
-  <defs
-     id="defs50">
-    <style
+     inkscape:current-layer="g58"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" /><defs
+     id="defs50"><style
        id="current-color-scheme"
        type="text/css">
    .ColorScheme-Text { color:#dfdfdf; } .ColorScheme-Highlight { color:#4285f4; } .ColorScheme-NeutralText { color:#ff9800; } .ColorScheme-PositiveText { color:#4caf50; } .ColorScheme-NegativeText { color:#f44336; }
-  </style>
-  </defs>
-  <g
+  </style><style
+       id="current-color-scheme-5"
+       type="text/css">
+   .ColorScheme-Text { color:#dfdfdf; } .ColorScheme-Highlight { color:#4285f4; } .ColorScheme-NeutralText { color:#ff9800; } .ColorScheme-PositiveText { color:#4caf50; } .ColorScheme-NegativeText { color:#f44336; }
+  </style></defs><g
      transform="translate(-57 -719.36)"
-     id="g58">
-    <path
+     id="g58"><path
        opacity="0.35"
-       style="color:#ff9800;fill:currentColor"
+       style="color:#ff9800;fill:#dfdfdf;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="m 60.50001,722.36 c -0.27701,0 -0.5,0.22301 -0.5,0.50001 v 0.5 l -2,-0.002 v -2.6e-4 l -1e-5,14.502 c 0,0.277 0.22299,0.5 0.5,0.5 h 6 c 0.27699,0 0.5,-0.223 0.5,-0.5 l 1e-5,-14.501 -0.50001,0.002 H 63 v -0.5 c 0,-0.277 -0.22301,-0.50001 -0.5,-0.50001 z"
-       id="path18" />
-    <path
-       style="color:#ff9800;fill:currentColor;stroke-width:0.865906"
+       id="path18" /><path
+       style="color:#ff9800;fill:#dfdfdf;stroke-width:0.865906;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="M 58.00001,733.86 58,737.98511 c -1e-5,0.20769 0.22299,0.37489 0.5,0.37489 h 6 c 0.27699,0 0.5,-0.1672 0.5,-0.37489 l 1e-5,-4.12511 z"
-       id="path20" />
-    <path
+       id="path20" /><path
        style="fill:#dfdfdf;fill-opacity:1;stroke-width:0.717355"
        d="m 72.5,722.36067 c -3.047,0 -5.5,3.38091 -5.5,7.58074 v 5.05368 c 0,0 0,2.52684 1.833333,2.52684 h 6.11e-4 v -6.31721 h -6.11e-4 v -1.26344 c 0,-2.79976 1.635334,-5.05368 3.666667,-5.05368 2.031333,0 3.666667,2.25397 3.666667,5.05368 v 0.83815 h 6.11e-4 v 6.74246 C 76.170678,737.52105 78,737.51889 78,734.99441 v -5.05368 C 78,725.74091 75.547,722.36 72.5,722.36 Z"
-       id="path538" />
-    <path
+       id="path538" /><path
        style="fill:#dfdfdf;fill-opacity:1;stroke-width:0.717355"
        d="M 68.833944,732.46551 V 738.36 h 1.833334 v -5.89449 z m 5.5,0 V 738.36 h 1.833334 v -5.89449 z"
-       id="path542" />
-  </g>
-</svg>
+       id="path542" /></g></svg>

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/headphones-040.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/headphones-040.svg
@@ -5,7 +5,7 @@
    version="1.1"
    id="svg60"
    sodipodi:docname="headphones-040.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,14 +20,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="34.954545"
-     inkscape:cx="5.5214565"
-     inkscape:cy="9.5552667"
+     inkscape:cx="5.5357608"
+     inkscape:cy="9.5409624"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g58" />
+     inkscape:current-layer="g58"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs50">
     <style
@@ -41,12 +43,12 @@
      id="g58">
     <path
        opacity="0.35"
-       style="color:#ff9800;fill:currentColor"
+       style="color:#ff9800;fill:#dfdfdf;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="m 60.50001,722.36 c -0.27701,0 -0.5,0.22301 -0.5,0.50001 v 0.5 l -2,-0.002 v -2.6e-4 l -1e-5,14.502 c 0,0.277 0.22299,0.5 0.5,0.5 h 6 c 0.27699,0 0.5,-0.223 0.5,-0.5 l 1e-5,-14.501 -0.50001,0.002 H 63 v -0.5 c 0,-0.277 -0.22301,-0.50001 -0.5,-0.50001 z"
        id="path18" />
     <path
-       style="color:#ff9800;fill:currentColor;stroke-width:0.999862"
+       style="color:#ff9800;fill:#dfdfdf;stroke-width:0.999862;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="M 58.00001,732.36 58,737.86014 c -1e-5,0.27692 0.22299,0.49986 0.5,0.49986 h 6 c 0.27699,0 0.5,-0.22294 0.5,-0.49986 l 1e-5,-5.50014 z"
        id="path20" />

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/keyboard-000.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/keyboard-000.svg
@@ -1,9 +1,55 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" version="1.1">
- <defs>
-  <style id="current-color-scheme" type="text/css">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="keyboard-000.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="36.045455"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-width="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs1">
+    <style
+       id="current-color-scheme"
+       type="text/css">
    .ColorScheme-Text { color:#dfdfdf; } .ColorScheme-Highlight { color:#4285f4; } .ColorScheme-NeutralText { color:#ff9800; } .ColorScheme-PositiveText { color:#4caf50; } .ColorScheme-NegativeText { color:#f44336; }
   </style>
- </defs>
- <path opacity=".35" style="fill:currentColor" class="ColorScheme-NegativeText" d="m3.5 3c-0.277 0-0.5 0.223-0.5 0.5v0.5l-2-0.002v-0.00026l-0.00002 14.502c0 0.277 0.223 0.5 0.5 0.5h6c0.277 0 0.5-0.223 0.5-0.5v-14.501l-0.50002 0.002h-1.5v-0.5c0-0.277-0.223-0.50001-0.5-0.50001z"/>
- <path style="fill:currentColor" class="ColorScheme-Text" d="m11 4c-0.554 0-1 0.446-1 1v13c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-13c0-0.554-0.446-1-1-1h-5zm0 3h1v1h-1v-1zm2 0h1v1h-1v-1zm2 1h1v7h-1v-7zm-4 1h1v1h-1v-1zm2 0h1v1h-1v-1zm-2 2h1v1h-1v-1zm2 0h1v1h-1v-1zm-2 2h1v1h-1v-1zm2 0h1v1h-1v-1zm-2 2h1v1h-1v-1zm2 0h1v1h-1v-1z"/>
+  </defs>
+  <path
+     opacity=".35"
+     style="fill:currentColor"
+     class="ColorScheme-NegativeText"
+     d="m3.5 3c-0.277 0-0.5 0.223-0.5 0.5v0.5l-2-0.002v-0.00026l-0.00002 14.502c0 0.277 0.223 0.5 0.5 0.5h6c0.277 0 0.5-0.223 0.5-0.5v-14.501l-0.50002 0.002h-1.5v-0.5c0-0.277-0.223-0.50001-0.5-0.50001z"
+     id="path1" />
+  <path
+     style="fill:currentColor"
+     class="ColorScheme-Text"
+     d="m11 4c-0.554 0-1 0.446-1 1v13c0 0.554 0.446 1 1 1h5c0.554 0 1-0.446 1-1v-13c0-0.554-0.446-1-1-1h-5zm0 3h1v1h-1v-1zm2 0h1v1h-1v-1zm2 1h1v7h-1v-7zm-4 1h1v1h-1v-1zm2 0h1v1h-1v-1zm-2 2h1v1h-1v-1zm2 0h1v1h-1v-1zm-2 2h1v1h-1v-1zm2 0h1v1h-1v-1zm-2 2h1v1h-1v-1zm2 0h1v1h-1v-1z"
+     id="path2" />
+  <path
+     style="color:#f44336;fill:currentColor"
+     class="ColorScheme-NegativeText"
+     d="m 6.5,10 v 4 l 0.25,2 h 1.5 L 8.5,14 v -4 z m 0,7 v 2 h 2 v -2 z"
+     id="path3" />
 </svg>

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/keyboard-020.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/keyboard-020.svg
@@ -5,7 +5,7 @@
    version="1.1"
    id="svg60"
    sodipodi:docname="keyboard-020.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,14 +20,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="34.954545"
-     inkscape:cx="5.5214565"
-     inkscape:cy="10.356307"
+     inkscape:cx="5.5357608"
+     inkscape:cy="10.342003"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g58" />
+     inkscape:current-layer="g58"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs50">
     <style
@@ -47,12 +49,12 @@
        id="path56" />
     <path
        opacity="0.35"
-       style="color:#f44336;fill:currentColor"
+       style="color:#f44336;fill:#ff9800;fill-opacity:1"
        class="ColorScheme-NegativeText"
        d="m 60.50002,722.36 c -0.277,0 -0.5,0.223 -0.5,0.5 v 0.5 l -2,-0.002 v -2.6e-4 l -2e-5,14.502 c 0,0.277 0.223,0.5 0.5,0.5 h 6 c 0.277,0 0.5,-0.223 0.5,-0.5 v -14.501 l -0.50002,0.002 h -1.5 v -0.5 c 0,-0.277 -0.223,-0.50001 -0.5,-0.50001 z"
        id="path5" />
     <path
-       style="color:#f44336;fill:currentColor;stroke-width:0.999996"
+       style="color:#f44336;fill:#ff9800;stroke-width:0.999996;fill-opacity:1"
        class="ColorScheme-NegativeText"
        d="m 58.00002,735.36 v 2.5 c 0,0.277 0.223,0.5 0.5,0.5 h 6 c 0.277,0 0.5,-0.223 0.5,-0.5 v -2.5 z"
        id="path7" />

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/keyboard-030.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/keyboard-030.svg
@@ -5,7 +5,7 @@
    version="1.1"
    id="svg60"
    sodipodi:docname="keyboard-030.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,14 +20,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="34.954545"
-     inkscape:cx="5.5214565"
-     inkscape:cy="9.5552667"
+     inkscape:cx="5.5357608"
+     inkscape:cy="9.5409624"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g58" />
+     inkscape:current-layer="g58"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs50">
     <style
@@ -41,12 +43,12 @@
      id="g58">
     <path
        opacity="0.35"
-       style="color:#ff9800;fill:currentColor"
+       style="color:#ff9800;fill:#dfdfdf;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="m 60.50001,722.36 c -0.27701,0 -0.5,0.22301 -0.5,0.50001 v 0.5 l -2,-0.002 v -2.6e-4 l -1e-5,14.502 c 0,0.277 0.22299,0.5 0.5,0.5 h 6 c 0.27699,0 0.5,-0.223 0.5,-0.5 l 1e-5,-14.501 -0.50001,0.002 H 63 v -0.5 c 0,-0.277 -0.22301,-0.50001 -0.5,-0.50001 z"
        id="path18" />
     <path
-       style="color:#ff9800;fill:currentColor;stroke-width:0.865906"
+       style="color:#ff9800;fill:#dfdfdf;stroke-width:0.865906;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="M 58.00001,733.86 58,737.98511 c -1e-5,0.20769 0.22299,0.37489 0.5,0.37489 h 6 c 0.27699,0 0.5,-0.1672 0.5,-0.37489 l 1e-5,-4.12511 z"
        id="path20" />

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/keyboard-040.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/keyboard-040.svg
@@ -5,7 +5,7 @@
    version="1.1"
    id="svg60"
    sodipodi:docname="keyboard-040.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,14 +20,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="34.954545"
-     inkscape:cx="5.5214565"
-     inkscape:cy="9.5552667"
+     inkscape:cx="5.5357608"
+     inkscape:cy="9.5409624"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g58" />
+     inkscape:current-layer="g58"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs50">
     <style
@@ -41,12 +43,12 @@
      id="g58">
     <path
        opacity="0.35"
-       style="color:#ff9800;fill:currentColor"
+       style="color:#ff9800;fill:#dfdfdf;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="m 60.50001,722.36 c -0.27701,0 -0.5,0.22301 -0.5,0.50001 v 0.5 l -2,-0.002 v -2.6e-4 l -1e-5,14.502 c 0,0.277 0.22299,0.5 0.5,0.5 h 6 c 0.27699,0 0.5,-0.223 0.5,-0.5 l 1e-5,-14.501 -0.50001,0.002 H 63 v -0.5 c 0,-0.277 -0.22301,-0.50001 -0.5,-0.50001 z"
        id="path18" />
     <path
-       style="color:#ff9800;fill:currentColor;stroke-width:0.999862"
+       style="color:#ff9800;fill:#dfdfdf;stroke-width:0.999862;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="M 58.00001,732.36 58,737.86014 c -1e-5,0.27692 0.22299,0.49986 0.5,0.49986 h 6 c 0.27699,0 0.5,-0.22294 0.5,-0.49986 l 1e-5,-5.50014 z"
        id="path20" />

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/mouse-000.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/mouse-000.svg
@@ -1,9 +1,58 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" version="1.1">
- <defs>
-  <style id="current-color-scheme" type="text/css">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="mouse-000.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="36.045455"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-width="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs1">
+    <style
+       id="current-color-scheme"
+       type="text/css">
    .ColorScheme-Text { color:#dfdfdf; } .ColorScheme-Highlight { color:#4285f4; } .ColorScheme-NeutralText { color:#ff9800; } .ColorScheme-PositiveText { color:#4caf50; } .ColorScheme-NegativeText { color:#f44336; }
   </style>
- </defs>
- <path opacity=".35" style="fill:currentColor" class="ColorScheme-NegativeText" d="m3.5 3c-0.277 0-0.5 0.223-0.5 0.5v0.5l-2-0.002v-0.00026l-0.00002 14.502c0 0.277 0.223 0.5 0.5 0.5h6c0.277 0 0.5-0.223 0.5-0.5v-14.501l-0.50002 0.002h-1.5v-0.5c0-0.277-0.223-0.50001-0.5-0.50001z"/>
- <path style="fill:currentColor" class="ColorScheme-Text" d="m15 3c-2.77 0-5 2.676-5 6h5zm1 0v6h5c0-3.324-2.23-6-5-6zm-6 7v3c0 3.324 2.23 6 5 6h1c2.77 0 5-2.676 5-6v-3h-5z"/>
+  </defs>
+  <path
+     opacity=".35"
+     style="fill:currentColor"
+     class="ColorScheme-NegativeText"
+     d="m3.5 3c-0.277 0-0.5 0.223-0.5 0.5v0.5l-2-0.002v-0.00026l-0.00002 14.502c0 0.277 0.223 0.5 0.5 0.5h6c0.277 0 0.5-0.223 0.5-0.5v-14.501l-0.50002 0.002h-1.5v-0.5c0-0.277-0.223-0.50001-0.5-0.50001z"
+     id="path1" />
+  <path
+     style="fill:currentColor"
+     class="ColorScheme-Text"
+     d="m15 3c-2.77 0-5 2.676-5 6h5zm1 0v6h5c0-3.324-2.23-6-5-6zm-6 7v3c0 3.324 2.23 6 5 6h1c2.77 0 5-2.676 5-6v-3h-5z"
+     id="path2" />
+  <g
+     id="g1">
+    <path
+       style="color:#f44336;fill:currentColor"
+       class="ColorScheme-NegativeText"
+       d="m 6.5,10 v 4 l 0.25,2 h 1.5 L 8.5,14 v -4 z m 0,7 v 2 h 2 v -2 z"
+       id="path3" />
+  </g>
 </svg>

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/mouse-020.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/mouse-020.svg
@@ -5,7 +5,7 @@
    version="1.1"
    id="svg60"
    sodipodi:docname="mouse-020.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,14 +20,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="34.954545"
-     inkscape:cx="5.5214565"
-     inkscape:cy="10.356307"
+     inkscape:cx="5.5357608"
+     inkscape:cy="10.342003"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g58" />
+     inkscape:current-layer="g58"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs50">
     <style
@@ -41,12 +43,12 @@
      id="g58">
     <path
        opacity="0.35"
-       style="color:#f44336;fill:currentColor"
+       style="color:#f44336;fill:#ff9800;fill-opacity:1"
        class="ColorScheme-NegativeText"
        d="m 60.50002,722.36 c -0.277,0 -0.5,0.223 -0.5,0.5 v 0.5 l -2,-0.002 v -2.6e-4 l -2e-5,14.502 c 0,0.277 0.223,0.5 0.5,0.5 h 6 c 0.277,0 0.5,-0.223 0.5,-0.5 v -14.501 l -0.50002,0.002 h -1.5 v -0.5 c 0,-0.277 -0.223,-0.50001 -0.5,-0.50001 z"
        id="path5" />
     <path
-       style="color:#f44336;fill:currentColor;stroke-width:0.999996"
+       style="color:#f44336;fill:#ff9800;stroke-width:0.999996;fill-opacity:1"
        class="ColorScheme-NegativeText"
        d="m 58.00002,735.36 v 2.5 c 0,0.277 0.223,0.5 0.5,0.5 h 6 c 0.277,0 0.5,-0.223 0.5,-0.5 v -2.5 z"
        id="path7" />

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/mouse-030.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/mouse-030.svg
@@ -5,7 +5,7 @@
    version="1.1"
    id="svg60"
    sodipodi:docname="mouse-030.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,14 +20,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="34.954545"
-     inkscape:cx="5.5214565"
-     inkscape:cy="9.5552667"
+     inkscape:cx="5.5357608"
+     inkscape:cy="9.5409624"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g58" />
+     inkscape:current-layer="g58"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs50">
     <style
@@ -41,12 +43,12 @@
      id="g58">
     <path
        opacity="0.35"
-       style="color:#ff9800;fill:currentColor"
+       style="color:#ff9800;fill:#dfdfdf;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="m 60.50001,722.36 c -0.27701,0 -0.5,0.22301 -0.5,0.50001 v 0.5 l -2,-0.002 v -2.6e-4 l -1e-5,14.502 c 0,0.277 0.22299,0.5 0.5,0.5 h 6 c 0.27699,0 0.5,-0.223 0.5,-0.5 l 1e-5,-14.501 -0.50001,0.002 H 63 v -0.5 c 0,-0.277 -0.22301,-0.50001 -0.5,-0.50001 z"
        id="path18" />
     <path
-       style="color:#ff9800;fill:currentColor;stroke-width:0.865906"
+       style="color:#ff9800;fill:#dfdfdf;stroke-width:0.865906;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="M 58.00001,733.86 58,737.98511 c -1e-5,0.20769 0.22299,0.37489 0.5,0.37489 h 6 c 0.27699,0 0.5,-0.1672 0.5,-0.37489 l 1e-5,-4.12511 z"
        id="path20" />

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/mouse-040.svg
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/icons/mouse-040.svg
@@ -5,7 +5,7 @@
    version="1.1"
    id="svg60"
    sodipodi:docname="mouse-040.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,14 +20,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="34.954545"
-     inkscape:cx="5.5214565"
-     inkscape:cy="9.5552667"
+     inkscape:cx="5.5357608"
+     inkscape:cy="9.5409624"
      inkscape:window-width="1920"
-     inkscape:window-height="1014"
-     inkscape:window-x="1920"
+     inkscape:window-height="997"
+     inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g58" />
+     inkscape:current-layer="g58"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs50">
     <style
@@ -41,12 +43,12 @@
      id="g58">
     <path
        opacity="0.35"
-       style="color:#ff9800;fill:currentColor"
+       style="color:#ff9800;fill:#dfdfdf;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="m 60.50001,722.36 c -0.27701,0 -0.5,0.22301 -0.5,0.50001 v 0.5 l -2,-0.002 v -2.6e-4 l -1e-5,14.502 c 0,0.277 0.22299,0.5 0.5,0.5 h 6 c 0.27699,0 0.5,-0.223 0.5,-0.5 l 1e-5,-14.501 -0.50001,0.002 H 63 v -0.5 c 0,-0.277 -0.22301,-0.50001 -0.5,-0.50001 z"
        id="path18" />
     <path
-       style="color:#ff9800;fill:currentColor;stroke-width:0.999862"
+       style="color:#ff9800;fill:#dfdfdf;stroke-width:0.999862;fill-opacity:1"
        class="ColorScheme-NeutralText"
        d="M 58.00001,732.36 58,737.86014 c -1e-5,0.27692 0.22299,0.49986 0.5,0.49986 h 6 c 0.27699,0 0.5,-0.22294 0.5,-0.49986 l 1e-5,-5.50014 z"
        id="path20" />


### PR DESCRIPTION
bluetooth-battery@zamszowy: treat 'HEADSET' device as a headphones

    Some headphones present themselves as a 'HEADSET' UPower device kind, so
    treat them as a headphones, instead of a generic (blacklisted by
    default) device.


bluetooth-battery@zamszowy: make icons more in line with the system

    Show battery level icons just like the system is showing its icons for
    the laptop battery:

        - don't round percent values, use floor instead (e.g. instead of
          showing icon for 30% when battery was 25-34, show 30% icon only
          when battery is 30-39)

        - show warning level only when between 20% - 29%
        - show critical level when between 0% - 19%
        - show now additionally exclamation mark when below 10%