### PR TITLE
shutdown-timer@webum.by: Changed "Shutdown" and "Log out" strings to the same ones used in cinnamon.mo to facilitate proper translation

### DIFF
--- a/shutdown-timer@webum.by/files/shutdown-timer@webum.by/applet.js
+++ b/shutdown-timer@webum.by/files/shutdown-timer@webum.by/applet.js
@@ -40,11 +40,11 @@ MyApplet.prototype = {
 
     	this.ArrayActions = {};
 		this.ArrayActions['lock-screen'] = 'Lock screen';
-		this.ArrayActions['log-out'] = 'Log Out';
+		this.ArrayActions['log-out'] = 'Logout';
 		this.ArrayActions['suspend'] = 'Suspend';
 		this.ArrayActions['hibernate'] = 'Hibernate';
 		this.ArrayActions['restart'] = 'Restart';
-		this.ArrayActions['shutdown'] = 'Shutdown';
+		this.ArrayActions['shutdown'] = 'Shut down';
 		this.ArrayActions['restart-cinnamon'] = 'Restart Cinnamon';
 
     		this.ArrayIcons = {};


### PR DESCRIPTION
The "Shutdown" and "Log out" options in the menu are presented in English even if running with a non-English locale. This is because the strings don't match the ones available in cinnamon.mo.