### PR TITLE
[placesCenter@scollins] v2.4 - Now compatible with Cinnamon 6.2 (Mint 22)

### DIFF
--- a/placesCenter@scollins/files/placesCenter@scollins/applet.js
+++ b/placesCenter@scollins/files/placesCenter@scollins/applet.js
@@ -429,12 +429,14 @@ class MyApplet extends Applet.TextIconApplet {
             let network = new PlaceMenuItem("network:///", _("Network"), "network-workgroup");
             this.systemSection.addMenuItem(network);
 
-            let bookmark = Main.placesManager.getDefaultPlaces()[2];
-            let connectToItem = new IconMenuItem(bookmark.name, bookmark.iconFactory(menu_item_icon_size));
-            this.systemSection.addMenuItem(connectToItem);
-            connectToItem.connect("activate", Lang.bind(this, function() {
-                bookmark.launch();
-            }));
+            if (Main.placesManager.getDefaultPlaces().length > 2) {
+                let bookmark = Main.placesManager.getDefaultPlaces()[2];
+                let connectToItem = new IconMenuItem(bookmark.name, bookmark.iconFactory(menu_item_icon_size));
+                this.systemSection.addMenuItem(connectToItem);
+                connectToItem.connect("activate", Lang.bind(this, function() {
+                    bookmark.launch();
+                }));
+            }
         }
     }
 

--- a/placesCenter@scollins/files/placesCenter@scollins/metadata.json
+++ b/placesCenter@scollins/files/placesCenter@scollins/metadata.json
@@ -4,7 +4,7 @@
     "description": "Provides an easy-to-read layout to access your places",
     "comments": "Places Center is a feature-rich, cross-platform Cinnamon applet that provides easy access to all of your most-used places. Feel free to contribute by submitting pull requests, bug reports and feature requests to my github repo.",
     "website": "https://github.com/linuxmint/cinnamon-spices-applets",
-    "version": "2.3",
+    "version": "2.4",
     "contributors": "Stephen Collins - Author,kehugter - Added configurability to middle click,claudiux - Improvements to the 'Recent' section.",
     "max-instances": -1,
     "author": "collinss"


### PR DESCRIPTION
Due to changes in `js/ui/placesManager.js`, this applet was buggy in Cinnamon 6.2 (Mint 22).

This PR fixes that.