### PR TITLE
feeds@jonbrettdev.wordpress.com: Fix resizing when adding new feeds

### DIFF
--- a/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/manage_feeds.py
+++ b/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/manage_feeds.py
@@ -320,7 +320,7 @@ class MainWindow(Gtk.Window):
         """ Adds a new row to the bottom of the array / Grid """        
         self.config.feeds.append([ConfigFileManager.get_new_id(), True, "http://", "", True, 5, False, False])        
         self.treeview.set_cursor(len(self.config.feeds) - 1, self.treeview.get_column(0), True)
-        self.set_size_request(-1, 150 + len(self.config.feeds) * 20 )
+        self.gtk_window_set_default_size(-1, 150 + len(self.config.feeds) * 20 )
         
 
     def save_clicked(self, button):


### PR DESCRIPTION
When adding a new feed, the method [set_size_request](https://docs.gtk.org/gtk3/method.Widget.set_size_request.html) is called.
This method increases the height of the dialog, so that the user can see the new line that he has created.

Unfortunately, setting the size request will force the user to leave the window at least as large as the size request (see [docs](https://docs.gtk.org/gtk3/method.Widget.set_size_request.html)).
This is a problem, if you already have too many feeds and adding another one increases the dialog to a height that is not supported by your monitor.

If that's the case, the user can't add feeds anymore.

Can we use [set_default_size](https://docs.gtk.org/gtk4/method.Window.set_default_size.html) instead?
This wouldn't remove the resize-functionality and just add another row with scroll-behavior.

---
And thanks for this applet! :)

@jake1164 