### PR TITLE
[CassiaWindowList@klangman] Version 2.3.0

### DIFF
--- a/CassiaWindowList@klangman/CHANGELOG.md
+++ b/CassiaWindowList@klangman/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.3.0
+
+* Allow rearranging Thumbnail menu items using drag-and-drop
+* Allow drag-and-drop of Thumbnail menu items to the desktop, matching the behaviour of window-list button drag-and-drop
+* Add options for hiding button labels when the windows workspace/monitor is not the current workspace/monitor
+* Fixed how labels are hidden for grouped buttons so that it's solely based on the current windows state
+* Added an option to sort the Thumbnail menu for grouped buttons based on the Workspace & Monitor index (pools will not be sorted!)
+* Fix a cases where Thumbnail menus can contain stale window titles or even contain windows that have been closed
+* Fix to show labels for application pools where some, but not all, windows in the pool don't qualify to have a label
+* Added 4 scroll-wheel actions options which applies when the scroll-wheel is used on a window-list button
+* Renamed "Activate # window in grouped button" mouse actions to "Restore/minimize # window in group"
+* Changed "Restore/minimize # window in group" so it will minimize the window if the window already has the focus
+* Added a "Restore/Minimize 1st window in group" option to the "Left button action for grouped buttons" list of options
+
 ## 2.2.0
 
 * Added support for drag-and-drop of window-list buttons to the desktop. This will move the window to the desktop that the drop occurred on. If you drop on a monitor where the window does not current reside, it will be moved to that monitor. If the window exists on a different workspace, it will be moved to the current workspace. If the window does not have the focus it will be activated and given the focus. Requires Cinnamon 5.4 (Mint 21.x)

--- a/CassiaWindowList@klangman/README.md
+++ b/CassiaWindowList@klangman/README.md
@@ -1,7 +1,12 @@
 This is a Cinnamon window list and panel launcher applet based on CobiWindowList with a number of additional features designed to give you more control over how your window-list operates.
 
-Recent new features (Aug 2023 - June 2024):
+Recent new features (Aug 2023 - July 2024):
 
+* Allow rearranging Thumbnail menu items using drag-and-drop, also allow dropping on the desktop
+* Add options for hiding button labels when the windows workspace/monitor is not the current workspace/monitor
+* Added an option to sort the Thumbnail menu for grouped buttons based on the Workspace & Monitor index
+* Added 4 scroll-wheel actions options which applies when the scroll-wheel is used on a window-list button
+* Added "Restore/Minimize 1st window in group" option to the "Left button action for grouped buttons" option list
 * Support "drag-&-drop to desktop" which will move a window to the workspace & monitor it's dropped on
 * "Move window here" context menu/mouse action options to move a window to the current monitor/workspace
 * Thumbnail menu items will now show the windows workspace/monitor number(s) when appropriate

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -52,12 +52,12 @@
     "general-mouse" : {
       "type" : "section",
       "title" : "Window list mouse settings",
-    "keys" : ["grouped-mouse-action-btn1", "launcher-mouse-action-btn1", "mouse-action-btn2", "mouse-action-btn8", "mouse-action-btn9"]
+    "keys" : ["grouped-mouse-action-btn1", "launcher-mouse-action-btn1", "mouse-action-btn2", "mouse-action-btn8", "mouse-action-btn9", "mouse-action-scroll"]
     },
     "preview-settings" : {
       "type" : "section",
       "title" : "Thumbnails menu settings",
-      "keys" : ["show-previews", "number-of-unshrunk-previews", "menu-all-windows-of-pool", "menu-all-windows-of-auto", "hover-peek-thumbnail", "no-click-activate-thumbnail"]
+      "keys" : ["show-previews", "number-of-unshrunk-previews", "menu-sort-groups", "menu-all-windows-of-pool", "menu-all-windows-of-auto", "hover-peek-thumbnail", "no-click-activate-thumbnail"]
     },
     "preview-mouse-section" : {
       "type" : "section",
@@ -115,10 +115,16 @@
     "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned window that are running will have a label\nFocused: Only the pinned window with focus will have a label"
   },
   "hide-caption-for-minimized": {
-    "type": "switch",
+    "type": "combobox",
     "default": 0,
-    "description": "Hide labels for minimized buttons",
-    "tooltip": "For groups/pools the label will still show unless all application windows are minimized"
+    "options": {
+      "None": 0,
+      "Minimized windows": 1,
+      "Windows on other workspaces": 2,
+      "Windows on other monitors": 3
+    },
+    "description": "Hide labels for",
+    "tooltip": "Select the type of window state for which window list button labels should be hidden. For application pools, the label will still show unless all application windows have the selected property"
   },
   "display-indicators": {
     "type": "combobox",
@@ -333,6 +339,13 @@
     "dependency": "show-previews",
     "description": "Default thumbnail window size"
   },
+  "menu-sort-groups": {
+    "type": "switch",
+    "default": false,
+    "dependency" : "group-windows!=3",
+    "description": "Sort grouped button thumbnail menu items",
+    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and the by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window-list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
+  },
   "menu-all-windows-of-pool": {
     "type": "switch",
     "default": true,
@@ -511,6 +524,7 @@
     "default": 2,
     "options": {
       "Restore/Minimize most recent window": 0,
+      "Restore/Minimize 1st window in group": 5,
       "Restore then cycle windows": 1,
       "Show thumbnail menu": 2,
       "Restore or hold for thumbnail menu": 3
@@ -525,6 +539,7 @@
     "default": 4,
     "options": {
       "Restore/Minimize most recent window": 0,
+      "Restore/Minimize 1st window in group": 5,
       "Restore then cycle windows": 1,
       "Show thumbnail menu": 2,
       "Restore or hold for thumbnail menu": 3,
@@ -545,10 +560,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
-      "Activate 1st window in grouped button": 35,
-      "Activate 2nd window in grouped button": 36,
-      "Activate 3rd window in grouped button": 37,
-      "Activate 4th window in grouped button": 38,
+      "Restore/minimize 1st window in group": 35,
+      "Restore/minimize 2nd window in group": 36,
+      "Restore/minimize 3rd window in group": 37,
+      "Restore/minimize 4th window in group": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -593,10 +608,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
-      "Activate 1st window in grouped button": 35,
-      "Activate 2nd window in grouped button": 36,
-      "Activate 3rd window in grouped button": 37,
-      "Activate 4th window in grouped button": 38,
+      "Restore/minimize 1st window in group": 35,
+      "Restore/minimize 2nd window in group": 36,
+      "Restore/minimize 3rd window in group": 37,
+      "Restore/minimize 4th window in group": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -641,10 +656,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
-      "Activate 1st window in grouped button": 35,
-      "Activate 2nd window in grouped button": 36,
-      "Activate 3rd window in grouped button": 37,
-      "Activate 4th window in grouped button": 38,
+      "Restore/minimize 1st window in group": 35,
+      "Restore/minimize 2nd window in group": 36,
+      "Restore/minimize 3rd window in group": 37,
+      "Restore/minimize 4th window in group": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -678,6 +693,20 @@
     },
     "description": "Forward button action",
     "tooltip": "Action taken when using the forward mouse button on window list entries"
+  },
+
+  "mouse-action-scroll": {
+    "type": "combobox",
+    "default": 1,
+    "options": {
+      "Minimize/Restore/Maximize window": 1,
+      "Change windows workspace": 2,
+      "Change windows monitor": 3,
+      "Change window tiling": 4,
+      "Do nothing": 0
+    },
+    "description": "Scroll wheel action",
+    "tooltip": "Action taken when using the mouse scroll wheel on a window list button. This scroll wheel action will be disabled if the Thumbnail menu is currently open"
   },
 
   "wheel-adjusts-preview-size": {
@@ -779,10 +808,10 @@
            "Minimize/Restore": 3,
            "Maximize/Restore": 4,
            "Restore most recent application window": 13,
-           "Activate 1st window in grouped button": 35,
-           "Activate 2nd window in grouped button": 36,
-           "Activate 3rd window in grouped button": 37,
-           "Activate 4th window in grouped button": 38,
+           "Restore/minimize 1st window in group": 35,
+           "Restore/minimize 2nd window in group": 36,
+           "Restore/minimize 3rd window in group": 37,
+           "Restore/minimize 4th window in group": 38,
            "Group/Ungroup windows": 5,
            "Open new window": 6,
            "Move to workspace 1": 7,

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
@@ -52,12 +52,12 @@
     "general-mouse" : {
       "type" : "section",
       "title" : "Window list mouse settings",
-    "keys" : ["grouped-mouse-action-btn1", "launcher-mouse-action-btn1", "mouse-action-btn2", "mouse-action-btn8", "mouse-action-btn9"]
+    "keys" : ["grouped-mouse-action-btn1", "launcher-mouse-action-btn1", "mouse-action-btn2", "mouse-action-btn8", "mouse-action-btn9", "mouse-action-scroll"]
     },
     "preview-settings" : {
       "type" : "section",
       "title" : "Thumbnails menu settings",
-      "keys" : ["show-previews", "number-of-unshrunk-previews", "menu-all-windows-of-pool", "menu-all-windows-of-auto", "hover-peek-thumbnail", "no-click-activate-thumbnail"]
+      "keys" : ["show-previews", "number-of-unshrunk-previews", "menu-sort-groups", "menu-all-windows-of-pool", "menu-all-windows-of-auto", "hover-peek-thumbnail", "no-click-activate-thumbnail"]
     },
     "preview-mouse-section" : {
       "type" : "section",
@@ -115,10 +115,16 @@
     "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned window that are running will have a label\nFocused: Only the pinned window with focus will have a label"
   },
   "hide-caption-for-minimized": {
-    "type": "switch",
+    "type": "combobox",
     "default": 0,
-    "description": "Hide labels for minimized buttons",
-    "tooltip": "For groups/pools the label will still show unless all application windows are minimized"
+    "options": {
+      "None": 0,
+      "Minimized windows": 1,
+      "Windows on other workspaces": 2,
+      "Windows on other monitors": 3
+    },
+    "description": "Hide labels for",
+    "tooltip": "Select the type of window state for which window list button labels should be hidden. For application pools, the label will still show unless all application windows have the selected property"
   },
   "display-indicators": {
     "type": "combobox",
@@ -333,6 +339,13 @@
     "dependency": "show-previews",
     "description": "Default thumbnail window size"
   },
+  "menu-sort-groups": {
+    "type": "switch",
+    "default": false,
+    "dependency" : "group-windows!=3",
+    "description": "Sort grouped button thumbnail menu items",
+    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and the by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window-list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
+  },
   "menu-all-windows-of-pool": {
     "type": "switch",
     "default": true,
@@ -511,6 +524,7 @@
     "default": 2,
     "options": {
       "Restore/Minimize most recent window": 0,
+      "Restore/Minimize 1st window in group": 5,
       "Restore then cycle windows": 1,
       "Show thumbnail menu": 2,
       "Restore or hold for thumbnail menu": 3
@@ -525,6 +539,7 @@
     "default": 4,
     "options": {
       "Restore/Minimize most recent window": 0,
+      "Restore/Minimize 1st window in group": 5,
       "Restore then cycle windows": 1,
       "Show thumbnail menu": 2,
       "Restore or hold for thumbnail menu": 3,
@@ -545,10 +560,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
-      "Activate 1st window in grouped button": 35,
-      "Activate 2nd window in grouped button": 36,
-      "Activate 3rd window in grouped button": 37,
-      "Activate 4th window in grouped button": 38,
+      "Restore/minimize 1st window in group": 35,
+      "Restore/minimize 2nd window in group": 36,
+      "Restore/minimize 3rd window in group": 37,
+      "Restore/minimize 4th window in group": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -593,10 +608,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
-      "Activate 1st window in grouped button": 35,
-      "Activate 2nd window in grouped button": 36,
-      "Activate 3rd window in grouped button": 37,
-      "Activate 4th window in grouped button": 38,
+      "Restore/minimize 1st window in group": 35,
+      "Restore/minimize 2nd window in group": 36,
+      "Restore/minimize 3rd window in group": 37,
+      "Restore/minimize 4th window in group": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -641,10 +656,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
-      "Activate 1st window in grouped button": 35,
-      "Activate 2nd window in grouped button": 36,
-      "Activate 3rd window in grouped button": 37,
-      "Activate 4th window in grouped button": 38,
+      "Restore/minimize 1st window in group": 35,
+      "Restore/minimize 2nd window in group": 36,
+      "Restore/minimize 3rd window in group": 37,
+      "Restore/minimize 4th window in group": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -678,6 +693,20 @@
     },
     "description": "Forward button action",
     "tooltip": "Action taken when using the forward mouse button on window list entries"
+  },
+
+  "mouse-action-scroll": {
+    "type": "combobox",
+    "default": 1,
+    "options": {
+      "Minimize/Restore/Maximize window": 1,
+      "Change windows workspace": 2,
+      "Change windows monitor": 3,
+      "Change window tiling": 4,
+      "Do nothing": 0
+    },
+    "description": "Scroll wheel action",
+    "tooltip": "Action taken when using the mouse scroll wheel on a window list button. This scroll wheel action will be disabled if the Thumbnail menu is currently open"
   },
 
   "wheel-adjusts-preview-size": {
@@ -779,10 +808,10 @@
            "Minimize/Restore": 3,
            "Maximize/Restore": 4,
            "Restore most recent application window": 13,
-           "Activate 1st window in grouped button": 35,
-           "Activate 2nd window in grouped button": 36,
-           "Activate 3rd window in grouped button": 37,
-           "Activate 4th window in grouped button": 38,
+           "Restore/minimize 1st window in group": 35,
+           "Restore/minimize 2nd window in group": 36,
+           "Restore/minimize 3rd window in group": 37,
+           "Restore/minimize 4th window in group": 38,
            "Group/Ungroup windows": 5,
            "Open new window": 6,
            "Move to workspace 1": 7,

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
@@ -5,6 +5,6 @@
     "max-instances": -1,
     "multiversion": true,
     "role": "panellauncher",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "author": "klangman"
 }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CassiaWindowList@klangman 2.2.0\n"
+"Project-Id-Version: CassiaWindowList@klangman 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-04 23:25-0400\n"
+"POT-Creation-Date: 2024-07-15 22:10-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,32 +17,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:550 6.0/applet.js:550
+#: 4.0/applet.js:567 6.0/applet.js:567
 msgid "all buttons"
 msgstr ""
 
-#: 4.0/applet.js:2767 6.0/applet.js:2767
+#: 4.0/applet.js:3087 6.0/applet.js:3087
 msgid "Applet Preferences"
 msgstr ""
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:3091 6.0/applet.js:3091
 msgid "About..."
 msgstr ""
 
-#: 4.0/applet.js:2775 6.0/applet.js:2775
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Configure..."
 msgstr ""
 
-#: 4.0/applet.js:2779 6.0/applet.js:2779
+#: 4.0/applet.js:3099 6.0/applet.js:3099
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2783 6.0/applet.js:2783
+#: 4.0/applet.js:3103 6.0/applet.js:3103
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: 4.0/applet.js:2785 6.0/applet.js:2785
+#: 4.0/applet.js:3105 6.0/applet.js:3105
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -58,71 +58,71 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2794 6.0/applet.js:2794
+#: 4.0/applet.js:3114 6.0/applet.js:3114
 msgid "Open new window"
 msgstr ""
 
-#: 4.0/applet.js:2802 6.0/applet.js:2802
+#: 4.0/applet.js:3122 6.0/applet.js:3122
 msgid "Remove from panel"
 msgstr ""
 
-#: 4.0/applet.js:2804 6.0/applet.js:2804
+#: 4.0/applet.js:3124 6.0/applet.js:3124
 msgid "Remove from this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2810 6.0/applet.js:2810
+#: 4.0/applet.js:3130 6.0/applet.js:3130
 msgid "Pin to panel"
 msgstr ""
 
-#: 4.0/applet.js:2812 6.0/applet.js:2812
+#: 4.0/applet.js:3132 6.0/applet.js:3132
 msgid "Pin to this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2853 6.0/applet.js:2853
+#: 4.0/applet.js:3173 6.0/applet.js:3173
 msgid "Pin to other workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2874 6.0/applet.js:2874
+#: 4.0/applet.js:3194 6.0/applet.js:3194
 msgid "Pin to all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2892 6.0/applet.js:2892
+#: 4.0/applet.js:3212 6.0/applet.js:3212
 msgid "Pin to launcher"
 msgstr ""
 
-#: 4.0/applet.js:2910 4.0/applet.js:3102 6.0/applet.js:2910 6.0/applet.js:3102
+#: 4.0/applet.js:3230 4.0/applet.js:3422 6.0/applet.js:3230 6.0/applet.js:3422
 msgid "Add new Hotkey for"
 msgstr ""
 
-#: 4.0/applet.js:2924 6.0/applet.js:2924
+#: 4.0/applet.js:3244 6.0/applet.js:3244
 msgid "Recent files"
 msgstr ""
 
-#: 4.0/applet.js:2948 6.0/applet.js:2948
+#: 4.0/applet.js:3268 6.0/applet.js:3268
 msgid "Places"
 msgstr ""
 
-#: 4.0/applet.js:2990 6.0/applet.js:2990
+#: 4.0/applet.js:3310 6.0/applet.js:3310
 msgid "Only on this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3312 6.0/applet.js:3312
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2993 6.0/applet.js:2993
+#: 4.0/applet.js:3313 6.0/applet.js:3313
 msgid "Move to another workspace"
 msgstr ""
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3322 6.0/applet.js:3322
 msgid " (this workspace)"
 msgstr ""
 
-#: 4.0/applet.js:3015 6.0/applet.js:3015
+#: 4.0/applet.js:3335 6.0/applet.js:3335
 msgid "Move to another monitor"
 msgstr ""
 
-#: 4.0/applet.js:3023 6.0/applet.js:3023
+#: 4.0/applet.js:3343 6.0/applet.js:3343
 msgid "Monitor"
 msgstr ""
 
@@ -138,47 +138,47 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3040 6.0/applet.js:3040
+#: 4.0/applet.js:3360 6.0/applet.js:3360
 msgid "Move window here"
 msgstr ""
 
-#: 4.0/applet.js:3057 6.0/applet.js:3057
+#: 4.0/applet.js:3377 6.0/applet.js:3377
 msgid "unassigned"
 msgstr ""
 
-#: 4.0/applet.js:3068 4.0/applet.js:3099 6.0/applet.js:3068 6.0/applet.js:3099
+#: 4.0/applet.js:3388 4.0/applet.js:3419 6.0/applet.js:3388 6.0/applet.js:3419
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#: 4.0/applet.js:3122 6.0/applet.js:3122
+#: 4.0/applet.js:3442 6.0/applet.js:3442
 msgid "Change application label contents"
 msgstr ""
 
-#: 4.0/applet.js:3125 6.0/applet.js:3125
+#: 4.0/applet.js:3445 6.0/applet.js:3445
 msgid "Remove custom setting"
 msgstr ""
 
-#: 4.0/applet.js:3132 6.0/applet.js:3132
+#: 4.0/applet.js:3452 6.0/applet.js:3452
 msgid "Use window title"
 msgstr ""
 
-#: 4.0/applet.js:3139 6.0/applet.js:3139
+#: 4.0/applet.js:3459 6.0/applet.js:3459
 msgid "Use application name"
 msgstr ""
 
-#: 4.0/applet.js:3146 6.0/applet.js:3146
+#: 4.0/applet.js:3466 6.0/applet.js:3466
 msgid "No label"
 msgstr ""
 
-#: 4.0/applet.js:3157 6.0/applet.js:3157
+#: 4.0/applet.js:3477 6.0/applet.js:3477
 msgid "Ungroup application windows"
 msgstr ""
 
-#: 4.0/applet.js:3166 6.0/applet.js:3166
+#: 4.0/applet.js:3486 6.0/applet.js:3486
 msgid "Group application windows"
 msgstr ""
 
-#: 4.0/applet.js:3179 6.0/applet.js:3179
+#: 4.0/applet.js:3499 6.0/applet.js:3499
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -194,31 +194,31 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3209 6.0/applet.js:3209
+#: 4.0/applet.js:3529 6.0/applet.js:3529
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#: 4.0/applet.js:3214 6.0/applet.js:3214
+#: 4.0/applet.js:3534 6.0/applet.js:3534
 msgid "Restore"
 msgstr ""
 
-#: 4.0/applet.js:3218 6.0/applet.js:3218
+#: 4.0/applet.js:3538 6.0/applet.js:3538
 msgid "Minimize"
 msgstr ""
 
-#: 4.0/applet.js:3224 6.0/applet.js:3224
+#: 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Unmaximize"
 msgstr ""
 
-#: 4.0/applet.js:3231 6.0/applet.js:3231
+#: 4.0/applet.js:3551 6.0/applet.js:3551
 msgid "Close others"
 msgstr ""
 
-#: 4.0/applet.js:3242 6.0/applet.js:3242
+#: 4.0/applet.js:3562 6.0/applet.js:3562
 msgid "Close all"
 msgstr ""
 
-#: 4.0/applet.js:3251 6.0/applet.js:3251
+#: 4.0/applet.js:3571 6.0/applet.js:3571
 msgid "Close"
 msgstr ""
 
@@ -393,26 +393,41 @@ msgid ""
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "None"
+msgstr ""
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "Minimized windows"
+msgstr ""
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+msgid "Windows on other workspaces"
+msgstr ""
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+msgid "Windows on other monitors"
+msgstr ""
+
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
-msgid "Hide labels for minimized buttons"
+msgid "Hide labels for"
 msgstr ""
 
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
-"For groups/pools the label will still show unless all application windows "
-"are minimized"
-msgstr ""
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "None"
-msgstr ""
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "Minimized windows"
+"Select the type of window state for which window list button labels should "
+"be hidden. For application pools, the label will still show unless all "
+"application windows have the selected property"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-indicators->options
@@ -818,6 +833,21 @@ msgstr ""
 #. 4.0->settings-schema.json->number-of-unshrunk-previews->description
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
+msgstr ""
+
+#. 4.0->settings-schema.json->menu-sort-groups->description
+#. 6.0->settings-schema.json->menu-sort-groups->description
+msgid "Sort grouped button thumbnail menu items"
+msgstr ""
+
+#. 4.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.0->settings-schema.json->menu-sort-groups->tooltip
+msgid ""
+"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"monitor number for grouped buttons. Pooled windows can not be sorted since "
+"the order is the same as the order on the window-list panel. With this "
+"option enabled, the thumbnail menu drag-and-drop reordering feature will be "
+"disabled for grouped button thumbnail menus."
 msgstr ""
 
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
@@ -1312,12 +1342,14 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr ""
 
@@ -1369,6 +1401,13 @@ msgstr ""
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
+msgstr ""
+
+#. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+msgid "Restore/Minimize 1st window in group"
 msgstr ""
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
@@ -1454,7 +1493,7 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 1st window in grouped button"
+msgid "Restore/minimize 1st window in group"
 msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
@@ -1463,7 +1502,7 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 2nd window in grouped button"
+msgid "Restore/minimize 2nd window in group"
 msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
@@ -1472,7 +1511,7 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 3rd window in grouped button"
+msgid "Restore/minimize 3rd window in group"
 msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
@@ -1481,7 +1520,7 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 4th window in grouped button"
+msgid "Restore/minimize 4th window in group"
 msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
@@ -1512,6 +1551,38 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn9->tooltip
 #. 6.0->settings-schema.json->mouse-action-btn9->tooltip
 msgid "Action taken when using the forward mouse button on window list entries"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Minimize/Restore/Maximize window"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows workspace"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change window tiling"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->description
+#. 6.0->settings-schema.json->mouse-action-scroll->description
+msgid "Scroll wheel action"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+msgid ""
+"Action taken when using the mouse scroll wheel on a window list button. This "
+"scroll wheel action will be disabled if the Thumbnail menu is currently open"
 msgstr ""
 
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ca.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-04 23:25-0400\n"
+"POT-Creation-Date: 2024-07-15 22:10-0400\n"
 "PO-Revision-Date: 2024-07-08 03:23+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,32 +18,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: 4.0/applet.js:550 6.0/applet.js:550
+#: 4.0/applet.js:567 6.0/applet.js:567
 msgid "all buttons"
 msgstr "tots els botons"
 
-#: 4.0/applet.js:2767 6.0/applet.js:2767
+#: 4.0/applet.js:3087 6.0/applet.js:3087
 msgid "Applet Preferences"
 msgstr "Preferències de la miniaplicació"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:3091 6.0/applet.js:3091
 msgid "About..."
 msgstr "Quant a..."
 
-#: 4.0/applet.js:2775 6.0/applet.js:2775
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Configure..."
 msgstr "Configura..."
 
-#: 4.0/applet.js:2779 6.0/applet.js:2779
+#: 4.0/applet.js:3099 6.0/applet.js:3099
 msgid "Website"
 msgstr "Lloc web"
 
-#: 4.0/applet.js:2783 6.0/applet.js:2783
+#: 4.0/applet.js:3103 6.0/applet.js:3103
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#: 4.0/applet.js:2785 6.0/applet.js:2785
+#: 4.0/applet.js:3105 6.0/applet.js:3105
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Segur que voleu eliminar aquesta instància de la Llista de Finestres Cassia?"
@@ -60,71 +60,71 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2794 6.0/applet.js:2794
+#: 4.0/applet.js:3114 6.0/applet.js:3114
 msgid "Open new window"
 msgstr "Obre una nova finestra"
 
-#: 4.0/applet.js:2802 6.0/applet.js:2802
+#: 4.0/applet.js:3122 6.0/applet.js:3122
 msgid "Remove from panel"
 msgstr "Elimina del tauler"
 
-#: 4.0/applet.js:2804 6.0/applet.js:2804
+#: 4.0/applet.js:3124 6.0/applet.js:3124
 msgid "Remove from this workspace"
 msgstr "Elimina d'aquest espai de treball"
 
-#: 4.0/applet.js:2810 6.0/applet.js:2810
+#: 4.0/applet.js:3130 6.0/applet.js:3130
 msgid "Pin to panel"
 msgstr "Fixar al tauler"
 
-#: 4.0/applet.js:2812 6.0/applet.js:2812
+#: 4.0/applet.js:3132 6.0/applet.js:3132
 msgid "Pin to this workspace"
 msgstr "Fixar a aquest espai de treball"
 
-#: 4.0/applet.js:2853 6.0/applet.js:2853
+#: 4.0/applet.js:3173 6.0/applet.js:3173
 msgid "Pin to other workspaces"
 msgstr "Fixar a altres espais de treball"
 
-#: 4.0/applet.js:2874 6.0/applet.js:2874
+#: 4.0/applet.js:3194 6.0/applet.js:3194
 msgid "Pin to all workspaces"
 msgstr "Fixar a tots els espais de treball"
 
-#: 4.0/applet.js:2892 6.0/applet.js:2892
+#: 4.0/applet.js:3212 6.0/applet.js:3212
 msgid "Pin to launcher"
 msgstr "Fixar al llançador"
 
-#: 4.0/applet.js:2910 4.0/applet.js:3102 6.0/applet.js:2910 6.0/applet.js:3102
+#: 4.0/applet.js:3230 4.0/applet.js:3422 6.0/applet.js:3230 6.0/applet.js:3422
 msgid "Add new Hotkey for"
 msgstr "Afegir nova drecera per a"
 
-#: 4.0/applet.js:2924 6.0/applet.js:2924
+#: 4.0/applet.js:3244 6.0/applet.js:3244
 msgid "Recent files"
 msgstr "Fitxers recents"
 
-#: 4.0/applet.js:2948 6.0/applet.js:2948
+#: 4.0/applet.js:3268 6.0/applet.js:3268
 msgid "Places"
 msgstr "Llocs"
 
-#: 4.0/applet.js:2990 6.0/applet.js:2990
+#: 4.0/applet.js:3310 6.0/applet.js:3310
 msgid "Only on this workspace"
 msgstr "Només en aquest espai de treball"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3312 6.0/applet.js:3312
 msgid "Visible on all workspaces"
 msgstr "Visible a tots els espais de treball"
 
-#: 4.0/applet.js:2993 6.0/applet.js:2993
+#: 4.0/applet.js:3313 6.0/applet.js:3313
 msgid "Move to another workspace"
 msgstr "Moure a un altre espai de treball"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3322 6.0/applet.js:3322
 msgid " (this workspace)"
 msgstr " (aquest espai de treball)"
 
-#: 4.0/applet.js:3015 6.0/applet.js:3015
+#: 4.0/applet.js:3335 6.0/applet.js:3335
 msgid "Move to another monitor"
 msgstr "Moure a un altre monitor"
 
-#: 4.0/applet.js:3023 6.0/applet.js:3023
+#: 4.0/applet.js:3343 6.0/applet.js:3343
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -140,47 +140,47 @@ msgstr "Monitor"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3040 6.0/applet.js:3040
+#: 4.0/applet.js:3360 6.0/applet.js:3360
 msgid "Move window here"
 msgstr "Moure finestra aquí"
 
-#: 4.0/applet.js:3057 6.0/applet.js:3057
+#: 4.0/applet.js:3377 6.0/applet.js:3377
 msgid "unassigned"
 msgstr "sense assignar"
 
-#: 4.0/applet.js:3068 4.0/applet.js:3099 6.0/applet.js:3068 6.0/applet.js:3099
+#: 4.0/applet.js:3388 4.0/applet.js:3419 6.0/applet.js:3388 6.0/applet.js:3419
 msgid "Assign window to a hotkey"
 msgstr "Assignar finestra a una drecera"
 
-#: 4.0/applet.js:3122 6.0/applet.js:3122
+#: 4.0/applet.js:3442 6.0/applet.js:3442
 msgid "Change application label contents"
 msgstr "Canviar el contingut de l'etiqueta de l'aplicació"
 
-#: 4.0/applet.js:3125 6.0/applet.js:3125
+#: 4.0/applet.js:3445 6.0/applet.js:3445
 msgid "Remove custom setting"
 msgstr "Eliminar preferència personalitzada"
 
-#: 4.0/applet.js:3132 6.0/applet.js:3132
+#: 4.0/applet.js:3452 6.0/applet.js:3452
 msgid "Use window title"
 msgstr "Utilitzar el títol de la finestra"
 
-#: 4.0/applet.js:3139 6.0/applet.js:3139
+#: 4.0/applet.js:3459 6.0/applet.js:3459
 msgid "Use application name"
 msgstr "Utilitzar el nom de l'aplicació"
 
-#: 4.0/applet.js:3146 6.0/applet.js:3146
+#: 4.0/applet.js:3466 6.0/applet.js:3466
 msgid "No label"
 msgstr "Sense etiqueta"
 
-#: 4.0/applet.js:3157 6.0/applet.js:3157
+#: 4.0/applet.js:3477 6.0/applet.js:3477
 msgid "Ungroup application windows"
 msgstr "Desagrupar les finestres de l'aplicació"
 
-#: 4.0/applet.js:3166 6.0/applet.js:3166
+#: 4.0/applet.js:3486 6.0/applet.js:3486
 msgid "Group application windows"
 msgstr "Agrupar les finestres de l'aplicació"
 
-#: 4.0/applet.js:3179 6.0/applet.js:3179
+#: 4.0/applet.js:3499 6.0/applet.js:3499
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupar/Desagrupar automàticament"
 
@@ -196,31 +196,31 @@ msgstr "Agrupar/Desagrupar automàticament"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3209 6.0/applet.js:3209
+#: 4.0/applet.js:3529 6.0/applet.js:3529
 msgid "Move titlebar on to screen"
 msgstr "Moure la barra del títol a la pantalla"
 
-#: 4.0/applet.js:3214 6.0/applet.js:3214
+#: 4.0/applet.js:3534 6.0/applet.js:3534
 msgid "Restore"
 msgstr "Restaurar"
 
-#: 4.0/applet.js:3218 6.0/applet.js:3218
+#: 4.0/applet.js:3538 6.0/applet.js:3538
 msgid "Minimize"
 msgstr "Minimitzar"
 
-#: 4.0/applet.js:3224 6.0/applet.js:3224
+#: 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Unmaximize"
 msgstr "Desmaximitzar"
 
-#: 4.0/applet.js:3231 6.0/applet.js:3231
+#: 4.0/applet.js:3551 6.0/applet.js:3551
 msgid "Close others"
 msgstr "Tancar altres"
 
-#: 4.0/applet.js:3242 6.0/applet.js:3242
+#: 4.0/applet.js:3562 6.0/applet.js:3562
 msgid "Close all"
 msgstr "Tancar totes"
 
-#: 4.0/applet.js:3251 6.0/applet.js:3251
+#: 4.0/applet.js:3571 6.0/applet.js:3571
 msgid "Close"
 msgstr "Tancar"
 
@@ -406,29 +406,45 @@ msgstr ""
 "En execució: Només les finestres fixades en execució tindran etiqueta\n"
 "Enfocada: Només la finestra enfocada tindrà etiqueta"
 
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "None"
+msgstr "Cap"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "Minimized windows"
+msgstr "Finestres minimitzades"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other workspaces"
+msgstr "Fixar a altres espais de treball"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other monitors"
+msgstr "Botons per finestres en altres monitors"
+
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
-msgid "Hide labels for minimized buttons"
+#, fuzzy
+msgid "Hide labels for"
 msgstr "Amaga les etiquetes dels botons minimitzats"
 
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
-"For groups/pools the label will still show unless all application windows "
-"are minimized"
+"Select the type of window state for which window list button labels should "
+"be hidden. For application pools, the label will still show unless all "
+"application windows have the selected property"
 msgstr ""
-"Pel que fa a grups, l'etiqueta es mostrarà a no ser que totes les finestres "
-"de l'aplicació estiguin minimitzades"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "None"
-msgstr "Cap"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "Minimized windows"
-msgstr "Finestres minimitzades"
 
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
@@ -902,6 +918,22 @@ msgstr "La més petita"
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
 msgstr "Mida de la miniatura de la finestra"
+
+#. 4.0->settings-schema.json->menu-sort-groups->description
+#. 6.0->settings-schema.json->menu-sort-groups->description
+#, fuzzy
+msgid "Sort grouped button thumbnail menu items"
+msgstr "Restaurar o mantenir pressionat per a veure el menú de miniatures"
+
+#. 4.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.0->settings-schema.json->menu-sort-groups->tooltip
+msgid ""
+"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"monitor number for grouped buttons. Pooled windows can not be sorted since "
+"the order is the same as the order on the window-list panel. With this "
+"option enabled, the thumbnail menu drag-and-drop reordering feature will be "
+"disabled for grouped button thumbnail menus."
+msgstr ""
 
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->description
@@ -1402,12 +1434,14 @@ msgstr "Sortir del mode mosaic"
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr "No fer res"
 
@@ -1468,6 +1502,14 @@ msgstr ""
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
+msgstr "Restaurar/Minimitzar la finestra més recent"
+
+#. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#, fuzzy
+msgid "Restore/Minimize 1st window in group"
 msgstr "Restaurar/Minimitzar la finestra més recent"
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
@@ -1557,8 +1599,9 @@ msgstr "Restaurar la finestra d'aplicació més recent"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 1st window in grouped button"
-msgstr "Activar la 1a finestra en un botó agrupat"
+#, fuzzy
+msgid "Restore/minimize 1st window in group"
+msgstr "Restaurar/Minimitzar la finestra més recent"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1566,8 +1609,9 @@ msgstr "Activar la 1a finestra en un botó agrupat"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 2nd window in grouped button"
-msgstr "Activar la 2a finestra en un botó agrupat"
+#, fuzzy
+msgid "Restore/minimize 2nd window in group"
+msgstr "Restaurar/Minimitzar la finestra més recent"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1575,8 +1619,9 @@ msgstr "Activar la 2a finestra en un botó agrupat"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 3rd window in grouped button"
-msgstr "Activar la 3a finestra en un botó agrupat"
+#, fuzzy
+msgid "Restore/minimize 3rd window in group"
+msgstr "Restaurar/Minimitzar la finestra més recent"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1584,8 +1629,9 @@ msgstr "Activar la 3a finestra en un botó agrupat"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 4th window in grouped button"
-msgstr "Activar la 4a finestra en un botó agrupat"
+#, fuzzy
+msgid "Restore/minimize 4th window in group"
+msgstr "Restaurar/Minimitzar la finestra més recent"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description
@@ -1622,6 +1668,41 @@ msgid "Action taken when using the forward mouse button on window list entries"
 msgstr ""
 "Acció a dur a terme quan s'utilitza el botó d'avançada en entrades de la "
 "llista de finestres"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Minimize/Restore/Maximize window"
+msgstr "Minimitzar/Restaurar"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change windows workspace"
+msgstr "Inclou finestres de tots els espais de treball"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change window tiling"
+msgstr "Utilitzar el títol de la finestra"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->description
+#. 6.0->settings-schema.json->mouse-action-scroll->description
+msgid "Scroll wheel action"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+msgid ""
+"Action taken when using the mouse scroll wheel on a window list button. This "
+"scroll wheel action will be disabled if the Thumbnail menu is currently open"
+msgstr ""
 
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-04 23:25-0400\n"
+"POT-Creation-Date: 2024-07-15 22:10-0400\n"
 "PO-Revision-Date: 2024-01-01 10:11+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -14,32 +14,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: 4.0/applet.js:550 6.0/applet.js:550
+#: 4.0/applet.js:567 6.0/applet.js:567
 msgid "all buttons"
 msgstr "alle knapper"
 
-#: 4.0/applet.js:2767 6.0/applet.js:2767
+#: 4.0/applet.js:3087 6.0/applet.js:3087
 msgid "Applet Preferences"
 msgstr "Indstillinger"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:3091 6.0/applet.js:3091
 msgid "About..."
 msgstr "Om …"
 
-#: 4.0/applet.js:2775 6.0/applet.js:2775
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Configure..."
 msgstr "Konfigurér …"
 
-#: 4.0/applet.js:2779 6.0/applet.js:2779
+#: 4.0/applet.js:3099 6.0/applet.js:3099
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2783 6.0/applet.js:2783
+#: 4.0/applet.js:3103 6.0/applet.js:3103
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Fjern “%s”"
 
-#: 4.0/applet.js:2785 6.0/applet.js:2785
+#: 4.0/applet.js:3105 6.0/applet.js:3105
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 
@@ -55,71 +55,71 @@ msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2794 6.0/applet.js:2794
+#: 4.0/applet.js:3114 6.0/applet.js:3114
 msgid "Open new window"
 msgstr "Åbn nyt vindue"
 
-#: 4.0/applet.js:2802 6.0/applet.js:2802
+#: 4.0/applet.js:3122 6.0/applet.js:3122
 msgid "Remove from panel"
 msgstr "Fjern fra panel"
 
-#: 4.0/applet.js:2804 6.0/applet.js:2804
+#: 4.0/applet.js:3124 6.0/applet.js:3124
 msgid "Remove from this workspace"
 msgstr "Fjern fra dette arbejdsområde"
 
-#: 4.0/applet.js:2810 6.0/applet.js:2810
+#: 4.0/applet.js:3130 6.0/applet.js:3130
 msgid "Pin to panel"
 msgstr "Fastgør til panel"
 
-#: 4.0/applet.js:2812 6.0/applet.js:2812
+#: 4.0/applet.js:3132 6.0/applet.js:3132
 msgid "Pin to this workspace"
 msgstr "Fastgør til dette arbejdsområde"
 
-#: 4.0/applet.js:2853 6.0/applet.js:2853
+#: 4.0/applet.js:3173 6.0/applet.js:3173
 msgid "Pin to other workspaces"
 msgstr "Fastgør til andre arbejdsområder"
 
-#: 4.0/applet.js:2874 6.0/applet.js:2874
+#: 4.0/applet.js:3194 6.0/applet.js:3194
 msgid "Pin to all workspaces"
 msgstr "Fastgør til alle arbejdsområder"
 
-#: 4.0/applet.js:2892 6.0/applet.js:2892
+#: 4.0/applet.js:3212 6.0/applet.js:3212
 msgid "Pin to launcher"
 msgstr "Fastgør til programstarter"
 
-#: 4.0/applet.js:2910 4.0/applet.js:3102 6.0/applet.js:2910 6.0/applet.js:3102
+#: 4.0/applet.js:3230 4.0/applet.js:3422 6.0/applet.js:3230 6.0/applet.js:3422
 msgid "Add new Hotkey for"
 msgstr "Tilføj ny genvejstast til"
 
-#: 4.0/applet.js:2924 6.0/applet.js:2924
+#: 4.0/applet.js:3244 6.0/applet.js:3244
 msgid "Recent files"
 msgstr "Seneste filer"
 
-#: 4.0/applet.js:2948 6.0/applet.js:2948
+#: 4.0/applet.js:3268 6.0/applet.js:3268
 msgid "Places"
 msgstr "Steder"
 
-#: 4.0/applet.js:2990 6.0/applet.js:2990
+#: 4.0/applet.js:3310 6.0/applet.js:3310
 msgid "Only on this workspace"
 msgstr "Kun på dette arbejdsområde"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3312 6.0/applet.js:3312
 msgid "Visible on all workspaces"
 msgstr "Synlig på alle arbejdsområder"
 
-#: 4.0/applet.js:2993 6.0/applet.js:2993
+#: 4.0/applet.js:3313 6.0/applet.js:3313
 msgid "Move to another workspace"
 msgstr "Flyt til et andet arbejdsområde"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3322 6.0/applet.js:3322
 msgid " (this workspace)"
 msgstr " (dette arbejdsområde)"
 
-#: 4.0/applet.js:3015 6.0/applet.js:3015
+#: 4.0/applet.js:3335 6.0/applet.js:3335
 msgid "Move to another monitor"
 msgstr "Flyt til en anden skærm"
 
-#: 4.0/applet.js:3023 6.0/applet.js:3023
+#: 4.0/applet.js:3343 6.0/applet.js:3343
 msgid "Monitor"
 msgstr "Skærm"
 
@@ -135,48 +135,48 @@ msgstr "Skærm"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3040 6.0/applet.js:3040
+#: 4.0/applet.js:3360 6.0/applet.js:3360
 #, fuzzy
 msgid "Move window here"
 msgstr "Luk vindue"
 
-#: 4.0/applet.js:3057 6.0/applet.js:3057
+#: 4.0/applet.js:3377 6.0/applet.js:3377
 msgid "unassigned"
 msgstr "ikke tildelt"
 
-#: 4.0/applet.js:3068 4.0/applet.js:3099 6.0/applet.js:3068 6.0/applet.js:3099
+#: 4.0/applet.js:3388 4.0/applet.js:3419 6.0/applet.js:3388 6.0/applet.js:3419
 msgid "Assign window to a hotkey"
 msgstr "Tildel en genvejstast til vindue"
 
-#: 4.0/applet.js:3122 6.0/applet.js:3122
+#: 4.0/applet.js:3442 6.0/applet.js:3442
 msgid "Change application label contents"
 msgstr "Ændr indholdet af programetiket"
 
-#: 4.0/applet.js:3125 6.0/applet.js:3125
+#: 4.0/applet.js:3445 6.0/applet.js:3445
 msgid "Remove custom setting"
 msgstr "Fjern brugerdefineret indstilling"
 
-#: 4.0/applet.js:3132 6.0/applet.js:3132
+#: 4.0/applet.js:3452 6.0/applet.js:3452
 msgid "Use window title"
 msgstr "Brug vinduestitel"
 
-#: 4.0/applet.js:3139 6.0/applet.js:3139
+#: 4.0/applet.js:3459 6.0/applet.js:3459
 msgid "Use application name"
 msgstr "Brug programnavn"
 
-#: 4.0/applet.js:3146 6.0/applet.js:3146
+#: 4.0/applet.js:3466 6.0/applet.js:3466
 msgid "No label"
 msgstr "Ingen etiket"
 
-#: 4.0/applet.js:3157 6.0/applet.js:3157
+#: 4.0/applet.js:3477 6.0/applet.js:3477
 msgid "Ungroup application windows"
 msgstr "Opsplit gruppen af programmervinduer"
 
-#: 4.0/applet.js:3166 6.0/applet.js:3166
+#: 4.0/applet.js:3486 6.0/applet.js:3486
 msgid "Group application windows"
 msgstr "Gruppér programvinduer"
 
-#: 4.0/applet.js:3179 6.0/applet.js:3179
+#: 4.0/applet.js:3499 6.0/applet.js:3499
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisk gruppering/opsplitning af gruppe"
 
@@ -192,31 +192,31 @@ msgstr "Automatisk gruppering/opsplitning af gruppe"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3209 6.0/applet.js:3209
+#: 4.0/applet.js:3529 6.0/applet.js:3529
 msgid "Move titlebar on to screen"
 msgstr "Flyt titellinje til skærm"
 
-#: 4.0/applet.js:3214 6.0/applet.js:3214
+#: 4.0/applet.js:3534 6.0/applet.js:3534
 msgid "Restore"
 msgstr "Gendan"
 
-#: 4.0/applet.js:3218 6.0/applet.js:3218
+#: 4.0/applet.js:3538 6.0/applet.js:3538
 msgid "Minimize"
 msgstr "Minimér"
 
-#: 4.0/applet.js:3224 6.0/applet.js:3224
+#: 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Unmaximize"
 msgstr "Gendan"
 
-#: 4.0/applet.js:3231 6.0/applet.js:3231
+#: 4.0/applet.js:3551 6.0/applet.js:3551
 msgid "Close others"
 msgstr "Luk andre"
 
-#: 4.0/applet.js:3242 6.0/applet.js:3242
+#: 4.0/applet.js:3562 6.0/applet.js:3562
 msgid "Close all"
 msgstr "Luk alle"
 
-#: 4.0/applet.js:3251 6.0/applet.js:3251
+#: 4.0/applet.js:3571 6.0/applet.js:3571
 msgid "Close"
 msgstr "Luk"
 
@@ -402,29 +402,45 @@ msgstr ""
 "Kørende: Kun fastgjorte vinduer, der kører, vil have en etiket\n"
 "Fokuseret: Kun det fastgjorte vindue med fokus vil have en etiket"
 
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "None"
+msgstr "Ingen"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "Minimized windows"
+msgstr "Minimerede vinduer"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other workspaces"
+msgstr "Fastgør til andre arbejdsområder"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other monitors"
+msgstr "Knapper for vinduer på andre skærme"
+
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
-msgid "Hide labels for minimized buttons"
+#, fuzzy
+msgid "Hide labels for"
 msgstr "Skjul etiketter for minimerede knapper"
 
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
-"For groups/pools the label will still show unless all application windows "
-"are minimized"
+"Select the type of window state for which window list button labels should "
+"be hidden. For application pools, the label will still show unless all "
+"application windows have the selected property"
 msgstr ""
-"For grupper/puljer vises etiketten stadig, medmindre alle programvinduer er "
-"minimeret"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "None"
-msgstr "Ingen"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "Minimized windows"
-msgstr "Minimerede vinduer"
 
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
@@ -878,6 +894,22 @@ msgstr "Ekstra lille"
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
 msgstr "Standardstørrelse på miniaturevindue"
+
+#. 4.0->settings-schema.json->menu-sort-groups->description
+#. 6.0->settings-schema.json->menu-sort-groups->description
+#, fuzzy
+msgid "Sort grouped button thumbnail menu items"
+msgstr "Gendan eller hold nede for miniaturemenu"
+
+#. 4.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.0->settings-schema.json->menu-sort-groups->tooltip
+msgid ""
+"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"monitor number for grouped buttons. Pooled windows can not be sorted since "
+"the order is the same as the order on the window-list panel. With this "
+"option enabled, the thumbnail menu drag-and-drop reordering feature will be "
+"disabled for grouped button thumbnail menus."
+msgstr ""
 
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->description
@@ -1380,12 +1412,14 @@ msgstr "Luk vindue"
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr "Gør intet"
 
@@ -1440,6 +1474,14 @@ msgstr ""
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
+msgstr "Gendan/minimér seneste vindue"
+
+#. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#, fuzzy
+msgid "Restore/Minimize 1st window in group"
 msgstr "Gendan/minimér seneste vindue"
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
@@ -1529,8 +1571,9 @@ msgstr "Gendan seneste programvindue"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 1st window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 1st window in group"
+msgstr "Gendan/minimér seneste vindue"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1538,8 +1581,9 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 2nd window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 2nd window in group"
+msgstr "Gendan/minimér seneste vindue"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1547,8 +1591,9 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 3rd window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 3rd window in group"
+msgstr "Gendan/minimér seneste vindue"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1556,8 +1601,9 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 4th window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 4th window in group"
+msgstr "Gendan/minimér seneste vindue"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description
@@ -1588,6 +1634,41 @@ msgstr "Handling ved fremklik"
 #. 6.0->settings-schema.json->mouse-action-btn9->tooltip
 msgid "Action taken when using the forward mouse button on window list entries"
 msgstr "Handling ved brug af fremmuseknappen på vindueslisteposter"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Minimize/Restore/Maximize window"
+msgstr "Minimér/gendan"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change windows workspace"
+msgstr "Medtag vinduer fra alle arbejdsområder"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change window tiling"
+msgstr "Brug vinduestitel"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->description
+#. 6.0->settings-schema.json->mouse-action-scroll->description
+msgid "Scroll wheel action"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+msgid ""
+"Action taken when using the mouse scroll wheel on a window list button. This "
+"scroll wheel action will be disabled if the Thumbnail menu is currently open"
+msgstr ""
 
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-04 23:25-0400\n"
+"POT-Creation-Date: 2024-07-15 22:10-0400\n"
 "PO-Revision-Date: 2024-06-05 11:48-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,32 +18,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: 4.0/applet.js:550 6.0/applet.js:550
+#: 4.0/applet.js:567 6.0/applet.js:567
 msgid "all buttons"
 msgstr "todos los botones"
 
-#: 4.0/applet.js:2767 6.0/applet.js:2767
+#: 4.0/applet.js:3087 6.0/applet.js:3087
 msgid "Applet Preferences"
 msgstr "Preferencias del applet"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:3091 6.0/applet.js:3091
 msgid "About..."
 msgstr "Acerca de..."
 
-#: 4.0/applet.js:2775 6.0/applet.js:2775
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Configure..."
 msgstr "Configurar..."
 
-#: 4.0/applet.js:2779 6.0/applet.js:2779
+#: 4.0/applet.js:3099 6.0/applet.js:3099
 msgid "Website"
 msgstr "Sitio web"
 
-#: 4.0/applet.js:2783 6.0/applet.js:2783
+#: 4.0/applet.js:3103 6.0/applet.js:3103
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#: 4.0/applet.js:2785 6.0/applet.js:2785
+#: 4.0/applet.js:3105 6.0/applet.js:3105
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 
@@ -59,71 +59,71 @@ msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2794 6.0/applet.js:2794
+#: 4.0/applet.js:3114 6.0/applet.js:3114
 msgid "Open new window"
 msgstr "Abrir nueva ventana"
 
-#: 4.0/applet.js:2802 6.0/applet.js:2802
+#: 4.0/applet.js:3122 6.0/applet.js:3122
 msgid "Remove from panel"
 msgstr "Quitar del panel"
 
-#: 4.0/applet.js:2804 6.0/applet.js:2804
+#: 4.0/applet.js:3124 6.0/applet.js:3124
 msgid "Remove from this workspace"
 msgstr "Eliminar de este espacio de trabajo"
 
-#: 4.0/applet.js:2810 6.0/applet.js:2810
+#: 4.0/applet.js:3130 6.0/applet.js:3130
 msgid "Pin to panel"
 msgstr "Anclar al panel"
 
-#: 4.0/applet.js:2812 6.0/applet.js:2812
+#: 4.0/applet.js:3132 6.0/applet.js:3132
 msgid "Pin to this workspace"
 msgstr "Anclar a este espacio de trabajo"
 
-#: 4.0/applet.js:2853 6.0/applet.js:2853
+#: 4.0/applet.js:3173 6.0/applet.js:3173
 msgid "Pin to other workspaces"
 msgstr "Anclar a otros espacios de trabajo"
 
-#: 4.0/applet.js:2874 6.0/applet.js:2874
+#: 4.0/applet.js:3194 6.0/applet.js:3194
 msgid "Pin to all workspaces"
 msgstr "Anclar a todos los espacios de trabajo"
 
-#: 4.0/applet.js:2892 6.0/applet.js:2892
+#: 4.0/applet.js:3212 6.0/applet.js:3212
 msgid "Pin to launcher"
 msgstr "Anclar al lanzador"
 
-#: 4.0/applet.js:2910 4.0/applet.js:3102 6.0/applet.js:2910 6.0/applet.js:3102
+#: 4.0/applet.js:3230 4.0/applet.js:3422 6.0/applet.js:3230 6.0/applet.js:3422
 msgid "Add new Hotkey for"
 msgstr "Añadir nueva tecla de acceso rápido para"
 
-#: 4.0/applet.js:2924 6.0/applet.js:2924
+#: 4.0/applet.js:3244 6.0/applet.js:3244
 msgid "Recent files"
 msgstr "Archivos recientes"
 
-#: 4.0/applet.js:2948 6.0/applet.js:2948
+#: 4.0/applet.js:3268 6.0/applet.js:3268
 msgid "Places"
 msgstr "Lugares"
 
-#: 4.0/applet.js:2990 6.0/applet.js:2990
+#: 4.0/applet.js:3310 6.0/applet.js:3310
 msgid "Only on this workspace"
 msgstr "Sólo en este espacio de trabajo"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3312 6.0/applet.js:3312
 msgid "Visible on all workspaces"
 msgstr "Visible en todos los espacios de trabajo"
 
-#: 4.0/applet.js:2993 6.0/applet.js:2993
+#: 4.0/applet.js:3313 6.0/applet.js:3313
 msgid "Move to another workspace"
 msgstr "Mover a otro espacio de trabajo"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3322 6.0/applet.js:3322
 msgid " (this workspace)"
 msgstr " (este espacio de trabajo)"
 
-#: 4.0/applet.js:3015 6.0/applet.js:3015
+#: 4.0/applet.js:3335 6.0/applet.js:3335
 msgid "Move to another monitor"
 msgstr "Mover a otro monitor"
 
-#: 4.0/applet.js:3023 6.0/applet.js:3023
+#: 4.0/applet.js:3343 6.0/applet.js:3343
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -139,47 +139,47 @@ msgstr "Monitor"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3040 6.0/applet.js:3040
+#: 4.0/applet.js:3360 6.0/applet.js:3360
 msgid "Move window here"
 msgstr "Mover la ventana aquí"
 
-#: 4.0/applet.js:3057 6.0/applet.js:3057
+#: 4.0/applet.js:3377 6.0/applet.js:3377
 msgid "unassigned"
 msgstr "no asignado"
 
-#: 4.0/applet.js:3068 4.0/applet.js:3099 6.0/applet.js:3068 6.0/applet.js:3099
+#: 4.0/applet.js:3388 4.0/applet.js:3419 6.0/applet.js:3388 6.0/applet.js:3419
 msgid "Assign window to a hotkey"
 msgstr "Asignar ventana a una tecla de acceso rápido"
 
-#: 4.0/applet.js:3122 6.0/applet.js:3122
+#: 4.0/applet.js:3442 6.0/applet.js:3442
 msgid "Change application label contents"
 msgstr "Cambiar el contenido de la etiqueta de la aplicación"
 
-#: 4.0/applet.js:3125 6.0/applet.js:3125
+#: 4.0/applet.js:3445 6.0/applet.js:3445
 msgid "Remove custom setting"
 msgstr "Eliminar configuración personalizada"
 
-#: 4.0/applet.js:3132 6.0/applet.js:3132
+#: 4.0/applet.js:3452 6.0/applet.js:3452
 msgid "Use window title"
 msgstr "Utilizar título de ventana"
 
-#: 4.0/applet.js:3139 6.0/applet.js:3139
+#: 4.0/applet.js:3459 6.0/applet.js:3459
 msgid "Use application name"
 msgstr "Utilizar nombre de aplicación"
 
-#: 4.0/applet.js:3146 6.0/applet.js:3146
+#: 4.0/applet.js:3466 6.0/applet.js:3466
 msgid "No label"
 msgstr "Sin etiqueta"
 
-#: 4.0/applet.js:3157 6.0/applet.js:3157
+#: 4.0/applet.js:3477 6.0/applet.js:3477
 msgid "Ungroup application windows"
 msgstr "Ventanas de aplicaciones separadas"
 
-#: 4.0/applet.js:3166 6.0/applet.js:3166
+#: 4.0/applet.js:3486 6.0/applet.js:3486
 msgid "Group application windows"
 msgstr "Ventanas de aplicaciones agrupadas"
 
-#: 4.0/applet.js:3179 6.0/applet.js:3179
+#: 4.0/applet.js:3499 6.0/applet.js:3499
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupación/desagrupación automática"
 
@@ -195,31 +195,31 @@ msgstr "Agrupación/desagrupación automática"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3209 6.0/applet.js:3209
+#: 4.0/applet.js:3529 6.0/applet.js:3529
 msgid "Move titlebar on to screen"
 msgstr "Mover la barra de título a la pantalla"
 
-#: 4.0/applet.js:3214 6.0/applet.js:3214
+#: 4.0/applet.js:3534 6.0/applet.js:3534
 msgid "Restore"
 msgstr "Restaurar"
 
-#: 4.0/applet.js:3218 6.0/applet.js:3218
+#: 4.0/applet.js:3538 6.0/applet.js:3538
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: 4.0/applet.js:3224 6.0/applet.js:3224
+#: 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Unmaximize"
 msgstr "Desmaximizar"
 
-#: 4.0/applet.js:3231 6.0/applet.js:3231
+#: 4.0/applet.js:3551 6.0/applet.js:3551
 msgid "Close others"
 msgstr "Cerrar otros"
 
-#: 4.0/applet.js:3242 6.0/applet.js:3242
+#: 4.0/applet.js:3562 6.0/applet.js:3562
 msgid "Close all"
 msgstr "Cerrar todo"
 
-#: 4.0/applet.js:3251 6.0/applet.js:3251
+#: 4.0/applet.js:3571 6.0/applet.js:3571
 msgid "Close"
 msgstr "Cerrar"
 
@@ -406,29 +406,45 @@ msgstr ""
 "etiqueta\n"
 "Enfocada: Sólo la ventana anclada con foco tendrá una etiqueta"
 
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "None"
+msgstr "Ninguna"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "Minimized windows"
+msgstr "Ventanas minimizadas"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other workspaces"
+msgstr "Anclar a otros espacios de trabajo"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other monitors"
+msgstr "Botones para ventanas en otros monitores"
+
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
-msgid "Hide labels for minimized buttons"
+#, fuzzy
+msgid "Hide labels for"
 msgstr "Ocultar las etiquetas de los botones minimizados"
 
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
-"For groups/pools the label will still show unless all application windows "
-"are minimized"
+"Select the type of window state for which window list button labels should "
+"be hidden. For application pools, the label will still show unless all "
+"application windows have the selected property"
 msgstr ""
-"Para grupos/pools, la etiqueta seguirá mostrándose a menos que todas las "
-"ventanas de la aplicación estén minimizadas"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "None"
-msgstr "Ninguna"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "Minimized windows"
-msgstr "Ventanas minimizadas"
 
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
@@ -913,6 +929,22 @@ msgstr "Extra pequeño"
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
 msgstr "Tamaño predeterminado de la ventana de miniaturas"
+
+#. 4.0->settings-schema.json->menu-sort-groups->description
+#. 6.0->settings-schema.json->menu-sort-groups->description
+#, fuzzy
+msgid "Sort grouped button thumbnail menu items"
+msgstr "Restablecer o mantener presionado para ver el menú de miniaturas"
+
+#. 4.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.0->settings-schema.json->menu-sort-groups->tooltip
+msgid ""
+"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"monitor number for grouped buttons. Pooled windows can not be sorted since "
+"the order is the same as the order on the window-list panel. With this "
+"option enabled, the thumbnail menu drag-and-drop reordering feature will be "
+"disabled for grouped button thumbnail menus."
+msgstr ""
 
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->description
@@ -1415,12 +1447,14 @@ msgstr "Salir del modo mosaico"
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr "No hacer nada"
 
@@ -1483,6 +1517,14 @@ msgstr ""
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
+msgstr "Restaurar/Minimizar la ventana más reciente"
+
+#. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#, fuzzy
+msgid "Restore/Minimize 1st window in group"
 msgstr "Restaurar/Minimizar la ventana más reciente"
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
@@ -1572,8 +1614,9 @@ msgstr "Restaurar la ventana de la aplicación más reciente"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 1st window in grouped button"
-msgstr "Activar 1ª ventana en botón agrupado"
+#, fuzzy
+msgid "Restore/minimize 1st window in group"
+msgstr "Restaurar/Minimizar la ventana más reciente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1581,8 +1624,9 @@ msgstr "Activar 1ª ventana en botón agrupado"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 2nd window in grouped button"
-msgstr "Activar 2ª ventana en botón agrupado"
+#, fuzzy
+msgid "Restore/minimize 2nd window in group"
+msgstr "Restaurar/Minimizar la ventana más reciente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1590,8 +1634,9 @@ msgstr "Activar 2ª ventana en botón agrupado"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 3rd window in grouped button"
-msgstr "Activar 3ª ventana en botón agrupado"
+#, fuzzy
+msgid "Restore/minimize 3rd window in group"
+msgstr "Restaurar/Minimizar la ventana más reciente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1599,8 +1644,9 @@ msgstr "Activar 3ª ventana en botón agrupado"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 4th window in grouped button"
-msgstr "Activar 4ª ventana en botón agrupado"
+#, fuzzy
+msgid "Restore/minimize 4th window in group"
+msgstr "Restaurar/Minimizar la ventana más reciente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description
@@ -1637,6 +1683,41 @@ msgid "Action taken when using the forward mouse button on window list entries"
 msgstr ""
 "Acción realizada al utilizar el botón de avance del ratón en las entradas de "
 "la lista de ventanas"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Minimize/Restore/Maximize window"
+msgstr "Minimizar/Restaurar"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change windows workspace"
+msgstr "Incluir ventanas de todos los espacios de trabajo"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change window tiling"
+msgstr "Utilizar título de ventana"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->description
+#. 6.0->settings-schema.json->mouse-action-scroll->description
+msgid "Scroll wheel action"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+msgid ""
+"Action taken when using the mouse scroll wheel on a window list button. This "
+"scroll wheel action will be disabled if the Thumbnail menu is currently open"
+msgstr ""
 
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-04 23:25-0400\n"
+"POT-Creation-Date: 2024-07-15 22:10-0400\n"
 "PO-Revision-Date: 2024-06-27 16:35+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -19,32 +19,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: 4.0/applet.js:550 6.0/applet.js:550
+#: 4.0/applet.js:567 6.0/applet.js:567
 msgid "all buttons"
 msgstr "tous les boutons"
 
-#: 4.0/applet.js:2767 6.0/applet.js:2767
+#: 4.0/applet.js:3087 6.0/applet.js:3087
 msgid "Applet Preferences"
 msgstr "Préférences"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:3091 6.0/applet.js:3091
 msgid "About..."
 msgstr "À propos..."
 
-#: 4.0/applet.js:2775 6.0/applet.js:2775
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Configure..."
 msgstr "Configurer..."
 
-#: 4.0/applet.js:2779 6.0/applet.js:2779
+#: 4.0/applet.js:3099 6.0/applet.js:3099
 msgid "Website"
 msgstr "Site web"
 
-#: 4.0/applet.js:2783 6.0/applet.js:2783
+#: 4.0/applet.js:3103 6.0/applet.js:3103
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Supprimer '%s'"
 
-#: 4.0/applet.js:2785 6.0/applet.js:2785
+#: 4.0/applet.js:3105 6.0/applet.js:3105
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 
@@ -60,71 +60,71 @@ msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2794 6.0/applet.js:2794
+#: 4.0/applet.js:3114 6.0/applet.js:3114
 msgid "Open new window"
 msgstr "Ouvrir une nouvelle fenêtre"
 
-#: 4.0/applet.js:2802 6.0/applet.js:2802
+#: 4.0/applet.js:3122 6.0/applet.js:3122
 msgid "Remove from panel"
 msgstr "Retirer du panneau"
 
-#: 4.0/applet.js:2804 6.0/applet.js:2804
+#: 4.0/applet.js:3124 6.0/applet.js:3124
 msgid "Remove from this workspace"
 msgstr "Retirer de cet espace de travail"
 
-#: 4.0/applet.js:2810 6.0/applet.js:2810
+#: 4.0/applet.js:3130 6.0/applet.js:3130
 msgid "Pin to panel"
 msgstr "Épingler au panneau"
 
-#: 4.0/applet.js:2812 6.0/applet.js:2812
+#: 4.0/applet.js:3132 6.0/applet.js:3132
 msgid "Pin to this workspace"
 msgstr "Épingler à cet espace de travail"
 
-#: 4.0/applet.js:2853 6.0/applet.js:2853
+#: 4.0/applet.js:3173 6.0/applet.js:3173
 msgid "Pin to other workspaces"
 msgstr "Épingler aux autres espaces de travail"
 
-#: 4.0/applet.js:2874 6.0/applet.js:2874
+#: 4.0/applet.js:3194 6.0/applet.js:3194
 msgid "Pin to all workspaces"
 msgstr "Épingler à tous les espaces de travail"
 
-#: 4.0/applet.js:2892 6.0/applet.js:2892
+#: 4.0/applet.js:3212 6.0/applet.js:3212
 msgid "Pin to launcher"
 msgstr "Épingler au lanceur"
 
-#: 4.0/applet.js:2910 4.0/applet.js:3102 6.0/applet.js:2910 6.0/applet.js:3102
+#: 4.0/applet.js:3230 4.0/applet.js:3422 6.0/applet.js:3230 6.0/applet.js:3422
 msgid "Add new Hotkey for"
 msgstr "Ajouter un nouveau raccourci clavier pour"
 
-#: 4.0/applet.js:2924 6.0/applet.js:2924
+#: 4.0/applet.js:3244 6.0/applet.js:3244
 msgid "Recent files"
 msgstr "Fichiers récents"
 
-#: 4.0/applet.js:2948 6.0/applet.js:2948
+#: 4.0/applet.js:3268 6.0/applet.js:3268
 msgid "Places"
 msgstr "Emplacements"
 
-#: 4.0/applet.js:2990 6.0/applet.js:2990
+#: 4.0/applet.js:3310 6.0/applet.js:3310
 msgid "Only on this workspace"
 msgstr "Seulement sur cet espace de travail"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3312 6.0/applet.js:3312
 msgid "Visible on all workspaces"
 msgstr "Visible sur tous les espaces de travail"
 
-#: 4.0/applet.js:2993 6.0/applet.js:2993
+#: 4.0/applet.js:3313 6.0/applet.js:3313
 msgid "Move to another workspace"
 msgstr "Déplacer vers un autre espace de travail"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3322 6.0/applet.js:3322
 msgid " (this workspace)"
 msgstr " (cet espace de travail)"
 
-#: 4.0/applet.js:3015 6.0/applet.js:3015
+#: 4.0/applet.js:3335 6.0/applet.js:3335
 msgid "Move to another monitor"
 msgstr "Déplacer vers un autre moniteur"
 
-#: 4.0/applet.js:3023 6.0/applet.js:3023
+#: 4.0/applet.js:3343 6.0/applet.js:3343
 msgid "Monitor"
 msgstr "Moniteur"
 
@@ -140,47 +140,47 @@ msgstr "Moniteur"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3040 6.0/applet.js:3040
+#: 4.0/applet.js:3360 6.0/applet.js:3360
 msgid "Move window here"
 msgstr "Déplacer la fenêtre ici"
 
-#: 4.0/applet.js:3057 6.0/applet.js:3057
+#: 4.0/applet.js:3377 6.0/applet.js:3377
 msgid "unassigned"
 msgstr "non attribué"
 
-#: 4.0/applet.js:3068 4.0/applet.js:3099 6.0/applet.js:3068 6.0/applet.js:3099
+#: 4.0/applet.js:3388 4.0/applet.js:3419 6.0/applet.js:3388 6.0/applet.js:3419
 msgid "Assign window to a hotkey"
 msgstr "Attribuer une fenêtre à un raccourci clavier"
 
-#: 4.0/applet.js:3122 6.0/applet.js:3122
+#: 4.0/applet.js:3442 6.0/applet.js:3442
 msgid "Change application label contents"
 msgstr "Modifier le libellé de l'étiquette de l'application"
 
-#: 4.0/applet.js:3125 6.0/applet.js:3125
+#: 4.0/applet.js:3445 6.0/applet.js:3445
 msgid "Remove custom setting"
 msgstr "Supprimer le paramètre personnalisé"
 
-#: 4.0/applet.js:3132 6.0/applet.js:3132
+#: 4.0/applet.js:3452 6.0/applet.js:3452
 msgid "Use window title"
 msgstr "Utiliser le titre de fenêtre"
 
-#: 4.0/applet.js:3139 6.0/applet.js:3139
+#: 4.0/applet.js:3459 6.0/applet.js:3459
 msgid "Use application name"
 msgstr "Utiliser le nom de l'application"
 
-#: 4.0/applet.js:3146 6.0/applet.js:3146
+#: 4.0/applet.js:3466 6.0/applet.js:3466
 msgid "No label"
 msgstr "Sans étiquette"
 
-#: 4.0/applet.js:3157 6.0/applet.js:3157
+#: 4.0/applet.js:3477 6.0/applet.js:3477
 msgid "Ungroup application windows"
 msgstr "Dégrouper les fenêtres de l'application"
 
-#: 4.0/applet.js:3166 6.0/applet.js:3166
+#: 4.0/applet.js:3486 6.0/applet.js:3486
 msgid "Group application windows"
 msgstr "Grouper les fenêtres par application"
 
-#: 4.0/applet.js:3179 6.0/applet.js:3179
+#: 4.0/applet.js:3499 6.0/applet.js:3499
 msgid "Automatic grouping/ungrouping"
 msgstr "Regrouper/dégrouper automatiquement"
 
@@ -196,31 +196,31 @@ msgstr "Regrouper/dégrouper automatiquement"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3209 6.0/applet.js:3209
+#: 4.0/applet.js:3529 6.0/applet.js:3529
 msgid "Move titlebar on to screen"
 msgstr "Déplacer la barre de titre sur l'écran"
 
-#: 4.0/applet.js:3214 6.0/applet.js:3214
+#: 4.0/applet.js:3534 6.0/applet.js:3534
 msgid "Restore"
 msgstr "Restaurer"
 
-#: 4.0/applet.js:3218 6.0/applet.js:3218
+#: 4.0/applet.js:3538 6.0/applet.js:3538
 msgid "Minimize"
 msgstr "Minimiser"
 
-#: 4.0/applet.js:3224 6.0/applet.js:3224
+#: 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Unmaximize"
 msgstr "Démaximiser"
 
-#: 4.0/applet.js:3231 6.0/applet.js:3231
+#: 4.0/applet.js:3551 6.0/applet.js:3551
 msgid "Close others"
 msgstr "Fermer les autres"
 
-#: 4.0/applet.js:3242 6.0/applet.js:3242
+#: 4.0/applet.js:3562 6.0/applet.js:3562
 msgid "Close all"
 msgstr "Tout fermer"
 
-#: 4.0/applet.js:3251 6.0/applet.js:3251
+#: 4.0/applet.js:3571 6.0/applet.js:3571
 msgid "Close"
 msgstr "Fermer"
 
@@ -408,29 +408,45 @@ msgstr ""
 "auront une étiquette\n"
 "Focalisé : Seule la fenêtre épinglée ayant le focus aura une étiquette"
 
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "None"
+msgstr "Aucun"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "Minimized windows"
+msgstr "Fenêtres minimisées"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other workspaces"
+msgstr "Épingler aux autres espaces de travail"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other monitors"
+msgstr "Boutons pour les fenêtres sur d'autres écrans"
+
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
-msgid "Hide labels for minimized buttons"
+#, fuzzy
+msgid "Hide labels for"
 msgstr "Masquer les étiquettes des boutons réduits"
 
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
-"For groups/pools the label will still show unless all application windows "
-"are minimized"
+"Select the type of window state for which window list button labels should "
+"be hidden. For application pools, the label will still show unless all "
+"application windows have the selected property"
 msgstr ""
-"Pour les groupes, l'étiquette reste affichée sauf si toutes les fenêtres "
-"d'application sont réduites"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "None"
-msgstr "Aucun"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "Minimized windows"
-msgstr "Fenêtres minimisées"
 
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
@@ -920,6 +936,22 @@ msgstr "Tout petit"
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
 msgstr "Taille par défaut des vignettes"
+
+#. 4.0->settings-schema.json->menu-sort-groups->description
+#. 6.0->settings-schema.json->menu-sort-groups->description
+#, fuzzy
+msgid "Sort grouped button thumbnail menu items"
+msgstr "Restaurer ou maintenir le menu des vignettes"
+
+#. 4.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.0->settings-schema.json->menu-sort-groups->tooltip
+msgid ""
+"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"monitor number for grouped buttons. Pooled windows can not be sorted since "
+"the order is the same as the order on the window-list panel. With this "
+"option enabled, the thumbnail menu drag-and-drop reordering feature will be "
+"disabled for grouped button thumbnail menus."
+msgstr ""
 
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->description
@@ -1424,12 +1456,14 @@ msgstr "Enlever cette fenêtre de la mosaïque"
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr "Ne rien faire"
 
@@ -1495,6 +1529,14 @@ msgstr ""
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
+msgstr "Restaurer/réduire la fenêtre la plus récente"
+
+#. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#, fuzzy
+msgid "Restore/Minimize 1st window in group"
 msgstr "Restaurer/réduire la fenêtre la plus récente"
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
@@ -1584,8 +1626,9 @@ msgstr "Rétablir la fenêtre de l'application la plus récente"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 1st window in grouped button"
-msgstr "Activer la 1ère fenêtre dans le bouton de groupe"
+#, fuzzy
+msgid "Restore/minimize 1st window in group"
+msgstr "Restaurer/réduire la fenêtre la plus récente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1593,8 +1636,9 @@ msgstr "Activer la 1ère fenêtre dans le bouton de groupe"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 2nd window in grouped button"
-msgstr "Activer la 2ème fenêtre dans le bouton de groupe"
+#, fuzzy
+msgid "Restore/minimize 2nd window in group"
+msgstr "Restaurer/réduire la fenêtre la plus récente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1602,8 +1646,9 @@ msgstr "Activer la 2ème fenêtre dans le bouton de groupe"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 3rd window in grouped button"
-msgstr "Activer la 3ème fenêtre dans le bouton de groupe"
+#, fuzzy
+msgid "Restore/minimize 3rd window in group"
+msgstr "Restaurer/réduire la fenêtre la plus récente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1611,8 +1656,9 @@ msgstr "Activer la 3ème fenêtre dans le bouton de groupe"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 4th window in grouped button"
-msgstr "Activer la 4ème fenêtre dans le bouton de groupe"
+#, fuzzy
+msgid "Restore/minimize 4th window in group"
+msgstr "Restaurer/réduire la fenêtre la plus récente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description
@@ -1649,6 +1695,41 @@ msgid "Action taken when using the forward mouse button on window list entries"
 msgstr ""
 "Action effectuée sur les entrées de la liste des fenêtres lors de "
 "l'utilisation du bouton \"avant\" de la souris"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Minimize/Restore/Maximize window"
+msgstr "Minimiser/Restaurer"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change windows workspace"
+msgstr "Inclure les fenêtres de tous les espaces de travail"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change window tiling"
+msgstr "Utiliser le titre de fenêtre"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->description
+#. 6.0->settings-schema.json->mouse-action-scroll->description
+msgid "Scroll wheel action"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+msgid ""
+"Action taken when using the mouse scroll wheel on a window list button. This "
+"scroll wheel action will be disabled if the Thumbnail menu is currently open"
+msgstr ""
 
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-07-10 01:48-0400\n"
+"POT-Creation-Date: 2024-07-15 22:10-0400\n"
 "PO-Revision-Date: 2024-07-10 01:53-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,32 +18,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: 4.0/applet.js:550 6.0/applet.js:550
+#: 4.0/applet.js:567 6.0/applet.js:567
 msgid "all buttons"
 msgstr "minden gomb"
 
-#: 4.0/applet.js:2767 6.0/applet.js:2767
+#: 4.0/applet.js:3087 6.0/applet.js:3087
 msgid "Applet Preferences"
 msgstr "Kisalkalmazás beállítások"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:3091 6.0/applet.js:3091
 msgid "About..."
 msgstr "Névjegy…"
 
-#: 4.0/applet.js:2775 6.0/applet.js:2775
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Configure..."
 msgstr "Beállítások…"
 
-#: 4.0/applet.js:2779 6.0/applet.js:2779
+#: 4.0/applet.js:3099 6.0/applet.js:3099
 msgid "Website"
 msgstr "Weboldal"
 
-#: 4.0/applet.js:2783 6.0/applet.js:2783
+#: 4.0/applet.js:3103 6.0/applet.js:3103
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eltávolítás: „%s”"
 
-#: 4.0/applet.js:2785 6.0/applet.js:2785
+#: 4.0/applet.js:3105 6.0/applet.js:3105
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példányát?"
 
@@ -59,71 +59,71 @@ msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példány
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2794 6.0/applet.js:2794
+#: 4.0/applet.js:3114 6.0/applet.js:3114
 msgid "Open new window"
 msgstr "Új ablak megnyitása"
 
-#: 4.0/applet.js:2802 6.0/applet.js:2802
+#: 4.0/applet.js:3122 6.0/applet.js:3122
 msgid "Remove from panel"
 msgstr "Eltávolítás a panelról"
 
-#: 4.0/applet.js:2804 6.0/applet.js:2804
+#: 4.0/applet.js:3124 6.0/applet.js:3124
 msgid "Remove from this workspace"
 msgstr "Eltávolítás erről a munkaterületről"
 
-#: 4.0/applet.js:2810 6.0/applet.js:2810
+#: 4.0/applet.js:3130 6.0/applet.js:3130
 msgid "Pin to panel"
 msgstr "Panelhez rögzítés"
 
-#: 4.0/applet.js:2812 6.0/applet.js:2812
+#: 4.0/applet.js:3132 6.0/applet.js:3132
 msgid "Pin to this workspace"
 msgstr "Erre a munkaterületre rögzítés"
 
-#: 4.0/applet.js:2853 6.0/applet.js:2853
+#: 4.0/applet.js:3173 6.0/applet.js:3173
 msgid "Pin to other workspaces"
 msgstr "Más munkaterületre rögzítés"
 
-#: 4.0/applet.js:2874 6.0/applet.js:2874
+#: 4.0/applet.js:3194 6.0/applet.js:3194
 msgid "Pin to all workspaces"
 msgstr "Az összes munkaterületre rögzítés"
 
-#: 4.0/applet.js:2892 6.0/applet.js:2892
+#: 4.0/applet.js:3212 6.0/applet.js:3212
 msgid "Pin to launcher"
 msgstr "Alkalmazásindítóhoz rögzítés"
 
-#: 4.0/applet.js:2910 4.0/applet.js:3102 6.0/applet.js:2910 6.0/applet.js:3102
+#: 4.0/applet.js:3230 4.0/applet.js:3422 6.0/applet.js:3230 6.0/applet.js:3422
 msgid "Add new Hotkey for"
 msgstr "Új gyorsbillentyű hozzáadása ehhez"
 
-#: 4.0/applet.js:2924 6.0/applet.js:2924
+#: 4.0/applet.js:3244 6.0/applet.js:3244
 msgid "Recent files"
 msgstr "Nemrég használt fájlok"
 
-#: 4.0/applet.js:2948 6.0/applet.js:2948
+#: 4.0/applet.js:3268 6.0/applet.js:3268
 msgid "Places"
 msgstr "Helyek"
 
-#: 4.0/applet.js:2990 6.0/applet.js:2990
+#: 4.0/applet.js:3310 6.0/applet.js:3310
 msgid "Only on this workspace"
 msgstr "Csak ezen a munkaterületen"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3312 6.0/applet.js:3312
 msgid "Visible on all workspaces"
 msgstr "Minden munkaterületen látható"
 
-#: 4.0/applet.js:2993 6.0/applet.js:2993
+#: 4.0/applet.js:3313 6.0/applet.js:3313
 msgid "Move to another workspace"
 msgstr "Áthelyezés másik munkaterületre"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3322 6.0/applet.js:3322
 msgid " (this workspace)"
 msgstr " (ez a munkaterület)"
 
-#: 4.0/applet.js:3015 6.0/applet.js:3015
+#: 4.0/applet.js:3335 6.0/applet.js:3335
 msgid "Move to another monitor"
 msgstr "Áthelyezés a másik kijelzőre"
 
-#: 4.0/applet.js:3023 6.0/applet.js:3023
+#: 4.0/applet.js:3343 6.0/applet.js:3343
 msgid "Monitor"
 msgstr "Kijelző"
 
@@ -139,47 +139,47 @@ msgstr "Kijelző"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3040 6.0/applet.js:3040
+#: 4.0/applet.js:3360 6.0/applet.js:3360
 msgid "Move window here"
 msgstr "Ablak mozdítása ide"
 
-#: 4.0/applet.js:3057 6.0/applet.js:3057
+#: 4.0/applet.js:3377 6.0/applet.js:3377
 msgid "unassigned"
 msgstr "nincs társítva"
 
-#: 4.0/applet.js:3068 4.0/applet.js:3099 6.0/applet.js:3068 6.0/applet.js:3099
+#: 4.0/applet.js:3388 4.0/applet.js:3419 6.0/applet.js:3388 6.0/applet.js:3419
 msgid "Assign window to a hotkey"
 msgstr "Az ablak hozzárendelése egy gyorsbillentyűhöz"
 
-#: 4.0/applet.js:3122 6.0/applet.js:3122
+#: 4.0/applet.js:3442 6.0/applet.js:3442
 msgid "Change application label contents"
 msgstr "Az alkalmazáscímke tartalmának módosítása"
 
-#: 4.0/applet.js:3125 6.0/applet.js:3125
+#: 4.0/applet.js:3445 6.0/applet.js:3445
 msgid "Remove custom setting"
 msgstr "Egyéni beállítás eltávolítása"
 
-#: 4.0/applet.js:3132 6.0/applet.js:3132
+#: 4.0/applet.js:3452 6.0/applet.js:3452
 msgid "Use window title"
 msgstr "Ablakcím használata"
 
-#: 4.0/applet.js:3139 6.0/applet.js:3139
+#: 4.0/applet.js:3459 6.0/applet.js:3459
 msgid "Use application name"
 msgstr "Alkalmazásnév használata"
 
-#: 4.0/applet.js:3146 6.0/applet.js:3146
+#: 4.0/applet.js:3466 6.0/applet.js:3466
 msgid "No label"
 msgstr "Nincs címke"
 
-#: 4.0/applet.js:3157 6.0/applet.js:3157
+#: 4.0/applet.js:3477 6.0/applet.js:3477
 msgid "Ungroup application windows"
 msgstr "Ablakokat ne csoportosítsa alkalmazás szerint"
 
-#: 4.0/applet.js:3166 6.0/applet.js:3166
+#: 4.0/applet.js:3486 6.0/applet.js:3486
 msgid "Group application windows"
 msgstr "Alkalmazás ablakok csoportosítása"
 
-#: 4.0/applet.js:3179 6.0/applet.js:3179
+#: 4.0/applet.js:3499 6.0/applet.js:3499
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 
@@ -195,31 +195,31 @@ msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3209 6.0/applet.js:3209
+#: 4.0/applet.js:3529 6.0/applet.js:3529
 msgid "Move titlebar on to screen"
 msgstr "Címsor mozgatása a kijelzőre"
 
-#: 4.0/applet.js:3214 6.0/applet.js:3214
+#: 4.0/applet.js:3534 6.0/applet.js:3534
 msgid "Restore"
 msgstr "Visszaállítás"
 
-#: 4.0/applet.js:3218 6.0/applet.js:3218
+#: 4.0/applet.js:3538 6.0/applet.js:3538
 msgid "Minimize"
 msgstr "Minimalizálás"
 
-#: 4.0/applet.js:3224 6.0/applet.js:3224
+#: 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Unmaximize"
 msgstr "Eredeti méret"
 
-#: 4.0/applet.js:3231 6.0/applet.js:3231
+#: 4.0/applet.js:3551 6.0/applet.js:3551
 msgid "Close others"
 msgstr "Többi bezárása"
 
-#: 4.0/applet.js:3242 6.0/applet.js:3242
+#: 4.0/applet.js:3562 6.0/applet.js:3562
 msgid "Close all"
 msgstr "Minden bezárása"
 
-#: 4.0/applet.js:3251 6.0/applet.js:3251
+#: 4.0/applet.js:3571 6.0/applet.js:3571
 msgid "Close"
 msgstr "Bezárás"
 
@@ -403,29 +403,45 @@ msgstr ""
 "Futás: Csak a futó rögzített ablakoknak lesz címkéje\n"
 "Fókuszált: Csak a fókuszált rögzített ablakon lesz címke"
 
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "None"
+msgstr "Nincs"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "Minimized windows"
+msgstr "Minimalizált ablakok"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other workspaces"
+msgstr "Más munkaterületre rögzítés"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other monitors"
+msgstr "Gombok más monitorokon lévő ablakokhoz"
+
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
-msgid "Hide labels for minimized buttons"
+#, fuzzy
+msgid "Hide labels for"
 msgstr "A minimalizált gombok címkéinek elrejtése"
 
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
-"For groups/pools the label will still show unless all application windows "
-"are minimized"
+"Select the type of window state for which window list button labels should "
+"be hidden. For application pools, the label will still show unless all "
+"application windows have the selected property"
 msgstr ""
-"Csoportok/készletek esetén a címke továbbra is megjelenik, hacsak nincs az "
-"összes alkalmazásablak minimalizálva"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "None"
-msgstr "Nincs"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "Minimized windows"
-msgstr "Minimalizált ablakok"
 
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
@@ -896,6 +912,22 @@ msgstr "Nagyon kicsi"
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
 msgstr "Alapértelmezett miniatűr ablakméret"
+
+#. 4.0->settings-schema.json->menu-sort-groups->description
+#. 6.0->settings-schema.json->menu-sort-groups->description
+#, fuzzy
+msgid "Sort grouped button thumbnail menu items"
+msgstr "Állítsa vissza vagy tartsa lenyomva a miniatűr menü megjelenítéséhez"
+
+#. 4.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.0->settings-schema.json->menu-sort-groups->tooltip
+msgid ""
+"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"monitor number for grouped buttons. Pooled windows can not be sorted since "
+"the order is the same as the order on the window-list panel. With this "
+"option enabled, the thumbnail menu drag-and-drop reordering feature will be "
+"disabled for grouped button thumbnail menus."
+msgstr ""
 
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->description
@@ -1397,12 +1429,14 @@ msgstr "Csempézetlen ablak"
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr "Ne tegyen semmit"
 
@@ -1465,6 +1499,14 @@ msgstr ""
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
+msgstr "A legutóbbi ablak visszaállítása/kicsinyítése"
+
+#. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#, fuzzy
+msgid "Restore/Minimize 1st window in group"
 msgstr "A legutóbbi ablak visszaállítása/kicsinyítése"
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
@@ -1554,8 +1596,9 @@ msgstr "A legutóbbi alkalmazásablak visszaállítása"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 1st window in grouped button"
-msgstr "Csoportosított gomb 1. ablakának aktiválása"
+#, fuzzy
+msgid "Restore/minimize 1st window in group"
+msgstr "A legutóbbi ablak visszaállítása/kicsinyítése"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1563,8 +1606,9 @@ msgstr "Csoportosított gomb 1. ablakának aktiválása"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 2nd window in grouped button"
-msgstr "Csoportosított gomb 2. ablakának aktiválása"
+#, fuzzy
+msgid "Restore/minimize 2nd window in group"
+msgstr "A legutóbbi ablak visszaállítása/kicsinyítése"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1572,8 +1616,9 @@ msgstr "Csoportosított gomb 2. ablakának aktiválása"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 3rd window in grouped button"
-msgstr "Csoportosított gomb 3. ablakának aktiválása"
+#, fuzzy
+msgid "Restore/minimize 3rd window in group"
+msgstr "A legutóbbi ablak visszaállítása/kicsinyítése"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1581,8 +1626,9 @@ msgstr "Csoportosított gomb 3. ablakának aktiválása"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 4th window in grouped button"
-msgstr "Csoportosított gomb 4. ablakának aktiválása"
+#, fuzzy
+msgid "Restore/minimize 4th window in group"
+msgstr "A legutóbbi ablak visszaállítása/kicsinyítése"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description
@@ -1616,6 +1662,41 @@ msgstr "Előre gomb művelet"
 msgid "Action taken when using the forward mouse button on window list entries"
 msgstr ""
 "Az ablaklista-bejegyzéseknél az előremutató egérgombbal végzett műveletek"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Minimize/Restore/Maximize window"
+msgstr "Minimalizálás/Visszaállítás"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change windows workspace"
+msgstr "Tartalmazzon ablakokat minden munkaterületről"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change window tiling"
+msgstr "Ablakcím használata"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->description
+#. 6.0->settings-schema.json->mouse-action-scroll->description
+msgid "Scroll wheel action"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+msgid ""
+"Action taken when using the mouse scroll wheel on a window list button. This "
+"scroll wheel action will be disabled if the Thumbnail menu is currently open"
+msgstr ""
 
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-04 23:25-0400\n"
+"POT-Creation-Date: 2024-07-15 22:10-0400\n"
 "PO-Revision-Date: 2024-06-18 14:30+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,32 +19,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: 4.0/applet.js:550 6.0/applet.js:550
+#: 4.0/applet.js:567 6.0/applet.js:567
 msgid "all buttons"
 msgstr "tutti i pulsanti"
 
-#: 4.0/applet.js:2767 6.0/applet.js:2767
+#: 4.0/applet.js:3087 6.0/applet.js:3087
 msgid "Applet Preferences"
 msgstr "Preferenze Applet"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:3091 6.0/applet.js:3091
 msgid "About..."
 msgstr "Informazioni su..."
 
-#: 4.0/applet.js:2775 6.0/applet.js:2775
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Configure..."
 msgstr "Configura..."
 
-#: 4.0/applet.js:2779 6.0/applet.js:2779
+#: 4.0/applet.js:3099 6.0/applet.js:3099
 msgid "Website"
 msgstr "Sito web"
 
-#: 4.0/applet.js:2783 6.0/applet.js:2783
+#: 4.0/applet.js:3103 6.0/applet.js:3103
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Rimuovi '%s'"
 
-#: 4.0/applet.js:2785 6.0/applet.js:2785
+#: 4.0/applet.js:3105 6.0/applet.js:3105
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 
@@ -60,71 +60,71 @@ msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2794 6.0/applet.js:2794
+#: 4.0/applet.js:3114 6.0/applet.js:3114
 msgid "Open new window"
 msgstr "Apri una nuova finestra"
 
-#: 4.0/applet.js:2802 6.0/applet.js:2802
+#: 4.0/applet.js:3122 6.0/applet.js:3122
 msgid "Remove from panel"
 msgstr "Rimuovi dal pannello"
 
-#: 4.0/applet.js:2804 6.0/applet.js:2804
+#: 4.0/applet.js:3124 6.0/applet.js:3124
 msgid "Remove from this workspace"
 msgstr "Rimuovi da questa area di lavoro"
 
-#: 4.0/applet.js:2810 6.0/applet.js:2810
+#: 4.0/applet.js:3130 6.0/applet.js:3130
 msgid "Pin to panel"
 msgstr "Appunta al pannello"
 
-#: 4.0/applet.js:2812 6.0/applet.js:2812
+#: 4.0/applet.js:3132 6.0/applet.js:3132
 msgid "Pin to this workspace"
 msgstr "Appunta a questo spazio di lavoro"
 
-#: 4.0/applet.js:2853 6.0/applet.js:2853
+#: 4.0/applet.js:3173 6.0/applet.js:3173
 msgid "Pin to other workspaces"
 msgstr "Appunta ad altre aree di lavoro"
 
-#: 4.0/applet.js:2874 6.0/applet.js:2874
+#: 4.0/applet.js:3194 6.0/applet.js:3194
 msgid "Pin to all workspaces"
 msgstr "Appunta in tutte le aree di lavoro"
 
-#: 4.0/applet.js:2892 6.0/applet.js:2892
+#: 4.0/applet.js:3212 6.0/applet.js:3212
 msgid "Pin to launcher"
 msgstr "Appunta al launcher"
 
-#: 4.0/applet.js:2910 4.0/applet.js:3102 6.0/applet.js:2910 6.0/applet.js:3102
+#: 4.0/applet.js:3230 4.0/applet.js:3422 6.0/applet.js:3230 6.0/applet.js:3422
 msgid "Add new Hotkey for"
 msgstr "Aggiungi un nuovo tasto di scelta rapida per"
 
-#: 4.0/applet.js:2924 6.0/applet.js:2924
+#: 4.0/applet.js:3244 6.0/applet.js:3244
 msgid "Recent files"
 msgstr "Recenti"
 
-#: 4.0/applet.js:2948 6.0/applet.js:2948
+#: 4.0/applet.js:3268 6.0/applet.js:3268
 msgid "Places"
 msgstr "Posizioni"
 
-#: 4.0/applet.js:2990 6.0/applet.js:2990
+#: 4.0/applet.js:3310 6.0/applet.js:3310
 msgid "Only on this workspace"
 msgstr "Solo su questo spazio di lavoro"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3312 6.0/applet.js:3312
 msgid "Visible on all workspaces"
 msgstr "Visibile su tutte le aree di lavoro"
 
-#: 4.0/applet.js:2993 6.0/applet.js:2993
+#: 4.0/applet.js:3313 6.0/applet.js:3313
 msgid "Move to another workspace"
 msgstr "Sposta su un'altra area di lavoro"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3322 6.0/applet.js:3322
 msgid " (this workspace)"
 msgstr " (questa area di lavoro)"
 
-#: 4.0/applet.js:3015 6.0/applet.js:3015
+#: 4.0/applet.js:3335 6.0/applet.js:3335
 msgid "Move to another monitor"
 msgstr "Sposta su un altro schermo"
 
-#: 4.0/applet.js:3023 6.0/applet.js:3023
+#: 4.0/applet.js:3343 6.0/applet.js:3343
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -140,47 +140,47 @@ msgstr "Monitor"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3040 6.0/applet.js:3040
+#: 4.0/applet.js:3360 6.0/applet.js:3360
 msgid "Move window here"
 msgstr "Sposta la finestra qui"
 
-#: 4.0/applet.js:3057 6.0/applet.js:3057
+#: 4.0/applet.js:3377 6.0/applet.js:3377
 msgid "unassigned"
 msgstr "non assegnato"
 
-#: 4.0/applet.js:3068 4.0/applet.js:3099 6.0/applet.js:3068 6.0/applet.js:3099
+#: 4.0/applet.js:3388 4.0/applet.js:3419 6.0/applet.js:3388 6.0/applet.js:3419
 msgid "Assign window to a hotkey"
 msgstr "Assegna finestra ad un tasto di scelta rapida"
 
-#: 4.0/applet.js:3122 6.0/applet.js:3122
+#: 4.0/applet.js:3442 6.0/applet.js:3442
 msgid "Change application label contents"
 msgstr "Cambia il contenuto dell'etichetta dell'applicazione"
 
-#: 4.0/applet.js:3125 6.0/applet.js:3125
+#: 4.0/applet.js:3445 6.0/applet.js:3445
 msgid "Remove custom setting"
 msgstr "Rimuovi impostazioni personalizzate"
 
-#: 4.0/applet.js:3132 6.0/applet.js:3132
+#: 4.0/applet.js:3452 6.0/applet.js:3452
 msgid "Use window title"
 msgstr "Usa il titolo della finestra"
 
-#: 4.0/applet.js:3139 6.0/applet.js:3139
+#: 4.0/applet.js:3459 6.0/applet.js:3459
 msgid "Use application name"
 msgstr "Usa il nome dell'applicazione"
 
-#: 4.0/applet.js:3146 6.0/applet.js:3146
+#: 4.0/applet.js:3466 6.0/applet.js:3466
 msgid "No label"
 msgstr "Nessuna etichetta"
 
-#: 4.0/applet.js:3157 6.0/applet.js:3157
+#: 4.0/applet.js:3477 6.0/applet.js:3477
 msgid "Ungroup application windows"
 msgstr "Separa le finestre dell'applicazione"
 
-#: 4.0/applet.js:3166 6.0/applet.js:3166
+#: 4.0/applet.js:3486 6.0/applet.js:3486
 msgid "Group application windows"
 msgstr "Raggruppa le finestre dell'applicazione"
 
-#: 4.0/applet.js:3179 6.0/applet.js:3179
+#: 4.0/applet.js:3499 6.0/applet.js:3499
 msgid "Automatic grouping/ungrouping"
 msgstr "Raggruppamento/separazione automatica"
 
@@ -196,31 +196,31 @@ msgstr "Raggruppamento/separazione automatica"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3209 6.0/applet.js:3209
+#: 4.0/applet.js:3529 6.0/applet.js:3529
 msgid "Move titlebar on to screen"
 msgstr "Sposta la barra del titolo sullo schermo"
 
-#: 4.0/applet.js:3214 6.0/applet.js:3214
+#: 4.0/applet.js:3534 6.0/applet.js:3534
 msgid "Restore"
 msgstr "Ripristina"
 
-#: 4.0/applet.js:3218 6.0/applet.js:3218
+#: 4.0/applet.js:3538 6.0/applet.js:3538
 msgid "Minimize"
 msgstr "Minimizza"
 
-#: 4.0/applet.js:3224 6.0/applet.js:3224
+#: 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Unmaximize"
 msgstr "De-massimizza"
 
-#: 4.0/applet.js:3231 6.0/applet.js:3231
+#: 4.0/applet.js:3551 6.0/applet.js:3551
 msgid "Close others"
 msgstr "Chiudi altri"
 
-#: 4.0/applet.js:3242 6.0/applet.js:3242
+#: 4.0/applet.js:3562 6.0/applet.js:3562
 msgid "Close all"
 msgstr "Chiudi tutto"
 
-#: 4.0/applet.js:3251 6.0/applet.js:3251
+#: 4.0/applet.js:3571 6.0/applet.js:3571
 msgid "Close"
 msgstr "Chiudi"
 
@@ -407,29 +407,45 @@ msgstr ""
 "In esecuzione: solo le finestre aggiunte in esecuzione avranno un'etichetta\n"
 "Focalizzata: solo la finestra bloccata con focus avrà un'etichetta"
 
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "None"
+msgstr "Nessuna"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "Minimized windows"
+msgstr "Finestre ridotte a icona"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other workspaces"
+msgstr "Appunta ad altre aree di lavoro"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other monitors"
+msgstr "Pulsanti per finestre su altri monitor"
+
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
-msgid "Hide labels for minimized buttons"
+#, fuzzy
+msgid "Hide labels for"
 msgstr "Nascondi le etichette per i pulsanti ridotti a icona"
 
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
-"For groups/pools the label will still show unless all application windows "
-"are minimized"
+"Select the type of window state for which window list button labels should "
+"be hidden. For application pools, the label will still show unless all "
+"application windows have the selected property"
 msgstr ""
-"Per i gruppi/pool l'etichetta verrà comunque visualizzata a meno che tutte "
-"le finestre dell'applicazione non siano ridotte a icona"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "None"
-msgstr "Nessuna"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "Minimized windows"
-msgstr "Finestre ridotte a icona"
 
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
@@ -918,6 +934,22 @@ msgstr "Extra piccola"
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
 msgstr "Dimensione predefinita della finestra delle miniature"
+
+#. 4.0->settings-schema.json->menu-sort-groups->description
+#. 6.0->settings-schema.json->menu-sort-groups->description
+#, fuzzy
+msgid "Sort grouped button thumbnail menu items"
+msgstr "Ripristina o tieni premuto per il menù delle miniature"
+
+#. 4.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.0->settings-schema.json->menu-sort-groups->tooltip
+msgid ""
+"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"monitor number for grouped buttons. Pooled windows can not be sorted since "
+"the order is the same as the order on the window-list panel. With this "
+"option enabled, the thumbnail menu drag-and-drop reordering feature will be "
+"disabled for grouped button thumbnail menus."
+msgstr ""
 
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->description
@@ -1422,12 +1454,14 @@ msgstr "De-piastrella finestra"
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr "Non fare niente"
 
@@ -1491,6 +1525,14 @@ msgstr ""
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
+msgstr "Ripristina/Riduci a icona la finestra più recente"
+
+#. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#, fuzzy
+msgid "Restore/Minimize 1st window in group"
 msgstr "Ripristina/Riduci a icona la finestra più recente"
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
@@ -1580,8 +1622,9 @@ msgstr "Ripristina la finestra dell'applicazione più recente"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 1st window in grouped button"
-msgstr "Attiva la prima finestra nel pulsante raggruppato"
+#, fuzzy
+msgid "Restore/minimize 1st window in group"
+msgstr "Ripristina/Riduci a icona la finestra più recente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1589,8 +1632,9 @@ msgstr "Attiva la prima finestra nel pulsante raggruppato"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 2nd window in grouped button"
-msgstr "Attiva la seconda finestra nel pulsante raggruppato"
+#, fuzzy
+msgid "Restore/minimize 2nd window in group"
+msgstr "Ripristina/Riduci a icona la finestra più recente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1598,8 +1642,9 @@ msgstr "Attiva la seconda finestra nel pulsante raggruppato"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 3rd window in grouped button"
-msgstr "Attiva la terza finestra nel pulsante raggruppato"
+#, fuzzy
+msgid "Restore/minimize 3rd window in group"
+msgstr "Ripristina/Riduci a icona la finestra più recente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1607,8 +1652,9 @@ msgstr "Attiva la terza finestra nel pulsante raggruppato"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 4th window in grouped button"
-msgstr "Attiva la quarta finestra nel pulsante raggruppato"
+#, fuzzy
+msgid "Restore/minimize 4th window in group"
+msgstr "Ripristina/Riduci a icona la finestra più recente"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description
@@ -1645,6 +1691,41 @@ msgid "Action taken when using the forward mouse button on window list entries"
 msgstr ""
 "Azione eseguita quando si utilizza il pulsante avanti del mouse sulle voci "
 "dell'elenco delle finestre"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Minimize/Restore/Maximize window"
+msgstr "Minimizza/Ripristina"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change windows workspace"
+msgstr "Includi finestre da tutte le aree di lavoro"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change window tiling"
+msgstr "Usa il titolo della finestra"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->description
+#. 6.0->settings-schema.json->mouse-action-scroll->description
+msgid "Scroll wheel action"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+msgid ""
+"Action taken when using the mouse scroll wheel on a window list button. This "
+"scroll wheel action will be disabled if the Thumbnail menu is currently open"
+msgstr ""
 
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-04 23:25-0400\n"
+"POT-Creation-Date: 2024-07-15 22:10-0400\n"
 "PO-Revision-Date: 2024-04-20 10:46+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,32 +16,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:550 6.0/applet.js:550
+#: 4.0/applet.js:567 6.0/applet.js:567
 msgid "all buttons"
 msgstr "alle knoppen"
 
-#: 4.0/applet.js:2767 6.0/applet.js:2767
+#: 4.0/applet.js:3087 6.0/applet.js:3087
 msgid "Applet Preferences"
 msgstr "Applet Voorkeuren"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:3091 6.0/applet.js:3091
 msgid "About..."
 msgstr "Over..."
 
-#: 4.0/applet.js:2775 6.0/applet.js:2775
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Configure..."
 msgstr "Configureren..."
 
-#: 4.0/applet.js:2779 6.0/applet.js:2779
+#: 4.0/applet.js:3099 6.0/applet.js:3099
 msgid "Website"
 msgstr "Website"
 
-#: 4.0/applet.js:2783 6.0/applet.js:2783
+#: 4.0/applet.js:3103 6.0/applet.js:3103
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Verwijder '%s'"
 
-#: 4.0/applet.js:2785 6.0/applet.js:2785
+#: 4.0/applet.js:3105 6.0/applet.js:3105
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Weet u zeker dat u deze instantie van CassiaWindowList wilt verwijderen?"
@@ -58,71 +58,71 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2794 6.0/applet.js:2794
+#: 4.0/applet.js:3114 6.0/applet.js:3114
 msgid "Open new window"
 msgstr "Open een nieuw venster"
 
-#: 4.0/applet.js:2802 6.0/applet.js:2802
+#: 4.0/applet.js:3122 6.0/applet.js:3122
 msgid "Remove from panel"
 msgstr "Verwijderen van paneel"
 
-#: 4.0/applet.js:2804 6.0/applet.js:2804
+#: 4.0/applet.js:3124 6.0/applet.js:3124
 msgid "Remove from this workspace"
 msgstr "Verwijderen van deze werkruimte"
 
-#: 4.0/applet.js:2810 6.0/applet.js:2810
+#: 4.0/applet.js:3130 6.0/applet.js:3130
 msgid "Pin to panel"
 msgstr "Vastmaken aan paneel"
 
-#: 4.0/applet.js:2812 6.0/applet.js:2812
+#: 4.0/applet.js:3132 6.0/applet.js:3132
 msgid "Pin to this workspace"
 msgstr "Vastmaken aan deze werkruimte"
 
-#: 4.0/applet.js:2853 6.0/applet.js:2853
+#: 4.0/applet.js:3173 6.0/applet.js:3173
 msgid "Pin to other workspaces"
 msgstr "Vastmaken aan andere werkruimtes"
 
-#: 4.0/applet.js:2874 6.0/applet.js:2874
+#: 4.0/applet.js:3194 6.0/applet.js:3194
 msgid "Pin to all workspaces"
 msgstr "Vastmaken aan alle werkruimtes"
 
-#: 4.0/applet.js:2892 6.0/applet.js:2892
+#: 4.0/applet.js:3212 6.0/applet.js:3212
 msgid "Pin to launcher"
 msgstr "Vastmaken aan launcher"
 
-#: 4.0/applet.js:2910 4.0/applet.js:3102 6.0/applet.js:2910 6.0/applet.js:3102
+#: 4.0/applet.js:3230 4.0/applet.js:3422 6.0/applet.js:3230 6.0/applet.js:3422
 msgid "Add new Hotkey for"
 msgstr "Voeg nieuwe sneltoets toe voor"
 
-#: 4.0/applet.js:2924 6.0/applet.js:2924
+#: 4.0/applet.js:3244 6.0/applet.js:3244
 msgid "Recent files"
 msgstr "Recente bestanden"
 
-#: 4.0/applet.js:2948 6.0/applet.js:2948
+#: 4.0/applet.js:3268 6.0/applet.js:3268
 msgid "Places"
 msgstr "Locaties"
 
-#: 4.0/applet.js:2990 6.0/applet.js:2990
+#: 4.0/applet.js:3310 6.0/applet.js:3310
 msgid "Only on this workspace"
 msgstr "Alleen op deze werkruimte"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3312 6.0/applet.js:3312
 msgid "Visible on all workspaces"
 msgstr "Zichtbaar op alle werkruimtes"
 
-#: 4.0/applet.js:2993 6.0/applet.js:2993
+#: 4.0/applet.js:3313 6.0/applet.js:3313
 msgid "Move to another workspace"
 msgstr "Verplaatsen naar een andere werkruimte"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3322 6.0/applet.js:3322
 msgid " (this workspace)"
 msgstr " (deze werkruimte)"
 
-#: 4.0/applet.js:3015 6.0/applet.js:3015
+#: 4.0/applet.js:3335 6.0/applet.js:3335
 msgid "Move to another monitor"
 msgstr "Verplaatsen naar een ander beeldscherm"
 
-#: 4.0/applet.js:3023 6.0/applet.js:3023
+#: 4.0/applet.js:3343 6.0/applet.js:3343
 msgid "Monitor"
 msgstr "Beeldscherm"
 
@@ -138,48 +138,48 @@ msgstr "Beeldscherm"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3040 6.0/applet.js:3040
+#: 4.0/applet.js:3360 6.0/applet.js:3360
 #, fuzzy
 msgid "Move window here"
 msgstr "Sluit venster"
 
-#: 4.0/applet.js:3057 6.0/applet.js:3057
+#: 4.0/applet.js:3377 6.0/applet.js:3377
 msgid "unassigned"
 msgstr "niet toegewezen"
 
-#: 4.0/applet.js:3068 4.0/applet.js:3099 6.0/applet.js:3068 6.0/applet.js:3099
+#: 4.0/applet.js:3388 4.0/applet.js:3419 6.0/applet.js:3388 6.0/applet.js:3419
 msgid "Assign window to a hotkey"
 msgstr "Wijs venster toe aan een sneltoets"
 
-#: 4.0/applet.js:3122 6.0/applet.js:3122
+#: 4.0/applet.js:3442 6.0/applet.js:3442
 msgid "Change application label contents"
 msgstr "Wijzig inhoud van applicatielabel"
 
-#: 4.0/applet.js:3125 6.0/applet.js:3125
+#: 4.0/applet.js:3445 6.0/applet.js:3445
 msgid "Remove custom setting"
 msgstr "Verwijder aangepaste instelling"
 
-#: 4.0/applet.js:3132 6.0/applet.js:3132
+#: 4.0/applet.js:3452 6.0/applet.js:3452
 msgid "Use window title"
 msgstr "Gebruik venstertitel"
 
-#: 4.0/applet.js:3139 6.0/applet.js:3139
+#: 4.0/applet.js:3459 6.0/applet.js:3459
 msgid "Use application name"
 msgstr "Gebruik applicatienaam"
 
-#: 4.0/applet.js:3146 6.0/applet.js:3146
+#: 4.0/applet.js:3466 6.0/applet.js:3466
 msgid "No label"
 msgstr "Geen label"
 
-#: 4.0/applet.js:3157 6.0/applet.js:3157
+#: 4.0/applet.js:3477 6.0/applet.js:3477
 msgid "Ungroup application windows"
 msgstr "Applicatie-vensters niet groeperen"
 
-#: 4.0/applet.js:3166 6.0/applet.js:3166
+#: 4.0/applet.js:3486 6.0/applet.js:3486
 msgid "Group application windows"
 msgstr "Applicatie-vensters groeperen"
 
-#: 4.0/applet.js:3179 6.0/applet.js:3179
+#: 4.0/applet.js:3499 6.0/applet.js:3499
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisch groeperen/ongroeperen"
 
@@ -195,31 +195,31 @@ msgstr "Automatisch groeperen/ongroeperen"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3209 6.0/applet.js:3209
+#: 4.0/applet.js:3529 6.0/applet.js:3529
 msgid "Move titlebar on to screen"
 msgstr "Verplaats titelbalk naar het scherm"
 
-#: 4.0/applet.js:3214 6.0/applet.js:3214
+#: 4.0/applet.js:3534 6.0/applet.js:3534
 msgid "Restore"
 msgstr "Herstellen"
 
-#: 4.0/applet.js:3218 6.0/applet.js:3218
+#: 4.0/applet.js:3538 6.0/applet.js:3538
 msgid "Minimize"
 msgstr "Minimaliseren"
 
-#: 4.0/applet.js:3224 6.0/applet.js:3224
+#: 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Unmaximize"
 msgstr "Ontmaximaliseren"
 
-#: 4.0/applet.js:3231 6.0/applet.js:3231
+#: 4.0/applet.js:3551 6.0/applet.js:3551
 msgid "Close others"
 msgstr "Sluit anderen"
 
-#: 4.0/applet.js:3242 6.0/applet.js:3242
+#: 4.0/applet.js:3562 6.0/applet.js:3562
 msgid "Close all"
 msgstr "Sluit alle"
 
-#: 4.0/applet.js:3251 6.0/applet.js:3251
+#: 4.0/applet.js:3571 6.0/applet.js:3571
 msgid "Close"
 msgstr "Sluiten"
 
@@ -405,29 +405,45 @@ msgstr ""
 "Bezig: Alleen vastgemaakte vensters die bezig zijn, krijgen een label\n"
 "Gefocust: Alleen het vastgemaakte venster met focus krijgt een label"
 
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "None"
+msgstr "Geen"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "Minimized windows"
+msgstr "Geminimaliseerde vensters"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other workspaces"
+msgstr "Vastmaken aan andere werkruimtes"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other monitors"
+msgstr "Knoppen voor vensters op andere beeldschermen"
+
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
-msgid "Hide labels for minimized buttons"
+#, fuzzy
+msgid "Hide labels for"
 msgstr "Labels verbergen voor geminimaliseerde knoppen"
 
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
-"For groups/pools the label will still show unless all application windows "
-"are minimized"
+"Select the type of window state for which window list button labels should "
+"be hidden. For application pools, the label will still show unless all "
+"application windows have the selected property"
 msgstr ""
-"Voor groepen/pools wordt het label nog steeds weergegeven tenzij alle "
-"applicatievensters zijn geminimaliseerd"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "None"
-msgstr "Geen"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "Minimized windows"
-msgstr "Geminimaliseerde vensters"
 
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
@@ -909,6 +925,22 @@ msgstr "Extra klein"
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
 msgstr "Standaardgrootte van het miniaturenvenster"
+
+#. 4.0->settings-schema.json->menu-sort-groups->description
+#. 6.0->settings-schema.json->menu-sort-groups->description
+#, fuzzy
+msgid "Sort grouped button thumbnail menu items"
+msgstr "Herstellen of ingedrukt houden voor het miniaturenmenu"
+
+#. 4.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.0->settings-schema.json->menu-sort-groups->tooltip
+msgid ""
+"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"monitor number for grouped buttons. Pooled windows can not be sorted since "
+"the order is the same as the order on the window-list panel. With this "
+"option enabled, the thumbnail menu drag-and-drop reordering feature will be "
+"disabled for grouped button thumbnail menus."
+msgstr ""
 
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->description
@@ -1413,12 +1445,14 @@ msgstr "Venster onttegelen"
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr "Doe niets"
 
@@ -1482,6 +1516,14 @@ msgstr ""
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
+msgstr "Meest recente venster herstellen/minimaliseren"
+
+#. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#, fuzzy
+msgid "Restore/Minimize 1st window in group"
 msgstr "Meest recente venster herstellen/minimaliseren"
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
@@ -1571,8 +1613,9 @@ msgstr "Meest recente applicatievenster herstellen"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 1st window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 1st window in group"
+msgstr "Meest recente venster herstellen/minimaliseren"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1580,8 +1623,9 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 2nd window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 2nd window in group"
+msgstr "Meest recente venster herstellen/minimaliseren"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1589,8 +1633,9 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 3rd window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 3rd window in group"
+msgstr "Meest recente venster herstellen/minimaliseren"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1598,8 +1643,9 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 4th window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 4th window in group"
+msgstr "Meest recente venster herstellen/minimaliseren"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description
@@ -1636,6 +1682,41 @@ msgid "Action taken when using the forward mouse button on window list entries"
 msgstr ""
 "Actie die wordt uitgevoerd bij het gebruik van de vooruitknop van de muis op "
 "vensterlijstvermeldingen"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Minimize/Restore/Maximize window"
+msgstr "Minimaliseer/Herstel"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change windows workspace"
+msgstr "Vensters van alle werkruimtes opnemen"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change window tiling"
+msgstr "Gebruik venstertitel"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->description
+#. 6.0->settings-schema.json->mouse-action-scroll->description
+msgid "Scroll wheel action"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+msgid ""
+"Action taken when using the mouse scroll wheel on a window list button. This "
+"scroll wheel action will be disabled if the Thumbnail menu is currently open"
+msgstr ""
 
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-04 23:25-0400\n"
+"POT-Creation-Date: 2024-07-15 22:10-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -14,32 +14,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.1\n"
 
-#: 4.0/applet.js:550 6.0/applet.js:550
+#: 4.0/applet.js:567 6.0/applet.js:567
 msgid "all buttons"
 msgstr "все кнопки"
 
-#: 4.0/applet.js:2767 6.0/applet.js:2767
+#: 4.0/applet.js:3087 6.0/applet.js:3087
 msgid "Applet Preferences"
 msgstr "Настройки Апплета"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:3091 6.0/applet.js:3091
 msgid "About..."
 msgstr "О Апплете..."
 
-#: 4.0/applet.js:2775 6.0/applet.js:2775
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Configure..."
 msgstr "Настроить..."
 
-#: 4.0/applet.js:2779 6.0/applet.js:2779
+#: 4.0/applet.js:3099 6.0/applet.js:3099
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2783 6.0/applet.js:2783
+#: 4.0/applet.js:3103 6.0/applet.js:3103
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Удалить '%s'"
 
-#: 4.0/applet.js:2785 6.0/applet.js:2785
+#: 4.0/applet.js:3105 6.0/applet.js:3105
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Вы действительно хотите удалить этот экземпляр CassiaWindowList?"
 
@@ -55,72 +55,72 @@ msgstr "Вы действительно хотите удалить этот э�
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2794 6.0/applet.js:2794
+#: 4.0/applet.js:3114 6.0/applet.js:3114
 msgid "Open new window"
 msgstr "Открыть новое окно"
 
-#: 4.0/applet.js:2802 6.0/applet.js:2802
+#: 4.0/applet.js:3122 6.0/applet.js:3122
 msgid "Remove from panel"
 msgstr "Удалить с панели"
 
-#: 4.0/applet.js:2804 6.0/applet.js:2804
+#: 4.0/applet.js:3124 6.0/applet.js:3124
 msgid "Remove from this workspace"
 msgstr "Удалить из этого рабочего стола"
 
-#: 4.0/applet.js:2810 6.0/applet.js:2810
+#: 4.0/applet.js:3130 6.0/applet.js:3130
 msgid "Pin to panel"
 msgstr "Закрепить на панели"
 
-#: 4.0/applet.js:2812 6.0/applet.js:2812
+#: 4.0/applet.js:3132 6.0/applet.js:3132
 msgid "Pin to this workspace"
 msgstr "Закрепить на этом рабочем столе"
 
-#: 4.0/applet.js:2853 6.0/applet.js:2853
+#: 4.0/applet.js:3173 6.0/applet.js:3173
 msgid "Pin to other workspaces"
 msgstr "Закрепить на другом рабочем столе"
 
-#: 4.0/applet.js:2874 6.0/applet.js:2874
+#: 4.0/applet.js:3194 6.0/applet.js:3194
 msgid "Pin to all workspaces"
 msgstr "Закрепить на всех рабочих столах"
 
-#: 4.0/applet.js:2892 6.0/applet.js:2892
+#: 4.0/applet.js:3212 6.0/applet.js:3212
 msgid "Pin to launcher"
 msgstr "Закрепить в лаунчере"
 
-#: 4.0/applet.js:2910 4.0/applet.js:3102 6.0/applet.js:2910 6.0/applet.js:3102
+#: 4.0/applet.js:3230 4.0/applet.js:3422 6.0/applet.js:3230 6.0/applet.js:3422
 msgid "Add new Hotkey for"
 msgstr "Добавить новую горячую клавишу для"
 
-#: 4.0/applet.js:2924 6.0/applet.js:2924
+#: 4.0/applet.js:3244 6.0/applet.js:3244
 msgid "Recent files"
 msgstr "Недавние файлы"
 
-#: 4.0/applet.js:2948 6.0/applet.js:2948
+#: 4.0/applet.js:3268 6.0/applet.js:3268
 msgid "Places"
 msgstr "Места"
 
-#: 4.0/applet.js:2990 6.0/applet.js:2990
+#: 4.0/applet.js:3310 6.0/applet.js:3310
 msgid "Only on this workspace"
 msgstr "Только на этом рабочем столе"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3312 6.0/applet.js:3312
 msgid "Visible on all workspaces"
 msgstr "Видно на всех рабочих столах"
 
-#: 4.0/applet.js:2993 6.0/applet.js:2993
+#: 4.0/applet.js:3313 6.0/applet.js:3313
 msgid "Move to another workspace"
 msgstr "Переместить на другой рабочий стол"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3322 6.0/applet.js:3322
 #, fuzzy
 msgid " (this workspace)"
 msgstr "Закрепить на этом рабочем столе"
 
-#: 4.0/applet.js:3015 6.0/applet.js:3015
+#: 4.0/applet.js:3335 6.0/applet.js:3335
 msgid "Move to another monitor"
 msgstr "Переместить на другой монитор"
 
-#: 4.0/applet.js:3023 6.0/applet.js:3023
+#: 4.0/applet.js:3343 6.0/applet.js:3343
 msgid "Monitor"
 msgstr "Монитор"
 
@@ -136,48 +136,48 @@ msgstr "Монитор"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3040 6.0/applet.js:3040
+#: 4.0/applet.js:3360 6.0/applet.js:3360
 #, fuzzy
 msgid "Move window here"
 msgstr "Закрой окно"
 
-#: 4.0/applet.js:3057 6.0/applet.js:3057
+#: 4.0/applet.js:3377 6.0/applet.js:3377
 msgid "unassigned"
 msgstr "не назначено"
 
-#: 4.0/applet.js:3068 4.0/applet.js:3099 6.0/applet.js:3068 6.0/applet.js:3099
+#: 4.0/applet.js:3388 4.0/applet.js:3419 6.0/applet.js:3388 6.0/applet.js:3419
 msgid "Assign window to a hotkey"
 msgstr "Назначить окно горячей клавише"
 
-#: 4.0/applet.js:3122 6.0/applet.js:3122
+#: 4.0/applet.js:3442 6.0/applet.js:3442
 msgid "Change application label contents"
 msgstr "Изменить текст названия приложения"
 
-#: 4.0/applet.js:3125 6.0/applet.js:3125
+#: 4.0/applet.js:3445 6.0/applet.js:3445
 msgid "Remove custom setting"
 msgstr "Удалить свои настройки"
 
-#: 4.0/applet.js:3132 6.0/applet.js:3132
+#: 4.0/applet.js:3452 6.0/applet.js:3452
 msgid "Use window title"
 msgstr "Использовать заголовок окон"
 
-#: 4.0/applet.js:3139 6.0/applet.js:3139
+#: 4.0/applet.js:3459 6.0/applet.js:3459
 msgid "Use application name"
 msgstr "Использовать названия программ"
 
-#: 4.0/applet.js:3146 6.0/applet.js:3146
+#: 4.0/applet.js:3466 6.0/applet.js:3466
 msgid "No label"
 msgstr "Без названий"
 
-#: 4.0/applet.js:3157 6.0/applet.js:3157
+#: 4.0/applet.js:3477 6.0/applet.js:3477
 msgid "Ungroup application windows"
 msgstr "Не группировать окна приложений"
 
-#: 4.0/applet.js:3166 6.0/applet.js:3166
+#: 4.0/applet.js:3486 6.0/applet.js:3486
 msgid "Group application windows"
 msgstr "Группировать окна приложений"
 
-#: 4.0/applet.js:3179 6.0/applet.js:3179
+#: 4.0/applet.js:3499 6.0/applet.js:3499
 msgid "Automatic grouping/ungrouping"
 msgstr "Автоматически группировать/разгруппировать"
 
@@ -193,31 +193,31 @@ msgstr "Автоматически группировать/разгруппир
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3209 6.0/applet.js:3209
+#: 4.0/applet.js:3529 6.0/applet.js:3529
 msgid "Move titlebar on to screen"
 msgstr "Переместить на другой экран"
 
-#: 4.0/applet.js:3214 6.0/applet.js:3214
+#: 4.0/applet.js:3534 6.0/applet.js:3534
 msgid "Restore"
 msgstr "Восстановить"
 
-#: 4.0/applet.js:3218 6.0/applet.js:3218
+#: 4.0/applet.js:3538 6.0/applet.js:3538
 msgid "Minimize"
 msgstr "Свернуть"
 
-#: 4.0/applet.js:3224 6.0/applet.js:3224
+#: 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Unmaximize"
 msgstr "Обычный размер"
 
-#: 4.0/applet.js:3231 6.0/applet.js:3231
+#: 4.0/applet.js:3551 6.0/applet.js:3551
 msgid "Close others"
 msgstr "Закрыть другие"
 
-#: 4.0/applet.js:3242 6.0/applet.js:3242
+#: 4.0/applet.js:3562 6.0/applet.js:3562
 msgid "Close all"
 msgstr "Закрыть всё"
 
-#: 4.0/applet.js:3251 6.0/applet.js:3251
+#: 4.0/applet.js:3571 6.0/applet.js:3571
 msgid "Close"
 msgstr "Закрыть"
 
@@ -404,27 +404,45 @@ msgstr ""
 "Выполняется: только закрепленное запущенное окно будет иметь надпись\n"
 "Когда в фокусе: только закрепленное окно с фокусом будет иметь надпись"
 
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "None"
+msgstr "Ничего"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->display-indicators->options
+msgid "Minimized windows"
+msgstr "Свёрнутые окна"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other workspaces"
+msgstr "Закрепить на другом рабочем столе"
+
+#. 4.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#, fuzzy
+msgid "Windows on other monitors"
+msgstr "Показывать окна только на одном мониторе"
+
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
-msgid "Hide labels for minimized buttons"
+#, fuzzy
+msgid "Hide labels for"
 msgstr "Скрыть надписи свёрнутых окон"
 
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
-"For groups/pools the label will still show unless all application windows "
-"are minimized"
-msgstr "Для группы надпись будет отображена пока открыто окно из группы"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "None"
-msgstr "Ничего"
-
-#. 4.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->display-indicators->options
-msgid "Minimized windows"
-msgstr "Свёрнутые окна"
+"Select the type of window state for which window list button labels should "
+"be hidden. For application pools, the label will still show unless all "
+"application windows have the selected property"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
@@ -875,6 +893,22 @@ msgstr "Очень маленький"
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
 msgstr "Размер окна миниатюр по умолчанию"
+
+#. 4.0->settings-schema.json->menu-sort-groups->description
+#. 6.0->settings-schema.json->menu-sort-groups->description
+#, fuzzy
+msgid "Sort grouped button thumbnail menu items"
+msgstr "Восстановить или удерживать меню миниатюр"
+
+#. 4.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.0->settings-schema.json->menu-sort-groups->tooltip
+msgid ""
+"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"monitor number for grouped buttons. Pooled windows can not be sorted since "
+"the order is the same as the order on the window-list panel. With this "
+"option enabled, the thumbnail menu drag-and-drop reordering feature will be "
+"disabled for grouped button thumbnail menus."
+msgstr ""
 
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->description
@@ -1375,12 +1409,14 @@ msgstr "Закрой окно"
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr "Ничего не делать"
 
@@ -1435,6 +1471,14 @@ msgstr ""
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
+msgstr "Восстановить/свернуть последнее окно"
+
+#. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#, fuzzy
+msgid "Restore/Minimize 1st window in group"
 msgstr "Восстановить/свернуть последнее окно"
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
@@ -1524,8 +1568,9 @@ msgstr "Восстановить последнее окно приложени�
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 1st window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 1st window in group"
+msgstr "Восстановить/свернуть последнее окно"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1533,8 +1578,9 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 2nd window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 2nd window in group"
+msgstr "Восстановить/свернуть последнее окно"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1542,8 +1588,9 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 3rd window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 3rd window in group"
+msgstr "Восстановить/свернуть последнее окно"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
@@ -1551,8 +1598,9 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Activate 4th window in grouped button"
-msgstr ""
+#, fuzzy
+msgid "Restore/minimize 4th window in group"
+msgstr "Восстановить/свернуть последнее окно"
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description
@@ -1588,6 +1636,41 @@ msgstr "Действие кнопки Вперед"
 msgid "Action taken when using the forward mouse button on window list entries"
 msgstr ""
 "Действие, выполняемое при нажатии кнопки мыши вперед на элементах списка окон"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Minimize/Restore/Maximize window"
+msgstr "Свернуть/Восстановить"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change windows workspace"
+msgstr "Включить окна из всех рабочих столов"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Change windows monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Change window tiling"
+msgstr "Использовать заголовок окон"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->description
+#. 6.0->settings-schema.json->mouse-action-scroll->description
+msgid "Scroll wheel action"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+msgid ""
+"Action taken when using the mouse scroll wheel on a window list button. This "
+"scroll wheel action will be disabled if the Thumbnail menu is currently open"
+msgstr ""
 
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options


### PR DESCRIPTION
 1. Allow rearranging Thumbnail menu items using drag-and-drop
 2. Allow drag-and-drop from the Thumbnail menu to the desktop, matching the behaviour of window-list button drag-and-drop
 3. Add options for hiding button labels when the windows workspace/monitor is not the current workspace/monitor
 4. Fixed how labels are hidden for grouped buttons so that it's solely based on the current windows state
 5. Added an option to sort the Thumbnail menu for grouped buttons based on the Workspace & Monitor index
 6. Fix a cases where Thumbnail menus can contain stale window titles or even contain windows that have been closed
 7. Fix to show labels for application pools where some, but not all, windows in the pool don't qualify to have a label
 8. Updated the tooltip for the "Hide labels for" option to better describe the option and it's effect on application pools
 9. Added 4 scroll-wheel actions options for when the scroll-wheel is used on a window-list button
10. Changed "Activate # window in grouped button" mouse actions to "Restore/minimize # window in group" and now it will minimize the window if the window already has the focus.
11. Added a "Restore/Minimize 1st window in group" option to the "Left button action for grouped buttons" list of options