### PR TITLE
ddcci-multi-monitor@tim-we: bugfix

### DIFF
--- a/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
+++ b/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
@@ -7,6 +7,7 @@ const St = imports.gi.St;
 const ModalDialog = imports.ui.modalDialog;
 const Clutter = imports.gi.Clutter;
 const Gettext = imports.gettext;
+const GLib = imports.gi.GLib;
 
 // l10n/translation support
 const UUID = "ddcci-multi-monitor@tim-we";


### PR DESCRIPTION
ddcci-multi-monitor@tim-we is not working after last update, gives an error Glib not found. Fixed this error.