### PR TITLE
Radio3.0@claudiux: Add German (de) translations

### DIFF
--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/de.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/de.po
@@ -1,0 +1,3114 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-31 02:53+0200\n"
+"PO-Revision-Date: 2024-09-13 08:48+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: applet.js:325
+msgid "This is your own list of Categories and Radio Stations."
+msgstr "Dies ist Ihre eigene Liste von Kategorien und Radiosendern."
+
+#: applet.js:326
+msgid "You can add more using the [+] button."
+msgstr "Sie können mit der [+]-Schaltfäche weitere hinzufügen."
+
+#: applet.js:327
+msgid "For a category, fill in only its name; leave the other fields empty."
+msgstr ""
+"Für eine Kategorie geben Sie nur den Namen ein; lassen Sie die anderen "
+"Felder leer."
+
+#: applet.js:328
+msgid "For a radio station, enter only its name and its streaming URL."
+msgstr ""
+"Für einen Radiosender geben Sie nur den Namen und die Streaming-URL ein."
+
+#: applet.js:329
+msgid ""
+"You can order the rows by dragging and dropping or by using the buttons and "
+"tools below the list."
+msgstr ""
+"Sie können die Zeilen durch Ziehen und Ablegen oder mit den Schaltflächen "
+"und Werkzeugen unterhalb der Liste anordnen."
+
+#: applet.js:330
+msgid ""
+"The buttons on the right below the list allow you to navigate page by page "
+"or category by category."
+msgstr ""
+"Die Schaltflächen rechts unter der Liste ermöglichen es Ihnen, seitenweise "
+"oder kategorieweise zu navigieren."
+
+#: applet.js:331
+msgid ""
+"To search for one of your stations, click on the list and start writing its "
+"name."
+msgstr ""
+"Um nach einem Ihrer Sender zu suchen, klicken Sie auf die Liste und beginnen "
+"Sie, den Namen einzugeben."
+
+#: applet.js:332
+msgid ""
+"To easily add stations to your list, use the following 2 tabs: Search and "
+"Import."
+msgstr ""
+"Um Stationen einfach zu Ihrer Liste hinzuzufügen, verwenden Sie die "
+"folgenden 2 Tabs: Suche und Importieren."
+
+#: applet.js:333
+msgid "Check its 'Menu' box to display a station or category in the menu."
+msgstr ""
+"Aktivieren Sie das 'Menü'-Feld, um eine Station oder Kategorie im Menü "
+"anzuzeigen."
+
+#: applet.js:334
+msgid ""
+"Check its '♪/➟' box to listen to the station or move it to another category "
+"using the tools below the list."
+msgstr ""
+"Aktivieren Sie das '♪/➟'-Feld, um den Sender zu hören oder ihn mit den "
+"Werkzeugen unterhalb der Liste in eine andere Kategorie zu verschieben."
+
+#: applet.js:336
+msgid "You can have your list of stations checked by internet databases."
+msgstr ""
+"Sie können Ihre Liste von Sendern von Internetdatenbanken überprüfen lassen."
+
+#: applet.js:337
+msgid ""
+"Any station recognized by one of these databases will receive a Universal "
+"Unique Identifier (UUID) provided by this database."
+msgstr ""
+"Jeder Sender, der von einer dieser Datenbanken erkannt wird, erhält eine "
+"Universell Eindeutige Kennung (UUID), die von dieser Datenbank "
+"bereitgestellt wird."
+
+#: applet.js:338
+msgid ""
+"So, if a streaming URL was changed, a next check would update it and you can "
+"continue to listen to the affected station."
+msgstr ""
+"Wenn sich also eine Streaming-URL geändert hat, würde eine nächste "
+"Überprüfung sie aktualisieren, und Sie können den betroffenen Sender "
+"weiterhin hören."
+
+#: applet.js:340
+msgid ""
+"Here you can search for other stations in a free radio database accessible "
+"via the Internet."
+msgstr ""
+"Hier können Sie nach anderen Sendern in einer freien Radiodatenbank suchen, "
+"die über das Internet zugänglich ist."
+
+#: applet.js:341
+msgid ""
+"Fill in at least a few fields of the form below then click on the "
+"'Search ...' button."
+msgstr ""
+"Füllen Sie mindestens ein paar Felder des unten stehenden Formulars aus und "
+"klicken Sie dann auf die Schaltfläche 'Suchen ...'."
+
+#: applet.js:342
+msgid ""
+"Each time this button is clicked, a new results page is displayed in the "
+"second part of this page, where you can test certain stations and include "
+"them in the menu."
+msgstr ""
+"Jedes Mal, wenn diese Schaltfläche angeklickt wird, wird eine neue "
+"Ergebnisseite im zweiten Teil dieser Seite angezeigt, auf der Sie bestimmte "
+"Sender testen und in das Menü aufnehmen können."
+
+#: applet.js:343
+msgid ""
+"A station already in your menu will only appear in search results if its "
+"streaming URL has changed."
+msgstr ""
+"Ein Sender, der bereits in Ihrem Menü ist, erscheint nur in den "
+"Suchergebnissen, wenn sich seine Streaming-URL geändert hat."
+
+#: applet.js:344
+msgid ""
+"When no new page appears, it means that all results matching your search "
+"criteria have been displayed."
+msgstr ""
+"Wenn keine neue Seite erscheint, bedeutet das, dass alle Ergebnisse, die "
+"Ihren Suchkriterien entsprechen, angezeigt wurden."
+
+#: applet.js:346
+msgid ""
+"You can import a file containing the name and streaming URL of at least one "
+"radio station."
+msgstr ""
+"Sie können eine Datei importieren, die den Namen und die Streaming-URL von "
+"mindestens einem Radiosender enthält."
+
+#: applet.js:347
+msgid ""
+"These radio stations are displayed in the list below. You can test them by "
+"checking their ♪ box."
+msgstr ""
+"Diese Radiosender werden in der Liste unten angezeigt. Sie können sie "
+"testen, indem Sie ihr ♪-Feld aktivieren."
+
+#: applet.js:348
+msgid "Then manage this list with the buttons at the bottom of this tab."
+msgstr ""
+"Verwalten Sie diese Liste dann mit den Schaltflächen am unteren Rand dieses "
+"Tabs."
+
+#: applet.js:350
+msgid ""
+"In the Shoutcast directory, click the download button to the left of the "
+"station name."
+msgstr ""
+"Im Shoutcast-Verzeichnis klicken Sie auf die Schaltfläche zum Herunterladen "
+"links neben dem Sendernamen."
+
+#: applet.js:351
+msgid ""
+"Select the open format (.XSPF) and save the file giving it the same name as "
+"the station."
+msgstr ""
+"Wählen Sie das offene Format (.XSPF) und speichern Sie die Datei, indem Sie "
+"ihr denselben Namen wie dem Sender geben."
+
+#: applet.js:352
+msgid "This file can then be imported here."
+msgstr "Diese Datei kann dann hier importiert werden."
+
+#: applet.js:354
+#, javascript-format
+msgid "%s bytes = %s GB = %s GiB"
+msgstr "%s Bytes = %s GB = %s GiB"
+
+#. settings-schema.json->category-to-move->options
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->sched-radio->options
+#. settings-schema.json->search-country->options
+#. settings-schema.json->search-codec->options
+#. settings-schema.json->search-order->options
+#: applet.js:520 applet.js:534 applet.js:5047 applet.js:5059
+msgid "(Undefined)"
+msgstr "(Undefiniert)"
+
+#: applet.js:732
+msgid "Radio3.0 web page..."
+msgstr "Radio3.0 Website ..."
+
+#: applet.js:2056
+msgid "Start"
+msgstr "Start"
+
+#: applet.js:2064 applet.js:2768
+msgid "Stop"
+msgstr "Stop"
+
+# Better use "Mittelklick"?
+#: applet.js:2299 applet.js:2335 applet.js:2382
+msgid "Middle-Click: Stop Recording"
+msgstr "Klick mit mittlerer Maustaste: Aufnahme stoppen"
+
+#: applet.js:2331 applet.js:2378
+msgid "Volume: %s%"
+msgstr "Lautstärke: %s%"
+
+#: applet.js:2337 applet.js:2384
+msgid "Middle-click: ON/OFF"
+msgstr "Klick mit mittlerer Maustaste: EIN/AUS"
+
+#: applet.js:2339 applet.js:2386
+msgid "Click: Select another station"
+msgstr "Klicken: Anderen Sender auswählen"
+
+#: applet.js:2352
+msgid "Click to select a station"
+msgstr "Klicken, um einen Sender auszuwählen"
+
+#: applet.js:2388
+msgid "Scroll wheel: volume change"
+msgstr "Scrollrad: Lautstärke ändern"
+
+#: applet.js:2438 applet.js:2786 applet.js:4663
+msgid "Configure..."
+msgstr "Konfigurieren..."
+
+#: applet.js:2442 applet.js:2778
+msgid "Search for new stations..."
+msgstr "Nach neuen Sendern suchen..."
+
+#: applet.js:2448 applet.js:2790 applet.js:4700
+msgid "Sound Settings"
+msgstr "Toneinstellungen"
+
+#: applet.js:2518
+msgid "Watch on YT"
+msgstr "Auf YT ansehen"
+
+#: applet.js:2525
+msgid "Try to download it from YT (unsafe)"
+msgstr "Versuchen, es von YT herunterzuladen (unsicher)"
+
+#: applet.js:2588
+msgid "Recently Played Stations:"
+msgstr "Kürzlich gespielte Sender:"
+
+#: applet.js:2630
+msgid "Visit the home page of this station"
+msgstr "Besuchen Sie die Homepage dieses Senders"
+
+#: applet.js:2669
+msgid "Categories"
+msgstr "Kategorien"
+
+#: applet.js:2671
+msgid "Radio Stations"
+msgstr "Radiosender"
+
+#: applet.js:2681
+msgid "All Categories"
+msgstr "Alle Kategorien"
+
+#: applet.js:2711
+msgid "My Radio Stations"
+msgstr "Meine Radiosender"
+
+#: applet.js:2910
+msgid "Downloading..."
+msgstr "Herunterladen..."
+
+#: applet.js:2912
+msgid "Stop downloading"
+msgstr "Herunterladen stoppen"
+
+#: applet.js:3016
+msgid "Download complete"
+msgstr "Download abgeschlossen"
+
+#. settings-schema.json->button-open-rec-folder->description
+#. settings-schema.json->recordings-open-folder->description
+#: applet.js:3018 applet.js:3027 applet.js:4462 applet.js:4471 applet.js:4480
+#: applet.js:4790
+msgid "Open the recordings folder"
+msgstr "Öffnen Sie den Aufnahmen-Ordner"
+
+#: applet.js:3025 applet.js:4459 applet.js:4469 applet.js:4478
+msgid "An error seems to have occurred during recording!"
+msgstr "Während der Aufnahme scheint ein Fehler aufgetreten zu sein!"
+
+#: applet.js:3026 applet.js:4461 applet.js:4470 applet.js:4479
+msgid "Please check this record."
+msgstr "Bitte überprüfen Sie diese Aufnahme."
+
+#: applet.js:3133 applet.js:3167
+msgid "Record from now"
+msgstr "Jetzt aufnehmen"
+
+#: applet.js:3151 applet.js:4953
+msgid "Stop Current Recording"
+msgstr "Aktuelle Aufnahme stoppen"
+
+#: applet.js:3279
+#, javascript-format
+msgid "Playing %s%s"
+msgstr "Spielt %s%s"
+
+#: applet.js:3332
+msgid "Radio OFF"
+msgstr "Radio AUS"
+
+#: applet.js:3460
+msgid "Unable to record anything!"
+msgstr "Kann nichts aufnehmen!"
+
+#: applet.js:3460 applet.js:4810
+msgid "Insufficient space"
+msgstr "Unzureichender Speicherplatz"
+
+#: applet.js:3460
+msgid "The limit you set has been reached."
+msgstr "Das von Ihnen gesetzte Limit wurde erreicht."
+
+# Please check. But comma should be okay here since there is a 2nd part.
+#: applet.js:3846
+msgid "Please Log Out then Log In"
+msgstr "Bitte loggen Sie sich aus und dann wieder ein"
+
+#: applet.js:3846
+msgid "to finalize yt-dlp update"
+msgstr "um das yt-dlp-Update abzuschließen"
+
+#: applet.js:3951
+msgid "Nothing to save."
+msgstr "Nichts zu speichern."
+
+#: applet.js:3964
+msgid "List of saved radio stations"
+msgstr "Liste der gespeicherten Radiosender"
+
+#: applet.js:3982
+msgid "This will replace all current radio stations."
+msgstr "Dies wird alle aktuellen Radiosender ersetzen."
+
+#: applet.js:3983
+msgid "Are you sure you want to continue?"
+msgstr "Sind Sie sicher, dass Sie fortfahren möchten?"
+
+#: applet.js:4043
+msgid "Update in progress"
+msgstr "Update läuft"
+
+#: applet.js:4043
+msgid "It may take a while ... Please wait."
+msgstr "Es kann eine Weile dauern ... Bitte warten."
+
+#: applet.js:4133
+msgid "Update completed successfully"
+msgstr "Update erfolgreich abgeschlossen"
+
+#: applet.js:4343 applet.js:4399
+msgid "ERROR: Invalid YT video URL!"
+msgstr "FEHLER: Ungültige YT-Video-URL!"
+
+#: applet.js:4368
+msgid "Unable to extract a single soundtrack"
+msgstr "Kann keinen einzelnen Soundtrack extrahieren"
+
+#: applet.js:4368
+msgid "Maybe it's a playlist?"
+msgstr "Vielleicht ist es eine Playlist?"
+
+#: applet.js:4401
+msgid "Close"
+msgstr "Schließen"
+
+#: applet.js:4621
+msgid "About..."
+msgstr "Über..."
+
+#: applet.js:4644
+msgid "Manual..."
+msgstr "Handbuch..."
+
+#: applet.js:4676
+msgid "Schedule a background record..."
+msgstr "Hintergrundaufnahme planen..."
+
+#: applet.js:4688
+msgid "Extract soundtrack from YouTube video..."
+msgstr "Soundtrack aus YouTube-Video extrahieren..."
+
+#: applet.js:4709
+msgid "Pulse Effects"
+msgstr "Pulse-Effekte"
+
+#: applet.js:4718
+msgid "Easy Effects"
+msgstr "Einfache Effekte"
+
+#: applet.js:4727
+#, javascript-format
+msgid "Remove '%s'"
+msgstr "Entfernen '%s'"
+
+#: applet.js:4740
+msgid "Radio ON at startup"
+msgstr "Radio beim Start einschalten"
+
+#: applet.js:4754
+msgid "Display Station Logo"
+msgstr "Senderlogo anzeigen"
+
+#. settings-schema.json->dont-check-dependencies->description
+#: applet.js:4768
+msgid "Do not check about dependencies"
+msgstr "Nicht nach Abhängigkeiten prüfen"
+
+#: applet.js:4807
+msgid "(auto)"
+msgstr "(auto)"
+
+#: applet.js:4807
+msgid "(manual)"
+msgstr "(manuell)"
+
+#: applet.js:4810 applet.js:5002
+msgid "Stop Recording"
+msgstr "Aufnahme stoppen"
+
+#: applet.js:4810
+msgid "Start Recording"
+msgstr "Aufnahme starten"
+
+#: applet.js:4831
+msgid "Reload this applet"
+msgstr "Dieses Applet neu laden"
+
+#. settings-schema.json->show-volume-level-near-icon->description
+#: applet.js:4847
+msgid "Display volume level near icon"
+msgstr "Lautstärkepegel neben dem Symbol anzeigen"
+
+#: applet.js:4865
+msgid "Cancel downloads from YT"
+msgstr "Downloads von YT abbrechen"
+
+#: applet.js:5003
+msgid "Close without stopping recording"
+msgstr "Schließen ohne Aufnahme zu stoppen"
+
+#: applet.js:5213
+#, javascript-format
+msgid "Starting recording from %s:%s to %s:%s"
+msgstr "Aufnahme startet von %s:%s bis %s:%s"
+
+#: applet.js:5225
+msgid "Recording completed"
+msgstr "Aufnahme abgeschlossen"
+
+#: applet.js:5320
+msgid "This will import a new file containing radio stations."
+msgstr "Dies wird eine neue Datei mit Radiosendern importieren."
+
+#: applet.js:5321
+msgid "Do you want to continue?"
+msgstr "Möchten Sie fortfahren?"
+
+#: applet.js:5392
+msgid "No new radio in your list."
+msgstr "Kein neuer Sender in Ihrer Liste."
+
+#: applet.js:5394
+msgid "One more radio in your list."
+msgstr "Ein weiterer Sender in Ihrer Liste."
+
+#: applet.js:5396
+#, javascript-format
+msgid "%s more radios in your list."
+msgstr "%s weitere Sender in Ihrer Liste."
+
+#: applet.js:5603
+msgid "There are no new stations to add to the Radio3.0 applet menu"
+msgstr ""
+"Es gibt keine neuen Sender, die dem Radio3.0-Applet-Menü hinzugefügt werden "
+"können"
+
+#: applet.js:5605
+msgid "A new station has been added to the Radio3.0 applet menu"
+msgstr "Ein neuer Sender wurde dem Radio3.0-Applet-Menü hinzugefügt"
+
+#: applet.js:5607
+#, javascript-format
+msgid "%s new stations have been added to the Radio3.0 applet menu"
+msgstr "%s neue Sender wurden dem Radio3.0-Applet-Menü hinzugefügt"
+
+#: applet.js:5808
+#, javascript-format
+msgid "%s kbps"
+msgstr "%s kbps"
+
+#: lib/checkDependencies.js:392
+#, javascript-format
+msgid "The applet %s is fully functional."
+msgstr "Das Applet %s ist voll funktionsfähig."
+
+#: lib/checkDependencies.js:393
+msgid "All dependencies are installed"
+msgstr "Alle Abhängigkeiten sind installiert"
+
+#: lib/checkDependencies.js:423
+msgid ""
+"You appear to be missing some of the programs required for this applet to "
+"have all its features."
+msgstr ""
+"Es scheint, dass einige der Programme fehlen, die für dieses Applet "
+"erforderlich sind für einen vollen Funktionsumfang."
+
+#: lib/checkDependencies.js:424
+msgid "Please execute, in the just opened terminal, the commands:"
+msgstr "Bitte führen Sie im gerade geöffneten Terminal die Befehle aus:"
+
+#: lib/checkDependencies.js:425
+msgid "Some dependencies are not installed!"
+msgstr "Einige Abhängigkeiten sind nicht installiert!"
+
+#: lib/checkTranslations.js:108
+msgid "To finalize the translation installation, please restart Cinnamon"
+msgstr ""
+"Um die Übersetzungsinstallation abzuschließen, bitte Cinnamon neu starten"
+
+#: lib/util.js:245
+#, javascript-format
+msgid "Execution of '%s' failed:"
+msgstr "Ausführung von '%s' fehlgeschlagen:"
+
+#: xs/xlet-settings.py:214
+msgid "Previous instance"
+msgstr "Vorherige Instanz"
+
+#: xs/xlet-settings.py:218
+msgid "Next instance"
+msgstr "Nächste Instanz"
+
+#: xs/xlet-settings.py:227
+msgid "More options"
+msgstr "Weitere Optionen"
+
+#: xs/xlet-settings.py:233
+msgid "Import from a file"
+msgstr "Aus einer Datei importieren"
+
+#: xs/xlet-settings.py:238
+msgid "Export to a file"
+msgstr "In eine Datei exportieren"
+
+#: xs/xlet-settings.py:243
+msgid "Reset to defaults"
+msgstr "Auf Standardeinstellungen zurücksetzen"
+
+#: xs/xlet-settings.py:252
+#, python-format
+msgid "Reload %s"
+msgstr "%s neu laden"
+
+#: xs/xlet-settings.py:441
+#, python-format
+msgid "Settings for %s"
+msgstr "Einstellungen für %s"
+
+#: xs/xlet-settings.py:533
+msgid "Select or enter file to export to"
+msgstr "Datei zum Exportieren auswählen oder eingeben"
+
+#: xs/xlet-settings.py:541 xs/xlet-settings.py:562
+msgid "JSON files"
+msgstr "JSON-Dateien"
+
+#: xs/xlet-settings.py:555
+msgid "Select a JSON file to import"
+msgstr "JSON-Datei zum Importieren auswählen"
+
+#: xs/bin/R3TreeListWidgets.py:278 xs/bin/R3TreeListWidgets.py:501
+msgid "Add new entry"
+msgstr "Neuen Eintrag hinzufügen"
+
+#: xs/bin/R3TreeListWidgets.py:282
+msgid "Remove selected entry"
+msgstr "Ausgewählten Eintrag entfernen"
+
+#: xs/bin/R3TreeListWidgets.py:287
+msgid "Edit selected entry"
+msgstr "Ausgewählten Eintrag bearbeiten"
+
+#: xs/bin/R3TreeListWidgets.py:292
+msgid "Unselect the selected row"
+msgstr "Ausgewählte Zeile abwählen"
+
+#: xs/bin/R3TreeListWidgets.py:297
+msgid "Move selected entry up"
+msgstr "Ausgewählten Eintrag nach oben verschieben"
+
+#: xs/bin/R3TreeListWidgets.py:302
+msgid "Move selected entry down"
+msgstr "Ausgewählten Eintrag nach unten verschieben"
+
+#: xs/bin/R3TreeListWidgets.py:325
+msgid "Go to bottom"
+msgstr "Zum Ende gehen"
+
+#: xs/bin/R3TreeListWidgets.py:331
+msgid "Go to next page"
+msgstr "Zur nächsten Seite gehen"
+
+#: xs/bin/R3TreeListWidgets.py:337
+msgid "Go to previous page"
+msgstr "Zur vorherigen Seite gehen"
+
+#: xs/bin/R3TreeListWidgets.py:342
+msgid "Go to top"
+msgstr "Zum Anfang gehen"
+
+#: xs/bin/R3TreeListWidgets.py:356
+msgid "Go to next category"
+msgstr "Zur nächsten Kategorie gehen"
+
+#: xs/bin/R3TreeListWidgets.py:366
+msgid "Go to previous category"
+msgstr "Zur vorherigen Kategorie gehen"
+
+#: xs/bin/R3TreeListWidgets.py:503
+msgid "Edit entry"
+msgstr "Eintrag bearbeiten"
+
+#. metadata.json->description
+msgid "The Ultimate Internet Radio Receiver & Recorder for Cinnamon"
+msgstr "Der ultimative Internet-Radioempfänger & -Recorder für Cinnamon"
+
+#. metadata.json->name
+msgid "Radio3.0"
+msgstr "Radio3.0"
+
+#. settings-schema.json->pageStations->title
+#. settings-schema.json->import-list->description
+#. settings-schema.json->search-list->description
+msgid "Radios"
+msgstr "Radios"
+
+#. settings-schema.json->pageImport->title
+msgid "Import"
+msgstr "Importieren"
+
+#. settings-schema.json->pageSearch->title
+msgid "Search"
+msgstr "Suchen"
+
+#. settings-schema.json->pageMenu->title
+#. settings-schema.json->sectionMenuMenu->title
+#. settings-schema.json->radios->columns->title
+msgid "Menu"
+msgstr "Menü"
+
+#. settings-schema.json->pageBehavior->title
+msgid "Behavior"
+msgstr "Verhalten"
+
+#. settings-schema.json->pageRecording->title
+msgid "Recording"
+msgstr "Aufnahme"
+
+#. settings-schema.json->pageYT->title
+msgid "YT"
+msgstr "YT"
+
+#. settings-schema.json->pageScheduling->title
+msgid "Scheduling"
+msgstr "Planung"
+
+#. settings-schema.json->pageNetwork->title
+msgid "Network"
+msgstr "Netzwerk"
+
+#. settings-schema.json->sectionStationsList->title
+msgid "Stations and Categories on the menu"
+msgstr "Sender und Kategorien im Menü"
+
+#. settings-schema.json->sectionStationsMove->title
+msgid "Moving selected stations"
+msgstr "Ausgewählte Sender verschieben"
+
+#. settings-schema.json->sectionStationsSaveRestore->title
+msgid "Save and Restore"
+msgstr "Speichern und Wiederherstellen"
+
+#. settings-schema.json->sectionStationsUpdate->title
+msgid "Update this station list"
+msgstr "Diese Senderliste aktualisieren"
+
+# Please check
+#. settings-schema.json->sectionImportShoutcast->title
+msgid "Get files on Shoutcast to import here"
+msgstr "Dateien von Shoutcast zum Importieren hier abrufen"
+
+#. settings-schema.json->sectionImportFile->title
+msgid "File to import"
+msgstr "Zu importierende Datei"
+
+#. settings-schema.json->sectionImportList->title
+msgid "File contents"
+msgstr "Dateiinhalte"
+
+#. settings-schema.json->sectionSearchOptions->title
+msgid "Search for Radio Stations"
+msgstr "Nach Radiosendern suchen"
+
+#. settings-schema.json->sectionSearchResults->title
+msgid "Search results"
+msgstr "Suchergebnisse"
+
+#. settings-schema.json->sectionBehaviorStartUp->title
+msgid "Start-up"
+msgstr "Start"
+
+#. settings-schema.json->sectionBehaviorVolumeStep->title
+msgid "Volume step"
+msgstr "Lautstärkeschritt"
+
+#. settings-schema.json->sectionBehaviorTooltip->title
+msgid "Show Help"
+msgstr "Hilfe anzeigen"
+
+#. settings-schema.json->sectionMenuPrivacy->title
+msgid "Privacy"
+msgstr "Datenschutz"
+
+#. settings-schema.json->sectionMenuContextual->title
+msgid "Contextual Menu"
+msgstr "Kontextmenü"
+
+#. settings-schema.json->sectionMenuShortcuts->title
+msgid "Keyboard shortcuts"
+msgstr "Tastaturkürzel"
+
+#. settings-schema.json->sectionBehaviorNotifications->title
+msgid "Notifications"
+msgstr "Benachrichtigungen"
+
+#. settings-schema.json->sectionBehaviorBitrate->title
+msgid "Codec and Bitrate"
+msgstr "Codec und Bitrate"
+
+# Better leave it as "Icon"?
+#. settings-schema.json->sectionBehaviorSymbolicIconColor->title
+#. settings-schema.json->sectionRecordingIcon->title
+#. settings-schema.json->sectionYTIcon->title
+msgid "Icon"
+msgstr "Symbol"
+
+#. settings-schema.json->sectionNetworkQuality->title
+msgid "Quality"
+msgstr "Qualität"
+
+#. settings-schema.json->sectionNetworkMonitoring->title
+msgid "Monitoring"
+msgstr "Überwachung"
+
+#. settings-schema.json->sectionNetworkProxy->title
+msgid "Proxy"
+msgstr "Proxy"
+
+#. settings-schema.json->sectionNetworkDatabase->title
+msgid "Database Info"
+msgstr "Datenbankinfo"
+
+#. settings-schema.json->sectionExperimental->title
+msgid "EXPERIMENTAL"
+msgstr "EXPERIMENTELL"
+
+#. settings-schema.json->sectionRecordingCache->title
+msgid "Cache"
+msgstr "Cache"
+
+#. settings-schema.json->sectionRecordingRecordings->title
+#. settings-schema.json->sectionYTFormat->title
+msgid "Recordings"
+msgstr "Aufnahmen"
+
+# Sounds weird!
+#. settings-schema.json->sectionRecordingLimits->title
+msgid "Preservation of hard disk space"
+msgstr "Erhaltung des Festplattenspeichers"
+
+#. settings-schema.json->sectionYTExtract->title
+msgid "Extract soundtrack from YouTube video"
+msgstr "Soundtrack aus YouTube-Video extrahieren"
+
+#. settings-schema.json->sectionRecordingScheduleARecording->title
+msgid "Schedule a background recording"
+msgstr "Eine Hintergrundaufnahme planen"
+
+#. settings-schema.json->sectionRecordingUnableToScheduleARecording->title
+msgid "Unable to schedule a background recording"
+msgstr "Eine Hintergrundaufnahme kann nicht geplant werden"
+
+#. settings-schema.json->sectionRecordingScheduledRecordings->title
+#. settings-schema.json->sched-recordings->description
+msgid "Scheduled recordings"
+msgstr "Geplante Aufnahmen"
+
+#. settings-schema.json->show-help-in-tabs->description
+msgid "Show help labels in each tab of this Settings window"
+msgstr "Hilfetexte in jedem Tab dieses Einstellungsfensters anzeigen"
+
+#. settings-schema.json->show-help-in-tabs->tooltip
+msgid ""
+"You can uncheck this option when you are familiar with all of these settings."
+msgstr ""
+"Sie können diese Option deaktivieren, wenn Sie mit allen diesen "
+"Einstellungen vertraut sind."
+
+#. settings-schema.json->stations-help->description
+#. settings-schema.json->button-update-help->description
+#. settings-schema.json->import-shoutcast-help->description
+#. settings-schema.json->import-help->description
+#. settings-schema.json->search-help->description
+msgid "Help"
+msgstr "Hilfe"
+
+#. settings-schema.json->radios->description
+msgid "List of stations"
+msgstr "Liste der Sender"
+
+#. settings-schema.json->radios->columns->title
+msgid "♪/➟"
+msgstr "♪/➟"
+
+#. settings-schema.json->radios->columns->title
+msgid "Station or Category"
+msgstr "Sender oder Kategorie"
+
+#. settings-schema.json->radios->columns->title
+#. settings-schema.json->import-list->columns->title
+#. settings-schema.json->search-list->columns->title
+msgid ""
+"Bitrate\n"
+"(kbps)"
+msgstr ""
+"Bitrate\n"
+"(kbps)"
+
+#. settings-schema.json->radios->columns->title
+#. settings-schema.json->import-list->columns->title
+#. settings-schema.json->search-list->columns->title
+#. settings-schema.json->search-codec->description
+msgid "Codec"
+msgstr "Codec"
+
+#. settings-schema.json->radios->columns->title
+msgid "Streaming URL (empty for a category)"
+msgstr "Streaming-URL (leer für eine Kategorie)"
+
+#. settings-schema.json->radios->columns->title
+#. settings-schema.json->search-list->columns->title
+msgid "Unique identifier"
+msgstr "Eindeutige Kennung"
+
+#. settings-schema.json->radios->columns->title
+#. settings-schema.json->search-list->columns->title
+msgid "Home page"
+msgstr "Homepage"
+
+#. settings-schema.json->radios->columns->title
+#. settings-schema.json->search-list->columns->title
+msgid "Tags"
+msgstr "Tags"
+
+#. settings-schema.json->radios->columns->title
+#. settings-schema.json->search-list->columns->title
+msgid "Favicon"
+msgstr "Favicon"
+
+# Check this again!
+# Maybe "Künstler/Titel tauschen"
+#. settings-schema.json->radios->columns->title
+msgid "Artist/Title swap"
+msgstr "Künstler/Titel-Tausch"
+
+#. settings-schema.json->stations-list-play-button->description
+#. settings-schema.json->import-list-play-button->description
+#. settings-schema.json->search-list-play-button->description
+msgid "♪ Play the next station to test"
+msgstr "♪ Nächsten Sender zum Testen abspielen"
+
+#. settings-schema.json->category-to-move->description
+msgid "Category to which to move the selected stations:"
+msgstr "Kategorie, in die die ausgewählten Sender verschoben werden sollen:"
+
+#. settings-schema.json->button-moving->description
+msgid "➟ Move selected stations to this category"
+msgstr "➟ Ausgewählte Sender in diese Kategorie verschieben"
+
+#. settings-schema.json->button_go_to_category->description
+msgid "Go to this category"
+msgstr "Zu dieser Kategorie gehen"
+
+#. settings-schema.json->button-show-all->description
+msgid "Show all stations and categories in the menu"
+msgstr "Alle Sender und Kategorien im Menü anzeigen"
+
+#. settings-schema.json->button-hide-all->description
+msgid "Hide all stations and categories (so the menu becomes empty)"
+msgstr "Alle Sender und Kategorien ausblenden (damit das Menü leer wird)"
+
+#. settings-schema.json->button-save->description
+msgid "Save this list of stations"
+msgstr "Diese Senderliste speichern"
+
+#. settings-schema.json->button-restore->description
+msgid "Restore a list of stations"
+msgstr "Eine Liste von Sendern wiederherstellen"
+
+#. settings-schema.json->button_open_folder->description
+msgid "Open the folder containing these lists"
+msgstr "Den Ordner mit diesen Listen öffnen"
+
+#. settings-schema.json->button-update->description
+msgid "Update my station list with the Radio Database data"
+msgstr "Meine Senderliste mit den Daten der Radiodatenbank aktualisieren"
+
+#. settings-schema.json->scale-update->description
+#. settings-schema.json->recordings-extract-update->description
+msgid "%"
+msgstr "%"
+
+#. settings-schema.json->import-shoutcast-button->description
+msgid "Open the Shoutcast directory"
+msgstr "Das Shoutcast-Verzeichnis öffnen"
+
+#. settings-schema.json->import-file-button->description
+msgid "Import a .csv, .m3u, .pls, .xspf or .json file"
+msgstr "Eine .csv-, .m3u-, .pls-, .xspf- oder .json-Datei importieren"
+
+#. settings-schema.json->import-list->columns->title
+#. settings-schema.json->search-list->columns->title
+msgid "Select"
+msgstr "Auswählen"
+
+#. settings-schema.json->import-list->columns->title
+#. settings-schema.json->search-list->columns->title
+msgid "♪"
+msgstr "♪"
+
+#. settings-schema.json->import-list->columns->title
+msgid "Title"
+msgstr "Titel"
+
+#. settings-schema.json->import-list->columns->title
+#. settings-schema.json->search-list->columns->title
+msgid "Streaming URL"
+msgstr "Streaming-URL"
+
+#. settings-schema.json->import-list-button->description
+#. settings-schema.json->search-list-button->description
+msgid "Import the selected stations into my own list"
+msgstr "Die ausgewählten Sender in meine eigene Liste importieren"
+
+#. settings-schema.json->import-remove-from-list-button->description
+#. settings-schema.json->search-remove-from-list-button->description
+msgid "Remove selected items from this list"
+msgstr "Ausgewählte Elemente aus dieser Liste entfernen"
+
+#. settings-schema.json->import-select-all->description
+#. settings-schema.json->search-select-all->description
+msgid "Select all items"
+msgstr "Alle Elemente auswählen"
+
+#. settings-schema.json->import-unselect-all->description
+#. settings-schema.json->search-unselect-all->description
+msgid "Unselect all items"
+msgstr "Alle Elemente abwählen"
+
+#. settings-schema.json->search-list->columns->title
+#. settings-schema.json->sched-recordings->columns->title
+msgid "Station"
+msgstr "Sender"
+
+# Is the line break intended here?
+#. settings-schema.json->search-list->columns->title
+msgid ""
+"Country\n"
+"Code"
+msgstr ""
+"Länder\n"
+"Code"
+
+#. settings-schema.json->search-list->columns->title
+#. settings-schema.json->search-country->description
+msgid "Country"
+msgstr "Land"
+
+#. settings-schema.json->search-list-page-label->description
+msgid "Page:"
+msgstr "Seite:"
+
+#. settings-schema.json->switch-on-last-station-at-start-up->description
+msgid "Turn on the radio when Cinnamon starts up"
+msgstr "Radio einschalten, wenn Cinnamon startet"
+
+# Long sentence. Maybe improve.
+#. settings-schema.json->switch-on-last-station-at-start-up->tooltip
+msgid ""
+"The selected radio will be the last you listened to, even if you stopped "
+"it.\n"
+"\n"
+"VPN users: By checking this, the radio broadcast could use your VPN link in "
+"the event that this one is active before the start of this applet."
+msgstr ""
+"Der ausgewählte Sender wird der letzte sein, den Sie gehört haben, auch wenn "
+"Sie ihn gestoppt haben.\n"
+"\n"
+"VPN-Benutzer: Wenn Sie dies aktivieren, dann kann die Übertragung Ihre VPN-"
+"Verbindung nutzen, falls diese aktiv ist, bevor dieses Applet gestartet wird."
+
+# Check please!
+#. settings-schema.json->volume-at-startup->description
+msgid "Volume level starting a new radio (%)"
+msgstr "Lautstärkepegel beim Start eines neuen Radios (%)"
+
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->recent-number->options
+#. settings-schema.json->search-minimalBitrate->options
+msgid "0"
+msgstr "0"
+
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->recent-number->options
+#. settings-schema.json->search-limit->options
+msgid "10"
+msgstr "10"
+
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->search-limit->options
+msgid "15"
+msgstr "15"
+
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->search-limit->options
+msgid "20"
+msgstr "20"
+
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->search-limit->options
+msgid "25"
+msgstr "25"
+
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->search-limit->options
+msgid "30"
+msgstr "39"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "35"
+msgstr "35"
+
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->search-limit->options
+msgid "40"
+msgstr "40"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "45"
+msgstr "45"
+
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->yt-progress-interval->options
+#. settings-schema.json->search-limit->options
+msgid "50"
+msgstr "50"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "55"
+msgstr "55"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "60"
+msgstr "60"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "65"
+msgstr "65"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "70"
+msgstr "70"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "75"
+msgstr "75"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "80"
+msgstr "80"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "85"
+msgstr "85"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "90"
+msgstr "90"
+
+#. settings-schema.json->volume-at-startup->options
+msgid "95"
+msgstr "95"
+
+#. settings-schema.json->volume-at-startup->options
+#. settings-schema.json->yt-progress-interval->options
+#. settings-schema.json->search-limit->options
+msgid "100"
+msgstr "100"
+
+# Maybe translate "volume level" only with "Lautstärke"?
+#. settings-schema.json->volume-at-startup->tooltip
+msgid ""
+"If set, then this will change the volume level starting a new radio, in "
+"percentage of the general volume level.\n"
+"Default is (Undefined): The volume level remains unchanged.\n"
+"\n"
+"Please note that you can change the volume level scrolling on this applet "
+"icon, or using the slider in the context menu."
+msgstr ""
+"Wenn festgelegt, ändert dies den Lautstärkepegel beim Start eines neuen "
+"Radios, in Prozent des allgemeinen Lautstärkepegels.\n"
+"Standard ist (Undefiniert): Der Lautstärkepegel bleibt unverändert.\n"
+"\n"
+"Bitte beachten Sie, dass Sie den Lautstärkepegel ändern können, indem Sie "
+"auf diesem Applet-Symbol scrollen oder den Schieberegler im Kontextmenü "
+"verwenden."
+
+#. settings-schema.json->volume-step->description
+msgid "Volume step scrolling on icon"
+msgstr "Lautstärkeschritt beim Scrollen auf dem Symbol"
+
+#. settings-schema.json->volume-step->options
+msgid "±0%"
+msgstr "±0%"
+
+#. settings-schema.json->volume-step->options
+msgid "±1%"
+msgstr "±1%"
+
+#. settings-schema.json->volume-step->options
+msgid "±2%"
+msgstr "±2%"
+
+#. settings-schema.json->volume-step->options
+msgid "±3%"
+msgstr "±3%"
+
+#. settings-schema.json->volume-step->options
+msgid "±4%"
+msgstr "±4%"
+
+#. settings-schema.json->volume-step->options
+msgid "±5%"
+msgstr "±5%"
+
+#. settings-schema.json->volume-step->tooltip
+msgid ""
+"By how much increase or decrease the volume using the mouse scroll wheel on "
+"the icon."
+msgstr ""
+"Um wie viel die Lautstärke beim Scrollen mit dem Mausrad auf dem Symbol "
+"erhöht oder verringert wird."
+
+# "magnetisieren" sounds weird
+#. settings-schema.json->volume-magnetic-on->description
+msgid "Magnetize all multiples of 25%"
+msgstr "Alle Vielfachen von 25 % magnetisieren"
+
+#. settings-schema.json->volume-show-osd->description
+msgid "Show OSD while changing volume"
+msgstr "OSD beim Ändern der Lautstärke anzeigen"
+
+#. settings-schema.json->volume-show-osd->tooltip
+msgid "Should OSD (On-Screen Display) be displayed when changing volume?"
+msgstr ""
+"Soll das OSD (On-Screen Display) beim Ändern der Lautstärke angezeigt werden?"
+
+#. settings-schema.json->volume-show-osd-starting-radio->description
+msgid "Show volume OSD when changing radio station"
+msgstr "Lautstärke-OSD beim Ändern des Radiosenders anzeigen"
+
+#. settings-schema.json->show-title-and-version->description
+msgid "Show the name and the version of this applet in the menu"
+msgstr "Den Namen und die Version dieses Applets im Menü anzeigen"
+
+#. settings-schema.json->recent-number->description
+msgid "Number of Recently Played Stations in menu"
+msgstr "Anzahl der zuletzt gespielten Sender im Menü"
+
+#. settings-schema.json->recent-number->options
+msgid "1"
+msgstr "1"
+
+#. settings-schema.json->recent-number->options
+msgid "2"
+msgstr "2"
+
+#. settings-schema.json->recent-number->options
+msgid "3"
+msgstr "3"
+
+#. settings-schema.json->recent-number->options
+msgid "4"
+msgstr "4"
+
+#. settings-schema.json->recent-number->options
+#. settings-schema.json->search-limit->options
+msgid "5"
+msgstr "5"
+
+#. settings-schema.json->recent-number->options
+msgid "6"
+msgstr "6"
+
+#. settings-schema.json->recent-number->options
+msgid "7"
+msgstr "7"
+
+#. settings-schema.json->recent-number->options
+msgid "8"
+msgstr "8"
+
+#. settings-schema.json->recent-number->options
+msgid "9"
+msgstr "9"
+
+#. settings-schema.json->recent-number->tooltip
+msgid "How many recently listened stations do you want to display in the menu?"
+msgstr "Wie viele kürzlich gehörte Sender möchten Sie im Menü anzeigen?"
+
+#. settings-schema.json->reset-recents->description
+msgid "Empty your Recently Played Stations list at startup"
+msgstr "Liste der kürzlich gespielten Sender beim Start leeren"
+
+#. settings-schema.json->button-reset-recents->description
+msgid "Empty your Recently Played Stations list now"
+msgstr "Liste der kürzlich gespielten Sender jetzt leeren"
+
+#. settings-schema.json->show-by-category->description
+msgid "Display the Station list beside the Category list"
+msgstr "Senderliste neben der Kategorieliste anzeigen"
+
+#. settings-schema.json->show-by-category->tooltip
+msgid ""
+"Checked: Hover (without clicking) over a Category to display its list of "
+"Stations; then select your station.\n"
+"Unchecked: Single list containing each category followed by its stations."
+msgstr ""
+"Markiert: Über eine Kategorie fahren (ohne zu klicken), um ihre Senderliste "
+"anzuzeigen; dann wählen Sie Ihren Sender aus.\n"
+"Nicht markiert: Eine Liste, die jede Kategorie gefolgt von ihren Sendern "
+"enthält."
+
+#. settings-schema.json->show-system-items->description
+msgid "Show system items in the menu"
+msgstr "Systemelemente im Menü anzeigen"
+
+#. settings-schema.json->show-system-items->tooltip
+msgid ""
+"Do you want to show 'Configure...' and 'Sound Settings' items in the menu?"
+msgstr ""
+"Möchten Sie die Elemente 'Konfigurieren...' und 'Toneinstellungen' im Menü "
+"anzeigen?"
+
+#. settings-schema.json->show-reload->description
+msgid "Show the 'Reload this applet' item in the contextual menu"
+msgstr "Das Element 'Dieses Applet neu laden' im Kontextmenü anzeigen"
+
+#. settings-schema.json->show-reload->tooltip
+msgid "For developers only"
+msgstr "Nur für Entwickler"
+
+#. settings-schema.json->shortcut-volume-up->description
+msgid "Increase Volume"
+msgstr "Lautstärke erhöhen"
+
+#. settings-schema.json->shortcut-volume-down->description
+msgid "Decrease Volume"
+msgstr "Lautstärke verringern"
+
+#. settings-schema.json->shortcut-volume-cut->description
+msgid "Mute"
+msgstr "Stummschalten"
+
+#. settings-schema.json->shortcut-radio-on-off->description
+msgid "Radio ON/OFF"
+msgstr "Radio EIN/AUS"
+
+#. settings-schema.json->shortcut-next-recent-radio->description
+msgid "Next station"
+msgstr "Nächster Sender"
+
+#. settings-schema.json->shortcut-next-recent-radio->tooltip
+msgid "Next station recently listened to"
+msgstr "Nächster kürzlich gehörter Sender"
+
+#. settings-schema.json->shortcut-previous-recent-radio->description
+msgid "Previous station"
+msgstr "Vorheriger Sender"
+
+#. settings-schema.json->shortcut-previous-recent-radio->tooltip
+msgid "Previous station recently listened to"
+msgstr "Vorheriger kürzlich gehörter Sender"
+
+#. settings-schema.json->show-help-in-tooltip->description
+msgid "Show help for mouse actions in the tooltip"
+msgstr "Hilfe für Mausaktionen im Tooltip anzeigen"
+
+#. settings-schema.json->show-help-in-tooltip->tooltip
+msgid "You can uncheck this option when you are familiar with all mouse roles."
+msgstr ""
+"Sie können diese Option deaktivieren, wenn Sie mit allen Mausfunktionen "
+"vertraut sind."
+
+# Is here ment the station?
+#. settings-schema.json->notif-station-change->description
+msgid "Change of radio"
+msgstr "Wechsel des Radios"
+
+#. settings-schema.json->notif-song-change->description
+msgid "Change of song or program"
+msgstr "Wechsel des Liedes oder Programms"
+
+#. settings-schema.json->notif-song-change->tooltip
+msgid ""
+"Please note that some radios do not notify you of a song or program change."
+msgstr ""
+"Bitte beachten Sie, dass einige Radios Sie nicht über einen Wechsel des "
+"Liedes oder Programms informieren."
+
+#. settings-schema.json->notif-song-duration->units
+msgid "seconds"
+msgstr "Sekunden"
+
+#. settings-schema.json->notif-song-duration->description
+msgid "Duration of a song or program change notification"
+msgstr "Dauer einer Benachrichtigung über einen Lied- oder Programmwechsel"
+
+#. settings-schema.json->notif-buttons-allowed->description
+msgid "Show in notifications the buttons to start and stop recordings"
+msgstr ""
+"In den Benachrichtigungen die Schaltflächen zum Starten und Stoppen von "
+"Aufnahmen anzeigen"
+
+#. settings-schema.json->notif-buttons-allowed->tooltip
+msgid ""
+"Please note that this will have no effect if you do not wish to be notified "
+"of a song or program change."
+msgstr ""
+"Bitte beachten Sie, dass dies keine Wirkung hat, wenn Sie nicht über einen "
+"Lied- oder Programmwechsel benachrichtigt werden möchten."
+
+#. settings-schema.json->show-codec->description
+msgid "Show codec"
+msgstr "Codec anzeigen"
+
+#. settings-schema.json->show-bitrate->description
+msgid "Show bit rate"
+msgstr "Bitrate anzeigen"
+
+#. settings-schema.json->show-bitrate->tooltip
+msgid ""
+"Unit: kbps (kilobit per second).\n"
+"The higher this bit rate, the better the sound quality of the stream."
+msgstr ""
+"Einheit: kbps (Kilobit pro Sekunde).\n"
+"Je höher diese Bitrate, desto besser die Klangqualität des Streams."
+
+#. settings-schema.json->color-on->description
+msgid "Color of the symbolic icon while the radio is on"
+msgstr "Farbe des symbolischen Symbols, während das Radio eingeschaltet ist"
+
+#. settings-schema.json->color-off->description
+msgid "Color of the symbolic icon while the radio is off"
+msgstr "Farbe des symbolischen Symbols, während das Radio ausgeschaltet ist"
+
+#. settings-schema.json->color-recording->description
+msgid "Color of the symbolic icon while recording"
+msgstr "Farbe des symbolischen Symbols während der Aufnahme"
+
+#. settings-schema.json->show-favicon->description
+msgid "Display the logo of the radio station listened to"
+msgstr "Das Logo des gehörten Radiosenders anzeigen"
+
+#. settings-schema.json->show-favicon->tooltip
+msgid "Replace this applet icon with the radio station logo, if it exists."
+msgstr ""
+"Dieses Applet-Symbol durch das Logo des Radiosenders ersetzen, falls "
+"vorhanden."
+
+#. settings-schema.json->network-quality->description
+msgid "Network Quality"
+msgstr "Netzwerkqualität"
+
+#. settings-schema.json->network-quality->options
+msgid "High"
+msgstr "Hoch"
+
+#. settings-schema.json->network-quality->options
+msgid "Low"
+msgstr "Niedrig"
+
+# Please improve!
+#. settings-schema.json->network-quality->tooltip
+msgid ""
+"High Quality: The recordings you make while listening to the radio will "
+"double the bit rate usually required to just listen to the radio. Thus, the "
+"recordings will not be disturbed by extraneous sounds or by a change in the "
+"volume of the radio.\n"
+"\n"
+"Low Quality: These recordings come directly from the sound card, which "
+"relieves the network but risks polluting them with extraneous sounds (system "
+"sounds for example). The volume of the radio will be set to 100% in order to "
+"obtain the best possible quality."
+msgstr ""
+"Hohe Qualität: Die Aufnahmen, die Sie beim Radiohören machen, verdoppeln die "
+"normalerweise zum Radiohören erforderliche Bitrate. So werden die Aufnahmen "
+"nicht durch Fremdgeräusche oder eine Änderung der Radio-Lautstärke gestört.\n"
+"\n"
+"Niedrige Qualität: Diese Aufnahmen kommen direkt von der Soundkarte, was das "
+"Netzwerk entlastet, aber das Risiko birgt, sie mit Fremdgeräuschen (z. B. "
+"Systemgeräuschen) zu verschmutzen. Die Lautstärke des Radios wird auf 100 % "
+"gesetzt, um die bestmögliche Qualität zu erzielen."
+
+#. settings-schema.json->network-monitoring->description
+msgid "Monitor the network"
+msgstr "Netzwerk überwachen"
+
+#. settings-schema.json->network-monitoring->tooltip
+msgid ""
+"Whether or not to restart the radio when the network becomes active again "
+"after an interruption.\n"
+"\n"
+"VPN users: By checking this, the radio broadcast may use your VPN link."
+msgstr ""
+"Ob das Radio neu gestartet werden soll oder nicht, wenn das Netzwerk nach "
+"einer Unterbrechung wieder aktiv wird.\n"
+"\n"
+"VPN-Benutzer: Wenn Sie dies aktivieren, kann die Übertragung Ihre VPN-"
+"Verbindung nutzen."
+
+#. settings-schema.json->http-proxy->description
+msgid "HTTP Proxy"
+msgstr "HTTP-Proxy"
+
+#. settings-schema.json->http-proxy->tooltip
+msgid ""
+"Format: http://[user:pass@]URL[:port]\n"
+"Default: empty.\n"
+"If empty, the environment variables http_proxy and ALL_PROXY will be used if "
+"present.\n"
+"If set, this proxy will not be used for https requests."
+msgstr ""
+"Format: http://[Benutzername:Passwort@]URL[:Port]\n"
+"Standard: leer.\n"
+"Wenn leer, werden die Umgebungsvariablen http_proxy und ALL_PROXY verwendet, "
+"falls vorhanden.\n"
+"Wenn festgelegt, wird dieser Proxy nicht für HTTPS-Anfragen verwendet."
+
+#. settings-schema.json->apply-http-proxy->description
+msgid "Apply HTTP Proxy"
+msgstr "HTTP-Proxy anwenden"
+
+#. settings-schema.json->database-favorite->description
+msgid "Your favorite database:"
+msgstr "Ihre bevorzugte Datenbank:"
+
+#. settings-schema.json->database-favorite->options
+msgid "Random"
+msgstr "Zufällig"
+
+#. settings-schema.json->database-url->description
+msgid "Database URL"
+msgstr "Datenbank-URL"
+
+#. settings-schema.json->cache-no-cache->description
+msgid "No cache"
+msgstr "Kein Cache"
+
+#. settings-schema.json->cache-no-cache->tooltip
+msgid ""
+"Checking this option limits memory usage, but no longer allows the user to "
+"rewind the cache (using the sound150@claudiux applet)."
+msgstr ""
+"Wenn Sie diese Option aktivieren, wird der Speicherverbrauch begrenzt, aber "
+"es ist nicht mehr möglich, den Cache zurückzuspulen (mit dem "
+"sound150@claudiux-Applet)."
+
+#. settings-schema.json->cache-mins->description
+msgid ""
+"Minutes to cache\n"
+"0 means no limit (default). 1 hour = 60 minutes. 24 hours = 1440 minutes."
+msgstr ""
+"Minuten zum Cachen\n"
+"0 bedeutet kein Limit (Standard). 1 Stunde = 60 Minuten. 24 Stunden = 1440 "
+"Minuten."
+
+#. settings-schema.json->cache-on-disk->description
+msgid ""
+"Cache on disk\n"
+"(Write packet data to a temporary file, instead of keeping them in memory.)"
+msgstr ""
+"Cache auf Festplatte\n"
+"(Paketdaten in eine temporäre Datei schreiben, anstatt sie im Speicher zu "
+"halten.)"
+
+#. settings-schema.json->cache-dir->description
+msgid ""
+"Directory used for data caching\n"
+"(Use with caution on SSD disks. Prefer a directory stored in RAM, with "
+"sufficient free space.)"
+msgstr ""
+"Verzeichnis für die Datencache-Nutzung\n"
+"(Vorsicht bei SSD-Festplatten. Bevorzugen Sie ein Verzeichnis, das im RAM "
+"gespeichert ist, mit ausreichend freiem Speicherplatz.)"
+
+#. settings-schema.json->cache-dir-open->description
+msgid "Open cache directory"
+msgstr "Cache-Verzeichnis öffnen"
+
+#. settings-schema.json->cache-stream-size->description
+msgid "Stream cache size"
+msgstr "Stream-Cache-Größe"
+
+#. settings-schema.json->cache-stream-size->tooltip
+msgid ""
+"The amount of stream cache. Default: 1 MiB.\n"
+"Beware, setting this to a large value can reduce performance."
+msgstr ""
+"Die Menge des Stream-Caches. Standard: 1 MiB.\n"
+"Vorsicht, das Setzen auf einen großen Wert kann die Leistung verringern."
+
+#. settings-schema.json->cache-stream-size->options
+msgid "No limit"
+msgstr "Kein Limit"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "64 KiB"
+msgstr "64 KiB"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "128 KiB"
+msgstr "128 KiB"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "256 KiB"
+msgstr "256 KiB"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "512 KiB"
+msgstr "512 KiB"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "1 MiB"
+msgstr "1 MiB"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "2 Mib"
+msgstr "2 Mib"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "3 MiB"
+msgstr "3 MiB"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "4 MiB"
+msgstr "4 MiB"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "5 MiB"
+msgstr "5 MiB"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "10 MiB"
+msgstr "10 MiB"
+
+#. settings-schema.json->cache-stream-size->options
+msgid "20 MiB"
+msgstr "20 MiB"
+
+#. settings-schema.json->recording-path->description
+msgid "Path to the folder that will contain your future recordings"
+msgstr "Pfad zu dem Ordner, der Ihre zukünftigen Aufnahmen enthalten wird"
+
+#. settings-schema.json->button-rec-path-to-default->description
+msgid "Set this path to default one"
+msgstr "Diesen Pfad auf den Standardpfad setzen"
+
+#. settings-schema.json->recording-format->description
+msgid "Recording format"
+msgstr "Aufnahmeformat"
+
+#. settings-schema.json->recording-format->options
+#. settings-schema.json->search-codec->options
+msgid "FLAC"
+msgstr "FLAC"
+
+#. settings-schema.json->recording-format->options
+#. settings-schema.json->search-codec->options
+msgid "MP3"
+msgstr "MP3"
+
+#. settings-schema.json->recording-format->options
+#. settings-schema.json->search-codec->options
+msgid "OGG"
+msgstr "OGG"
+
+#. settings-schema.json->recording-format->options
+msgid "RAW"
+msgstr "RAW"
+
+#. settings-schema.json->recording-format->options
+msgid "WAV"
+msgstr "WAV"
+
+#. settings-schema.json->recording-format->tooltip
+#. settings-schema.json->recording-ends-auto->tooltip
+msgid ""
+"Please note that this choice will have no effect on any current recording, "
+"but on subsequent ones."
+msgstr ""
+"Bitte beachten Sie, dass diese Auswahl keine Auswirkungen auf aktuelle "
+"Aufnahmen hat, sondern auf nachfolgende."
+
+#. settings-schema.json->recording-ends-auto->description
+msgid "Way to stop recording"
+msgstr "Art, die Aufnahme zu stoppen"
+
+#. settings-schema.json->recording-ends-auto->options
+msgid "automatically, when the current song ends"
+msgstr "automatisch, wenn das aktuelle Lied endet"
+
+#. settings-schema.json->recording-ends-auto->options
+msgid "manually; thus, several recordings can follow one another"
+msgstr "manuell; so können mehrere Aufnahmen aufeinander folgen"
+
+#. settings-schema.json->limits-hd-space-left-label->description
+msgid "Space remaining on disk when opening this window:"
+msgstr ""
+"Verbleibender Speicherplatz auf der Festplatte beim Öffnen dieses Fensters:"
+
+#. settings-schema.json->limits-hd-size-prefixes->description
+msgid ""
+"Disk space unit as defined in Nemo's display preferences (File size prefixes)"
+msgstr ""
+"Festplattenspeichereinheit, wie in Nemos Anzeigeeinstellungen definiert "
+"(Dateigrößenpräfixe)"
+
+#. settings-schema.json->limits-hd-size-prefixes->options
+msgid "GB (decimal)"
+msgstr "GB (dezimal)"
+
+#. settings-schema.json->limits-hd-size-prefixes->options
+msgid "GB (decimal long)"
+msgstr "GB (dezimal lang)"
+
+#. settings-schema.json->limits-hd-size-prefixes->options
+msgid "GiB (binary)"
+msgstr "GiB (binär)"
+
+#. settings-schema.json->limits-hd-size-prefixes->options
+msgid "GiB (binary long)"
+msgstr "GiB (binär lang)"
+
+#. settings-schema.json->limits-hd-size-prefixes->tooltip
+msgid "Changing this also changes Nemo's file size prefixes."
+msgstr "Ändern Sie dies, um auch Nemos Dateigrößenpräfixe zu ändern."
+
+#. settings-schema.json->limits-hd-value->units
+msgid "Units: As defined above"
+msgstr "Einheiten: Wie oben definiert"
+
+#. settings-schema.json->limits-hd-value->description
+msgid "Space to be left free on the hard disk"
+msgstr "Freizuhaltender Speicherplatz auf der Festplatte"
+
+#. settings-schema.json->highlight-icon-while-background-
+#. recording->description
+msgid "Highlight this applet icon during background recording"
+msgstr "Dieses Applet-Symbol während der Hintergrundaufnahme hervorheben"
+
+#. settings-schema.json->yt-cookies-from->description
+msgid "Use cookies from"
+msgstr "Cookies verwenden von"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "(None)"
+msgstr "(Keine)"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "Brave"
+msgstr "Brave"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "Chrome"
+msgstr "Chrome"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "Chromium"
+msgstr "Chromium"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "Chromium (basictext)"
+msgstr "Chromium (basictext)"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "Chromium (gnomekeyring)"
+msgstr "Chromium (gnomekeyring)"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "Chromium (kwallet)"
+msgstr "Chromium (kwallet)"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "Firefox"
+msgstr "Firefox"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "Opera"
+msgstr "Opera"
+
+#. settings-schema.json->yt-cookies-from->options
+msgid "Vivaldi"
+msgstr "Vivaldi"
+
+#. settings-schema.json->yt-cookies-from->tooltip
+msgid ""
+"Cookies are used by YouTube to determine which videos you may watch. For "
+"Chromium, you can select the method (in parentheses) you chose to save "
+"cookies."
+msgstr ""
+"Cookies werden von YouTube verwendet, um zu bestimmen, welche Videos Sie "
+"ansehen dürfen. Für Chromium können Sie die Methode (in Klammern) auswählen, "
+"die Sie zum Speichern von Cookies gewählt haben."
+
+#. settings-schema.json->show-yt-progress->description
+msgid "Display, under the icon, the progress of downloads from YT."
+msgstr "Unter dem Symbol den Fortschritt der Downloads von YT anzeigen."
+
+#. settings-schema.json->yt-progress-interval->description
+msgid "Progression interval (ms)"
+msgstr "Fortschrittsintervall (ms)"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "Depending on network quality"
+msgstr "Abhängig von der Netzwerkqualität"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "150"
+msgstr "150"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "200"
+msgstr "200"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "300"
+msgstr "300"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "400"
+msgstr "400"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "500"
+msgstr "500"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "600"
+msgstr "600"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "750"
+msgstr "750"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "1000"
+msgstr "1000"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "2000"
+msgstr "2000"
+
+#. settings-schema.json->yt-progress-interval->options
+msgid "3000"
+msgstr "3000"
+
+#. settings-schema.json->recordings-extract-url->description
+msgid "YouTube video link"
+msgstr "YouTube-Video-Link"
+
+#. settings-schema.json->recordings-paste-button->description
+msgid "Paste above the YouTube link you copied"
+msgstr "Fügen Sie den oben kopierten YouTube-Link ein"
+
+#. settings-schema.json->recordings-yesno-playlist->description
+msgid "In case of playlist"
+msgstr "Im Falle einer Playlist"
+
+#. settings-schema.json->recordings-yesno-playlist->options
+msgid "Extract single soundtrack"
+msgstr "Einzelnen Soundtrack extrahieren"
+
+#. settings-schema.json->recordings-yesno-playlist->options
+msgid "Extract whole playlist"
+msgstr "Ganze Playlist extrahieren"
+
+#. settings-schema.json->recordings-keep-video->description
+msgid "Keep video (slower)"
+msgstr "Video behalten (langsamer)"
+
+#. settings-schema.json->recordings-keep-video->tooltip
+msgid ""
+"Whether or not to keep the intermediate video file on disk after post-"
+"processing"
+msgstr ""
+"Ob die Zwischenvideodatei nach der Nachbearbeitung auf der Festplatte "
+"behalten werden soll oder nicht"
+
+#. settings-schema.json->recordings-subdirectory->description
+msgid "Record in subdirectory"
+msgstr "In Unterverzeichnis aufnehmen"
+
+#. settings-schema.json->recordings-subdirectory->tooltip
+msgid "(without leading or trailing slash)"
+msgstr "(ohne führenden oder abschließenden Schrägstrich)"
+
+#. settings-schema.json->recordings-extract-button->description
+msgid "Extract soundtrack"
+msgstr "Soundtrack extrahieren"
+
+#. settings-schema.json->sched-radio->description
+msgid "Radio"
+msgstr "Radio"
+
+#. settings-schema.json->sched-begin-date->description
+#. settings-schema.json->sched-recordings->columns->title
+msgid "Date"
+msgstr "Datum"
+
+# Check: "Zeit" or really "Uhrzeit"?
+#. settings-schema.json->sched-begin-time->description
+msgid "Time"
+msgstr "Uhrzeit"
+
+#. settings-schema.json->sched-begin-time->tooltip
+#. settings-schema.json->sched-duration->tooltip
+msgid "Seconds will be ignored."
+msgstr "Sekunden werden ignoriert."
+
+#. settings-schema.json->sched-duration->description
+msgid "Duration"
+msgstr "Dauer"
+
+#. settings-schema.json->sched-button->description
+msgid "Schedule this recording"
+msgstr "Diese Aufnahme planen"
+
+#. settings-schema.json->sched-alert-no-space->description
+msgid "You are running out of disk space. See in the Recording tab."
+msgstr "Sie haben nur noch wenig Speicherplatz. Siehe im Aufnahme-Tab."
+
+#. settings-schema.json->sched-recordings->columns->title
+msgid "Remove?"
+msgstr "Entfernen?"
+
+#. settings-schema.json->sched-recordings->columns->title
+msgid "In progress"
+msgstr "In Bearbeitung"
+
+#. settings-schema.json->sched-recordings->columns->title
+msgid "Action"
+msgstr "Aktion"
+
+#. settings-schema.json->sched-recordings->columns->title
+msgid "Identifier"
+msgstr "Kennung"
+
+#. settings-schema.json->sched-recordings->tooltip
+msgid "Do not modify anything in this list, except in the \"Remove?\" column"
+msgstr "Ändern Sie nichts in dieser Liste, außer in der Spalte \"Entfernen?\""
+
+#. settings-schema.json->search-name->description
+msgid "Station Name"
+msgstr "Sendername"
+
+#. settings-schema.json->search-name->tooltip
+msgid "OPTIONAL. Name (or part of the name) of the radio station."
+msgstr "OPTIONAL. Name (oder Teil des Namens) des Radiosenders."
+
+#. settings-schema.json->search-country->options
+msgid "(My Country)"
+msgstr "(Mein Land)"
+
+#. settings-schema.json->search-country->options
+msgid "Afghanistan - AF"
+msgstr "Afghanistan - AF"
+
+#. settings-schema.json->search-country->options
+msgid "Åland Islands - AX"
+msgstr "Åland-Inseln - AX"
+
+#. settings-schema.json->search-country->options
+msgid "Albania - AL"
+msgstr "Albanien - AL"
+
+#. settings-schema.json->search-country->options
+msgid "Algeria - DZ"
+msgstr "Algerien - DZ"
+
+#. settings-schema.json->search-country->options
+msgid "American Samoa - AS"
+msgstr "Amerikanisch-Samoa - AS"
+
+#. settings-schema.json->search-country->options
+msgid "Andorra - AD"
+msgstr "Andorra - AD"
+
+#. settings-schema.json->search-country->options
+msgid "Angola - AO"
+msgstr "Angola - AO"
+
+#. settings-schema.json->search-country->options
+msgid "Anguilla - AI"
+msgstr "Anguilla - AI"
+
+#. settings-schema.json->search-country->options
+msgid "Antarctica - AQ"
+msgstr "Antarktis - AQ"
+
+#. settings-schema.json->search-country->options
+msgid "Antigua And Barbuda - AG"
+msgstr "Antigua und Barbuda - AG"
+
+#. settings-schema.json->search-country->options
+msgid "Argentina - AR"
+msgstr "Argentinien - AR"
+
+#. settings-schema.json->search-country->options
+msgid "Armenia - AM"
+msgstr "Armenien - AM"
+
+#. settings-schema.json->search-country->options
+msgid "Aruba - AW"
+msgstr "Aruba - AW"
+
+#. settings-schema.json->search-country->options
+msgid "Australia - AU"
+msgstr "Australien - AU"
+
+#. settings-schema.json->search-country->options
+msgid "Austria - AT"
+msgstr "Österreich - AT"
+
+#. settings-schema.json->search-country->options
+msgid "Azerbaijan - AZ"
+msgstr "Aserbaidschan - AZ"
+
+#. settings-schema.json->search-country->options
+msgid "Bahamas - BS"
+msgstr "Bahamas - BS"
+
+#. settings-schema.json->search-country->options
+msgid "Bahrain - BH"
+msgstr "Bahrain - BH"
+
+#. settings-schema.json->search-country->options
+msgid "Bangladesh - BD"
+msgstr "Bangladesch - BD"
+
+#. settings-schema.json->search-country->options
+msgid "Barbados - BB"
+msgstr "Barbados - BB"
+
+#. settings-schema.json->search-country->options
+msgid "Belarus - BY"
+msgstr "Belarus - BY"
+
+#. settings-schema.json->search-country->options
+msgid "Belgium - BE"
+msgstr "Belgien - BE"
+
+#. settings-schema.json->search-country->options
+msgid "Belize - BZ"
+msgstr "Belize - BZ"
+
+#. settings-schema.json->search-country->options
+msgid "Benin - BJ"
+msgstr "Benin - BJ"
+
+#. settings-schema.json->search-country->options
+msgid "Bermuda - BM"
+msgstr "Bermuda - BM"
+
+#. settings-schema.json->search-country->options
+msgid "Bhutan - BT"
+msgstr "Bhutan - BT"
+
+#. settings-schema.json->search-country->options
+msgid "Bolivia (Plurinational State Of) - BO"
+msgstr "Bolivien (Plurinationaler Staat) - BO"
+
+#. settings-schema.json->search-country->options
+msgid "Bonaire (Sint Eustatius And Saba) - BQ"
+msgstr "Bonaire (Sint Eustatius und Saba) - BQ"
+
+#. settings-schema.json->search-country->options
+msgid "Bosnia And Herzegovina - BA"
+msgstr "Bosnien und Herzegowina - BA"
+
+#. settings-schema.json->search-country->options
+msgid "Botswana - BW"
+msgstr "Botswana - BW"
+
+#. settings-schema.json->search-country->options
+msgid "Bouvet Island - BV"
+msgstr "Bouvetinsel - BV"
+
+#. settings-schema.json->search-country->options
+msgid "Brazil - BR"
+msgstr "Brasilien - BR"
+
+#. settings-schema.json->search-country->options
+msgid "British Indian Ocean Territory - IO"
+msgstr "Britisches Territorium im Indischen Ozean - IO"
+
+#. settings-schema.json->search-country->options
+msgid "Brunei Darussalam - BN"
+msgstr "Brunei Darussalam - BN"
+
+#. settings-schema.json->search-country->options
+msgid "Bulgaria - BG"
+msgstr "Bulgarien - BG"
+
+#. settings-schema.json->search-country->options
+msgid "Burkina Faso - BF"
+msgstr "Burkina Faso - BF"
+
+#. settings-schema.json->search-country->options
+msgid "Burundi - BI"
+msgstr "Burundi - BI"
+
+#. settings-schema.json->search-country->options
+msgid "Cambodia - KH"
+msgstr "Kambodscha - KH"
+
+#. settings-schema.json->search-country->options
+msgid "Cameroon - CM"
+msgstr "Kamerun - CM"
+
+#. settings-schema.json->search-country->options
+msgid "Canada - CA"
+msgstr "Kanada - CA"
+
+#. settings-schema.json->search-country->options
+msgid "Cape Verde - CV"
+msgstr "Kap Verde - CV"
+
+#. settings-schema.json->search-country->options
+msgid "Cayman Islands - KY"
+msgstr "Kaimaninseln - KY"
+
+#. settings-schema.json->search-country->options
+msgid "Central African Republic - CF"
+msgstr "Zentralafrikanische Republik - CF"
+
+#. settings-schema.json->search-country->options
+msgid "Chad - TD"
+msgstr "Tschad - TD"
+
+#. settings-schema.json->search-country->options
+msgid "Chile - CL"
+msgstr "Chile - CL"
+
+#. settings-schema.json->search-country->options
+msgid "China - CN"
+msgstr "China - CN"
+
+#. settings-schema.json->search-country->options
+msgid "Christmas Island - CX"
+msgstr "Weihnachtsinsel - CX"
+
+#. settings-schema.json->search-country->options
+msgid "Cocos (Keeling) Islands - CC"
+msgstr "Kokosinseln (Keeling) - CC"
+
+#. settings-schema.json->search-country->options
+msgid "Colombia - CO"
+msgstr "Kolumbien - CO"
+
+#. settings-schema.json->search-country->options
+msgid "Comoros - KM"
+msgstr "Komoren - KM"
+
+#. settings-schema.json->search-country->options
+msgid "Congo - CG"
+msgstr "Kongo - CG"
+
+#. settings-schema.json->search-country->options
+msgid "Congo (The Democratic Republic Of The) - CD"
+msgstr "Kongo (Demokratische Republik) - CD"
+
+#. settings-schema.json->search-country->options
+msgid "Cook Islands - CK"
+msgstr "Cookinseln - CK"
+
+#. settings-schema.json->search-country->options
+msgid "Costa Rica - CR"
+msgstr "Costa Rica - CR"
+
+#. settings-schema.json->search-country->options
+msgid "Côte D'Ivoire - CI"
+msgstr "Côte d'Ivoire - CI"
+
+#. settings-schema.json->search-country->options
+msgid "Croatia - HR"
+msgstr "Kroatien - HR"
+
+#. settings-schema.json->search-country->options
+msgid "Cuba - CU"
+msgstr "Kuba - CU"
+
+#. settings-schema.json->search-country->options
+msgid "Curaçao - CW"
+msgstr "Curaçao - CW"
+
+#. settings-schema.json->search-country->options
+msgid "Cyprus - CY"
+msgstr "Zypern - CY"
+
+#. settings-schema.json->search-country->options
+msgid "Czech Republic - CZ"
+msgstr "Tschechische Republik - CZ"
+
+#. settings-schema.json->search-country->options
+msgid "Denmark - DK"
+msgstr "Dänemark - DK"
+
+#. settings-schema.json->search-country->options
+msgid "Djibouti - DJ"
+msgstr "Dschibuti - DJ"
+
+#. settings-schema.json->search-country->options
+msgid "Dominica - DM"
+msgstr "Dominica - DM"
+
+#. settings-schema.json->search-country->options
+msgid "Dominican Republic - DO"
+msgstr "Dominikanische Republik - DO"
+
+#. settings-schema.json->search-country->options
+msgid "Ecuador - EC"
+msgstr "Ecuador - EC"
+
+#. settings-schema.json->search-country->options
+msgid "Egypt - EG"
+msgstr "Ägypten - EG"
+
+#. settings-schema.json->search-country->options
+msgid "El Salvador - SV"
+msgstr "El Salvador - SV"
+
+#. settings-schema.json->search-country->options
+msgid "Equatorial Guinea - GQ"
+msgstr "Äquatorialguinea - GQ"
+
+#. settings-schema.json->search-country->options
+msgid "Eritrea - ER"
+msgstr "Eritrea - ER"
+
+#. settings-schema.json->search-country->options
+msgid "Estonia - EE"
+msgstr "Estland - EE"
+
+#. settings-schema.json->search-country->options
+msgid "Ethiopia - ET"
+msgstr "Äthiopien - ET"
+
+#. settings-schema.json->search-country->options
+msgid "Falkland Islands (Malvinas) - FK"
+msgstr "Falklandinseln (Malwinen) - FK"
+
+#. settings-schema.json->search-country->options
+msgid "Faroe Islands - FO"
+msgstr "Färöer - FO"
+
+#. settings-schema.json->search-country->options
+msgid "Fiji - FJ"
+msgstr "Fidschi - FJ"
+
+#. settings-schema.json->search-country->options
+msgid "Finland - FI"
+msgstr "Finnland - FI"
+
+#. settings-schema.json->search-country->options
+msgid "France - FR"
+msgstr "Frankreich - FR"
+
+#. settings-schema.json->search-country->options
+msgid "French Guiana - GF"
+msgstr "Französisch-Guayana - GF"
+
+#. settings-schema.json->search-country->options
+msgid "French Polynesia - PF"
+msgstr "Französisch-Polynesien - PF"
+
+#. settings-schema.json->search-country->options
+msgid "French Southern Territories - TF"
+msgstr "Französische Süd- und Antarktisgebiete - TF"
+
+#. settings-schema.json->search-country->options
+msgid "Gabon - GA"
+msgstr "Gabun - GA"
+
+#. settings-schema.json->search-country->options
+msgid "Gambia - GM"
+msgstr "Gambia - GM"
+
+#. settings-schema.json->search-country->options
+msgid "Georgia - GE"
+msgstr "Georgien - GE"
+
+#. settings-schema.json->search-country->options
+msgid "Germany - DE"
+msgstr "Deutschland - DE"
+
+#. settings-schema.json->search-country->options
+msgid "Ghana - GH"
+msgstr "Ghana - GH"
+
+#. settings-schema.json->search-country->options
+msgid "Gibraltar - GI"
+msgstr "Gibraltar - GI"
+
+#. settings-schema.json->search-country->options
+msgid "Greece - GR"
+msgstr "Griechenland - GR"
+
+#. settings-schema.json->search-country->options
+msgid "Greenland - GL"
+msgstr "Grönland - GL"
+
+#. settings-schema.json->search-country->options
+msgid "Grenada - GD"
+msgstr "Grenada - GD"
+
+#. settings-schema.json->search-country->options
+msgid "Guadeloupe - GP"
+msgstr "Guadeloupe - GP"
+
+#. settings-schema.json->search-country->options
+msgid "Guam - GU"
+msgstr "Guam - GU"
+
+#. settings-schema.json->search-country->options
+msgid "Guatemala - GT"
+msgstr "Guatemala - GT"
+
+#. settings-schema.json->search-country->options
+msgid "Guernsey - GG"
+msgstr "Guernsey - GG"
+
+#. settings-schema.json->search-country->options
+msgid "Guinea - GN"
+msgstr "Guinea - GN"
+
+#. settings-schema.json->search-country->options
+msgid "Guinea-Bissau - GW"
+msgstr "Guinea-Bissau - GW"
+
+#. settings-schema.json->search-country->options
+msgid "Guyana - GY"
+msgstr "Guyana - GY"
+
+#. settings-schema.json->search-country->options
+msgid "Haiti - HT"
+msgstr "Haiti - HT"
+
+#. settings-schema.json->search-country->options
+msgid "Heard Island And Mcdonald Islands - HM"
+msgstr "Heard und McDonaldinseln - HM"
+
+#. settings-schema.json->search-country->options
+msgid "Holy See (Vatican City State) - VA"
+msgstr "Heiliger Stuhl (Staat der Vatikanstadt) - VA"
+
+#. settings-schema.json->search-country->options
+msgid "Honduras - HN"
+msgstr "Honduras - HN"
+
+#. settings-schema.json->search-country->options
+msgid "Hong Kong - HK"
+msgstr "Hongkong - HK"
+
+#. settings-schema.json->search-country->options
+msgid "Hungary - HU"
+msgstr "Ungarn - HU"
+
+#. settings-schema.json->search-country->options
+msgid "Iceland - IS"
+msgstr "Island - IS"
+
+#. settings-schema.json->search-country->options
+msgid "India - IN"
+msgstr "Indien - IN"
+
+#. settings-schema.json->search-country->options
+msgid "Indonesia - ID"
+msgstr "Indonesien - ID"
+
+#. settings-schema.json->search-country->options
+msgid "Iran (Islamic Republic Of) - IR"
+msgstr "Iran (Islamische Republik) - IR"
+
+#. settings-schema.json->search-country->options
+msgid "Iraq - IQ"
+msgstr "Irak - IQ"
+
+#. settings-schema.json->search-country->options
+msgid "Ireland - IE"
+msgstr "Irland - IE"
+
+#. settings-schema.json->search-country->options
+msgid "Isle Of Man - IM"
+msgstr "Isle of Man - IM"
+
+#. settings-schema.json->search-country->options
+msgid "Israel - IL"
+msgstr "Israel - IL"
+
+#. settings-schema.json->search-country->options
+msgid "Italy - IT"
+msgstr "Italien - IT"
+
+#. settings-schema.json->search-country->options
+msgid "Jamaica - JM"
+msgstr "Jamaika - JM"
+
+#. settings-schema.json->search-country->options
+msgid "Japan - JP"
+msgstr "Japan - JP"
+
+#. settings-schema.json->search-country->options
+msgid "Jersey - JE"
+msgstr "Jersey - JE"
+
+#. settings-schema.json->search-country->options
+msgid "Jordan - JO"
+msgstr "Jordanien - JO"
+
+#. settings-schema.json->search-country->options
+msgid "Kazakhstan - KZ"
+msgstr "Kasachstan - KZ"
+
+#. settings-schema.json->search-country->options
+msgid "Kenya - KE"
+msgstr "Kenia - KE"
+
+#. settings-schema.json->search-country->options
+msgid "Kiribati - KI"
+msgstr "Kiribati - KI"
+
+#. settings-schema.json->search-country->options
+msgid "Korea (Democratic People'S Republic Of) - KP"
+msgstr "Korea (Demokratische Volksrepublik) - KP"
+
+#. settings-schema.json->search-country->options
+msgid "Korea (Republic Of) - KR"
+msgstr "Korea (Republik) - KR"
+
+#. settings-schema.json->search-country->options
+msgid "Kuwait - KW"
+msgstr "Kuwait - KW"
+
+#. settings-schema.json->search-country->options
+msgid "Kyrgyzstan - KG"
+msgstr "Kirgisistan - KG"
+
+#. settings-schema.json->search-country->options
+msgid "Lao People'S Democratic Republic - LA"
+msgstr "Laos (Demokratische Volksrepublik) - LA"
+
+#. settings-schema.json->search-country->options
+msgid "Latvia - LV"
+msgstr "Lettland - LV"
+
+#. settings-schema.json->search-country->options
+msgid "Lebanon - LB"
+msgstr "Libanon - LB"
+
+#. settings-schema.json->search-country->options
+msgid "Lesotho - LS"
+msgstr "Lesotho - LS"
+
+#. settings-schema.json->search-country->options
+msgid "Liberia - LR"
+msgstr "Liberia - LR"
+
+#. settings-schema.json->search-country->options
+msgid "Libya - LY"
+msgstr "Libyen - LY"
+
+#. settings-schema.json->search-country->options
+msgid "Liechtenstein - LI"
+msgstr "Liechtenstein - LI"
+
+#. settings-schema.json->search-country->options
+msgid "Lithuania - LT"
+msgstr "Litauen - LT"
+
+#. settings-schema.json->search-country->options
+msgid "Luxembourg - LU"
+msgstr "Luxemburg - LU"
+
+#. settings-schema.json->search-country->options
+msgid "Macao - MO"
+msgstr "Macao - MO"
+
+#. settings-schema.json->search-country->options
+msgid "Macedonia (The Former Yugoslav Republic Of) - MK"
+msgstr "Nordmazedonien - MK"
+
+#. settings-schema.json->search-country->options
+msgid "Madagascar - MG"
+msgstr "Madagaskar - MG"
+
+#. settings-schema.json->search-country->options
+msgid "Malawi - MW"
+msgstr "Malawi - MW"
+
+#. settings-schema.json->search-country->options
+msgid "Malaysia - MY"
+msgstr "Malaysia - MY"
+
+#. settings-schema.json->search-country->options
+msgid "Maldives - MV"
+msgstr "Malediven - MV"
+
+#. settings-schema.json->search-country->options
+msgid "Mali - ML"
+msgstr "Mali - ML"
+
+#. settings-schema.json->search-country->options
+msgid "Malta - MT"
+msgstr "Malta - MT"
+
+#. settings-schema.json->search-country->options
+msgid "Marshall Islands - MH"
+msgstr "Marshallinseln - MH"
+
+#. settings-schema.json->search-country->options
+msgid "Martinique - MQ"
+msgstr "Martinique - MQ"
+
+#. settings-schema.json->search-country->options
+msgid "Mauritania - MR"
+msgstr "Mauretanien - MR"
+
+#. settings-schema.json->search-country->options
+msgid "Mauritius - MU"
+msgstr "Mauritius - MU"
+
+#. settings-schema.json->search-country->options
+msgid "Mayotte - YT"
+msgstr "Mayotte - YT"
+
+#. settings-schema.json->search-country->options
+msgid "Mexico - MX"
+msgstr "Mexiko - MX"
+
+#. settings-schema.json->search-country->options
+msgid "Micronesia (Federated States Of) - FM"
+msgstr "Mikronesien (Föderierte Staaten von) - FM"
+
+#. settings-schema.json->search-country->options
+msgid "Moldova (Republic Of) - MD"
+msgstr "Moldau (Republik) - MD"
+
+#. settings-schema.json->search-country->options
+msgid "Monaco - MC"
+msgstr "Monaco - MC"
+
+#. settings-schema.json->search-country->options
+msgid "Mongolia - MN"
+msgstr "Mongolei - MN"
+
+#. settings-schema.json->search-country->options
+msgid "Montenegro - ME"
+msgstr "Montenegro - ME"
+
+#. settings-schema.json->search-country->options
+msgid "Montserrat - MS"
+msgstr "Montserrat"
+
+#. settings-schema.json->search-country->options
+msgid "Morocco - MA"
+msgstr "Marokko - MA"
+
+#. settings-schema.json->search-country->options
+msgid "Mozambique - MZ"
+msgstr "Mosambik - MZ"
+
+#. settings-schema.json->search-country->options
+msgid "Myanmar - MM"
+msgstr "Myanmar - MM"
+
+#. settings-schema.json->search-country->options
+msgid "Namibia - NA"
+msgstr "Namibia - NA"
+
+#. settings-schema.json->search-country->options
+msgid "Nauru - NR"
+msgstr "Nauru - NR"
+
+#. settings-schema.json->search-country->options
+msgid "Nepal - NP"
+msgstr "Nepal - NP"
+
+#. settings-schema.json->search-country->options
+msgid "Netherlands - NL"
+msgstr "Niederlande - NL"
+
+#. settings-schema.json->search-country->options
+msgid "New Caledonia - NC"
+msgstr "Neukaledonien - NC"
+
+#. settings-schema.json->search-country->options
+msgid "New Zealand - NZ"
+msgstr "Neuseeland - NZ"
+
+#. settings-schema.json->search-country->options
+msgid "Nicaragua - NI"
+msgstr "Nicaragua - NI"
+
+#. settings-schema.json->search-country->options
+msgid "Niger - NE"
+msgstr "Niger - NE"
+
+#. settings-schema.json->search-country->options
+msgid "Nigeria - NG"
+msgstr "Nigeria - NG"
+
+#. settings-schema.json->search-country->options
+msgid "Niue - NU"
+msgstr "Niue - NU"
+
+#. settings-schema.json->search-country->options
+msgid "Norfolk Island - NF"
+msgstr "Norfolkinsel - NF"
+
+#. settings-schema.json->search-country->options
+msgid "Northern Mariana Islands - MP"
+msgstr "Nördliche Marianen - MP"
+
+#. settings-schema.json->search-country->options
+msgid "Norway - NO"
+msgstr "Norwegen - NO"
+
+#. settings-schema.json->search-country->options
+msgid "Oman - OM"
+msgstr "Oman - OM"
+
+#. settings-schema.json->search-country->options
+msgid "Pakistan - PK"
+msgstr "Pakistan - PK"
+
+#. settings-schema.json->search-country->options
+msgid "Palau - PW"
+msgstr "Palau - PW"
+
+#. settings-schema.json->search-country->options
+msgid "Palestine (State Of) - PS"
+msgstr "Palästina (Staat) - PS"
+
+#. settings-schema.json->search-country->options
+msgid "Panama - PA"
+msgstr "Panama - PA"
+
+#. settings-schema.json->search-country->options
+msgid "Papua New Guinea - PG"
+msgstr "Papua-Neuguinea - PG"
+
+#. settings-schema.json->search-country->options
+msgid "Paraguay - PY"
+msgstr "Paraguay - PY"
+
+#. settings-schema.json->search-country->options
+msgid "Peru - PE"
+msgstr "Peru - PE"
+
+#. settings-schema.json->search-country->options
+msgid "Philippines - PH"
+msgstr "Philippinen - PH"
+
+#. settings-schema.json->search-country->options
+msgid "Pitcairn - PN"
+msgstr "Pitcairninseln - PN"
+
+#. settings-schema.json->search-country->options
+msgid "Poland - PL"
+msgstr "Polen - PL"
+
+#. settings-schema.json->search-country->options
+msgid "Portugal - PT"
+msgstr "Portugal - PT"
+
+#. settings-schema.json->search-country->options
+msgid "Puerto Rico - PR"
+msgstr "Puerto Rico - PR"
+
+#. settings-schema.json->search-country->options
+msgid "Qatar - QA"
+msgstr "Katar - QA"
+
+#. settings-schema.json->search-country->options
+msgid "Réunion - RE"
+msgstr "Réunion - RE"
+
+#. settings-schema.json->search-country->options
+msgid "Romania - RO"
+msgstr "Rumänien - RO"
+
+#. settings-schema.json->search-country->options
+msgid "Russian Federation - RU"
+msgstr "Russische Föderation - RU"
+
+#. settings-schema.json->search-country->options
+msgid "Rwanda - RW"
+msgstr "Ruanda - RW"
+
+#. settings-schema.json->search-country->options
+msgid "Saint Barthélemy - BL"
+msgstr "Saint-Barthélemy - BL"
+
+#. settings-schema.json->search-country->options
+msgid "Saint Helena (Ascension And Tristan Da Cunha) - SH"
+msgstr "St. Helena (Ascension und Tristan da Cunha) - SH"
+
+#. settings-schema.json->search-country->options
+msgid "Saint Kitts And Nevis - KN"
+msgstr "St. Kitts und Nevis - KN"
+
+#. settings-schema.json->search-country->options
+msgid "Saint Lucia - LC"
+msgstr "St. Lucia - LC"
+
+#. settings-schema.json->search-country->options
+msgid "Saint Martin (French Part) - MF"
+msgstr "Saint-Martin (Französischer Teil) - MF"
+
+#. settings-schema.json->search-country->options
+msgid "Saint Pierre And Miquelon - PM"
+msgstr "Saint-Pierre und Miquelon - PM"
+
+#. settings-schema.json->search-country->options
+msgid "Saint Vincent And The Grenadines - VC"
+msgstr "St. Vincent und die Grenadinen - VC"
+
+#. settings-schema.json->search-country->options
+msgid "Samoa - WS"
+msgstr "Samoa - WS"
+
+#. settings-schema.json->search-country->options
+msgid "San Marino - SM"
+msgstr "San Marino - SM"
+
+#. settings-schema.json->search-country->options
+msgid "Sao Tome And Principe - ST"
+msgstr "São Tomé und Príncipe - ST"
+
+#. settings-schema.json->search-country->options
+msgid "Saudi Arabia - SA"
+msgstr "Saudi-Arabien - SA"
+
+#. settings-schema.json->search-country->options
+msgid "Senegal - SN"
+msgstr "Senegal - SN"
+
+#. settings-schema.json->search-country->options
+msgid "Serbia - RS"
+msgstr "Serbien - RS"
+
+#. settings-schema.json->search-country->options
+msgid "Seychelles - SC"
+msgstr "Seychellen - SC"
+
+#. settings-schema.json->search-country->options
+msgid "Sierra Leone - SL"
+msgstr "Sierra Leone - SL"
+
+#. settings-schema.json->search-country->options
+msgid "Singapore - SG"
+msgstr "Singapur - SG"
+
+#. settings-schema.json->search-country->options
+msgid "Sint Maarten (Dutch Part) - SX"
+msgstr "Sint Maarten (Niederländischer Teil) - SX"
+
+#. settings-schema.json->search-country->options
+msgid "Slovakia - SK"
+msgstr "Slowakei - SK"
+
+#. settings-schema.json->search-country->options
+msgid "Slovenia - SI"
+msgstr "Slowenien - SI"
+
+#. settings-schema.json->search-country->options
+msgid "Solomon Islands - SB"
+msgstr "Salomonen - SB"
+
+#. settings-schema.json->search-country->options
+msgid "Somalia - SO"
+msgstr "Somalia - SO"
+
+#. settings-schema.json->search-country->options
+msgid "South Africa - ZA"
+msgstr "Südafrika - ZA"
+
+#. settings-schema.json->search-country->options
+msgid "South Georgia And The South Sandwich Islands - GS"
+msgstr "Südgeorgien und die Südlichen Sandwichinseln - GS"
+
+#. settings-schema.json->search-country->options
+msgid "South Sudan - SS"
+msgstr "Südsudan - SS"
+
+#. settings-schema.json->search-country->options
+msgid "Spain - ES"
+msgstr "Spanien - ES"
+
+#. settings-schema.json->search-country->options
+msgid "Sri Lanka - LK"
+msgstr "Sri Lanka - LK"
+
+#. settings-schema.json->search-country->options
+msgid "Sudan - SD"
+msgstr "Sudan - SD"
+
+#. settings-schema.json->search-country->options
+msgid "Suriname - SR"
+msgstr "Suriname - SR"
+
+#. settings-schema.json->search-country->options
+msgid "Svalbard And Jan Mayen - SJ"
+msgstr "Svalbard und Jan Mayen - SJ"
+
+#. settings-schema.json->search-country->options
+msgid "Swaziland - SZ"
+msgstr "Eswatini - SZ"
+
+#. settings-schema.json->search-country->options
+msgid "Sweden - SE"
+msgstr "Schweden - SE"
+
+#. settings-schema.json->search-country->options
+msgid "Switzerland - CH"
+msgstr "Schweiz - CH"
+
+#. settings-schema.json->search-country->options
+msgid "Syrian Arab Republic - SY"
+msgstr "Syrische Arabische Republik - SY"
+
+#. settings-schema.json->search-country->options
+msgid "Taiwan (Province Of China) - TW"
+msgstr "Taiwan (Provinz von China) - TW"
+
+#. settings-schema.json->search-country->options
+msgid "Tajikistan - TJ"
+msgstr "Tadschikistan - TJ"
+
+#. settings-schema.json->search-country->options
+msgid "Tanzania (United Republic Of) - TZ"
+msgstr "Tansania (Vereinigte Republik) - TZ"
+
+#. settings-schema.json->search-country->options
+msgid "Thailand - TH"
+msgstr "Thailand - TH"
+
+#. settings-schema.json->search-country->options
+msgid "Timor-Leste - TL"
+msgstr "Timor-Leste - TL"
+
+#. settings-schema.json->search-country->options
+msgid "Togo - TG"
+msgstr "Togo - TG"
+
+#. settings-schema.json->search-country->options
+msgid "Tokelau - TK"
+msgstr "Tokelau - TK"
+
+#. settings-schema.json->search-country->options
+msgid "Tonga - TO"
+msgstr "Tonga - TO"
+
+#. settings-schema.json->search-country->options
+msgid "Trinidad And Tobago - TT"
+msgstr "Trinidad und Tobago - TT"
+
+#. settings-schema.json->search-country->options
+msgid "Tunisia - TN"
+msgstr "Tunesien - TN"
+
+#. settings-schema.json->search-country->options
+msgid "Turkey - TR"
+msgstr "Türkei - TR"
+
+#. settings-schema.json->search-country->options
+msgid "Turkmenistan - TM"
+msgstr "Turkmenistan - TM"
+
+#. settings-schema.json->search-country->options
+msgid "Turks And Caicos Islands - TC"
+msgstr "Turks- und Caicosinseln - TC"
+
+#. settings-schema.json->search-country->options
+msgid "Tuvalu - TV"
+msgstr "Tuvalu - TV"
+
+#. settings-schema.json->search-country->options
+msgid "Uganda - UG"
+msgstr "Uganda - UG"
+
+#. settings-schema.json->search-country->options
+msgid "Ukraine - UA"
+msgstr "Ukraine - UA"
+
+#. settings-schema.json->search-country->options
+msgid "United Arab Emirates - AE"
+msgstr "Vereinigte Arabische Emirate - AE"
+
+#. settings-schema.json->search-country->options
+msgid "United Kingdom - GB"
+msgstr "Vereinigtes Königreich - GB"
+
+#. settings-schema.json->search-country->options
+msgid "United States - US"
+msgstr "Vereinigte Staaten - US"
+
+#. settings-schema.json->search-country->options
+msgid "United States Minor Outlying Islands - UM"
+msgstr "Kleinere Inselbesitzungen der Vereinigten Staaten - UM"
+
+#. settings-schema.json->search-country->options
+msgid "Uruguay - UY"
+msgstr "Uruguay - UY"
+
+#. settings-schema.json->search-country->options
+msgid "Uzbekistan - UZ"
+msgstr "Usbekistan - UZ"
+
+#. settings-schema.json->search-country->options
+msgid "Vanuatu - VU"
+msgstr "Vanuatu - VU"
+
+#. settings-schema.json->search-country->options
+msgid "Venezuela (Bolivarian Republic Of) - VE"
+msgstr "Venezuela (Bolivarische Republik) - VE"
+
+#. settings-schema.json->search-country->options
+msgid "Viet Nam - VN"
+msgstr "Vietnam - VN"
+
+#. settings-schema.json->search-country->options
+msgid "Virgin Islands (British) - VG"
+msgstr "Britische Jungferninseln - VG"
+
+#. settings-schema.json->search-country->options
+msgid "Virgin Islands (U.S.) - VI"
+msgstr "Amerikanische Jungferninseln - VI"
+
+#. settings-schema.json->search-country->options
+msgid "Wallis And Futuna - WF"
+msgstr "Wallis und Futuna - WF"
+
+#. settings-schema.json->search-country->options
+msgid "Western Sahara - EH"
+msgstr "Westsahara - EH"
+
+#. settings-schema.json->search-country->options
+msgid "Yemen - YE"
+msgstr "Jemen - YE"
+
+#. settings-schema.json->search-country->options
+msgid "Zambia - ZM"
+msgstr "Sambia - ZM"
+
+#. settings-schema.json->search-country->options
+msgid "Zimbabwe - ZW"
+msgstr "Simbabwe - ZW"
+
+#. settings-schema.json->search-country->tooltip
+msgid "OPTIONAL. Choose a country."
+msgstr "OPTIONAL. Wählen Sie ein Land."
+
+#. settings-schema.json->search-tag->description
+msgid "Tag"
+msgstr "Tag"
+
+#. settings-schema.json->search-tag->tooltip
+msgid "OPTIONAL. Only one word, as blues or jazz or rock or talk or..."
+msgstr ""
+"OPTIONAL. Nur ein Wort, wie Blues oder Jazz oder Rock oder Talk oder..."
+
+#. settings-schema.json->search-codec->options
+msgid "AAC"
+msgstr "AAC"
+
+#. settings-schema.json->search-codec->options
+msgid "AAC+"
+msgstr "AAC+"
+
+#. settings-schema.json->search-codec->options
+msgid "FLV"
+msgstr "FLV"
+
+#. settings-schema.json->search-codec->options
+msgid "AAC,H.264"
+msgstr "AAC,H.264"
+
+#. settings-schema.json->search-codec->options
+msgid "AAC+,H.264"
+msgstr "AAC+,H.264"
+
+#. settings-schema.json->search-codec->options
+msgid "MP3,H.264"
+msgstr "MP3,H.264"
+
+#. settings-schema.json->search-codec->options
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#. settings-schema.json->search-codec->options
+msgid "Unknown,H.264"
+msgstr "Unbekannt,H.264"
+
+#. settings-schema.json->search-codec->tooltip
+msgid "OPTIONAL. Choose a codec."
+msgstr "OPTIONAL. Wählen Sie einen Codec."
+
+#. settings-schema.json->search-minimalBitrate->description
+msgid "Minimal Bitrate"
+msgstr "Minimale Bitrate"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "32"
+msgstr "32"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "48"
+msgstr "48"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "64"
+msgstr "64"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "96"
+msgstr "96"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "128"
+msgstr "128"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "192"
+msgstr "192"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "256"
+msgstr "256"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "320"
+msgstr "320"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "512"
+msgstr "512"
+
+#. settings-schema.json->search-minimalBitrate->options
+msgid "640"
+msgstr "640"
+
+#. settings-schema.json->search-minimalBitrate->tooltip
+msgid "OPTIONAL. Choose a minimal bitrate (in kbps)."
+msgstr "OPTIONAL. Wählen Sie eine minimale Bitrate (in kbps)."
+
+#. settings-schema.json->search-order->description
+msgid "Order"
+msgstr "Reihenfolge"
+
+#. settings-schema.json->search-order->options
+msgid "name"
+msgstr "Name"
+
+#. settings-schema.json->search-order->options
+msgid "url"
+msgstr "URL"
+
+#. settings-schema.json->search-order->options
+msgid "tags"
+msgstr "Tags"
+
+#. settings-schema.json->search-order->options
+msgid "country"
+msgstr "Land"
+
+#. settings-schema.json->search-order->options
+msgid "state"
+msgstr "Bundesland"
+
+#. settings-schema.json->search-order->options
+msgid "language"
+msgstr "Sprache"
+
+#. settings-schema.json->search-order->options
+msgid "votes"
+msgstr "Stimmen"
+
+#. settings-schema.json->search-order->options
+msgid "codec"
+msgstr "Codec"
+
+#. settings-schema.json->search-order->options
+msgid "bitrate"
+msgstr "Bitrate"
+
+# Maybe improve
+#. settings-schema.json->search-order->options
+msgid "last check-time"
+msgstr "Letzte Überprüfungszeit"
+
+# Okayish ..
+#. settings-schema.json->search-order->options
+msgid "click timestamp"
+msgstr "Klick-Zeitstempel"
+
+#. settings-schema.json->search-order->options
+msgid "click count"
+msgstr "Klick-Anzahl"
+
+#. settings-schema.json->search-order->options
+msgid "click trend"
+msgstr "Klick-Trend"
+
+#. settings-schema.json->search-order->options
+msgid "change timestamp"
+msgstr "Änderungs-Zeitstempel"
+
+#. settings-schema.json->search-order->options
+msgid "random"
+msgstr "Zufällig"
+
+#. settings-schema.json->search-order->tooltip
+msgid "OPTIONAL. Name of the attribute the result list will be sorted by."
+msgstr ""
+"OPTIONAL. Name des Attributs, nach dem die Ergebnisliste sortiert wird."
+
+#. settings-schema.json->search-limit->description
+msgid "Limit"
+msgstr "Limit"
+
+#. settings-schema.json->search-limit->tooltip
+msgid "Maximum number of results per page."
+msgstr "Maximale Anzahl von Ergebnissen pro Seite."
+
+#. settings-schema.json->search-page->description
+msgid "Next page number"
+msgstr "Nächste Seitenzahl"
+
+#. settings-schema.json->search-reset-button->description
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#. settings-schema.json->search-button->description
+msgid "Search..."
+msgstr "Suchen..."
+
+#. settings-schema.json->sched-rmbutton->description
+msgid "Remove selected items"
+msgstr "Ausgewählte Elemente entfernen"

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/de.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/de.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# RADIO3.0
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# claudiux, 2022
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-31 02:53+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-13 05:02-0400\n"
 "PO-Revision-Date: 2024-09-13 08:48+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,26 +19,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:325
+#. applet.js:325
 msgid "This is your own list of Categories and Radio Stations."
 msgstr "Dies ist Ihre eigene Liste von Kategorien und Radiosendern."
 
-#: applet.js:326
+#. applet.js:326
 msgid "You can add more using the [+] button."
 msgstr "Sie können mit der [+]-Schaltfäche weitere hinzufügen."
 
-#: applet.js:327
+#. applet.js:327
 msgid "For a category, fill in only its name; leave the other fields empty."
 msgstr ""
 "Für eine Kategorie geben Sie nur den Namen ein; lassen Sie die anderen "
 "Felder leer."
 
-#: applet.js:328
+#. applet.js:328
 msgid "For a radio station, enter only its name and its streaming URL."
 msgstr ""
 "Für einen Radiosender geben Sie nur den Namen und die Streaming-URL ein."
 
-#: applet.js:329
+#. applet.js:329
 msgid ""
 "You can order the rows by dragging and dropping or by using the buttons and "
 "tools below the list."
@@ -45,7 +46,7 @@ msgstr ""
 "Sie können die Zeilen durch Ziehen und Ablegen oder mit den Schaltflächen "
 "und Werkzeugen unterhalb der Liste anordnen."
 
-#: applet.js:330
+#. applet.js:330
 msgid ""
 "The buttons on the right below the list allow you to navigate page by page "
 "or category by category."
@@ -53,7 +54,7 @@ msgstr ""
 "Die Schaltflächen rechts unter der Liste ermöglichen es Ihnen, seitenweise "
 "oder kategorieweise zu navigieren."
 
-#: applet.js:331
+#. applet.js:331
 msgid ""
 "To search for one of your stations, click on the list and start writing its "
 "name."
@@ -61,7 +62,7 @@ msgstr ""
 "Um nach einem Ihrer Sender zu suchen, klicken Sie auf die Liste und beginnen "
 "Sie, den Namen einzugeben."
 
-#: applet.js:332
+#. applet.js:332
 msgid ""
 "To easily add stations to your list, use the following 2 tabs: Search and "
 "Import."
@@ -69,13 +70,13 @@ msgstr ""
 "Um Stationen einfach zu Ihrer Liste hinzuzufügen, verwenden Sie die "
 "folgenden 2 Tabs: Suche und Importieren."
 
-#: applet.js:333
+#. applet.js:333
 msgid "Check its 'Menu' box to display a station or category in the menu."
 msgstr ""
 "Aktivieren Sie das 'Menü'-Feld, um eine Station oder Kategorie im Menü "
 "anzuzeigen."
 
-#: applet.js:334
+#. applet.js:334
 msgid ""
 "Check its '♪/➟' box to listen to the station or move it to another category "
 "using the tools below the list."
@@ -83,12 +84,12 @@ msgstr ""
 "Aktivieren Sie das '♪/➟'-Feld, um den Sender zu hören oder ihn mit den "
 "Werkzeugen unterhalb der Liste in eine andere Kategorie zu verschieben."
 
-#: applet.js:336
+#. applet.js:336
 msgid "You can have your list of stations checked by internet databases."
 msgstr ""
 "Sie können Ihre Liste von Sendern von Internetdatenbanken überprüfen lassen."
 
-#: applet.js:337
+#. applet.js:337
 msgid ""
 "Any station recognized by one of these databases will receive a Universal "
 "Unique Identifier (UUID) provided by this database."
@@ -97,7 +98,7 @@ msgstr ""
 "Universell Eindeutige Kennung (UUID), die von dieser Datenbank "
 "bereitgestellt wird."
 
-#: applet.js:338
+#. applet.js:338
 msgid ""
 "So, if a streaming URL was changed, a next check would update it and you can "
 "continue to listen to the affected station."
@@ -106,7 +107,7 @@ msgstr ""
 "Überprüfung sie aktualisieren, und Sie können den betroffenen Sender "
 "weiterhin hören."
 
-#: applet.js:340
+#. applet.js:340
 msgid ""
 "Here you can search for other stations in a free radio database accessible "
 "via the Internet."
@@ -114,7 +115,7 @@ msgstr ""
 "Hier können Sie nach anderen Sendern in einer freien Radiodatenbank suchen, "
 "die über das Internet zugänglich ist."
 
-#: applet.js:341
+#. applet.js:341
 msgid ""
 "Fill in at least a few fields of the form below then click on the "
 "'Search ...' button."
@@ -122,7 +123,7 @@ msgstr ""
 "Füllen Sie mindestens ein paar Felder des unten stehenden Formulars aus und "
 "klicken Sie dann auf die Schaltfläche 'Suchen ...'."
 
-#: applet.js:342
+#. applet.js:342
 msgid ""
 "Each time this button is clicked, a new results page is displayed in the "
 "second part of this page, where you can test certain stations and include "
@@ -132,7 +133,7 @@ msgstr ""
 "Ergebnisseite im zweiten Teil dieser Seite angezeigt, auf der Sie bestimmte "
 "Sender testen und in das Menü aufnehmen können."
 
-#: applet.js:343
+#. applet.js:343
 msgid ""
 "A station already in your menu will only appear in search results if its "
 "streaming URL has changed."
@@ -140,7 +141,7 @@ msgstr ""
 "Ein Sender, der bereits in Ihrem Menü ist, erscheint nur in den "
 "Suchergebnissen, wenn sich seine Streaming-URL geändert hat."
 
-#: applet.js:344
+#. applet.js:344
 msgid ""
 "When no new page appears, it means that all results matching your search "
 "criteria have been displayed."
@@ -148,7 +149,7 @@ msgstr ""
 "Wenn keine neue Seite erscheint, bedeutet das, dass alle Ergebnisse, die "
 "Ihren Suchkriterien entsprechen, angezeigt wurden."
 
-#: applet.js:346
+#. applet.js:346
 msgid ""
 "You can import a file containing the name and streaming URL of at least one "
 "radio station."
@@ -156,7 +157,7 @@ msgstr ""
 "Sie können eine Datei importieren, die den Namen und die Streaming-URL von "
 "mindestens einem Radiosender enthält."
 
-#: applet.js:347
+#. applet.js:347
 msgid ""
 "These radio stations are displayed in the list below. You can test them by "
 "checking their ♪ box."
@@ -164,13 +165,13 @@ msgstr ""
 "Diese Radiosender werden in der Liste unten angezeigt. Sie können sie "
 "testen, indem Sie ihr ♪-Feld aktivieren."
 
-#: applet.js:348
+#. applet.js:348
 msgid "Then manage this list with the buttons at the bottom of this tab."
 msgstr ""
 "Verwalten Sie diese Liste dann mit den Schaltflächen am unteren Rand dieses "
 "Tabs."
 
-#: applet.js:350
+#. applet.js:350
 msgid ""
 "In the Shoutcast directory, click the download button to the left of the "
 "station name."
@@ -178,7 +179,7 @@ msgstr ""
 "Im Shoutcast-Verzeichnis klicken Sie auf die Schaltfläche zum Herunterladen "
 "links neben dem Sendernamen."
 
-#: applet.js:351
+#. applet.js:351
 msgid ""
 "Select the open format (.XSPF) and save the file giving it the same name as "
 "the station."
@@ -186,11 +187,11 @@ msgstr ""
 "Wählen Sie das offene Format (.XSPF) und speichern Sie die Datei, indem Sie "
 "ihr denselben Namen wie dem Sender geben."
 
-#: applet.js:352
+#. applet.js:352
 msgid "This file can then be imported here."
 msgstr "Diese Datei kann dann hier importiert werden."
 
-#: applet.js:354
+#. applet.js:354
 #, javascript-format
 msgid "%s bytes = %s GB = %s GiB"
 msgstr "%s Bytes = %s GB = %s GiB"
@@ -201,335 +202,335 @@ msgstr "%s Bytes = %s GB = %s GiB"
 #. settings-schema.json->search-country->options
 #. settings-schema.json->search-codec->options
 #. settings-schema.json->search-order->options
-#: applet.js:520 applet.js:534 applet.js:5047 applet.js:5059
+#. applet.js:520 applet.js:534 applet.js:5047 applet.js:5059
 msgid "(Undefined)"
 msgstr "(Undefiniert)"
 
-#: applet.js:732
+#. applet.js:732
 msgid "Radio3.0 web page..."
 msgstr "Radio3.0 Website ..."
 
-#: applet.js:2056
+#. applet.js:2056
 msgid "Start"
 msgstr "Start"
 
-#: applet.js:2064 applet.js:2768
+#. applet.js:2064 applet.js:2768
 msgid "Stop"
 msgstr "Stop"
 
 # Better use "Mittelklick"?
-#: applet.js:2299 applet.js:2335 applet.js:2382
+#. applet.js:2299 applet.js:2335 applet.js:2382
 msgid "Middle-Click: Stop Recording"
 msgstr "Klick mit mittlerer Maustaste: Aufnahme stoppen"
 
-#: applet.js:2331 applet.js:2378
+#. applet.js:2331 applet.js:2378
 msgid "Volume: %s%"
 msgstr "Lautstärke: %s%"
 
-#: applet.js:2337 applet.js:2384
+#. applet.js:2337 applet.js:2384
 msgid "Middle-click: ON/OFF"
 msgstr "Klick mit mittlerer Maustaste: EIN/AUS"
 
-#: applet.js:2339 applet.js:2386
+#. applet.js:2339 applet.js:2386
 msgid "Click: Select another station"
 msgstr "Klicken: Anderen Sender auswählen"
 
-#: applet.js:2352
+#. applet.js:2352
 msgid "Click to select a station"
 msgstr "Klicken, um einen Sender auszuwählen"
 
-#: applet.js:2388
+#. applet.js:2388
 msgid "Scroll wheel: volume change"
 msgstr "Scrollrad: Lautstärke ändern"
 
-#: applet.js:2438 applet.js:2786 applet.js:4663
+#. applet.js:2438 applet.js:2786 applet.js:4663
 msgid "Configure..."
 msgstr "Konfigurieren..."
 
-#: applet.js:2442 applet.js:2778
+#. applet.js:2442 applet.js:2778
 msgid "Search for new stations..."
 msgstr "Nach neuen Sendern suchen..."
 
-#: applet.js:2448 applet.js:2790 applet.js:4700
+#. applet.js:2448 applet.js:2790 applet.js:4700
 msgid "Sound Settings"
 msgstr "Toneinstellungen"
 
-#: applet.js:2518
+#. applet.js:2518
 msgid "Watch on YT"
 msgstr "Auf YT ansehen"
 
-#: applet.js:2525
+#. applet.js:2525
 msgid "Try to download it from YT (unsafe)"
 msgstr "Versuchen, es von YT herunterzuladen (unsicher)"
 
-#: applet.js:2588
+#. applet.js:2588
 msgid "Recently Played Stations:"
 msgstr "Kürzlich gespielte Sender:"
 
-#: applet.js:2630
+#. applet.js:2630
 msgid "Visit the home page of this station"
 msgstr "Besuchen Sie die Homepage dieses Senders"
 
-#: applet.js:2669
+#. applet.js:2669
 msgid "Categories"
 msgstr "Kategorien"
 
-#: applet.js:2671
+#. applet.js:2671
 msgid "Radio Stations"
 msgstr "Radiosender"
 
-#: applet.js:2681
+#. applet.js:2681
 msgid "All Categories"
 msgstr "Alle Kategorien"
 
-#: applet.js:2711
+#. applet.js:2711
 msgid "My Radio Stations"
 msgstr "Meine Radiosender"
 
-#: applet.js:2910
+#. applet.js:2910
 msgid "Downloading..."
 msgstr "Herunterladen..."
 
-#: applet.js:2912
+#. applet.js:2912
 msgid "Stop downloading"
 msgstr "Herunterladen stoppen"
 
-#: applet.js:3016
+#. applet.js:3016
 msgid "Download complete"
 msgstr "Download abgeschlossen"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#: applet.js:3018 applet.js:3027 applet.js:4462 applet.js:4471 applet.js:4480
-#: applet.js:4790
+#. applet.js:3018 applet.js:3027 applet.js:4462 applet.js:4471 applet.js:4480
+#. applet.js:4790
 msgid "Open the recordings folder"
 msgstr "Öffnen Sie den Aufnahmen-Ordner"
 
-#: applet.js:3025 applet.js:4459 applet.js:4469 applet.js:4478
+#. applet.js:3025 applet.js:4459 applet.js:4469 applet.js:4478
 msgid "An error seems to have occurred during recording!"
 msgstr "Während der Aufnahme scheint ein Fehler aufgetreten zu sein!"
 
-#: applet.js:3026 applet.js:4461 applet.js:4470 applet.js:4479
+#. applet.js:3026 applet.js:4461 applet.js:4470 applet.js:4479
 msgid "Please check this record."
 msgstr "Bitte überprüfen Sie diese Aufnahme."
 
-#: applet.js:3133 applet.js:3167
+#. applet.js:3133 applet.js:3167
 msgid "Record from now"
 msgstr "Jetzt aufnehmen"
 
-#: applet.js:3151 applet.js:4953
+#. applet.js:3151 applet.js:4953
 msgid "Stop Current Recording"
 msgstr "Aktuelle Aufnahme stoppen"
 
-#: applet.js:3279
+#. applet.js:3279
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Spielt %s%s"
 
-#: applet.js:3332
+#. applet.js:3332
 msgid "Radio OFF"
 msgstr "Radio AUS"
 
-#: applet.js:3460
+#. applet.js:3460
 msgid "Unable to record anything!"
 msgstr "Kann nichts aufnehmen!"
 
-#: applet.js:3460 applet.js:4810
+#. applet.js:3460 applet.js:4810
 msgid "Insufficient space"
 msgstr "Unzureichender Speicherplatz"
 
-#: applet.js:3460
+#. applet.js:3460
 msgid "The limit you set has been reached."
 msgstr "Das von Ihnen gesetzte Limit wurde erreicht."
 
 # Please check. But comma should be okay here since there is a 2nd part.
-#: applet.js:3846
+#. applet.js:3846
 msgid "Please Log Out then Log In"
 msgstr "Bitte loggen Sie sich aus und dann wieder ein"
 
-#: applet.js:3846
+#. applet.js:3846
 msgid "to finalize yt-dlp update"
 msgstr "um das yt-dlp-Update abzuschließen"
 
-#: applet.js:3951
+#. applet.js:3951
 msgid "Nothing to save."
 msgstr "Nichts zu speichern."
 
-#: applet.js:3964
+#. applet.js:3964
 msgid "List of saved radio stations"
 msgstr "Liste der gespeicherten Radiosender"
 
-#: applet.js:3982
+#. applet.js:3982
 msgid "This will replace all current radio stations."
 msgstr "Dies wird alle aktuellen Radiosender ersetzen."
 
-#: applet.js:3983
+#. applet.js:3983
 msgid "Are you sure you want to continue?"
 msgstr "Sind Sie sicher, dass Sie fortfahren möchten?"
 
-#: applet.js:4043
+#. applet.js:4043
 msgid "Update in progress"
 msgstr "Update läuft"
 
-#: applet.js:4043
+#. applet.js:4043
 msgid "It may take a while ... Please wait."
 msgstr "Es kann eine Weile dauern ... Bitte warten."
 
-#: applet.js:4133
+#. applet.js:4133
 msgid "Update completed successfully"
 msgstr "Update erfolgreich abgeschlossen"
 
-#: applet.js:4343 applet.js:4399
+#. applet.js:4343 applet.js:4399
 msgid "ERROR: Invalid YT video URL!"
 msgstr "FEHLER: Ungültige YT-Video-URL!"
 
-#: applet.js:4368
+#. applet.js:4368
 msgid "Unable to extract a single soundtrack"
 msgstr "Kann keinen einzelnen Soundtrack extrahieren"
 
-#: applet.js:4368
+#. applet.js:4368
 msgid "Maybe it's a playlist?"
 msgstr "Vielleicht ist es eine Playlist?"
 
-#: applet.js:4401
+#. applet.js:4401
 msgid "Close"
 msgstr "Schließen"
 
-#: applet.js:4621
+#. applet.js:4621
 msgid "About..."
 msgstr "Über..."
 
-#: applet.js:4644
+#. applet.js:4644
 msgid "Manual..."
 msgstr "Handbuch..."
 
-#: applet.js:4676
+#. applet.js:4676
 msgid "Schedule a background record..."
 msgstr "Hintergrundaufnahme planen..."
 
-#: applet.js:4688
+#. applet.js:4688
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Soundtrack aus YouTube-Video extrahieren..."
 
-#: applet.js:4709
+#. applet.js:4709
 msgid "Pulse Effects"
 msgstr "Pulse-Effekte"
 
-#: applet.js:4718
+#. applet.js:4718
 msgid "Easy Effects"
 msgstr "Einfache Effekte"
 
-#: applet.js:4727
+#. applet.js:4727
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Entfernen '%s'"
 
-#: applet.js:4740
+#. applet.js:4740
 msgid "Radio ON at startup"
 msgstr "Radio beim Start einschalten"
 
-#: applet.js:4754
+#. applet.js:4754
 msgid "Display Station Logo"
 msgstr "Senderlogo anzeigen"
 
 #. settings-schema.json->dont-check-dependencies->description
-#: applet.js:4768
+#. applet.js:4768
 msgid "Do not check about dependencies"
 msgstr "Nicht nach Abhängigkeiten prüfen"
 
-#: applet.js:4807
+#. applet.js:4807
 msgid "(auto)"
 msgstr "(auto)"
 
-#: applet.js:4807
+#. applet.js:4807
 msgid "(manual)"
 msgstr "(manuell)"
 
-#: applet.js:4810 applet.js:5002
+#. applet.js:4810 applet.js:5002
 msgid "Stop Recording"
 msgstr "Aufnahme stoppen"
 
-#: applet.js:4810
+#. applet.js:4810
 msgid "Start Recording"
 msgstr "Aufnahme starten"
 
-#: applet.js:4831
+#. applet.js:4831
 msgid "Reload this applet"
 msgstr "Dieses Applet neu laden"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#: applet.js:4847
+#. applet.js:4847
 msgid "Display volume level near icon"
 msgstr "Lautstärkepegel neben dem Symbol anzeigen"
 
-#: applet.js:4865
+#. applet.js:4865
 msgid "Cancel downloads from YT"
 msgstr "Downloads von YT abbrechen"
 
-#: applet.js:5003
+#. applet.js:5003
 msgid "Close without stopping recording"
 msgstr "Schließen ohne Aufnahme zu stoppen"
 
-#: applet.js:5213
+#. applet.js:5213
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Aufnahme startet von %s:%s bis %s:%s"
 
-#: applet.js:5225
+#. applet.js:5225
 msgid "Recording completed"
 msgstr "Aufnahme abgeschlossen"
 
-#: applet.js:5320
+#. applet.js:5320
 msgid "This will import a new file containing radio stations."
 msgstr "Dies wird eine neue Datei mit Radiosendern importieren."
 
-#: applet.js:5321
+#. applet.js:5321
 msgid "Do you want to continue?"
 msgstr "Möchten Sie fortfahren?"
 
-#: applet.js:5392
+#. applet.js:5392
 msgid "No new radio in your list."
 msgstr "Kein neuer Sender in Ihrer Liste."
 
-#: applet.js:5394
+#. applet.js:5394
 msgid "One more radio in your list."
 msgstr "Ein weiterer Sender in Ihrer Liste."
 
-#: applet.js:5396
+#. applet.js:5396
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s weitere Sender in Ihrer Liste."
 
-#: applet.js:5603
+#. applet.js:5603
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 "Es gibt keine neuen Sender, die dem Radio3.0-Applet-Menü hinzugefügt werden "
 "können"
 
-#: applet.js:5605
+#. applet.js:5605
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Ein neuer Sender wurde dem Radio3.0-Applet-Menü hinzugefügt"
 
-#: applet.js:5607
+#. applet.js:5607
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s neue Sender wurden dem Radio3.0-Applet-Menü hinzugefügt"
 
-#: applet.js:5808
+#. applet.js:5808
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
 
-#: lib/checkDependencies.js:392
+#. lib/checkDependencies.js:392
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "Das Applet %s ist voll funktionsfähig."
 
-#: lib/checkDependencies.js:393
+#. lib/checkDependencies.js:393
 msgid "All dependencies are installed"
 msgstr "Alle Abhängigkeiten sind installiert"
 
-#: lib/checkDependencies.js:423
+#. lib/checkDependencies.js:423
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -537,119 +538,119 @@ msgstr ""
 "Es scheint, dass einige der Programme fehlen, die für dieses Applet "
 "erforderlich sind für einen vollen Funktionsumfang."
 
-#: lib/checkDependencies.js:424
+#. lib/checkDependencies.js:424
 msgid "Please execute, in the just opened terminal, the commands:"
 msgstr "Bitte führen Sie im gerade geöffneten Terminal die Befehle aus:"
 
-#: lib/checkDependencies.js:425
+#. lib/checkDependencies.js:425
 msgid "Some dependencies are not installed!"
 msgstr "Einige Abhängigkeiten sind nicht installiert!"
 
-#: lib/checkTranslations.js:108
+#. lib/checkTranslations.js:108
 msgid "To finalize the translation installation, please restart Cinnamon"
 msgstr ""
 "Um die Übersetzungsinstallation abzuschließen, bitte Cinnamon neu starten"
 
-#: lib/util.js:245
+#. lib/util.js:245
 #, javascript-format
 msgid "Execution of '%s' failed:"
 msgstr "Ausführung von '%s' fehlgeschlagen:"
 
-#: xs/xlet-settings.py:214
+#. xs/xlet-settings.py:214
 msgid "Previous instance"
 msgstr "Vorherige Instanz"
 
-#: xs/xlet-settings.py:218
+#. xs/xlet-settings.py:218
 msgid "Next instance"
 msgstr "Nächste Instanz"
 
-#: xs/xlet-settings.py:227
+#. xs/xlet-settings.py:227
 msgid "More options"
 msgstr "Weitere Optionen"
 
-#: xs/xlet-settings.py:233
+#. xs/xlet-settings.py:233
 msgid "Import from a file"
 msgstr "Aus einer Datei importieren"
 
-#: xs/xlet-settings.py:238
+#. xs/xlet-settings.py:238
 msgid "Export to a file"
 msgstr "In eine Datei exportieren"
 
-#: xs/xlet-settings.py:243
+#. xs/xlet-settings.py:243
 msgid "Reset to defaults"
 msgstr "Auf Standardeinstellungen zurücksetzen"
 
-#: xs/xlet-settings.py:252
+#. xs/xlet-settings.py:252
 #, python-format
 msgid "Reload %s"
 msgstr "%s neu laden"
 
-#: xs/xlet-settings.py:441
+#. xs/xlet-settings.py:441
 #, python-format
 msgid "Settings for %s"
 msgstr "Einstellungen für %s"
 
-#: xs/xlet-settings.py:533
+#. xs/xlet-settings.py:533
 msgid "Select or enter file to export to"
 msgstr "Datei zum Exportieren auswählen oder eingeben"
 
-#: xs/xlet-settings.py:541 xs/xlet-settings.py:562
+#. xs/xlet-settings.py:541 xs/xlet-settings.py:562
 msgid "JSON files"
 msgstr "JSON-Dateien"
 
-#: xs/xlet-settings.py:555
+#. xs/xlet-settings.py:555
 msgid "Select a JSON file to import"
 msgstr "JSON-Datei zum Importieren auswählen"
 
-#: xs/bin/R3TreeListWidgets.py:278 xs/bin/R3TreeListWidgets.py:501
+#. xs/bin/R3TreeListWidgets.py:278 xs/bin/R3TreeListWidgets.py:501
 msgid "Add new entry"
 msgstr "Neuen Eintrag hinzufügen"
 
-#: xs/bin/R3TreeListWidgets.py:282
+#. xs/bin/R3TreeListWidgets.py:282
 msgid "Remove selected entry"
 msgstr "Ausgewählten Eintrag entfernen"
 
-#: xs/bin/R3TreeListWidgets.py:287
+#. xs/bin/R3TreeListWidgets.py:287
 msgid "Edit selected entry"
 msgstr "Ausgewählten Eintrag bearbeiten"
 
-#: xs/bin/R3TreeListWidgets.py:292
+#. xs/bin/R3TreeListWidgets.py:292
 msgid "Unselect the selected row"
 msgstr "Ausgewählte Zeile abwählen"
 
-#: xs/bin/R3TreeListWidgets.py:297
+#. xs/bin/R3TreeListWidgets.py:297
 msgid "Move selected entry up"
 msgstr "Ausgewählten Eintrag nach oben verschieben"
 
-#: xs/bin/R3TreeListWidgets.py:302
+#. xs/bin/R3TreeListWidgets.py:302
 msgid "Move selected entry down"
 msgstr "Ausgewählten Eintrag nach unten verschieben"
 
-#: xs/bin/R3TreeListWidgets.py:325
+#. xs/bin/R3TreeListWidgets.py:325
 msgid "Go to bottom"
 msgstr "Zum Ende gehen"
 
-#: xs/bin/R3TreeListWidgets.py:331
+#. xs/bin/R3TreeListWidgets.py:331
 msgid "Go to next page"
 msgstr "Zur nächsten Seite gehen"
 
-#: xs/bin/R3TreeListWidgets.py:337
+#. xs/bin/R3TreeListWidgets.py:337
 msgid "Go to previous page"
 msgstr "Zur vorherigen Seite gehen"
 
-#: xs/bin/R3TreeListWidgets.py:342
+#. xs/bin/R3TreeListWidgets.py:342
 msgid "Go to top"
 msgstr "Zum Anfang gehen"
 
-#: xs/bin/R3TreeListWidgets.py:356
+#. xs/bin/R3TreeListWidgets.py:356
 msgid "Go to next category"
 msgstr "Zur nächsten Kategorie gehen"
 
-#: xs/bin/R3TreeListWidgets.py:366
+#. xs/bin/R3TreeListWidgets.py:366
 msgid "Go to previous category"
 msgstr "Zur vorherigen Kategorie gehen"
 
-#: xs/bin/R3TreeListWidgets.py:503
+#. xs/bin/R3TreeListWidgets.py:503
 msgid "Edit entry"
 msgstr "Eintrag bearbeiten"
 


### PR DESCRIPTION
Provide German translations for Radio3.0 applet.

@claudiux
I could not translate the button labels for shortcuts in the menu since they were not in the pot file:
![Radio-Menu-Shortcuts](https://github.com/user-attachments/assets/296df990-3a29-4826-805c-cded0788567c)
