### PR TITLE
Add a batch of Catalan translations

### DIFF
--- a/AutostartPrograms@spacy01/files/AutostartPrograms@spacy01/po/ca.po
+++ b/AutostartPrograms@spacy01/files/AutostartPrograms@spacy01/po/ca.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-25 16:02+0200\n"
+"PO-Revision-Date: 2024-07-04 23:43+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. AutostartPrograms@spacy01->metadata.json->description
+#: applet.js:25
+msgid "Click here to add or remove programs to start with the session."
+msgstr "Feu clic aquí per afegir o eliminar aplicacions per començar amb l'inici de la sessió."
+
+#. AutostartPrograms@spacy01->metadata.json->name
+msgid "Autostart programs"
+msgstr "Programes de l'inici"

--- a/CustomApplicationsMenu@LLOBERA/files/CustomApplicationsMenu@LLOBERA/po/ca.po
+++ b/CustomApplicationsMenu@LLOBERA/files/CustomApplicationsMenu@LLOBERA/po/ca.po
@@ -1,0 +1,40 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-27 10:53+0800\n"
+"PO-Revision-Date: 2024-07-04 23:47+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. CustomApplicationsMenu@LLOBERA->metadata.json->name
+#: applet.js:48
+msgid "Custom Applications Menu"
+msgstr "Menú d'aplicacions personalitzat"
+
+#: applet.js:186
+msgid "Edit"
+msgstr "Editar"
+
+#: applet.js:191
+msgid "Help"
+msgstr "Ajuda"
+
+#: applet.js:196
+msgid "About"
+msgstr "Quant a"
+
+#. CustomApplicationsMenu@LLOBERA->metadata.json->description
+msgid "An applications drop-down list easily customisable"
+msgstr "Una llista desplegable d'aplicacions fàcilment personalitzable"

--- a/CustomPlaces@Nicolas01/files/CustomPlaces@Nicolas01/po/ca.po
+++ b/CustomPlaces@Nicolas01/files/CustomPlaces@Nicolas01/po/ca.po
@@ -1,0 +1,39 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: CustomPlaces@Nicolas01 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-04 23:50+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:176
+msgid "Edit"
+msgstr "Editar"
+
+#: applet.js:182
+msgid "Help"
+msgstr "Ajuda"
+
+#: applet.js:187
+msgid "About"
+msgstr "Quant a"
+
+#. metadata.json->description
+msgid "A places drop-down list easily customisable"
+msgstr "Una llista desplegable de llocs fàcilment personalitzable"
+
+#. metadata.json->name
+msgid "Custom Places"
+msgstr "Llocs personalitzats"

--- a/IntelTurboBoost@wsmenezes/files/IntelTurboBoost@wsmenezes/po/ca.po
+++ b/IntelTurboBoost@wsmenezes/files/IntelTurboBoost@wsmenezes/po/ca.po
@@ -1,0 +1,39 @@
+# cinnamon-applet-IntelTurboBoost - https://github.com/wsmenezes/cinnamon-applet-IntelTurboBoost
+# copyright (c) 2023 cinnamon-applet-IntelTurboBoost contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-18 19:54+0200\n"
+"PO-Revision-Date: 2024-07-04 23:52+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+#: applet.js:113
+msgid ""
+"Failed calling wrmsr, please make sure msr-tools package is installed and "
+"accessible."
+msgstr ""
+"Error cridant wrmsr, si us plau assegureu-vos que el paquet msr-tools "
+"està instal·lat i és accessible."

--- a/MessagingMenuV3@blub/files/MessagingMenuV3@blub/po/ca.po
+++ b/MessagingMenuV3@blub/files/MessagingMenuV3@blub/po/ca.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-02-18 00:57+0100\n"
+"PO-Revision-Date: 2024-07-04 23:56+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:182
+msgid "Compose New Message..."
+msgstr "Redactar un missatge nou..."
+
+#: applet.js:184
+msgid "Contacts"
+msgstr "Contactes"
+
+#. metadata.json->name
+msgid "Messaging Menu"
+msgstr "Menú de missatgeria"
+
+#. metadata.json->description
+msgid "Messaging Menu applet"
+msgstr "Miniaplicació de menú de missatgeria"

--- a/Mint-Unsplash-Background@omidmaldar/files/Mint-Unsplash-Background@omidmaldar/po/ca.po
+++ b/Mint-Unsplash-Background@omidmaldar/files/Mint-Unsplash-Background@omidmaldar/po/ca.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Mint-Unsplash-Background@omidmaldar 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-04 23:59+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:15
+msgid "Click here to change background"
+msgstr "Feu clic aquí per canviar el fons"
+
+#. metadata.json->name
+msgid "Mint Unsplash Background"
+msgstr "Fons Unsplash de Mint"
+
+#. metadata.json->description
+msgid ""
+"Click and change your Mint background image with a random photo originated "
+"from Unsplash.com "
+msgstr ""
+"Feu clic aquí per canviar el vostre fons de Mint per una imatge aleatòria "
+"d' Unsplash.com "

--- a/ScreenLocker@tuuxx/files/ScreenLocker@tuuxx/po/ca.po
+++ b/ScreenLocker@tuuxx/files/ScreenLocker@tuuxx/po/ca.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-01-22 20:28+0100\n"
+"PO-Revision-Date: 2024-07-05 00:02+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. ScreenLocker@tuuxx->metadata.json->description
+#: applet.js:19
+msgid "Click to lock the screen immediately"
+msgstr "Feu clic per bloquejar la pantalla d'immediat"
+
+#. ScreenLocker@tuuxx->metadata.json->name
+msgid "Screen locker"
+msgstr "Bloquejador de pantalla"

--- a/ScreenShot@tech71/files/ScreenShot@tech71/po/ca.po
+++ b/ScreenShot@tech71/files/ScreenShot@tech71/po/ca.po
@@ -1,0 +1,56 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-18 12:16+0800\n"
+"PO-Revision-Date: 2024-07-05 00:06+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:34
+msgid "Take A Screen Shot"
+msgstr "Fer una captura de pantalla"
+
+#. ScreenShot@tech71->metadata.json->name
+#: applet.js:45
+msgid "ScreenShot"
+msgstr "Captura de pantalla"
+
+#: applet.js:50
+msgid "Whole Screen"
+msgstr "Tota la pantalla"
+
+#: applet.js:52
+msgid "1 Second Delay"
+msgstr "1 segon d'endarreriment"
+
+#: applet.js:56
+msgid "3 Second Delay"
+msgstr "3 segons d'endarreriment"
+
+#: applet.js:60
+msgid "5 Second Delay"
+msgstr "5 segons d'endarreriment"
+
+#: applet.js:69
+msgid "Current Window"
+msgstr "Finestra actual"
+
+#: applet.js:74
+msgid "Selected Area"
+msgstr "Àrea seleccionada"
+
+#. ScreenShot@tech71->metadata.json->description
+msgid "Take a snapshot of your desktop or individual windows"
+msgstr "Feu una captura del vostre escriptori o de finestres individuals"

--- a/ShutdownApplet@DeathMD/files/ShutdownApplet@DeathMD/po/ca.po
+++ b/ShutdownApplet@DeathMD/files/ShutdownApplet@DeathMD/po/ca.po
@@ -1,0 +1,47 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-20 23:50+0800\n"
+"PO-Revision-Date: 2024-07-05 00:08+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:37 applet.js:63
+msgid "Shutdown"
+msgstr "Apagar"
+
+#: applet.js:44
+msgid "Screen Lock"
+msgstr "Bloqueig de pantalla"
+
+#: applet.js:50
+msgid "Suspend"
+msgstr "Suspendre"
+
+#: applet.js:55
+msgid "Restart"
+msgstr "Reiniciar"
+
+#: applet.js:59
+msgid "Log Out"
+msgstr "Tancar la sessió"
+
+#. ShutdownApplet@DeathMD->metadata.json->description
+msgid "An applet to shutdown, restart and suspend your system."
+msgstr "Una miniaplicació per apagar, reiniciar i suspendre el vostre sistema."
+
+#. ShutdownApplet@DeathMD->metadata.json->name
+msgid "Shutdown Applet"
+msgstr "Miniaplicació d'apagada"

--- a/ThemeRefresh@JosephM/files/ThemeRefresh@JosephM/po/ca.po
+++ b/ThemeRefresh@JosephM/files/ThemeRefresh@JosephM/po/ca.po
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-25 14:04+0800\n"
+"PO-Revision-Date: 2024-07-05 00:11+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:27
+msgid "Refresh Current Cinnamon Theme"
+msgstr "Refrescar el tema de Cinnamon actual"
+
+#. ThemeRefresh@JosephM->metadata.json->description
+msgid "A simple applet that allows you to refresh the current Cinnamon Theme"
+msgstr "Una miniaplicació simple que us permet refrescar el tema actual de Cinnamon"
+
+#. ThemeRefresh@JosephM->metadata.json->name
+msgid "Reload Current Theme"
+msgstr "Recarregar el tema actual"

--- a/asl@santiago/files/asl@santiago/po/ca.po
+++ b/asl@santiago/files/asl@santiago/po/ca.po
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-02-24 23:19+0100\n"
+"PO-Revision-Date: 2024-07-05 00:15+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:33
+msgid "American Sign Language"
+msgstr "Llenguatge de Signes Americà"
+
+#: applet.js:56
+msgid "Alphabet"
+msgstr "Alfabet"
+
+#: applet.js:59 applet.js:65 applet.js:71 applet.js:77 applet.js:83
+#: applet.js:89 applet.js:95 applet.js:101 applet.js:107 applet.js:113
+#: applet.js:119 applet.js:125 applet.js:131 applet.js:137 applet.js:143
+#: applet.js:149 applet.js:155 applet.js:161 applet.js:167 applet.js:173
+#: applet.js:179 applet.js:185 applet.js:191 applet.js:197 applet.js:203
+#: applet.js:209
+msgid "Letter"
+msgstr "Lletra"
+
+#: applet.js:60 applet.js:66 applet.js:72 applet.js:78 applet.js:84
+#: applet.js:90 applet.js:96 applet.js:102 applet.js:108 applet.js:114
+#: applet.js:120 applet.js:126 applet.js:132 applet.js:138 applet.js:144
+#: applet.js:150 applet.js:156 applet.js:162 applet.js:168 applet.js:174
+#: applet.js:180 applet.js:186 applet.js:192 applet.js:198 applet.js:204
+#: applet.js:210
+msgid "ASL"
+msgstr "ASL"
+
+#: applet.js:320
+msgid "Check more vocabulary"
+msgstr "Consultar més vocabulari"
+
+#. metadata.json->name
+msgid "American Sign Language vocabulary"
+msgstr "Vocabulari del llenguatge de signes americà"
+
+#. metadata.json->description
+msgid "Information to American Sign Language vocabulary"
+msgstr "Informació sobre el vocabulari del llenguatge de signes americà"

--- a/backgroundroll@Sokawaii25/files/backgroundroll@Sokawaii25/po/ca.po
+++ b/backgroundroll@Sokawaii25/files/backgroundroll@Sokawaii25/po/ca.po
@@ -1,0 +1,43 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-12-07 22:29+0000\n"
+"PO-Revision-Date: 2024-07-05 00:18+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+msgid "Background Roll"
+msgstr "Rotar Fons"
+
+#. metadata.json->description
+msgid ""
+"Changes the background randomly using the images in ~/Images/backgrounds\n"
+"Middle-click lets you roll back to previous background"
+msgstr ""
+"Canvia el fons de pantalla aleatòriament utilitzant imatges de ~/Imatges/fons\n"
+"El clic del mig us permet tornar al fons anterior"
+
+#. settings-schema.json->Settings->description
+msgid "Notifications"
+msgstr "Notificacions"
+
+#. settings-schema.json->Notifications->description
+msgid "Send a notification when the background is changed"
+msgstr "Enviar una notificació en canviar el fons"
+
+#. settings-schema.json->Notifications->tooltip
+msgid "Activate to see a notification when the background rolls"
+msgstr "Activeu-ho per a veure una notificació quan el fons roti"

--- a/batterypower@joka42/files/batterypower@joka42/po/ca.po
+++ b/batterypower@joka42/files/batterypower@joka42/po/ca.po
@@ -1,0 +1,43 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-12-07 22:41+0000\n"
+"PO-Revision-Date: 2024-07-05 00:21+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+msgid "Power Consumption Display"
+msgstr "Visualització del Consum d'Energia"
+
+#. metadata.json->description
+msgid "Shows power consumption when in battery mode"
+msgstr "Mostra el consum d'energia en mode bateria"
+
+#. settings-schema.json->show-unit->description
+msgid "Show unit"
+msgstr "Mostrar unitat"
+
+#. settings-schema.json->show-unit->tooltip
+msgid "Show Watt symbol after the value."
+msgstr "Mostra el símbol del Watt després del valor."
+
+#. settings-schema.json->interval->units
+msgid "ms"
+msgstr "ms"
+
+#. settings-schema.json->interval->description
+msgid "Update interval"
+msgstr "Interval d'actualització"

--- a/bing-wallpaper@starcross.dev/files/bing-wallpaper@starcross.dev/po/ca.po
+++ b/bing-wallpaper@starcross.dev/files/bing-wallpaper@starcross.dev/po/ca.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-12-07 22:54+0000\n"
+"PO-Revision-Date: 2024-07-05 00:23+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+msgid "Bing Desktop Wallpaper"
+msgstr "Fons de pantalla de Bing"
+
+#. metadata.json->description
+msgid "Download and apply Today's Bing Wallpaper to your desktop"
+msgstr "Descarregueu i apliqueu el fons de pantalla del dia de Bing al vostre escriptori"

--- a/bose@tuuxx/files/bose@tuuxx/po/ca.po
+++ b/bose@tuuxx/files/bose@tuuxx/po/ca.po
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: bose@tuuxx 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-06-27 12:11+0300\n"
+"PO-Revision-Date: 2024-07-05 00:27+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+msgid "Bose Quiet Comfort"
+msgstr "Bose Quiet Comfort"
+
+#. metadata.json->description
+msgid ""
+"Get connection details of BOSE Quiet Comfort 35 II, requires: bluez-tools"
+msgstr ""
+"Obteniu detalls de la connexió de Bose Quiet Comfort 35 II. Necessita: "
+"bluez-tools"
+
+#. settings-schema.json->head->description
+msgid "Settings for bose@tuuxx"
+msgstr "Configuració de bose@tuuxx"
+
+#. settings-schema.json->address->description
+msgid "Address of the Bluethooth BOSE device:"
+msgstr "Adreça Bluetooth del dispositiu BOSE:"
+
+#. settings-schema.json->address->tooltip
+msgid "Format: xx:xx:xx:xx:xx:xx"
+msgstr "Format: xx:xx:xx:xx:xx:xx"
+
+#. settings-schema.json->path->description
+msgid "Path of based-connect:"
+msgstr "Ruta de based-connect:"
+
+#. settings-schema.json->path->tooltip
+msgid "Path to the based-connect tool"
+msgstr "Ruta de l'eina based-connect"
+
+#. settings-schema.json->basedconnectLookup->description
+msgid "Get based-connect tool"
+msgstr "Obtenir eina based-connect"
+
+#. settings-schema.json->basedconnectLookup->tooltip
+msgid "Opens git webpage of the based-connect tool"
+msgstr "Obre el lloc web del repositori de l'eina based-connect"

--- a/clipboard-eraser@Techcrafter/files/clipboard-eraser@Techcrafter/po/ca.po
+++ b/clipboard-eraser@Techcrafter/files/clipboard-eraser@Techcrafter/po/ca.po
@@ -1,0 +1,33 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: clipboard-eraser@Techcrafter 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 00:29+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:20
+msgid "Click here to erase your clipboard contents"
+msgstr "Feu clic aquí per a eliminar el contingut del portapapers"
+
+#. metadata.json->name
+msgid "Clipboard Eraser"
+msgstr "Eliminador del Portapapers"
+
+#. metadata.json->description
+msgid "Click on the applet to erase your clipboard contents"
+msgstr ""
+"Feu clic a la miniaplicació per esborrar els continguts del vostre "
+"portapapers"

--- a/computer@brownsr/files/computer@brownsr/po/ca.po
+++ b/computer@brownsr/files/computer@brownsr/po/ca.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-10 17:55+0100\n"
+"PO-Revision-Date: 2024-07-05 00:32+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. computer@brownsr->metadata.json->name
+#: applet.js:20
+msgid "Computer"
+msgstr "Ordinador"
+
+#. computer@brownsr->metadata.json->description
+msgid "Show files at computer level"
+msgstr "Mostrar fitxers a nivell de l'ordinador"

--- a/ctrl4docker@hoffis-eck.de/files/ctrl4docker@hoffis-eck.de/po/ca.po
+++ b/ctrl4docker@hoffis-eck.de/files/ctrl4docker@hoffis-eck.de/po/ca.po
@@ -1,0 +1,43 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: ctrl4docker@hoffis-eck.de 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 00:36+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:93
+msgid "Checking status"
+msgstr "Comprovant estat"
+
+#. metadata.json->name
+msgid "Docker Control"
+msgstr "Control de Docker"
+
+#. metadata.json->description
+msgid "Activates/Deactivates Docker Container"
+msgstr "Activa/Desactiva el contenidor de Docker"
+
+#. settings-schema.json->image->description
+msgid "docker image"
+msgstr "imatge de docker"
+
+#. settings-schema.json->container->description
+msgid "container name"
+msgstr "nom del contenidor"
+
+#. settings-schema.json->parameter->description
+msgid "parameter for the container"
+msgstr "paràmetre pel contenidor"

--- a/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/po/ca.po
+++ b/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/po/ca.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: ddcci-multi-monitor@tim-we 1.1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-06-27 18:16+0300\n"
+"PO-Revision-Date: 2024-07-05 00:38+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+msgid "DDC/CI Multi-Monitor"
+msgstr "Multi-Monitor DDC/CI"
+
+#. metadata.json->description
+msgid "Adjust monitor brightness via DDC/CI"
+msgstr "Ajusta la brillantor del monitor a través de DDC/CI"

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/ca.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/ca.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"PO-Revision-Date: 2024-07-05 00:42+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+msgid "Desaturate All"
+msgstr "Desaturar Tot"
+
+#. metadata.json->description
+msgid "Convert your screen to grayscale."
+msgstr "Converteix la teva pantalla a escala de grisos."

--- a/devbar@ludvigbostrom/files/devbar@ludvigbostrom/po/ca.po
+++ b/devbar@ludvigbostrom/files/devbar@ludvigbostrom/po/ca.po
@@ -1,0 +1,33 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+msgid "DevBar"
+msgstr "DevBar"
+
+#. metadata.json->description
+msgid "This applet helps you keep track of your development workflow."
+msgstr "Aquesta miniaplicació us ajuda a mantenir-vos al dia pel que fa al vostre mètode de desenvolupament."
+
+#. settings-schema.json->url->description
+msgid "Url to fetch information from"
+msgstr "Url de la qual obtenir la informació"
+
+#. settings-schema.json->appendUsername->description
+msgid "Append your username to url"
+msgstr "Afegiu el vostre nom d'usuari a la url"
+
+#. settings-schema.json->interval->description
+msgid "Update interval in seconds"
+msgstr "Interval d'actualitzacions en segons"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/ca.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/ca.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 00:47+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+msgid "Duolingo Helper"
+msgstr "Ajudant de Duolingo"
+
+#. metadata.json->description
+msgid "Handy app to help practise with Duolingo."
+msgstr "Miniaplicació convenient per a ajudar-vos a practicar amb Duolingo."

--- a/force-quit@cinnamon.org/files/force-quit@cinnamon.org/po/ca.po
+++ b/force-quit@cinnamon.org/files/force-quit@cinnamon.org/po/ca.po
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-01 13:38+0200\n"
+"PO-Revision-Date: 2024-07-05 00:49+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:25
+msgid "Click here to kill a window"
+msgstr "Feu clic aquí per matar una finestra"
+
+#. metadata.json->name
+msgid "Force Quit"
+msgstr "Forçar Sortida"
+
+#. metadata.json->description
+msgid "Click on the applet to launch xkill and force any window to quit immediately"
+msgstr "Feu clic a la miniaplicació per a llançar xkill i forçar la sortida de qualsevol finestra immediatament"

--- a/gamemode@axel358/files/gamemode@axel358/po/ca.po
+++ b/gamemode@axel358/files/gamemode@axel358/po/ca.po
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: gamemode@axel358 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 00:51+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:25
+msgid "No active clients"
+msgstr "No hi ha clients actius"
+
+#. metadata.json->name
+msgid "GameMode"
+msgstr "GameMode"
+
+#. metadata.json->description
+msgid "GameMode status indicator"
+msgstr "Indicador d'estat de GameMode"

--- a/gnote@brett-smith/files/gnote@brett-smith/po/ca.po
+++ b/gnote@brett-smith/files/gnote@brett-smith/po/ca.po
@@ -1,0 +1,60 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-12-26 18:09+0000\n"
+"PO-Revision-Date: 2024-07-05 00:56+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:209
+msgid "Type to search..."
+msgstr "Escriviu per a buscar..."
+
+#: applet.js:302
+msgid "Gnote stopped working!"
+msgstr "Gnote ha deixat de funcionar!"
+
+#: applet.js:305
+msgid "Gnote isn't running! Do you have it installed?"
+msgstr "Gnote no està en marxa! El teniu instal·lat?"
+
+#. metadata.json->name
+#: applet.js:338
+msgid "Gnote"
+msgstr "Gnote"
+
+#: applet.js:359
+msgid "New Note"
+msgstr "Nota nova"
+
+#: applet.js:423
+msgid "GNote DBus service not found. Is GNote installed?"
+msgstr "No s'ha trobat el servei GNote Dbus. Teniu GNote instal·lat?"
+
+#: applet.js:425
+msgid "Click to see error!"
+msgstr "Clic per veure l'error!"
+
+#: applet.js:427
+msgid "Error: "
+msgstr "Error: "
+
+#: applet.js:428
+msgid "Retry"
+msgstr "Reintentar"
+
+#. metadata.json->description
+msgid "Lists notes, view, create notes and search notes."
+msgstr "Us permet llistar, mirar, crear i buscar notes."

--- a/healthyeyes@ipolozov/files/healthyeyes@ipolozov/po/ca.po
+++ b/healthyeyes@ipolozov/files/healthyeyes@ipolozov/po/ca.po
@@ -1,0 +1,33 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: healthyeyes@ipolozov 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 00:59+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->description
+msgid ""
+"Quiet reminder to take a break every half an hour. When the circle is red, "
+"give your eyes a rest by looking away from your monitor, then click the "
+"circle."
+msgstr ""
+"Recordatori silenciós per a prendre un descans cada mitja hora. Quan el "
+"cercle és vermell, doneu un descans als vostres ulls mirant fora del "
+"monitor. En acabar, cliqueu el cercle."
+
+#. metadata.json->name
+msgid "Healthy Eyes"
+msgstr "Ulls Sans"

--- a/ifstat@tagadan/files/ifstat@tagadan/po/ca.po
+++ b/ifstat@tagadan/files/ifstat@tagadan/po/ca.po
@@ -1,0 +1,49 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: ifstat@tagadan 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 01:03+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:23
+msgid ""
+"Device\n"
+"KB/s in: --\n"
+"KB/s out: --"
+msgstr ""
+"Dispositiu\n"
+"KB/s entrants: --\n"
+"KB/s sortints: --"
+
+#: applet.js:36
+msgid "please install ifstat and/or glib libraries"
+msgstr "si us plau, instal·leu ifstat i/o les llibreries glib"
+
+#: applet.js:60
+msgid ""
+"\n"
+"KB/s in: "
+msgstr ""
+"\n"
+"KB/s entrants: "
+
+#. metadata.json->description
+msgid "Show your internet usage in a smartphone style"
+msgstr "Mostra el vostre ús d'internet en estil de telèfon intel·ligent"
+
+#. metadata.json->name
+msgid "Tight Network Usage Indicator"
+msgstr "Indicador d'us de xarxa estret"

--- a/internet-indicator@sangorys/files/internet-indicator@sangorys/po/ca.po
+++ b/internet-indicator@sangorys/files/internet-indicator@sangorys/po/ca.po
@@ -1,0 +1,60 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: internet-indicator@sangorys 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 01:07+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:121
+msgid "Initializing"
+msgstr "Inicialitzant"
+
+#: applet.js:244
+msgid "Testing Internet connexion in progress..."
+msgstr "Prova de la connexió a Internet en procés..."
+
+#: applet.js:294
+msgid "Internet OK"
+msgstr "Internet OK"
+
+#: applet.js:312
+msgid "No Internet"
+msgstr "No hi ha internet"
+
+#. metadata.json->name
+msgid "Internet connection Indicator"
+msgstr "Indicador de la connexió a Internet"
+
+#. metadata.json->description
+msgid ""
+"Check your Internet connection (usefull to check if you are connected to "
+"Internet through a wifi hotspot. For instance when you are in a train)"
+msgstr ""
+"Revisa la vostra connexió (útil si esteu connectats a través de wifi fora "
+"de casa o en vehicles com ara un tren)"
+
+#. settings-schema.json->update-interval-when-no-internet->units
+#. settings-schema.json->update-interval-when-internet->units
+msgid "s"
+msgstr "s"
+
+#. settings-schema.json->update-interval-when-no-internet->description
+msgid "Update interval when no internet connection"
+msgstr "Interval d'actualització sense connexió a internet"
+
+#. settings-schema.json->update-interval-when-internet->description
+msgid "Update interval when internet is detected"
+msgstr "Interval d'actualització amb connexió a internet"

--- a/ioDisk@ctrlesc/files/ioDisk@ctrlesc/po/ca.po
+++ b/ioDisk@ctrlesc/files/ioDisk@ctrlesc/po/ca.po
@@ -1,0 +1,48 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-25 12:03+0800\n"
+"PO-Revision-Date: 2024-07-05 01:12+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. ioDisk@ctrlesc->metadata.json->name
+#: applet.js:95
+msgid "Disk Utilization"
+msgstr "Ús de Disc"
+
+#: applet.js:99
+msgid "Command [iostat] not found."
+msgstr "No s'ha trobat l'ordre [iostat]."
+
+#: applet.js:149
+msgid "No drives detected."
+msgstr "No s'han detectat discs."
+
+#: applet.js:223
+msgid "io: ??%"
+msgstr "io: ??%"
+
+#: applet.js:235
+msgid "Error executing iostat."
+msgstr "Error executant iostat."
+
+#. ioDisk@ctrlesc->metadata.json->description
+msgid ""
+"Shows the current max disk I/O utilization in the panel and per device "
+"utilization in a popup menu."
+msgstr ""
+"Mostra l'ús màxim actual del disc (entrada/sortida) al panell i l'ús "
+"per dispositiu a un menú emergent."

--- a/localip@mrieracrespi/files/localip@mrieracrespi/po/ca.po
+++ b/localip@mrieracrespi/files/localip@mrieracrespi/po/ca.po
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-25 13:43+0800\n"
+"PO-Revision-Date: 2024-07-05 01:15+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:42
+msgid "Your perceived location."
+msgstr "La teva ubicació percebuda."
+
+#. localip@mrieracrespi->metadata.json->description
+msgid "Shows local IP addresses."
+msgstr "Mostra adreces IP locals."
+
+#. localip@mrieracrespi->metadata.json->name
+msgid "Local IPs"
+msgstr "IPs Locals"

--- a/localipswithsettings@edaubert/files/localipswithsettings@edaubert/po/ca.po
+++ b/localipswithsettings@edaubert/files/localipswithsettings@edaubert/po/ca.po
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-23 10:37+0800\n"
+"PO-Revision-Date: 2024-07-05 01:19+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:47
+msgid "Your local IPs."
+msgstr "Les vostres IPs locals."
+
+#. localipswithsettings@edaubert->metadata.json->description
+msgid "Shows local IP addresses."
+msgstr "Mostra adreces IP locals."
+
+#. localipswithsettings@edaubert->metadata.json->name
+msgid "Local IPs with settings"
+msgstr "IPs locals amb opcions"
+
+#. localipswithsettings@edaubert->settings-
+#. schema.json->refreshInterval->description
+msgid "Update interval"
+msgstr "Interval de refresc"
+
+#. localipswithsettings@edaubert->settings-schema.json->refreshInterval->units
+msgid "seconds"
+msgstr "segons"
+
+#. localipswithsettings@edaubert->settings-schema.json->IPv4->description
+msgid "Display IPv4 information"
+msgstr "Mostrar informació IPv4"
+
+#. localipswithsettings@edaubert->settings-schema.json->inet->description
+msgid ""
+"List all interfaces we want to display.\n"
+"Separated by comma.\n"
+"Regex is accepted (usefull to list all docker interfaces for example)"
+msgstr ""
+"Llisteu totes les interfícies que voleu que es mostrin.\n"
+"Separades per coma.\n"
+"S'accepten expressions regulars (útils, per exemple, per a afegir interfícies de Docker)"
+
+#. localipswithsettings@edaubert->settings-schema.json->IPv6->description
+msgid "Display IPv6 information"
+msgstr "Mostrar informació IPv6"

--- a/location-detection@heimdall/files/location-detection@heimdall/po/ca.po
+++ b/location-detection@heimdall/files/location-detection@heimdall/po/ca.po
@@ -1,0 +1,60 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-26 17:55+0200\n"
+"PO-Revision-Date: 2024-07-05 01:24+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:56
+msgid "Your percieved location."
+msgstr "La vostra ubicació percebuda."
+
+#: applet.js:104
+msgid "Your IPInfoDB account has been suspended."
+msgstr "El vostre compte de IPInfoDB ha estat suspès."
+
+#: applet.js:104 applet.js:107
+msgid "Please set a valid API key in the applets settings."
+msgstr "Si us plau, assigneu una clau API vàlida a les preferències de la miniaplicació."
+
+#: applet.js:107
+msgid "Invalid API key."
+msgstr "Clau API invàlida."
+
+#: applet.js:119
+msgid "Something went Wrong!"
+msgstr "Alguna cosa ha anat malament!"
+
+#. location-detection@heimdall->metadata.json->description
+msgid "Shows the geographic location of your public IP and country-flag."
+msgstr "Mostra la ubicació geogràfica de la vostra IP pública i la bandera del país."
+
+#. location-detection@heimdall->metadata.json->name
+msgid "Location Detection + Flags"
+msgstr "Detecció d'Ubicació + Banderes"
+
+#. location-detection@heimdall->settings-schema.json->register-
+#. ipinfodb->description
+msgid "Register on IPInfoDB to get an API key"
+msgstr "Registreu-vos a IPInfoDB per rebre una clau API"
+
+#. location-detection@heimdall->settings-schema.json->api-key->description
+msgid "API key from IPInfoDB"
+msgstr "Clau API d' IPInfoDB"
+
+#. location-detection@heimdall->settings-schema.json->api-key->tooltip
+msgid "Get your API key from IPInfoDB and place it here."
+msgstr "Obteniu la vostra clau API d' IPInfoDB i afegiu-la aquí."

--- a/lorem@vxstorm/files/lorem@vxstorm/po/ca.po
+++ b/lorem@vxstorm/files/lorem@vxstorm/po/ca.po
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-05-06 10:09+0800\n"
+"PO-Revision-Date: 2024-07-05 01:27+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:30
+msgid "Copy Lorem Ipsum into your clipboard"
+msgstr "Copia Lorem Ipsum al portapapers"
+
+#. lorem@vxstorm->metadata.json->description
+msgid "Click to get a paragraph of Lorem Ipsum to your clipboard"
+msgstr "Cliqueu per a obtenir un paràgraf de Lorem Ipsum al vostre portapapers"
+
+#. lorem@vxstorm->metadata.json->name
+msgid "Lorem Pastesum"
+msgstr "Lorem Enganxasum"

--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/ca.po
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/ca.po
@@ -1,0 +1,39 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-20 22:25+0800\n"
+"PO-Revision-Date: 2024-07-05 01:29+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:33
+msgid "Open System Monitor"
+msgstr "Obrir el monitor del sistema"
+
+#: applet.js:72
+msgid "Click to open Gnome system monitor"
+msgstr "Clic per a obrir el monitor de sistema de Gnome"
+
+#. mem-monitor-text@datanom.net->metadata.json->description
+msgid "A simple applet that displays the memory usage."
+msgstr "Una miniaplicació simple que mostra l'ús de memòria."
+
+#. mem-monitor-text@datanom.net->metadata.json->name
+msgid "Simple Memory Monitor"
+msgstr "Monitor de Memòria Simple"
+
+#. mem-monitor-text@datanom.net->settings-schema.json->mem-label->tooltip
+msgid "Enter custom text to show in the panel."
+msgstr "Introduïu un text personalitzat per a mostrar al panell."

--- a/network@brownsr/files/network@brownsr/po/ca.po
+++ b/network@brownsr/files/network@brownsr/po/ca.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: network@brownsr 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 01:33+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+#: applet.js:20
+msgid "Network"
+msgstr "Xarxa"
+
+#. metadata.json->description
+msgid "Show network"
+msgstr "Mostra la xarxa"

--- a/nextslide@yaya-cout/files/nextslide@yaya-cout/po/ca.po
+++ b/nextslide@yaya-cout/files/nextslide@yaya-cout/po/ca.po
@@ -1,0 +1,37 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: nextslide@yaya-cout 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 01:36+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:18
+msgid "Click to change image"
+msgstr "Clic per a canviar la imatge"
+
+#: applet.js:21
+msgid "The slideshow is disabled"
+msgstr "La presentació de diapositives està desactivada"
+
+#. metadata.json->name
+msgid "Next slide"
+msgstr "Propera diapositiva"
+
+#. metadata.json->description
+msgid "Simple button to change background for the Cinnamon slideshow"
+msgstr ""
+"Botó simple per a canviar el fons de pantalla de la presentació de "
+"diapositives de Cinnamon"

--- a/nordvpn-indicator@nickdurante/files/nordvpn-indicator@nickdurante/po/ca.po
+++ b/nordvpn-indicator@nickdurante/files/nordvpn-indicator@nickdurante/po/ca.po
@@ -1,0 +1,39 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: nordvpn-indicator@nickdurante 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 01:39+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:25
+msgid "Manage your NordVPN connection"
+msgstr "Gestioneu la vostra connexió de NordVPN"
+
+#. metadata.json->name
+msgid "NordVPN Indicator"
+msgstr "Indicador de NordVPN"
+
+#. metadata.json->description
+msgid "Check your NordVPN connection"
+msgstr "Reviseu la vostra connexió de NordVPN"
+
+#. settings-schema.json->update-interval->units
+msgid "ms"
+msgstr "ms"
+
+#. settings-schema.json->update-interval->description
+msgid "Update interval"
+msgstr "Interval de refresc"

--- a/pa-equalizer@jschug.com/files/pa-equalizer@jschug.com/po/ca.po
+++ b/pa-equalizer@jschug.com/files/pa-equalizer@jschug.com/po/ca.po
@@ -1,0 +1,40 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-20 22:43+0800\n"
+"PO-Revision-Date: 2024-07-05 01:41+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. pa-equalizer@jschug.com->metadata.json->name
+#: applet.js:127
+msgid "Equalizer"
+msgstr "Equalitzador"
+
+#: applet.js:132
+msgid "Presets"
+msgstr "Preestablerts"
+
+#: applet.js:135
+msgid "Settings"
+msgstr "Opcions"
+
+#: applet.js:163
+msgid "Preset: "
+msgstr "Preestablert: "
+
+#. pa-equalizer@jschug.com->metadata.json->description
+msgid "An applet to control sound equalization"
+msgstr "Una miniaplicació per controlar l'equalització del so"

--- a/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/po/ca.po
+++ b/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/po/ca.po
@@ -1,0 +1,63 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-22 12:21-0300\n"
+"PO-Revision-Date: 2024-07-05 01:43+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:199
+msgid "Computer"
+msgstr "Ordinador"
+
+#: applet.js:211
+msgid "File System"
+msgstr "Sistema de fitxers"
+
+#. places-bookmarks@dmo60.de->metadata.json->name
+msgid "Places"
+msgstr "Llocs"
+
+#. places-bookmarks@dmo60.de->metadata.json->description
+msgid "Access your places and bookmarks"
+msgstr "Accediu als vostres llocs i marcadors"
+
+#. places-bookmarks@dmo60.de->settings-
+#. schema.json->pref_icon_size->description
+msgid "Menu items icon size"
+msgstr "Mida de la icona dels ítems al menú"
+
+#. places-bookmarks@dmo60.de->settings-schema.json->pref_icon_size->units
+msgid "pixels"
+msgstr "píxels"
+
+#. places-bookmarks@dmo60.de->settings-schema.json->head->description
+msgid "Settings for places-bookmarks@dmo60.de"
+msgstr "Configuració de places-bookmarks@dmo60.de"
+
+#. places-bookmarks@dmo60.de->settings-
+#. schema.json->pref_applet_icon->description
+msgid "Applet icon"
+msgstr "Icona de la miniaplicació"
+
+#. places-bookmarks@dmo60.de->settings-schema.json->pref_applet_icon->tooltip
+#. places-bookmarks@dmo60.de->settings-schema.json->pref_applet_label->tooltip
+msgid "Leave blank to remove."
+msgstr "Deixeu-ho en blanc per a eliminar."
+
+#. places-bookmarks@dmo60.de->settings-
+#. schema.json->pref_applet_label->description
+msgid "Applet label"
+msgstr "Etiqueta de la miniaplicació"

--- a/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/po/ca.po
+++ b/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/po/ca.po
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: places-with-terminal@mtwebster 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 01:47+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:99
+msgid "Places and bookmarks"
+msgstr "Llocs i marcadors"
+
+#: applet.js:106
+msgid "Refresh bookmarks..."
+msgstr "Refrescar marcadors..."
+
+#: applet.js:109
+msgid "Change default programs..."
+msgstr "Canviar els programes per defecte..."
+
+#: applet.js:153
+msgid "Computer"
+msgstr "Ordinador"
+
+#: applet.js:161
+msgid "File System"
+msgstr "Sistema de fitxers"
+
+#. metadata.json->name
+msgid "Places with Terminal Launcher"
+msgstr "Llocs amb llançadora del Terminal"
+
+#. metadata.json->description
+msgid "Access your places and bookmarks, or launch a terminal at that location"
+msgstr ""
+"Accediu als vostres llocs i marcadors o llanceu un terminal a aquella "
+"ubicació"
+
+#. settings-schema.json->icon->description
+msgid "icon"
+msgstr "icona"
+
+#. settings-schema.json->show-terminal->description
+msgid "Add terminal button to menu items"
+msgstr "Afegir botó del terminal als ítems del menú"

--- a/ptt@thbemme/files/ptt@thbemme/po/ca.po
+++ b/ptt@thbemme/files/ptt@thbemme/po/ca.po
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: ptt@thbemme 0.2\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 01:51+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:56 applet.js:232
+msgid "Click or press "
+msgstr "Cliqueu o polseu "
+
+#: applet.js:244
+msgid "PTT is active, "
+msgstr "El PTT està actiu, "
+
+#. metadata.json->name
+msgid "PTT Applet"
+msgstr "Miniaplicació PTT"
+
+#. metadata.json->description
+msgid "Push-to-talk applet and microphone indicator"
+msgstr "Miniaplicació Push-to-talk amb indicador de micròfon"
+
+#. settings-schema.json->head->description
+msgid "General Settings for the PTT Applet"
+msgstr "Configuració general per la miniaplicació PTT"
+
+#. settings-schema.json->darkmode->description
+msgid "Darkmode"
+msgstr "Mode fosc"
+
+#. settings-schema.json->keybinding_ptt_key->description
+msgid "PTT"
+msgstr "PTT"
+
+#. settings-schema.json->keybinding_ptt_toggle->description
+msgid "Switch bewteen PTT and normal mode"
+msgstr "Canvia entre PTT i mode normal"

--- a/restart-cinnamon@kolle/files/restart-cinnamon@kolle/po/ca.po
+++ b/restart-cinnamon@kolle/files/restart-cinnamon@kolle/po/ca.po
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-14 21:26+0200\n"
+"PO-Revision-Date: 2024-07-05 01:55+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:35
+msgid "Click here to restart Cinnamon"
+msgstr "Cliqueu aquí per reiniciar Cinnamon"
+
+#. metadata.json->name
+msgid "Restart Cinnamon"
+msgstr "Reiniciar Cinnamon"
+
+#. metadata.json->description
+msgid "Click on the applet to restart Cinnamon"
+msgstr "Cliqueu a la miniaplicació per reiniciar Cinnamon"
+
+#. metadata.json->contributors
+msgid "bimsebasse: added symbolic icon"
+msgstr "bimsebasse: icona simbòlica"
+
+#. metadata.json->contributors
+msgid "claudiux: OSD option"
+msgstr "claudiux: opció OSD"
+
+#. settings-schema.json->header-settings->description
+msgid "General Settings"
+msgstr "Configuració General"
+
+#. settings-schema.json->use-symbolic-icon->description
+msgid "Use symbolic icon"
+msgstr "Utilitza l' icona simbòlica"
+
+#. settings-schema.json->show-osd->description
+msgid "Show OSD"
+msgstr "Mostra OSD"

--- a/rswitcher@nixdev.com/files/rswitcher@nixdev.com/po/ca.po
+++ b/rswitcher@nixdev.com/files/rswitcher@nixdev.com/po/ca.po
@@ -1,0 +1,47 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-10-09 16:24+0200\n"
+"PO-Revision-Date: 2024-07-05 01:57+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:23
+msgid "Switch resolution on-the-fly, with HiDPI support"
+msgstr "Canvieu la resolució al vol, amb suport per HiDPI"
+
+#: applet.js:33
+msgid "HiDPI 200%"
+msgstr "200% HiDPI"
+
+#: applet.js:41
+msgid "HiDPI 150%"
+msgstr "150% HiDPI"
+
+#: applet.js:49
+msgid "2160p"
+msgstr "2160p"
+
+#: applet.js:57
+msgid "1080p"
+msgstr "1080p"
+
+#. metadata.json->name
+msgid "Resolution Switcher"
+msgstr "Canviador de Resolució"
+
+#. metadata.json->description
+msgid "Switch resolution on-the-fly with HiDPI support"
+msgstr "Canvieu la resolució al vol, amb suport per HiDPI"

--- a/separator2@zyzz/files/separator2@zyzz/po/ca.po
+++ b/separator2@zyzz/files/separator2@zyzz/po/ca.po
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-05-06 10:05+0800\n"
+"PO-Revision-Date: 2024-07-05 02:00+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:25
+msgid "Click here to move the applet where you want it."
+msgstr "Cliqueu aquí per moure la miniaplicació a on desitgeu."
+
+#. separator2@zyzz->metadata.json->description
+msgid "Use this applet to create a separator between your applets"
+msgstr "Utilitzeu aquesta miniaplicació per a crear separadors entre les vostres miniaplicacions"
+
+#. separator2@zyzz->metadata.json->name
+msgid "Separator2"
+msgstr "Separador2"

--- a/serviceLauncher@hulygun/files/serviceLauncher@hulygun/po/ca.po
+++ b/serviceLauncher@hulygun/files/serviceLauncher@hulygun/po/ca.po
@@ -1,0 +1,43 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-28 16:20+0800\n"
+"PO-Revision-Date: 2024-07-05 02:03+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:36
+msgid "Service launcher"
+msgstr "Llançador de serveis"
+
+#. serviceLauncher@hulygun->metadata.json->description
+msgid "Description"
+msgstr "Descripció"
+
+#. serviceLauncher@hulygun->metadata.json->name
+msgid "Service Launcher"
+msgstr "Llançador de Serveis"
+
+#. serviceLauncher@hulygun->settings-schema.json->services->description
+msgid "Set services"
+msgstr "Establir serveis"
+
+#. serviceLauncher@hulygun->settings-schema.json->services->tooltip
+msgid "use pattern Human Name:service.name;HumanName 2:service2.name"
+msgstr "usa el patró NomHumà1:nomservei1;NomHumà2:nomservei2"
+
+#. serviceLauncher@hulygun->settings-schema.json->header->description
+msgid "Set avaible services"
+msgstr "Establir serveis disponibles"

--- a/sleepTimer@JDatPNW/files/sleepTimer@JDatPNW/po/ca.po
+++ b/sleepTimer@JDatPNW/files/sleepTimer@JDatPNW/po/ca.po
@@ -1,0 +1,33 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: sleepTimer@JDatPNW 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-09 14:22-0400\n"
+"PO-Revision-Date: 2024-07-05 02:07+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+#. metadata.json->description
+#: applet.js:24
+msgid "sleepTimer"
+msgstr "temporitzadorSleep"
+
+#. settings-schema.json->update-interval->units
+msgid "ms"
+msgstr "ms"
+
+#. settings-schema.json->update-interval->description
+msgid "Update interval"
+msgstr "Interval de refresc"

--- a/smallcalc_applet@lerc.sds/files/smallcalc_applet@lerc.sds/po/ca.po
+++ b/smallcalc_applet@lerc.sds/files/smallcalc_applet@lerc.sds/po/ca.po
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-22 19:52+0200\n"
+"PO-Revision-Date: 2024-07-05 02:10+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:37 applet.js:98
+msgid "Show calculator"
+msgstr "Mostrar calculadora"
+
+#: applet.js:101
+msgid "Hide calculator"
+msgstr "Ocultar calculadora"
+
+#. metadata.json->name
+msgid "SmallCalc"
+msgstr "SmallCalc"
+
+#. metadata.json->description
+msgid "A nice compact popup calculator"
+msgstr "Una calculadora emergent compacta"
+
+#. settings-schema.json->definitionsheader->description
+msgid "Initial definitions"
+msgstr "Definicions inicials"
+
+#. settings-schema.json->definitions->description
+msgid "Define constants and functions to use in calculator"
+msgstr "Defineix constants i funcions per usar a la calculadora"
+
+#. settings-schema.json->precisionheader->description
+msgid "Precision"
+msgstr "Precisió"
+
+#. settings-schema.json->precision->description
+msgid "Number of significant digits:"
+msgstr "Nombre rellevant de dígits:"

--- a/softyubikey@yubiserver.include.gr/files/softyubikey@yubiserver.include.gr/po/ca.po
+++ b/softyubikey@yubiserver.include.gr/files/softyubikey@yubiserver.include.gr/po/ca.po
@@ -1,0 +1,55 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: softyubikey@yubiserver.include.gr 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-03-21 14:16-0400\n"
+"PO-Revision-Date: 2024-07-05 02:13+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:61
+msgid "Click here to create a OTP"
+msgstr "Clique aquí per crear un OTP"
+
+#: applet.js:63
+msgid "Configure your SoftYubikey"
+msgstr "Configureu el vostre SoftYubikey"
+
+#. metadata.json->name
+msgid "SoftYubikey"
+msgstr "SoftYubikey"
+
+#. metadata.json->description
+msgid "Click on the applet to create a OTP"
+msgstr "Cliqueu a la miniaplicació per crear un OTP"
+
+#: ui/softyubikey.ui:27
+msgid "Public ID"
+msgstr "ID Pública"
+
+#: ui/softyubikey.ui:40
+msgid "Private ID"
+msgstr "ID Privada"
+
+#: ui/softyubikey.ui:53
+msgid "AES key"
+msgstr "Clau AES"
+
+#: ui/softyubikey.ui:117
+msgid "Apply"
+msgstr "Aplicar"
+
+#: ui/softyubikey.ui:133
+msgid "Cancel"
+msgstr "Cancel·lar"

--- a/sync@szlldm/files/sync@szlldm/po/ca.po
+++ b/sync@szlldm/files/sync@szlldm/po/ca.po
@@ -1,0 +1,37 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-14 01:34+0900\n"
+"PO-Revision-Date: 2024-07-05 02:18+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:48
+msgid "Click to sync"
+msgstr "Cliqueu per a sincronitzar"
+
+#. metadata.json->description
+msgid ""
+"Monitor yet unwritten cached data. Click on the applet to sync (write out "
+"cached data). Useful when copying large files to slow removable medium(e.g. "
+"pendrive)."
+msgstr ""
+"Monitora la memòria cau encara no escrita. Cliqueu la miniaplicació per a "
+"sincronitzar (descartar la memòria cau). Útil al copiar fitxers grans a "
+"mitjans extraïbles lents (com ara un llapis USB)."
+
+#. metadata.json->name
+msgid "Sync"
+msgstr "Sincronitzar"

--- a/system-monitor@spacy01/files/system-monitor@spacy01/po/ca.po
+++ b/system-monitor@spacy01/files/system-monitor@spacy01/po/ca.po
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-23 22:11+0800\n"
+"PO-Revision-Date: 2024-07-05 02:21+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:25
+msgid "Click here to see a processes and etc."
+msgstr "Cliqueu aquí per veure els processos."
+
+#. system-monitor@spacy01->metadata.json->description
+msgid "Click here to see processes and etc."
+msgstr "Una miniaplicació per a veure els processos del sistema."
+
+#. system-monitor@spacy01->metadata.json->name
+msgid "System monitor"
+msgstr "Monitor del Sistema"

--- a/timeshift-spy@nicog60/files/timeshift-spy@nicog60/po/ca.po
+++ b/timeshift-spy@nicog60/files/timeshift-spy@nicog60/po/ca.po
@@ -1,0 +1,52 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-25 18:19+0200\n"
+"PO-Revision-Date: 2024-07-05 02:24+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:102
+msgid "Make a new snapshot"
+msgstr "Crea una instantània nova"
+
+#: applet.js:314
+msgid "Timeshift not configured"
+msgstr "Timeshift no està configurat"
+
+#: applet.js:317
+msgid "Backup device not found"
+msgstr ""
+"No s'ha trobat el dispositiu d'emmagatzematge de les còpies de seguretat"
+
+#: applet.js:322
+msgid "Wait for snapshot to begin"
+msgstr "Espereu a què la instantània comenci"
+
+#: applet.js:328
+msgid "Making snapshot..."
+msgstr "Creant instantània..."
+
+#. metadata.json->description
+msgid ""
+"Show the state of Timeshift, if it is currently making snapshots in the "
+"background"
+msgstr ""
+"Mostra l'estat de Timeshift i si s'està creant una instantània o no en "
+"aquest moment"
+
+#. metadata.json->name
+msgid "Timeshift Spy"
+msgstr "Espia de TimeShift"

--- a/todo@threefi/files/todo@threefi/po/ca.po
+++ b/todo@threefi/files/todo@threefi/po/ca.po
@@ -1,0 +1,47 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-24 19:36+0800\n"
+"PO-Revision-Date: 2024-07-05 02:28+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:77
+msgid "Click to edit the list"
+msgstr "Cliqueu per a editar la llista"
+
+#. todo@threefi->metadata.json->description
+msgid "a simple todo list ticker for cinammon"
+msgstr "una llista simple de tasques pendents per cinnamon"
+
+#. todo@threefi->metadata.json->name
+msgid "Todo"
+msgstr "Pendent"
+
+#. todo@threefi->settings-schema.json->important_color->description
+msgid "The color used to highlight important items"
+msgstr "Color utilitzat per a ressaltar tasques importants"
+
+#. todo@threefi->settings-schema.json->list_editor->description
+msgid "The editor that should be used to edit the list"
+msgstr "Editor a utilitzar per a modificar la llista"
+
+#. todo@threefi->settings-schema.json->lead_trail_time->description
+msgid "The time before/after scrolling that long items will be fixed"
+msgstr "Temps en què les tasques llargues es mantindran fixes abans/després de ser desplaçades"
+
+#. todo@threefi->settings-schema.json->text_width->description
+msgid "The width of text in characters"
+msgstr "Amplada del text en caràcters"

--- a/uiscaler@joka42/files/uiscaler@joka42/po/ca.po
+++ b/uiscaler@joka42/files/uiscaler@joka42/po/ca.po
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021 joka42
+# This file is distributed under the same license as the PACKAGE package.
+# joka42 jas_nombre@web.de, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-31 19:16+0800\n"
+"PO-Revision-Date: 2024-07-05 02:32+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:24
+msgid "Scale User Interface with one click"
+msgstr "Escaleu la interfície d'usuari amb un click"
+
+#: applet.js:34
+msgid "Scale 200%"
+msgstr "Escala al 200%"
+
+#: applet.js:38
+msgid "Scale 175%"
+msgstr "Escala al 175%"
+
+#: applet.js:42
+msgid "Scale 150%"
+msgstr "Escala al 150%"
+
+#: applet.js:46
+msgid "Scale 125%"
+msgstr "Escala al 125%"
+
+#: applet.js:50
+msgid "Reset 100%"
+msgstr "Reinicia al 100%"
+
+#. metadata.json->name
+msgid "UI Scaler for HiDPI Screens"
+msgstr "Escalador d'interfície d'usuari per a monitors HiDPI"
+
+#. metadata.json->description
+msgid "Scale your UI with one click for HiDPI screens"
+msgstr "Escaleu la vostra interfície d'usuari amb un clic (per monitors HiDPI)"

--- a/uptime@vatanuki.kun/files/uptime@vatanuki.kun/po/ca.po
+++ b/uptime@vatanuki.kun/files/uptime@vatanuki.kun/po/ca.po
@@ -1,0 +1,39 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-22 01:28+0800\n"
+"PO-Revision-Date: 2024-07-05 02:34+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:46
+msgid "Y"
+msgstr "A"
+
+#: applet.js:48 applet.js:52
+msgid "D"
+msgstr "D"
+
+#: applet.js:52
+msgid "h"
+msgstr "h"
+
+#. uptime@vatanuki.kun->metadata.json->description
+msgid "A simple applet that displays uptime."
+msgstr "Una miniaplicació simple que mostra el temps en marxa del dispositiu."
+
+#. uptime@vatanuki.kun->metadata.json->name
+msgid "Up Time"
+msgstr "Temps en marxa"

--- a/vboxlauncher@mockturtl/files/vboxlauncher@mockturtl/po/ca.po
+++ b/vboxlauncher@mockturtl/files/vboxlauncher@mockturtl/po/ca.po
@@ -1,0 +1,55 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-04-15 19:46+0200\n"
+"PO-Revision-Date: 2024-07-05 02:38+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:122
+msgid "Settings"
+msgstr "Configuració"
+
+#: applet.js:145
+msgid "Display"
+msgstr "Mostrar"
+
+#: applet.js:146
+msgid "Headless"
+msgstr "Mode Headless (servidor virtual remot)"
+
+#: applet.js:167
+msgid "ERROR. No compatible virtual machine programs found."
+msgstr "ERROR. No s'han trobat programes de virtualització compatibles."
+
+#: applet.js:273
+msgid "Update list"
+msgstr "Actualitzar llista"
+
+#. metadata.json->name
+msgid "Vbox Launcher"
+msgstr "Llançadora de Vbox"
+
+#. metadata.json->description
+msgid "An applet to launch virtual machines."
+msgstr "Una miniaplicació per a llançar màquines virtuals."
+
+#. settings-schema.json->autoUpdate->description
+msgid "Auto update (slow)"
+msgstr "Auto actualitzar (lent)"
+
+#. settings-schema.json->showHeadlessMode->description
+msgid "Show Headless Mode"
+msgstr "Mostrar el mode Headless"

--- a/web-developer-menu@infiniteshroom/files/web-developer-menu@infiniteshroom/po/ca.po
+++ b/web-developer-menu@infiniteshroom/files/web-developer-menu@infiniteshroom/po/ca.po
@@ -1,0 +1,55 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-20 12:38+0800\n"
+"PO-Revision-Date: 2024-07-05 02:41+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: applet.js:52
+msgid "Apache Web Server"
+msgstr "Servidor Web Apache"
+
+#: applet.js:53
+msgid "MySQL Server"
+msgstr "Servidor MySQL"
+
+#: applet.js:61
+msgid "Open Web Dir"
+msgstr "Obrir directori web"
+
+#: applet.js:66
+msgid "Launch Web Dir"
+msgstr "Iniciar directori web"
+
+#: applet.js:70
+msgid "Launch phpMyAdmin"
+msgstr "Iniciar phpMyAdmin"
+
+#: applet.js:75
+msgid "Edit default php.ini"
+msgstr "Editar el php.ini per defecte"
+
+#: applet.js:79
+msgid "Edit Apache Conf"
+msgstr "Editar la Conf. d'Apache"
+
+#. web-developer-menu@infiniteshroom->metadata.json->description
+msgid "A Menu for PHP/MySQL Web Developers"
+msgstr "Un menú per a desenvolupadors web amb PHP/MySQL"
+
+#. web-developer-menu@infiniteshroom->metadata.json->name
+msgid "Web Developer Menu"
+msgstr "Menú del Desenvolupador Web"

--- a/wireguard@nicoulaj.net/files/wireguard@nicoulaj.net/po/ca.po
+++ b/wireguard@nicoulaj.net/files/wireguard@nicoulaj.net/po/ca.po
@@ -1,0 +1,77 @@
+# cinnamon-applet-wireguard - https://github.com/nicoulaj/cinnamon-applet-wireguard
+# copyright (c) 2019 cinnamon-applet-wireguard contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-03 19:54+0200\n"
+"PO-Revision-Date: 2024-07-05 02:45+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+#: applet.js:54 applet.js:212
+msgid "WireGuard"
+msgstr "WireGuard"
+
+#: applet.js:67
+msgid ""
+"WireGuard configs directory /etc/wireguard does not exist, please make sure "
+"WireGuard is installed"
+msgstr ""
+"El directori de la configuració de WireGuard (/etc/wireguard) no existeix. "
+"Assegureu-vos que WireGuard està instal·lat"
+
+#: applet.js:135
+msgid "Failed toggling WireGuard interface"
+msgstr "Error alternant la interfície WireGuard"
+
+#: applet.js:139
+msgid ""
+"Failed calling wg-quick, please make sure it is installed and accessible"
+msgstr ""
+"Error cridant wg-quick. Assegureu-vos que està instal·lat i és accessible"
+
+#: applet.js:174
+msgid "Failed reading network interfaces"
+msgstr "Error llegint interfícies de xarxa"
+
+#: applet.js:186
+msgid ""
+"Failed accessing WireGuard configs directory, please make sure it is "
+"accessible\n"
+"sudo chmod o+r /etc/wireguard or sudo setfacl -m u:$username:rx /etc/"
+"wireguard"
+msgstr ""
+"Error accedint el directori de configuració de WireGuard. Assegureu-vos que "
+"sigui accessible\n"
+"sudo chmod o+r /etc/wireguard o sudo setfacl -m u:$username:rx /etc/"
+"wireguard"
+
+#: applet.js:219
+msgid "Error details"
+msgstr "Detalls de l'error"
+
+#. metadata.json->description
+msgid "Enable/disable WireGuard connections."
+msgstr "Activa/Desactiva connexions WireGuard."

--- a/workspace-name@willurd/files/workspace-name@willurd/po/ca.po
+++ b/workspace-name@willurd/files/workspace-name@willurd/po/ca.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-24 08:08+0800\n"
+"PO-Revision-Date: 2024-07-05 02:47+0200\n"
+"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. workspace-name@willurd->metadata.json->name
+msgid "Workspace Name"
+msgstr "Nom de l'espai de treball"
+
+#. workspace-name@willurd->metadata.json->description
+msgid "Show the current workspace name in the panel"
+msgstr "Mostra el nom de l'espai de treball actual al panell"


### PR DESCRIPTION
This bundle contains new Catalan translations for all the applets containing ten or less strings (listed below):

* asl@santiago
* AutostartPrograms@spacy01
* backgroundroll@Sokawaii25
* batterypower@joka42
* bing-wallpaper@starcross.dev
* bose@tuuxx
* clipboard-eraser@Techcrafter
* computer@brownsr
* ctrl4docker@hoffis-eck.de
* CustomApplicationsMenu@LLOBERA
* CustomPlaces@Nicolas01
* ddcci-multi-monitor@tim-we
* desaturate-all@hkoosha
* devbar@ludvigbostrom
* duolingo-helper@nodeengineer.com
* force-quit@cinnamon.org
* gamemode@axel358
* gnote@brett-smith
* healthyeyes@ipolozov
* ifstat@tagadan
* IntelTurboBoost@wsmenezes
* ioDisk@ctrlesc
* internet-indicator@sangorys
* localip@mrieracrespi
* localipswithsettings@edaubert
* location-detection@heimdall
* lorem@vxstorm
* mem-monitor-text@datanom.net
* MessagingMenuV3@blub
* Mint-Unsplash-Background@omidmaldar
* network@brownsr
* nextslide@yaya-cout
* nordvpn-indicator@nickdurante
* pa-equalizer@jschug.com
* places-bookmarks@dmo60.de
* places-with-terminal@mtwebster
* ptt@thbemme
* restart-cinnamon@kolle
* rswitcher@nixdev.com
* screenlocker@tuuxx
* ScreenShot@tech71
* serviceLauncher@hulygun
* separator2@zyzz
* sleepTimer@JDatPNW
* smallcalc_applet@lerc.sds
* softyubikey@yubiserver.include.gr
* sync@szlldm
* system-monitor@spacy01
* timeshift-spy@nicog60
* todo@threefi
* uiscaler@joka42
* uptime@vatanuki.kun
* vboxlauncher@mockturtl
* web-developer-menu@infiniteshroom
* wireguard@nicoulaj.net
* workspace-name@willurd