### PR TITLE
darkMode@linuxedo.com: adds prefer-light mode

### DIFF
--- a/darkMode@linuxedo.com/files/darkMode@linuxedo.com/5.8/applet.js
+++ b/darkMode@linuxedo.com/files/darkMode@linuxedo.com/5.8/applet.js
@@ -251,6 +251,7 @@ MyApplet.prototype = {
             gtk_theme = this.light_gtk_theme;
             cinnamon_theme = this.light_cinnamon_theme;
             icon_theme = this.light_icon_theme;
+            prefer_scheme = 'prefer-light'; // 'default' or 'prefer-dark' or 'prefer-light'
             this.set_applet_icon_symbolic_path(ICON_SUN);
         }
 


### PR DESCRIPTION
@slgobinath 

Added line 254 in 5.8 applet.js:

prefer_scheme = 'prefer-light'; 

I noticed that when turning off dark mode that Firefox does not switch to light mode.  This was due to the setting in cinnamon returning to "Let the application decide" instead of "prefer light mode"  This change fixes that issue and changes the setting to "prefer light mode" when the dark mode switch is turned off. 