### PR TITLE
added german translation for CustomPlaces@Nicolas01

### DIFF
--- a/CustomPlaces@Nicolas01/files/CustomPlaces@Nicolas01/po/de.po
+++ b/CustomPlaces@Nicolas01/files/CustomPlaces@Nicolas01/po/de.po
@@ -1,0 +1,38 @@
+# SOME DESCRIPTIVE TITLE.
+# This file is put in the public domain.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: CustomPlaces@Nicolas01 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-07-10 14:22-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applet.js:176
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: applet.js:182
+msgid "Help"
+msgstr "Hilfe"
+
+#: applet.js:187
+msgid "About"
+msgstr "Über"
+
+#. metadata.json->description
+msgid "A places drop-down list easily customisable"
+msgstr "Eine leicht anpassbare Dropdown-Liste für Orte"
+
+#. metadata.json->name
+msgid "Custom Places"
+msgstr "Benutzerdefinierte Orte"


### PR DESCRIPTION
Does this work like this? At first I tried with the command of the script to generate it but it gives me this error:

```
Traceback (most recent call last):
  File "/home/josh/Documents/Developement/Mint temp/cinnamon-spices-applets-translation/./cinnamon-spices-makepot", line 257, in <module>
    parse_args()
  File "/home/josh/Documents/Developement/Mint temp/cinnamon-spices-applets-translation/./cinnamon-spices-makepot", line 62, in parse_args
    output = make_pot(args.uuid)
             ^^^^^^^^^^^^^^^^^^^
  File "/home/josh/Documents/Developement/Mint temp/cinnamon-spices-applets-translation/./cinnamon-spices-makepot", line 200, in make_pot
    output += get_command_output(['cinnamon-xlet-makepot',
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/josh/Documents/Developement/Mint temp/cinnamon-spices-applets-translation/./cinnamon-spices-makepot", line 97, in get_command_output
    result = subprocess.run(cmd, cwd=cwd, check=check, stderr=stderr,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'cinnamon-xlet-makepot'
```