### PR TITLE
[download-and-upload-speed@cardsurf] v1.6.6 - Binary or decimal units can now be selected

### DIFF
--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
@@ -166,6 +166,7 @@ MyApplet.prototype = {
         for(let [binding, property_name, callback] of [
                         [Settings.BindingDirection.IN, "display_mode", null],
                         [Settings.BindingDirection.IN, "unit_type", null],
+                        [Settings.BindingDirection.IN, "is_binary", null],
                         [Settings.BindingDirection.IN, "update_every", null],
                         [Settings.BindingDirection.IN, "update_available_interfaces_every", null],
                         [Settings.BindingDirection.IN, "launch_terminal", null],
@@ -790,19 +791,34 @@ MyApplet.prototype = {
     },
 
     convert_bytes_to_readable_unit: function (bytes) {
+        if (this.is_binary === true) {
+            if(bytes >= Math.pow(2, 40)) {
+                return [bytes/Math.pow(2, 40), _("TiB")];
+            }
+            if(bytes >= Math.pow(2, 30)) {
+                return [bytes/Math.pow(2, 30), _("GiB")];
+            }
+            if(bytes >= Math.pow(2, 20)) {
+                return [bytes/Math.pow(2, 20), _("MiB")];
+            }
+            if(bytes >= Math.pow(2, 10)) {
+                return [bytes/Math.pow(2, 10), _("kiB")];
+            }
+            return [bytes, _("B")];
+        }
         if(bytes >= 1000000000000) {
-            return [bytes/1000000000000, "TB"];
+            return [bytes/1000000000000, _("TB")];
         }
         if(bytes >= 1000000000) {
-            return [bytes/1000000000, "GB"];
+            return [bytes/1000000000, _("GB")];
         }
         if(bytes >= 1000000) {
-            return [bytes/1000000, "MB"];
+            return [bytes/1000000, _("MB")];
         }
         if(bytes >= 1000) {
-            return [bytes/1000, "kB"];
+            return [bytes/1000, _("kB")];
         }
-        return [bytes, "B"];
+        return [bytes, _("B")];
     },
 
     convert_to_bits: function (bytes) {
@@ -810,17 +826,32 @@ MyApplet.prototype = {
     },
 
     convert_bits_to_readable_unit: function (bits) {
+        if (this.is_binary === true) {
+            if(bits >= Math.pow(2, 40)) {
+                return [bits/Math.pow(2, 40), _("Tib")];
+            }
+            if(bits >= Math.pow(2, 30)) {
+                return [bits/Math.pow(2, 30), _("Gib")];
+            }
+            if(bits >= Math.pow(2, 20)) {
+                return [bits/Math.pow(2, 20), _("Mib")];
+            }
+            if(bits >= Math.pow(2, 10)) {
+                return [bits/Math.pow(2, 10), _("kib")];
+            }
+            return [bits, _("b")];
+        }
         if(bits >= 1000000000000) {
-            return [bits/1000000000000, "Tb"];
+            return [bits/1000000000000, _("Tb")];
         }
         if(bits >= 1000000000) {
-            return [bits/1000000000, "Gb"];
+            return [bits/1000000000, _("Gb")];
         }
         if(bits >= 1000000) {
-            return [bits/1000000, "Mb"];
+            return [bits/1000000, _("Mb")];
         }
         if(bits >= 1000) {
-            return [bits/1000, "kb"];
+            return [bits/1000, _("kb")];
         }
         return [bits, _("b")];
     },

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/metadata.json
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/metadata.json
@@ -1,6 +1,7 @@
 {
     "description": "Shows usage of a network interface",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "uuid": "download-and-upload-speed@cardsurf",
-    "name": "Download and upload speed"
+    "name": "Download and upload speed",
+    "author": "cardsurf"
 }

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/bg.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/bg.po
@@ -1,322 +1,425 @@
 # Main translation file for download-and-upload-speed@cardsurf.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-20 22:14+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2017-11-20 22:44+0200\n"
+"Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: bg\n"
 
-#: applet.js:345
-msgid "Network interface"
+#. applet.js:438
+#, fuzzy
+msgid "Network interfaces"
 msgstr "Мрежов интерфейс"
 
-#: applet.js:366
+#. applet.js:507
 msgid "Total data start"
 msgstr "Общи данни начало"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:373
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Стартиране на аплета"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:374
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:515
 msgid "Today"
 msgstr "Днес"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:375
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Вчера"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:376
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:517
 msgid "3 days ago"
 msgstr "Отпреди 3 дни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:377
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:518
 msgid "5 days ago"
 msgstr "Отпреди 5 дни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:378
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:519
 msgid "7 days ago"
 msgstr "Отпреди 7 дни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:379
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:520
 msgid "10 days ago"
 msgstr "Отпреди 10 дни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:380
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:521
 msgid "14 days ago"
 msgstr "Отпреди 14 дни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:381
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:522
 msgid "30 days ago"
 msgstr "Отпреди 30 дни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:382
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:523
 msgid "Custom date"
 msgstr "Потребителска дата"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_start->description
-#: applet.js:465
+#. settings-schema.json->gui_start->description
+#. applet.js:560
 msgid "Gui"
 msgstr "Гпи"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->options
-#: applet.js:465
+#. settings-schema.json->gui_speed_type->options
+#. applet.js:560
 msgid "Compact"
 msgstr "Компактен"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->options
-#: applet.js:444
+#. settings-schema.json->gui_speed_type->options
+#. applet.js:560
 msgid "Large"
 msgstr "Голям"
 
-#: appletGui.js:362
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Гпи"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "МБ"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "МБ"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "МБ"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Гпи"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
+msgid "b"
+msgstr ""
+
+#. applet.js:845
+msgid "Tb"
+msgstr ""
+
+#. applet.js:848
+msgid "Gb"
+msgstr ""
+
+#. applet.js:851
+msgid "Mb"
+msgstr ""
+
+#. applet.js:854
+msgid "kb"
+msgstr ""
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Общо сваляне:"
 
-#: appletGui.js:363
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Общо качване:"
 
-#. download-and-upload-speed@cardsurf->metadata.json->name
-msgid "Download and upload speed"
-msgstr "Скорост на сваляне и качване"
-
-#. download-and-upload-speed@cardsurf->metadata.json->description
+#. metadata.json->description
 msgid "Shows usage of a network interface"
 msgstr "Показвай използването на мрежовия интерфейс"
 
-#. download-and-upload-speed@cardsurf->settings-schema.json->head->description
-msgid "Settings for download-and-upload-speed@cardsurf"
-msgstr "Настройки за скорост-на-сваляне-и-качване@cardsurf"
+#. metadata.json->name
+msgid "Download and upload speed"
+msgstr "Скорост на сваляне и качване"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->configuration->description
+#. settings-schema.json->configuration->description
 msgid "Configuration"
 msgstr "Конфигурация"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->description
+#. settings-schema.json->display_mode->description
 msgid "Show"
 msgstr "Показване"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->tooltip
-msgid "Values shown in the panel"
-msgstr "Стойности показвани в панела"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->options
+#. settings-schema.json->display_mode->options
 msgid "Average speed per second"
 msgstr "Средна скорост в секунда"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->options
+#. settings-schema.json->display_mode->options
 msgid "Amount of data transferred"
 msgstr "Количество на прехвърлени данни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->description
+#. settings-schema.json->display_mode->tooltip
+msgid "Values shown in the panel"
+msgstr "Стойности показвани в панела"
+
+#. settings-schema.json->unit_type->description
 msgid "Unit"
 msgstr "Единица"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->tooltip
-msgid "Base data unit shown in the panel"
-msgstr "Базова единица за данни, показвана в панела"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->options
+#. settings-schema.json->unit_type->options
 msgid "Bytes"
 msgstr "Байта"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->options
+#. settings-schema.json->unit_type->options
 msgid "Bits"
 msgstr "Бита"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->description
-msgid "Calculate every"
-msgstr "Пресмятай на всеки"
+#. settings-schema.json->unit_type->tooltip
+msgid "Base data unit shown in the panel"
+msgstr "Базова единица за данни, показвана в панела"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->tooltip
-msgid "How often to calculate download and upload speed"
-msgstr "Колко често да се пресмята скоростта на сваляне и качване"
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->units
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->units
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Място на десетицата"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
+
+#. settings-schema.json->update_every->units
+#. settings-schema.json->update_available_interfaces_every->units
+#. settings-schema.json->write_every->units
 msgid "seconds"
 msgstr "секунди"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->description
+#. settings-schema.json->update_every->description
+msgid "Calculate every"
+msgstr "Пресмятай на всеки"
+
+#. settings-schema.json->update_every->tooltip
+msgid "How often to calculate download and upload speed"
+msgstr "Колко често да се пресмята скоростта на сваляне и качване"
+
+#. settings-schema.json->update_available_interfaces_every->description
+msgid "Update available interfaces every"
+msgstr ""
+
+#. settings-schema.json->update_available_interfaces_every->tooltip
+msgid ""
+"How often to update list of available network interfaces. 0 means list of "
+"available network interfaces is not updated periodically."
+msgstr ""
+
+#. settings-schema.json->gui_speed_type->description
 msgid "Type"
 msgstr "Тип"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->tooltip
+#. settings-schema.json->gui_speed_type->tooltip
 msgid "Applet Gui"
 msgstr "Гпи на аплета"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->description
+#. settings-schema.json->gui_value_order->description
+msgid "Value order"
+msgstr ""
+
+#. settings-schema.json->gui_value_order->options
+#, fuzzy
+msgid "Download first"
+msgstr "Иконка за сваляне"
+
+#. settings-schema.json->gui_value_order->options
+#, fuzzy
+msgid "Upload first"
+msgstr "Иконка за качване"
+
+#. settings-schema.json->gui_value_order->tooltip
+msgid "An order of values shown in the panel and in the hover popup"
+msgstr ""
+
+#. settings-schema.json->decimal_places->description
 msgid "Decimal places"
 msgstr "Място на десетицата"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->tooltip
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Авто"
+
+#. settings-schema.json->decimal_places->options
+msgid "0 "
+msgstr "0"
+
+#. settings-schema.json->decimal_places->options
+msgid "1 "
+msgstr "1"
+
+#. settings-schema.json->decimal_places->options
+msgid "2 "
+msgstr "2"
+
+#. settings-schema.json->decimal_places->options
+msgid "3 "
+msgstr "3"
+
+#. settings-schema.json->decimal_places->tooltip
 msgid "Decimal places of download and upload speed shown in the panel"
 msgstr ""
 "Място на десетичния знак за скоростта на сваляне и качване, показвана в "
 "панела"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Авто"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
-msgid "0 "
-msgstr "0"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
-msgid "1 "
-msgstr "1"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
-msgid "2 "
-msgstr "2"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
-msgid "3 "
-msgstr "3"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_text_css->description
+#. settings-schema.json->gui_text_css->description
 msgid "Text CSS"
 msgstr "CSS на текста"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_text_css->tooltip
+#. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "CSS стила, прилаган за текста в панела"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_received_icon_filename->description
+#. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"
 msgstr "Иконка за сваляне"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_received_icon_filename->tooltip
-msgid "An icon displayed next to download speed in the panel"
-msgstr "Иконката, показвано до скоростта за сваляне в панела"
+#. settings-schema.json->gui_received_icon_filename->tooltip
+msgid ""
+"An icon displayed next to download speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_sent_icon_filename->description
+#. settings-schema.json->gui_sent_icon_filename->description
 msgid "Upload icon"
 msgstr "Иконка за качване"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_sent_icon_filename->tooltip
-msgid "An icon displayed next to upload speed in the panel"
-msgstr "Иконката, показвано до скоростта за качване в панела"
+#. settings-schema.json->gui_sent_icon_filename->tooltip
+msgid ""
+"An icon displayed next to upload speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_text_css->description
+#. settings-schema.json->gui_symbolic_icon->description
+msgid "Show a default set of symbolic icons"
+msgstr ""
+
+#. settings-schema.json->hover_popup_text_css->description
 msgid "Popup text CSS"
 msgstr "CSS на изскачащия текст"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_text_css->tooltip
+#. settings-schema.json->hover_popup_text_css->tooltip
 msgid "A CSS style applied to the description text in the hover popup"
 msgstr "CSS стила, приложен за текстовото описание в изскачащото прозороче"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_numbers_css->description
+#. settings-schema.json->hover_popup_numbers_css->description
 msgid "Popup numbers CSS"
 msgstr "CSS на изскачащите числа"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_numbers_css->tooltip
+#. settings-schema.json->hover_popup_numbers_css->tooltip
 msgid "A CSS style applied to numbers in the hover popup"
 msgstr "CSS стила, приложен за числата в изскачащото прозороче"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->total_data_start->description
+#. settings-schema.json->minimum_bytes_received_to_display->units
+#. settings-schema.json->minimum_bytes_sent_to_display->units
+#, fuzzy
+msgid "bytes"
+msgstr "Байта"
+
+#. settings-schema.json->minimum_bytes_received_to_display->description
+msgid "Minimum displayed download value"
+msgstr ""
+
+#. settings-schema.json->minimum_bytes_received_to_display->tooltip
+#, fuzzy
+msgid "A minimum download value to display in the panel"
+msgstr "Иконката, показвано до скоростта за качване в панела"
+
+#. settings-schema.json->minimum_bytes_sent_to_display->description
+msgid "Minimum displayed upload value"
+msgstr ""
+
+#. settings-schema.json->minimum_bytes_sent_to_display->tooltip
+#, fuzzy
+msgid "A minimum upload value to display in the panel"
+msgstr "Иконката, показвано до скоростта за качване в панела"
+
+#. settings-schema.json->total_data_start->description
 msgid "Total data"
 msgstr "Общи данни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->show_hover->description
+#. settings-schema.json->show_hover->description
 msgid "Show total download and upload on hover"
 msgstr "Показване на общите данни на сваляне и качване при показване"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->show_hover->tooltip
+#. settings-schema.json->show_hover->tooltip
 msgid "Show the hover popup with total amount of data downloaded and uploaded"
 msgstr ""
 "Показване на общото количество данни за сваляне и качване в изскачащия "
 "прозорец при посочване"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->description
+#. settings-schema.json->bytes_start_time->description
 msgid "Start"
 msgstr "Начало"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->tooltip
+#. settings-schema.json->bytes_start_time->tooltip
 msgid "Start time to count total amount of data downloaded and uploaded"
 msgstr "Начално време на общото количество свалени и качени данни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->custom_start_date->description
+#. settings-schema.json->custom_start_date->description
 msgid "Custom date "
 msgstr "Потребителска дата"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->custom_start_date->tooltip
+#. settings-schema.json->custom_start_date->tooltip
 msgid ""
 "A custom date in YYYY-MM-DD format used as start time. The option is used if "
 "\"Custom date\" is selected in \"Start\" combobox."
@@ -325,13 +428,11 @@ msgstr ""
 "Опцията се използва ако е избрано \"Потребителска дата\" в падащото меню на "
 "\"Начало\""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->description
+#. settings-schema.json->write_every->description
 msgid "Save every"
 msgstr "Запазвай на всеки"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->tooltip
+#. settings-schema.json->write_every->tooltip
 msgid ""
 "How often to save total amount of data downloaded and uploaded to the file. "
 "0 means no saving to the file."
@@ -339,58 +440,44 @@ msgstr ""
 "Колко често да се запазва общото количество данни за сваляне и качване във "
 "файл. 0 означава без запазване във файл."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_start->description
+#. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Лимити на данни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit->description
+#. settings-schema.json->data_limit->description
 msgid "Data limit"
 msgstr "Лимит на данни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit->tooltip
+#. settings-schema.json->data_limit->tooltip
 msgid "The maximum amount of data to download and upload. 0 means no limits."
 msgstr ""
 "Максималното количество данни за сваляне и качване. 0 означава без лимити."
 
-#. download-and-upload-speed@cardsurf->settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "МБ"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->description
+#. settings-schema.json->gui_data_limit_type->description
 msgid "Show data limit usage"
 msgstr "Показвай употребата на лимитирани данни"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->tooltip
-msgid "Show the percentage of data limit used in the panel"
-msgstr "Показвай процент от употребата на лимита за данни в панела"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "None"
 msgstr "Без"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
-msgid "Text"
-msgstr "Текст"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "Circle"
 msgstr "Кръг"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command_enabled->description
+#. settings-schema.json->gui_data_limit_type->options
+msgid "Text"
+msgstr "Текст"
+
+#. settings-schema.json->gui_data_limit_type->tooltip
+msgid "Show the percentage of data limit used in the panel"
+msgstr "Показвай процент от употребата на лимита за данни в панела"
+
+#. settings-schema.json->data_limit_command_enabled->description
 msgid "Invoke command when data limit exceeded"
 msgstr "Извикай команда, когато лиимита за данни е достигнат"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command_enabled->tooltip
+#. settings-schema.json->data_limit_command_enabled->tooltip
 msgid ""
 "Invoke a command when amount of data downloaded and uploaded exceeded the "
 "limit"
@@ -398,28 +485,23 @@ msgstr ""
 "Извикай команда, когато общото количество на свалени и качени данни е "
 "достигнал лимита"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command->description
+#. settings-schema.json->data_limit_command->description
 msgid "Command"
 msgstr "Команда"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command->tooltip
+#. settings-schema.json->data_limit_command->tooltip
 msgid "A command to invoke"
 msgstr "Команда за извикване"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->connections_start->description
+#. settings-schema.json->connections_start->description
 msgid "Connections"
 msgstr "Връзки"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->launch_terminal->description
+#. settings-schema.json->launch_terminal->description
 msgid "List current Internet connections on left mouse click"
 msgstr "Списък на текущите интернет връзки при клик с ляв бутон"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->launch_terminal->tooltip
+#. settings-schema.json->launch_terminal->tooltip
 msgid ""
 "Open a terminal with a list of current connections on a left mouse click. "
 "The next click closes the terminal."
@@ -427,12 +509,10 @@ msgstr ""
 "Отваряне на терминал със списък на текущите връзки при ляв клик. Следващия "
 "клик ще затвори терминала."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->list_connections_command->description
+#. settings-schema.json->list_connections_command->description
 msgid "Command "
 msgstr "Команда"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->list_connections_command->tooltip
+#. settings-schema.json->list_connections_command->tooltip
 msgid "A command used to list current Internet connections"
 msgstr "Команда използвана за списък на текущите интернет връзки"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/ca.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/ca.po
@@ -1,14 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
+# DOWNLOAD AND UPLOAD SPEED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2024-07-19 02:25+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,88 +19,165 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Interfícies de xarxa"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Inici del recompte de dades"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Des de l'inici de la miniaplicació"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "Avui"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Ahir"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "Fa 3 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "Fa 5 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "Fa 7 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "Fa 10 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "Fa 14 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "Fa 30 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "Data personalitzada"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "Interfície"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Compacta"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Gran"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Interfície"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Interfície"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Baixada total:"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Pujada total:"
 
@@ -146,6 +224,25 @@ msgstr "Bits"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Unit base de les dades mostrades al tauler"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Número de decimals"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -353,10 +450,6 @@ msgstr ""
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Límits de dades"
-
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
 
 #. settings-schema.json->data_limit->description
 msgid "Data limit"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/da.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/da.po
@@ -1,13 +1,14 @@
 # Main translation file for download-and-upload-speed@cardsurf.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2022-10-26 18:50+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,88 +19,165 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Netværksgrænseflader"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Total datastart"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Opstart af panelprogrammet"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "I dag"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "I går"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "Tilpasset dato"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "Grafisk brugergrænseflade"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Kompakt"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Stor"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Grafisk brugergrænseflade"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Grafisk brugergrænseflade"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Total download:"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Total upload:"
 
@@ -146,6 +224,25 @@ msgstr "Bit"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Dataenhed vist i panelet"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Decimaler"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -352,10 +449,6 @@ msgstr ""
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Datagrænser"
-
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
 
 #. settings-schema.json->data_limit->description
 msgid "Data limit"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/de.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/de.po
@@ -1,13 +1,14 @@
 # Main translation file for download-and-upload-speed@cardsurf.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2021-02-27 00:14+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,88 +19,165 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Netzwerkschnittstellen"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Start der Gesamtdaten"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Start des Applets"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "Heute"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Gestern"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "vor 3 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "vor 5 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "vor 7 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "vor 10 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "vor 14 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "vor 30 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "Benutzerdefiniertes Datum"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "Darstellung in der Leiste"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Kompakt"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Groß"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Darstellung in der Leiste"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Darstellung in der Leiste"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Gesamt-Download:"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Gesamt-Upload:"
 
@@ -146,6 +224,25 @@ msgstr "Bits"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Basisdateneinheit, welche in der Leiste angezeigt wird"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Nachkommastellen"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -362,10 +459,6 @@ msgstr ""
 msgid "Data limits"
 msgstr "Datengrenzen"
 
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
-
 #. settings-schema.json->data_limit->description
 msgid "Data limit"
 msgstr "Datenlimit"
@@ -439,11 +532,3 @@ msgstr "Befehl "
 #. settings-schema.json->list_connections_command->tooltip
 msgid "A command used to list current Internet connections"
 msgstr "Befehl, der zur Auflistung aktueller Internetverbindungen genutzt wird"
-
-#~ msgid "Settings for download-and-upload-speed@cardsurf"
-#~ msgstr "Einstellungen für download-and-upload-speed@cardsurf"
-
-#~ msgid "An icon displayed next to download speed in the panel"
-#~ msgstr ""
-#~ "Ein Symbol, welches neben der Downloadgeschwindigkeit in der Leiste "
-#~ "angezeigt wird"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/download-and-upload-speed@cardsurf.pot
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/download-and-upload-speed@cardsurf.pot
@@ -1,104 +1,173 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# DOWNLOAD AND UPLOAD SPEED
+# This file is put in the public domain.
+# cardsurf, 2016
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: download-and-upload-speed@cardsurf 1.6.6\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr ""
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr ""
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr ""
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr ""
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr ""
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+msgid "GiB"
+msgstr ""
+
+#. applet.js:802
+msgid "MiB"
+msgstr ""
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+msgid "B"
+msgstr ""
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr ""
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+msgid "Gib"
+msgstr ""
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr ""
 
-#: appletGui.js:470
+#. applet.js:845
+msgid "Tb"
+msgstr ""
+
+#. applet.js:848
+msgid "Gb"
+msgstr ""
+
+#. applet.js:851
+msgid "Mb"
+msgstr ""
+
+#. applet.js:854
+msgid "kb"
+msgstr ""
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr ""
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr ""
 
@@ -144,6 +213,24 @@ msgstr ""
 
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
+msgstr ""
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+msgid "Decimal"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
 msgstr ""
 
 #. settings-schema.json->update_every->units
@@ -317,8 +404,8 @@ msgstr ""
 
 #. settings-schema.json->custom_start_date->tooltip
 msgid ""
-"A custom date in YYYY-MM-DD format used as start time. The option is used if"
-" \"Custom date\" is selected in \"Start\" combobox."
+"A custom date in YYYY-MM-DD format used as start time. The option is used if "
+"\"Custom date\" is selected in \"Start\" combobox."
 msgstr ""
 
 #. settings-schema.json->write_every->description
@@ -333,10 +420,6 @@ msgstr ""
 
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
-msgstr ""
-
-#. settings-schema.json->data_limit->units
-msgid "MB"
 msgstr ""
 
 #. settings-schema.json->data_limit->description

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/es.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/es.po
@@ -1,105 +1,183 @@
-# SOME DESCRIPTIVE TITLE.
+# DOWNLOAD AND UPLOAD SPEED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2021-12-03 00:08-0300\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: es\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Interfaces de red"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Cantidad total de datos"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Desde el lanzamiento del applet"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "Desde hoy"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Desde ayer"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "Hace 3 días"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "Hace 5 días"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "Hace 7 días"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "Hace 10 días"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "Hace 14 días"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "Hace 30 días"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "Fecha personalizada"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "Estilo"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Compacto"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Grande"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Estilo"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Estilo"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Descarga total:"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Subida total:"
 
@@ -146,6 +224,25 @@ msgstr "Bits"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Unidad de los datos mostrados en el panel"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Cifras decimales"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -356,10 +453,6 @@ msgstr ""
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Límites de datos"
-
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
 
 #. settings-schema.json->data_limit->description
 msgid "Data limit"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/fi.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/fi.po
@@ -1,105 +1,183 @@
-# SOME DESCRIPTIVE TITLE.
+# DOWNLOAD AND UPLOAD SPEED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2022-11-23 14:56+0200\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Verkkoliitännät"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Datan määrä alkaen"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Sovelman avaamisesta"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "Tänään"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Eilen"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "Mukautettu päivämäärä"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "Gui"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Tiivis"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Suuri"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Gui"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "Mt"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "Mt"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "Mt"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Gui"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Lataus yhteensä:"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Lähetys yhteensä:"
 
@@ -146,6 +224,25 @@ msgstr "Bittiä"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Tietoyksikkö näkyy paneelissa"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Desimaalit"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -348,10 +445,6 @@ msgstr ""
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Datarajoitukset"
-
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "Mt"
 
 #. settings-schema.json->data_limit->description
 msgid "Data limit"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/fr.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/fr.po
@@ -1,105 +1,175 @@
 # Main translation file for download-and-upload-speed@cardsurf.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
-"PO-Revision-Date: 2021-02-28 18:06+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
+"PO-Revision-Date: 2024-09-24 09:57+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Interfaces réseau"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Quantités totales depuis..."
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "le lancement de l'applet"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "aujourd'hui"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "hier"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 jours"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 jours"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 jours"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 jours"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 jours"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 jours"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "la date choisie"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "Affichage"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Compact"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Étendu"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr " Tio"
+
+#. applet.js:799
+msgid "GiB"
+msgstr " Gio"
+
+#. applet.js:802
+msgid "MiB"
+msgstr " Mio"
+
+#. applet.js:805
+msgid "kiB"
+msgstr " kio"
+
+#. applet.js:807 applet.js:821
+msgid "B"
+msgstr " o"
+
+#. applet.js:810
+msgid "TB"
+msgstr " To"
+
+#. applet.js:813
+msgid "GB"
+msgstr " Go"
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "Mo"
+
+#. applet.js:819
+msgid "kB"
+msgstr " ko"
+
+#. applet.js:831
+msgid "Tib"
+msgstr " Tib"
+
+#. applet.js:834
+msgid "Gib"
+msgstr " Gib"
+
+#. applet.js:837
+msgid "Mib"
+msgstr " Mib"
+
+#. applet.js:840
+msgid "kib"
+msgstr " kib"
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+msgid "Tb"
+msgstr " Tb"
+
+#. applet.js:848
+msgid "Gb"
+msgstr " Gb"
+
+#. applet.js:851
+msgid "Mb"
+msgstr " Mb"
+
+#. applet.js:854
+msgid "kb"
+msgstr " kb"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Total reçu :"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Total envoyé :"
 
@@ -146,6 +216,26 @@ msgstr "Bits"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Unité de base des données affichées dans le panneau"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr "Décimal ou binaire"
+
+#. settings-schema.json->is_binary->options
+msgid "Decimal"
+msgstr "Décimal"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr "Binaire"
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
+"Décimal : k, M, G, T\n"
+"Binaire : ki, Mi, Gi, Ti"
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -357,10 +447,6 @@ msgstr ""
 msgid "Data limits"
 msgstr "Quantité limite de données"
 
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "Mo"
-
 #. settings-schema.json->data_limit->description
 msgid "Data limit"
 msgstr "Quantité limite de données"
@@ -439,17 +525,3 @@ msgid "A command used to list current Internet connections"
 msgstr ""
 "Saisir une commande permettant d'obtenir la liste des connexions internet "
 "disponibles"
-
-#~ msgid "An icon displayed next to download speed in the panel"
-#~ msgstr ""
-#~ "Choisir une icône affichée à côté de la vitesse de réception dans le "
-#~ "panneau"
-
-#~ msgid "An icon displayed next to upload speed in the panel"
-#~ msgstr ""
-#~ "Choisir une icône affichée à côté de la vitesse d'envoi dans le panneau"
-
-#~ msgid "Settings for download-and-upload-speed@cardsurf"
-#~ msgstr ""
-#~ "Réglages pour l'applet Vitesses d'Envoi et de Réception (download-and-"
-#~ "upload-speed@cardsurf)"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/hr.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/hr.po
@@ -6,331 +6,432 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-16 23:18+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2017-04-29 14:01+0100\n"
+"Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian\n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: gogo <trebelnik2@gmail.com>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: applet.js:345
-msgid "Network interface"
+#. applet.js:438
+#, fuzzy
+msgid "Network interfaces"
 msgstr "Mrežno sučelje"
 
-#: applet.js:366
+#. applet.js:507
 msgid "Total data start"
 msgstr "Pokreni s ukupno podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:373
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "od pokretanja apleta"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:374
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:515
 msgid "Today"
 msgstr "od danas"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:375
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:516
 msgid "Yesterday"
 msgstr "od jučer"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:376
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:517
 msgid "3 days ago"
 msgstr "od prije 3 dana"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:377
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:518
 msgid "5 days ago"
 msgstr "od prije 5 dana"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:378
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:519
 msgid "7 days ago"
 msgstr "od prije 7 dana"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:379
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:520
 msgid "10 days ago"
 msgstr "od prije 10 dana"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:380
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:521
 msgid "14 days ago"
 msgstr "od prije 14 dana"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:381
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:522
 msgid "30 days ago"
 msgstr "od prije 30 dana"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:382
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:523
 msgid "Custom date"
 msgstr "Prilagođeni datum"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_start->description
-#: applet.js:465
+#. settings-schema.json->gui_start->description
+#. applet.js:560
 msgid "Gui"
 msgstr "Grafičko sučelje"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->options
-#: applet.js:465
+#. settings-schema.json->gui_speed_type->options
+#. applet.js:560
 msgid "Compact"
 msgstr "Kompaktno"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->options
-#: applet.js:444
+#. settings-schema.json->gui_speed_type->options
+#. applet.js:560
 msgid "Large"
 msgstr "Veliko"
 
-#: appletGui.js:362
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Grafičko sučelje"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Grafičko sučelje"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
+msgid "b"
+msgstr ""
+
+#. applet.js:845
+msgid "Tb"
+msgstr ""
+
+#. applet.js:848
+msgid "Gb"
+msgstr ""
+
+#. applet.js:851
+msgid "Mb"
+msgstr ""
+
+#. applet.js:854
+msgid "kb"
+msgstr ""
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Ukupno preuzeto:"
 
-#: appletGui.js:363
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Ukupno poslano:"
 
-#. download-and-upload-speed@cardsurf->metadata.json->name
-msgid "Download and upload speed"
-msgstr "Brzina preuzimanja i slanja"
-
-#. download-and-upload-speed@cardsurf->metadata.json->description
+#. metadata.json->description
 msgid "Shows usage of a network interface"
 msgstr "Prikazuje korištenje mrežnih sučelja"
 
-#. download-and-upload-speed@cardsurf->settings-schema.json->head->description
-msgid "Settings for download-and-upload-speed@cardsurf"
-msgstr "Postavke za download-and-upload-speed@cardsurf"
+#. metadata.json->name
+msgid "Download and upload speed"
+msgstr "Brzina preuzimanja i slanja"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->configuration->description
+#. settings-schema.json->configuration->description
 msgid "Configuration"
 msgstr "Podešavanje"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->description
+#. settings-schema.json->display_mode->description
 msgid "Show"
 msgstr "Prikaži"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->tooltip
-msgid "Values shown in the panel"
-msgstr "Vrijednosti prikazane u panelu"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->options
+#. settings-schema.json->display_mode->options
 msgid "Average speed per second"
 msgstr "Prosječnu brzinu po sekundi"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->options
+#. settings-schema.json->display_mode->options
 msgid "Amount of data transferred"
 msgstr "Količinu prenesenih podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->description
+#. settings-schema.json->display_mode->tooltip
+msgid "Values shown in the panel"
+msgstr "Vrijednosti prikazane u panelu"
+
+#. settings-schema.json->unit_type->description
 msgid "Unit"
 msgstr "Mjerna jedinica"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->tooltip
-msgid "Base data unit shown in the panel"
-msgstr "Mjerna jedinica prikazana u panelu"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->options
+#. settings-schema.json->unit_type->options
 msgid "Bytes"
 msgstr "Bajtovi"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->options
+#. settings-schema.json->unit_type->options
 msgid "Bits"
 msgstr "Bitovi"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->description
-msgid "Calculate every"
-msgstr "Računaj svakih"
+#. settings-schema.json->unit_type->tooltip
+msgid "Base data unit shown in the panel"
+msgstr "Mjerna jedinica prikazana u panelu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->tooltip
-msgid "How often to calculate download and upload speed"
-msgstr "Koliko često izračunati brzinu preuzimanja i slanja"
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->units
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->units
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Decimalna mjesta"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
+
+#. settings-schema.json->update_every->units
+#. settings-schema.json->update_available_interfaces_every->units
+#. settings-schema.json->write_every->units
 msgid "seconds"
 msgstr "sekunde"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->description
+#. settings-schema.json->update_every->description
+msgid "Calculate every"
+msgstr "Računaj svakih"
+
+#. settings-schema.json->update_every->tooltip
+msgid "How often to calculate download and upload speed"
+msgstr "Koliko često izračunati brzinu preuzimanja i slanja"
+
+#. settings-schema.json->update_available_interfaces_every->description
+msgid "Update available interfaces every"
+msgstr ""
+
+#. settings-schema.json->update_available_interfaces_every->tooltip
+msgid ""
+"How often to update list of available network interfaces. 0 means list of "
+"available network interfaces is not updated periodically."
+msgstr ""
+
+#. settings-schema.json->gui_speed_type->description
 msgid "Type"
 msgstr "Vrsta prikaza"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->tooltip
+#. settings-schema.json->gui_speed_type->tooltip
 msgid "Applet Gui"
 msgstr "Grafičko sučelje apleta"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->description
+#. settings-schema.json->gui_value_order->description
+msgid "Value order"
+msgstr ""
+
+#. settings-schema.json->gui_value_order->options
+#, fuzzy
+msgid "Download first"
+msgstr "Ikona preuzimanja"
+
+#. settings-schema.json->gui_value_order->options
+#, fuzzy
+msgid "Upload first"
+msgstr "Ikona slanja"
+
+#. settings-schema.json->gui_value_order->tooltip
+msgid "An order of values shown in the panel and in the hover popup"
+msgstr ""
+
+#. settings-schema.json->decimal_places->description
 msgid "Decimal places"
 msgstr "Decimalna mjesta"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->tooltip
-msgid "Decimal places of download and upload speed shown in the panel"
-msgstr "Decimalna mjesta brzine preuzimanja i slanja prikazana u panelu"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "Auto"
 msgstr "Automatski"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "1 "
 msgstr "1"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "2 "
 msgstr "2"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "3 "
 msgstr "3"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_text_css->description
+#. settings-schema.json->decimal_places->tooltip
+msgid "Decimal places of download and upload speed shown in the panel"
+msgstr "Decimalna mjesta brzine preuzimanja i slanja prikazana u panelu"
+
+#. settings-schema.json->gui_text_css->description
 msgid "Text CSS"
 msgstr "CSS tekst"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_text_css->tooltip
+#. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "CSS izgled primijenjen na tekst u panelu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_received_icon_filename->description
+#. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"
 msgstr "Ikona preuzimanja"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_received_icon_filename->tooltip
-msgid "An icon displayed next to download speed in the panel"
-msgstr "Ikona prikazana pokraj brzine preuzimanja u panelu"
+#. settings-schema.json->gui_received_icon_filename->tooltip
+msgid ""
+"An icon displayed next to download speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_sent_icon_filename->description
+#. settings-schema.json->gui_sent_icon_filename->description
 msgid "Upload icon"
 msgstr "Ikona slanja"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_sent_icon_filename->tooltip
-msgid "An icon displayed next to upload speed in the panel"
-msgstr "Ikona prikazana pokraj brzine slanja u panelu"
+#. settings-schema.json->gui_sent_icon_filename->tooltip
+msgid ""
+"An icon displayed next to upload speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_text_css->description
+#. settings-schema.json->gui_symbolic_icon->description
+msgid "Show a default set of symbolic icons"
+msgstr ""
+
+#. settings-schema.json->hover_popup_text_css->description
 msgid "Popup text CSS"
 msgstr "CSS tekst skočnog prozora"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_text_css->tooltip
+#. settings-schema.json->hover_popup_text_css->tooltip
 msgid "A CSS style applied to the description text in the hover popup"
 msgstr "CSS izgled primijenjen na tekst u skočnom prozoru"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_numbers_css->description
+#. settings-schema.json->hover_popup_numbers_css->description
 msgid "Popup numbers CSS"
 msgstr "CSS brojevi skočnog prozora"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_numbers_css->tooltip
+#. settings-schema.json->hover_popup_numbers_css->tooltip
 msgid "A CSS style applied to numbers in the hover popup"
 msgstr "CSS izgled primijenjen na brojeve u skočnom prozoru"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->total_data_start->description
+#. settings-schema.json->minimum_bytes_received_to_display->units
+#. settings-schema.json->minimum_bytes_sent_to_display->units
+#, fuzzy
+msgid "bytes"
+msgstr "Bajtovi"
+
+#. settings-schema.json->minimum_bytes_received_to_display->description
+msgid "Minimum displayed download value"
+msgstr ""
+
+#. settings-schema.json->minimum_bytes_received_to_display->tooltip
+#, fuzzy
+msgid "A minimum download value to display in the panel"
+msgstr "Ikona prikazana pokraj brzine slanja u panelu"
+
+#. settings-schema.json->minimum_bytes_sent_to_display->description
+msgid "Minimum displayed upload value"
+msgstr ""
+
+#. settings-schema.json->minimum_bytes_sent_to_display->tooltip
+#, fuzzy
+msgid "A minimum upload value to display in the panel"
+msgstr "Ikona prikazana pokraj brzine slanja u panelu"
+
+#. settings-schema.json->total_data_start->description
 msgid "Total data"
 msgstr "Ukupno podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->show_hover->description
+#. settings-schema.json->show_hover->description
 msgid "Show total download and upload on hover"
 msgstr "Prikazuje ukupno preuzimanje i slanje pri lebdenju pokazivačem"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->show_hover->tooltip
+#. settings-schema.json->show_hover->tooltip
 msgid "Show the hover popup with total amount of data downloaded and uploaded"
 msgstr ""
 "Prikazuje skočni prozor sa ukupnom količinom preuzetih i poslanih podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->description
+#. settings-schema.json->bytes_start_time->description
 msgid "Start"
 msgstr "Pokretanje"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->tooltip
+#. settings-schema.json->bytes_start_time->tooltip
 msgid "Start time to count total amount of data downloaded and uploaded"
 msgstr ""
 "Početno vrijeme za računanje ukupne količine preuzetih i poslanih podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->custom_start_date->description
+#. settings-schema.json->custom_start_date->description
 msgid "Custom date "
 msgstr "Prilagođeni datum "
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->custom_start_date->tooltip
+#. settings-schema.json->custom_start_date->tooltip
 msgid ""
-"A custom date in YYYY-MM-DD format used as start time. The option is used if"
-" \"Custom date\" is selected in \"Start\" combobox."
+"A custom date in YYYY-MM-DD format used as start time. The option is used if "
+"\"Custom date\" is selected in \"Start\" combobox."
 msgstr ""
 "Prilagođeni datum u YYYY-MM-DD formatu korišten kao vrijeme pokretanja. "
 "Mogućnost se koristi ako je \"Prilagođeni datum\" odabran u \"Pokreni\" "
 "okviru."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->description
+#. settings-schema.json->write_every->description
 msgid "Save every"
 msgstr "Spremi svakih"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->tooltip
+#. settings-schema.json->write_every->tooltip
 msgid ""
 "How often to save total amount of data downloaded and uploaded to the file. "
 "0 means no saving to the file."
@@ -338,58 +439,44 @@ msgstr ""
 "Koliko često spremiti ukupnu količinu preuzetih i poslanih podataka u "
 "datoteku. 0 znači da se ne sprema u datoteku."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_start->description
+#. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Ograničenje podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit->description
+#. settings-schema.json->data_limit->description
 msgid "Data limit"
 msgstr "Ograničenje podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit->tooltip
+#. settings-schema.json->data_limit->tooltip
 msgid "The maximum amount of data to download and upload. 0 means no limits."
 msgstr ""
 "Najveća količina podataka za preuzimanje i slanje. 0 znači bez ograničenja."
 
-#. download-and-upload-speed@cardsurf->settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->description
+#. settings-schema.json->gui_data_limit_type->description
 msgid "Show data limit usage"
 msgstr "Prikaži upotrebu ograničenja podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->tooltip
-msgid "Show the percentage of data limit used in the panel"
-msgstr "Prikaži postotak upotrebe ograničenje podataka u panelu"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "None"
 msgstr "Nepoznato"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "Circle"
 msgstr "Krug"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "Text"
 msgstr "Tekst"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command_enabled->description
+#. settings-schema.json->gui_data_limit_type->tooltip
+msgid "Show the percentage of data limit used in the panel"
+msgstr "Prikaži postotak upotrebe ograničenje podataka u panelu"
+
+#. settings-schema.json->data_limit_command_enabled->description
 msgid "Invoke command when data limit exceeded"
 msgstr "Pozovi naredbu kada se dosegne ograničenje podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command_enabled->tooltip
+#. settings-schema.json->data_limit_command_enabled->tooltip
 msgid ""
 "Invoke a command when amount of data downloaded and uploaded exceeded the "
 "limit"
@@ -397,28 +484,23 @@ msgstr ""
 "Pozovi naredbu kada se dosegne ograničenje količine preuzetih i poslanih "
 "podataka"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command->description
+#. settings-schema.json->data_limit_command->description
 msgid "Command"
 msgstr "Naredba"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command->tooltip
+#. settings-schema.json->data_limit_command->tooltip
 msgid "A command to invoke"
 msgstr "Naredba za pozivanje"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->connections_start->description
+#. settings-schema.json->connections_start->description
 msgid "Connections"
 msgstr "Povezivanja"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->launch_terminal->description
+#. settings-schema.json->launch_terminal->description
 msgid "List current Internet connections on left mouse click"
 msgstr "Prikaži trenutna internetska povezivanja pri lijevom kliku"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->launch_terminal->tooltip
+#. settings-schema.json->launch_terminal->tooltip
 msgid ""
 "Open a terminal with a list of current connections on a left mouse click. "
 "The next click closes the terminal."
@@ -426,12 +508,10 @@ msgstr ""
 "Otvara terminal s popisom trenutnih povezivanja pri lijevom kliku. Sljedeći "
 "klik zatvara terminal."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->list_connections_command->description
+#. settings-schema.json->list_connections_command->description
 msgid "Command "
 msgstr "Naredba "
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->list_connections_command->tooltip
+#. settings-schema.json->list_connections_command->tooltip
 msgid "A command used to list current Internet connections"
 msgstr "Naredba korištena za prikaz trenutnih internetskih povezivanja"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/hu.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/hu.po
@@ -1,13 +1,14 @@
 # Main translation file for download-and-upload-speed@cardsurf.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2021-09-26 07:36+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -17,89 +18,165 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#: applet.js:437
-#| msgid "Network interface"
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Hálózati csatolók"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Összesített adatmennyiség indításkor"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Kisalkalmazás indítása"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "Ma"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Tegnap"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "Három nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "Öt nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "Hét nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "Tíz nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "Tízennégy nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "Harminc nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "Egyéni dátum"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "GUI"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Kompakt"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Nagy"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "GUI"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "GUI"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Összes letöltés:"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Összes feltöltés:"
 
@@ -146,6 +223,25 @@ msgstr "Bit"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "A panelen látható alapadat-egység"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Tizedesjegyek száma"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -279,7 +375,6 @@ msgstr "Az egérmutatóra előugró számokra alkalmazott CSS-stílus"
 
 #. settings-schema.json->minimum_bytes_received_to_display->units
 #. settings-schema.json->minimum_bytes_sent_to_display->units
-#| msgid "Bytes"
 msgid "bytes"
 msgstr "bytes"
 
@@ -351,10 +446,6 @@ msgstr ""
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Adatkorlátok"
-
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
 
 #. settings-schema.json->data_limit->description
 msgid "Data limit"
@@ -429,9 +520,3 @@ msgstr "Parancs "
 #. settings-schema.json->list_connections_command->tooltip
 msgid "A command used to list current Internet connections"
 msgstr "Az aktuális internetkapcsolatok felsorolására használt parancs"
-
-#~ msgid "Settings for download-and-upload-speed@cardsurf"
-#~ msgstr "Download-and-upload-speed@cardsurf beállításai"
-
-#~ msgid "An icon displayed next to download speed in the panel"
-#~ msgstr "Egy ikon jelenik meg a panelen a letöltési sebesség mellett"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/it.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/it.po
@@ -1,13 +1,14 @@
 # Main translation file for download-and-upload-speed@cardsurf.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2022-06-03 16:44+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,88 +19,165 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Interfacce di rete"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Dati totali dall'avvio"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Avvio dell'applet"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "Oggi"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Ieri"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "Data personalizzata"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "Interfaccia Grafica"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Compatto"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Grande"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Interfaccia Grafica"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Interfaccia Grafica"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Totale download:"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Totale upload:"
 
@@ -146,6 +224,25 @@ msgstr "Bits"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Unità di dati di base mostrata nel pannello"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Posizioni decimali"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -356,10 +453,6 @@ msgstr ""
 msgid "Data limits"
 msgstr "Limiti sui dati"
 
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
-
 #. settings-schema.json->data_limit->description
 msgid "Data limit"
 msgstr "Limite dati"
@@ -435,10 +528,3 @@ msgstr "Comando"
 #. settings-schema.json->list_connections_command->tooltip
 msgid "A command used to list current Internet connections"
 msgstr "Un comando utilizzato per elencare le connessioni Internet correnti"
-
-#~ msgid "Settings for download-and-upload-speed@cardsurf"
-#~ msgstr "Impostazioni di download-and-upload-speed@cardsurf"
-
-#~ msgid "An icon displayed next to download speed in the panel"
-#~ msgstr ""
-#~ "Un'icona visualizzata accanto alla velocità di download nel pannello"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/nl.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/nl.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# DOWNLOAD AND UPLOAD SPEED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2024-04-22 13:55+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,88 +17,165 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Netwerkinterfaces"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Totale gegevens start"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Start van applet"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "Vandaag"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Gisteren"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "Aangepaste datum"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "Grafische gebruikersinterface"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Compact"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Groot"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Grafische gebruikersinterface"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Grafische gebruikersinterface"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Totaal gedownload:"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Totaal geüpload:"
 
@@ -144,6 +222,25 @@ msgstr "Bits"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Basisgegevenseenheid weergegeven in het paneel"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Decimalen"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -353,10 +450,6 @@ msgstr ""
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Gegevenslimieten"
-
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
 
 #. settings-schema.json->data_limit->description
 msgid "Data limit"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/pl.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/pl.po
@@ -6,315 +6,418 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-06 18:27+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2018-04-06 22:12+0200\n"
+"Last-Translator: xearonet\n"
 "Language-Team: \n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: xearonet\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
-"Language: pl\n"
 
-#: applet.js:345
-msgid "Network interface"
+#. applet.js:438
+#, fuzzy
+msgid "Network interfaces"
 msgstr "Interfejs sieciowy"
 
-#: applet.js:366
+#. applet.js:507
 msgid "Total data start"
 msgstr "Początek zliczania danych"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:373
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Od uruchomienia"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:374
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:515
 msgid "Today"
 msgstr "Dzisiaj"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:375
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Wczoraj"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:376
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 dni temu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:377
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 dni temu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:378
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 dni temu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:379
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 dni temu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:380
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 dni temu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:381
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 dni temu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:382
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:523
 msgid "Custom date"
 msgstr "Niestandardowa data"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_start->description
-#: applet.js:465
+#. settings-schema.json->gui_start->description
+#. applet.js:560
 msgid "Gui"
 msgstr "Rozmiar"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->options
-#: applet.js:465
+#. settings-schema.json->gui_speed_type->options
+#. applet.js:560
 msgid "Compact"
 msgstr "Kompaktowy"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->options
-#: applet.js:444
+#. settings-schema.json->gui_speed_type->options
+#. applet.js:560
 msgid "Large"
 msgstr "Duży"
 
-#: appletGui.js:362
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Rozmiar"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Rozmiar"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
+msgid "b"
+msgstr ""
+
+#. applet.js:845
+msgid "Tb"
+msgstr ""
+
+#. applet.js:848
+msgid "Gb"
+msgstr ""
+
+#. applet.js:851
+msgid "Mb"
+msgstr ""
+
+#. applet.js:854
+msgid "kb"
+msgstr ""
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Pobrano:"
 
-#: appletGui.js:363
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Wysłano:"
 
-#. download-and-upload-speed@cardsurf->metadata.json->name
-msgid "Download and upload speed"
-msgstr "Szybkość pobierania i wysyłania"
-
-#. download-and-upload-speed@cardsurf->metadata.json->description
+#. metadata.json->description
 msgid "Shows usage of a network interface"
 msgstr "Pokazuje wykorzystanie interfejsu sieciowego"
 
-#. download-and-upload-speed@cardsurf->settings-schema.json->head->description
-msgid "Settings for download-and-upload-speed@cardsurf"
-msgstr "Ustawienia dla download-and-upload-speed@cardsurf"
+#. metadata.json->name
+msgid "Download and upload speed"
+msgstr "Szybkość pobierania i wysyłania"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->configuration->description
+#. settings-schema.json->configuration->description
 msgid "Configuration"
 msgstr "Konfiguracja"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->description
+#. settings-schema.json->display_mode->description
 msgid "Show"
 msgstr "Pokaż"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->tooltip
-msgid "Values shown in the panel"
-msgstr "Wartości wyświetlane w panelu"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->options
+#. settings-schema.json->display_mode->options
 msgid "Average speed per second"
 msgstr "Średnia prędkość na sekundę"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->options
+#. settings-schema.json->display_mode->options
 msgid "Amount of data transferred"
 msgstr "Ilość przesłanych danych"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->description
+#. settings-schema.json->display_mode->tooltip
+msgid "Values shown in the panel"
+msgstr "Wartości wyświetlane w panelu"
+
+#. settings-schema.json->unit_type->description
 msgid "Unit"
 msgstr "Jednostki"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->tooltip
-msgid "Base data unit shown in the panel"
-msgstr "Podstawowa jednostka danych wyświetlana w panelu"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->options
+#. settings-schema.json->unit_type->options
 msgid "Bytes"
 msgstr "Bajty"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->options
+#. settings-schema.json->unit_type->options
 msgid "Bits"
 msgstr "Bity"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->description
-msgid "Calculate every"
-msgstr "Oblicz co"
+#. settings-schema.json->unit_type->tooltip
+msgid "Base data unit shown in the panel"
+msgstr "Podstawowa jednostka danych wyświetlana w panelu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->tooltip
-msgid "How often to calculate download and upload speed"
-msgstr "Jak często będzie obliczana prędkość pobierania i wysyłania"
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->units
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->units
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Miejsca dziesiętne"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
+
+#. settings-schema.json->update_every->units
+#. settings-schema.json->update_available_interfaces_every->units
+#. settings-schema.json->write_every->units
 msgid "seconds"
 msgstr "sekund"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->description
+#. settings-schema.json->update_every->description
+msgid "Calculate every"
+msgstr "Oblicz co"
+
+#. settings-schema.json->update_every->tooltip
+msgid "How often to calculate download and upload speed"
+msgstr "Jak często będzie obliczana prędkość pobierania i wysyłania"
+
+#. settings-schema.json->update_available_interfaces_every->description
+msgid "Update available interfaces every"
+msgstr ""
+
+#. settings-schema.json->update_available_interfaces_every->tooltip
+msgid ""
+"How often to update list of available network interfaces. 0 means list of "
+"available network interfaces is not updated periodically."
+msgstr ""
+
+#. settings-schema.json->gui_speed_type->description
 msgid "Type"
 msgstr "Rozmiar"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->tooltip
+#. settings-schema.json->gui_speed_type->tooltip
 msgid "Applet Gui"
 msgstr "Określa rozmiar apletu na panelu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->description
+#. settings-schema.json->gui_value_order->description
+msgid "Value order"
+msgstr ""
+
+#. settings-schema.json->gui_value_order->options
+#, fuzzy
+msgid "Download first"
+msgstr "Ikona pobierania"
+
+#. settings-schema.json->gui_value_order->options
+#, fuzzy
+msgid "Upload first"
+msgstr "Ikona wysyłania"
+
+#. settings-schema.json->gui_value_order->tooltip
+msgid "An order of values shown in the panel and in the hover popup"
+msgstr ""
+
+#. settings-schema.json->decimal_places->description
 msgid "Decimal places"
 msgstr "Miejsca dziesiętne"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->tooltip
-msgid "Decimal places of download and upload speed shown in the panel"
-msgstr "Miejsca dziesiętne pobierania i wysyłania wyświetlane w panelu"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "Auto"
 msgstr "Automatycznie"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "1 "
 msgstr "1 "
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "2 "
 msgstr "2 "
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "3 "
 msgstr "3 "
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_text_css->description
+#. settings-schema.json->decimal_places->tooltip
+msgid "Decimal places of download and upload speed shown in the panel"
+msgstr "Miejsca dziesiętne pobierania i wysyłania wyświetlane w panelu"
+
+#. settings-schema.json->gui_text_css->description
 msgid "Text CSS"
 msgstr "Styl CSS tekstu w panelu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_text_css->tooltip
+#. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Styl CSS zastosowany do tekstu w panelu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_received_icon_filename->description
+#. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"
 msgstr "Ikona pobierania"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_received_icon_filename->tooltip
-msgid "An icon displayed next to download speed in the panel"
-msgstr "Ikona wyświetlana obok prędkości pobierania w panelu"
+#. settings-schema.json->gui_received_icon_filename->tooltip
+msgid ""
+"An icon displayed next to download speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_sent_icon_filename->description
+#. settings-schema.json->gui_sent_icon_filename->description
 msgid "Upload icon"
 msgstr "Ikona wysyłania"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_sent_icon_filename->tooltip
-msgid "An icon displayed next to upload speed in the panel"
-msgstr "Ikona wyświetlana obok prędkości wysyłania w panelu"
+#. settings-schema.json->gui_sent_icon_filename->tooltip
+msgid ""
+"An icon displayed next to upload speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_text_css->description
+#. settings-schema.json->gui_symbolic_icon->description
+msgid "Show a default set of symbolic icons"
+msgstr ""
+
+#. settings-schema.json->hover_popup_text_css->description
 msgid "Popup text CSS"
 msgstr "Styl CSS tekstu w wyskakującym okienku"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_text_css->tooltip
+#. settings-schema.json->hover_popup_text_css->tooltip
 msgid "A CSS style applied to the description text in the hover popup"
 msgstr "Styl CSS zastosowany do opisu w wyskakującym okienku"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_numbers_css->description
+#. settings-schema.json->hover_popup_numbers_css->description
 msgid "Popup numbers CSS"
 msgstr "Styl CSS liczb w wyskakującym okienku"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_numbers_css->tooltip
+#. settings-schema.json->hover_popup_numbers_css->tooltip
 msgid "A CSS style applied to numbers in the hover popup"
 msgstr "Styl CSS zastosowany do liczb w wyskakującym okienku"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->total_data_start->description
+#. settings-schema.json->minimum_bytes_received_to_display->units
+#. settings-schema.json->minimum_bytes_sent_to_display->units
+#, fuzzy
+msgid "bytes"
+msgstr "Bajty"
+
+#. settings-schema.json->minimum_bytes_received_to_display->description
+msgid "Minimum displayed download value"
+msgstr ""
+
+#. settings-schema.json->minimum_bytes_received_to_display->tooltip
+#, fuzzy
+msgid "A minimum download value to display in the panel"
+msgstr "Ikona wyświetlana obok prędkości wysyłania w panelu"
+
+#. settings-schema.json->minimum_bytes_sent_to_display->description
+msgid "Minimum displayed upload value"
+msgstr ""
+
+#. settings-schema.json->minimum_bytes_sent_to_display->tooltip
+#, fuzzy
+msgid "A minimum upload value to display in the panel"
+msgstr "Ikona wyświetlana obok prędkości wysyłania w panelu"
+
+#. settings-schema.json->total_data_start->description
 msgid "Total data"
 msgstr "Łączne dane"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->show_hover->description
+#. settings-schema.json->show_hover->description
 msgid "Show total download and upload on hover"
 msgstr "Pokaż łącznie pobrane i wysłane po najechaniu myszą"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->show_hover->tooltip
+#. settings-schema.json->show_hover->tooltip
 msgid "Show the hover popup with total amount of data downloaded and uploaded"
 msgstr ""
 "Pokaż wyskakujące okienko z łączną ilością danych pobranych i wysłanych"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->description
+#. settings-schema.json->bytes_start_time->description
 msgid "Start"
 msgstr "Czas rozpoczęcia"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->tooltip
+#. settings-schema.json->bytes_start_time->tooltip
 msgid "Start time to count total amount of data downloaded and uploaded"
 msgstr "Czas rozpoczęcia zliczania łącznej ilości danych pobranych i wysłanych"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->custom_start_date->description
+#. settings-schema.json->custom_start_date->description
 msgid "Custom date "
 msgstr "Niestandardowa data "
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->custom_start_date->tooltip
+#. settings-schema.json->custom_start_date->tooltip
 msgid ""
 "A custom date in YYYY-MM-DD format used as start time. The option is used if "
 "\"Custom date\" is selected in \"Start\" combobox."
@@ -323,13 +426,11 @@ msgstr ""
 "Ta opcja jest używana, jeśli \"Niestandardowa data\" jest wybrana w opcji "
 "\"Start\"."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->description
+#. settings-schema.json->write_every->description
 msgid "Save every"
 msgstr "Zapisz co"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->tooltip
+#. settings-schema.json->write_every->tooltip
 msgid ""
 "How often to save total amount of data downloaded and uploaded to the file. "
 "0 means no saving to the file."
@@ -337,58 +438,44 @@ msgstr ""
 "Jak często będzie zapisywana łączna ilość danych pobranych i wysłanych do "
 "pliku. 0 oznacza brak zapisywania do pliku."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_start->description
+#. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Limity danych"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit->description
+#. settings-schema.json->data_limit->description
 msgid "Data limit"
 msgstr "Limit danych"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit->tooltip
+#. settings-schema.json->data_limit->tooltip
 msgid "The maximum amount of data to download and upload. 0 means no limits."
 msgstr ""
 "Maksymalna ilość danych do pobrania i wysłania. 0 oznacza brak ograniczeń."
 
-#. download-and-upload-speed@cardsurf->settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->description
+#. settings-schema.json->gui_data_limit_type->description
 msgid "Show data limit usage"
 msgstr "Pokaż zużycie limitu danych w panelu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->tooltip
-msgid "Show the percentage of data limit used in the panel"
-msgstr "Pokazuje procent zużycia limitu danych w panelu"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "None"
 msgstr "Brak"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
-msgid "Text"
-msgstr "Tekstowy"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "Circle"
 msgstr "Kołowy"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command_enabled->description
+#. settings-schema.json->gui_data_limit_type->options
+msgid "Text"
+msgstr "Tekstowy"
+
+#. settings-schema.json->gui_data_limit_type->tooltip
+msgid "Show the percentage of data limit used in the panel"
+msgstr "Pokazuje procent zużycia limitu danych w panelu"
+
+#. settings-schema.json->data_limit_command_enabled->description
 msgid "Invoke command when data limit exceeded"
 msgstr "Wywołaj polecenie po przekroczeniu limitu danych"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command_enabled->tooltip
+#. settings-schema.json->data_limit_command_enabled->tooltip
 msgid ""
 "Invoke a command when amount of data downloaded and uploaded exceeded the "
 "limit"
@@ -396,29 +483,24 @@ msgstr ""
 "Wywołaj polecenie, gdy ilość danych pobranych i wysłanych przekroczy "
 "ustalony limit"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command->description
+#. settings-schema.json->data_limit_command->description
 msgid "Command"
 msgstr "Polecenie"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command->tooltip
+#. settings-schema.json->data_limit_command->tooltip
 msgid "A command to invoke"
 msgstr "Polecenie do wykonania po przekroczeniu limitu"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->connections_start->description
+#. settings-schema.json->connections_start->description
 msgid "Connections"
 msgstr "Połączenia"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->launch_terminal->description
+#. settings-schema.json->launch_terminal->description
 msgid "List current Internet connections on left mouse click"
 msgstr ""
 "Wyświetl bieżące połączenia internetowe po kliknięciu lewym przyciskiem myszy"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->launch_terminal->tooltip
+#. settings-schema.json->launch_terminal->tooltip
 msgid ""
 "Open a terminal with a list of current connections on a left mouse click. "
 "The next click closes the terminal."
@@ -426,12 +508,10 @@ msgstr ""
 "Otwórz terminal z listą bieżących połączeń po kliknięciu lewym przyciskiem "
 "myszy. Następne kliknięcie zamyka terminal."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->list_connections_command->description
+#. settings-schema.json->list_connections_command->description
 msgid "Command "
 msgstr "Polecenie"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->list_connections_command->tooltip
+#. settings-schema.json->list_connections_command->tooltip
 msgid "A command used to list current Internet connections"
 msgstr "Polecenie używane do wyświetlenia bieżących połączeń internetowych"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/pt.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/pt.po
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
+# DOWNLOAD AND UPLOAD SPEED
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 #, fuzzy
 msgid ""
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.6.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-23 03:28-0100\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2024-06-25 02:39-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,88 +18,161 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Interfaces de rede"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "Início do total dos dados"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Ao lançar do applet"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "Hoje"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Ontem"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "Data personalizada"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "Interface"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "Compacto"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "Largo"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Interface"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Interface"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr ""
 
-#: appletGui.js:478
+#. applet.js:845
+msgid "Tb"
+msgstr ""
+
+#. applet.js:848
+msgid "Gb"
+msgstr ""
+
+#. applet.js:851
+msgid "Mb"
+msgstr ""
+
+#. applet.js:854
+msgid "kb"
+msgstr ""
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Download total:"
 
-#: appletGui.js:479
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Upload total:"
 
@@ -146,6 +219,25 @@ msgstr "Bits"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Unidade base mostrada no painel"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Casas decimais"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -356,10 +448,6 @@ msgstr ""
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Limites dos dados"
-
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
 
 #. settings-schema.json->data_limit->description
 msgid "Data limit"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/sv.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/sv.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-08 11:57+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2017-04-29 14:01+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -18,315 +19,415 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:345
-msgid "Network interface"
+#. applet.js:438
+#, fuzzy
+msgid "Network interfaces"
 msgstr "Nätverksgränssnitt"
 
-#: applet.js:366
+#. applet.js:507
 msgid "Total data start"
 msgstr "Total datamängd börjar"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:373
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Programstart"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:374
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:515
 msgid "Today"
 msgstr "I dag"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:375
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:516
 msgid "Yesterday"
 msgstr "I går"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:376
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 dagar sedan"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:377
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 dagar sedan"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:378
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 dagar sedan"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:379
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 dagar sedan"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:380
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 dagar sedan"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:381
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 dagar sedan"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->options
-#: applet.js:382
+#. settings-schema.json->bytes_start_time->options
+#. applet.js:523
 msgid "Custom date"
 msgstr "Anpassat datum"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_start->description
-#: applet.js:465
+#. settings-schema.json->gui_start->description
+#. applet.js:560
 msgid "Gui"
 msgstr "GUI"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->options
-#: applet.js:465
+#. settings-schema.json->gui_speed_type->options
+#. applet.js:560
 msgid "Compact"
 msgstr "Kompakt"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->options
-#: applet.js:444
+#. settings-schema.json->gui_speed_type->options
+#. applet.js:560
 msgid "Large"
 msgstr "Stor"
 
-#: appletGui.js:362
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "GUI"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "GUI"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
+msgid "b"
+msgstr ""
+
+#. applet.js:845
+msgid "Tb"
+msgstr ""
+
+#. applet.js:848
+msgid "Gb"
+msgstr ""
+
+#. applet.js:851
+msgid "Mb"
+msgstr ""
+
+#. applet.js:854
+msgid "kb"
+msgstr ""
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Totalt nerladdat:"
 
-#: appletGui.js:363
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Totalt uppladdat:"
 
-#. download-and-upload-speed@cardsurf->metadata.json->name
-msgid "Download and upload speed"
-msgstr "Ner- och uppladdningshastighet"
-
-#. download-and-upload-speed@cardsurf->metadata.json->description
+#. metadata.json->description
 msgid "Shows usage of a network interface"
 msgstr "Visar användningen av ett nätverksgränssnitt"
 
-#. download-and-upload-speed@cardsurf->settings-schema.json->head->description
-msgid "Settings for download-and-upload-speed@cardsurf"
-msgstr "Settings for download-and-upload-speed@cardsurf"
+#. metadata.json->name
+msgid "Download and upload speed"
+msgstr "Ner- och uppladdningshastighet"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->configuration->description
+#. settings-schema.json->configuration->description
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->description
+#. settings-schema.json->display_mode->description
 msgid "Show"
 msgstr "Show"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->tooltip
-msgid "Values shown in the panel"
-msgstr "Värden visas i panelen"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->options
+#. settings-schema.json->display_mode->options
 msgid "Average speed per second"
 msgstr "Medelhastighet per sekund"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->display_mode->options
+#. settings-schema.json->display_mode->options
 msgid "Amount of data transferred"
 msgstr "Mängden överförd data"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->description
+#. settings-schema.json->display_mode->tooltip
+msgid "Values shown in the panel"
+msgstr "Värden visas i panelen"
+
+#. settings-schema.json->unit_type->description
 msgid "Unit"
 msgstr "Enhet"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->tooltip
-msgid "Base data unit shown in the panel"
-msgstr "Basdataenhet visad i panelen"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->options
+#. settings-schema.json->unit_type->options
 msgid "Bytes"
 msgstr "Byte"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->unit_type->options
+#. settings-schema.json->unit_type->options
 msgid "Bits"
 msgstr "Bit"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->description
-msgid "Calculate every"
-msgstr "Beräkna varje"
+#. settings-schema.json->unit_type->tooltip
+msgid "Base data unit shown in the panel"
+msgstr "Basdataenhet visad i panelen"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->tooltip
-msgid "How often to calculate download and upload speed"
-msgstr "Hur ofta ner- och uppladdningshastigheten skall beräknas"
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->update_every->units
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->units
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Decimaler"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
+
+#. settings-schema.json->update_every->units
+#. settings-schema.json->update_available_interfaces_every->units
+#. settings-schema.json->write_every->units
 msgid "seconds"
 msgstr "seconds"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->description
+#. settings-schema.json->update_every->description
+msgid "Calculate every"
+msgstr "Beräkna varje"
+
+#. settings-schema.json->update_every->tooltip
+msgid "How often to calculate download and upload speed"
+msgstr "Hur ofta ner- och uppladdningshastigheten skall beräknas"
+
+#. settings-schema.json->update_available_interfaces_every->description
+msgid "Update available interfaces every"
+msgstr ""
+
+#. settings-schema.json->update_available_interfaces_every->tooltip
+msgid ""
+"How often to update list of available network interfaces. 0 means list of "
+"available network interfaces is not updated periodically."
+msgstr ""
+
+#. settings-schema.json->gui_speed_type->description
 msgid "Type"
 msgstr "Typ"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_speed_type->tooltip
+#. settings-schema.json->gui_speed_type->tooltip
 msgid "Applet Gui"
 msgstr "Panelikonens utseende"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->description
+#. settings-schema.json->gui_value_order->description
+msgid "Value order"
+msgstr ""
+
+#. settings-schema.json->gui_value_order->options
+#, fuzzy
+msgid "Download first"
+msgstr "Nerladdningsikon"
+
+#. settings-schema.json->gui_value_order->options
+#, fuzzy
+msgid "Upload first"
+msgstr "Uppladdningsikon"
+
+#. settings-schema.json->gui_value_order->tooltip
+msgid "An order of values shown in the panel and in the hover popup"
+msgstr ""
+
+#. settings-schema.json->decimal_places->description
 msgid "Decimal places"
 msgstr "Decimaler"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->tooltip
-msgid "Decimal places of download and upload speed shown in the panel"
-msgstr "Antal decimaler i ner- och uppladdningshastigheten, i panelen"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "Auto"
 msgstr "Auto"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "1 "
 msgstr "1"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "2 "
 msgstr "2"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->decimal_places->options
+#. settings-schema.json->decimal_places->options
 msgid "3 "
 msgstr "3"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_text_css->description
+#. settings-schema.json->decimal_places->tooltip
+msgid "Decimal places of download and upload speed shown in the panel"
+msgstr "Antal decimaler i ner- och uppladdningshastigheten, i panelen"
+
+#. settings-schema.json->gui_text_css->description
 msgid "Text CSS"
 msgstr "CSS-stil för paneltext"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_text_css->tooltip
+#. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "CSS-stil som tillämpas på text i panelen"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_received_icon_filename->description
+#. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"
 msgstr "Nerladdningsikon"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_received_icon_filename->tooltip
-msgid "An icon displayed next to download speed in the panel"
-msgstr "Ikon som visas intill nerladdningshastigheten i panelen"
+#. settings-schema.json->gui_received_icon_filename->tooltip
+msgid ""
+"An icon displayed next to download speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_sent_icon_filename->description
+#. settings-schema.json->gui_sent_icon_filename->description
 msgid "Upload icon"
 msgstr "Uppladdningsikon"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_sent_icon_filename->tooltip
-msgid "An icon displayed next to upload speed in the panel"
-msgstr "Ikon som visas intill uppladdningshastigheten i panelen"
+#. settings-schema.json->gui_sent_icon_filename->tooltip
+msgid ""
+"An icon displayed next to upload speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_text_css->description
+#. settings-schema.json->gui_symbolic_icon->description
+msgid "Show a default set of symbolic icons"
+msgstr ""
+
+#. settings-schema.json->hover_popup_text_css->description
 msgid "Popup text CSS"
 msgstr "CSS-stil för popup-text"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_text_css->tooltip
+#. settings-schema.json->hover_popup_text_css->tooltip
 msgid "A CSS style applied to the description text in the hover popup"
 msgstr "CSS-stil som tillämpas på texten i panelikonens hovrings-popup"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_numbers_css->description
+#. settings-schema.json->hover_popup_numbers_css->description
 msgid "Popup numbers CSS"
 msgstr "CSS-stil för popup-siffror"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->hover_popup_numbers_css->tooltip
+#. settings-schema.json->hover_popup_numbers_css->tooltip
 msgid "A CSS style applied to numbers in the hover popup"
 msgstr "CSS-stil som tillämpas på siffror i panelikonens hovrings-popup"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->total_data_start->description
+#. settings-schema.json->minimum_bytes_received_to_display->units
+#. settings-schema.json->minimum_bytes_sent_to_display->units
+#, fuzzy
+msgid "bytes"
+msgstr "Byte"
+
+#. settings-schema.json->minimum_bytes_received_to_display->description
+msgid "Minimum displayed download value"
+msgstr ""
+
+#. settings-schema.json->minimum_bytes_received_to_display->tooltip
+#, fuzzy
+msgid "A minimum download value to display in the panel"
+msgstr "Ikon som visas intill uppladdningshastigheten i panelen"
+
+#. settings-schema.json->minimum_bytes_sent_to_display->description
+msgid "Minimum displayed upload value"
+msgstr ""
+
+#. settings-schema.json->minimum_bytes_sent_to_display->tooltip
+#, fuzzy
+msgid "A minimum upload value to display in the panel"
+msgstr "Ikon som visas intill uppladdningshastigheten i panelen"
+
+#. settings-schema.json->total_data_start->description
 msgid "Total data"
 msgstr "Total datamängd"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->show_hover->description
+#. settings-schema.json->show_hover->description
 msgid "Show total download and upload on hover"
 msgstr "Visa total mängd ner- och uppladdad data vid hovring"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->show_hover->tooltip
+#. settings-schema.json->show_hover->tooltip
 msgid "Show the hover popup with total amount of data downloaded and uploaded"
 msgstr "Visa hovrings-popup med total mängd ner- och uppladdad data"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->description
+#. settings-schema.json->bytes_start_time->description
 msgid "Start"
 msgstr "Start"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->bytes_start_time->tooltip
+#. settings-schema.json->bytes_start_time->tooltip
 msgid "Start time to count total amount of data downloaded and uploaded"
 msgstr "Starttid för beräkning av total mängd ner- och uppladdad data"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->custom_start_date->description
+#. settings-schema.json->custom_start_date->description
 msgid "Custom date "
 msgstr "Anpassat datum"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->custom_start_date->tooltip
+#. settings-schema.json->custom_start_date->tooltip
 msgid ""
-"A custom date in YYYY-MM-DD format used as start time. The option is used if"
-" \"Custom date\" is selected in \"Start\" combobox."
+"A custom date in YYYY-MM-DD format used as start time. The option is used if "
+"\"Custom date\" is selected in \"Start\" combobox."
 msgstr ""
 "Anpassat datum i formatet YYYY-MM-DD, används som startid. Detta alternativ "
 "tillämpas om \"Anpassat datum\" valts i kombinationslistan under \"Start\"."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->description
+#. settings-schema.json->write_every->description
 msgid "Save every"
 msgstr "Spara varje"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->write_every->tooltip
+#. settings-schema.json->write_every->tooltip
 msgid ""
 "How often to save total amount of data downloaded and uploaded to the file. "
 "0 means no saving to the file."
@@ -334,85 +435,66 @@ msgstr ""
 "Hur ofta totala mängden ner- och uppladdad data skall sparas i filen. 0 "
 "innebär att ingen data sparas i filen."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_start->description
+#. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Datagränser"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit->description
+#. settings-schema.json->data_limit->description
 msgid "Data limit"
 msgstr "Databegränsning"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit->tooltip
+#. settings-schema.json->data_limit->tooltip
 msgid "The maximum amount of data to download and upload. 0 means no limits."
 msgstr "Maxgräns för ner- och uppladdad data. 0 betyder obegränsad datamängd."
 
-#. download-and-upload-speed@cardsurf->settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->description
+#. settings-schema.json->gui_data_limit_type->description
 msgid "Show data limit usage"
 msgstr "Visa använd andel av datagräns"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->tooltip
-msgid "Show the percentage of data limit used in the panel"
-msgstr "Visa använd procentandel av angiven datagräns i panelen"
-
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "None"
 msgstr "Ingen"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "Circle"
 msgstr "Cirkel"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->gui_data_limit_type->options
+#. settings-schema.json->gui_data_limit_type->options
 msgid "Text"
 msgstr "Text"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command_enabled->description
+#. settings-schema.json->gui_data_limit_type->tooltip
+msgid "Show the percentage of data limit used in the panel"
+msgstr "Visa använd procentandel av angiven datagräns i panelen"
+
+#. settings-schema.json->data_limit_command_enabled->description
 msgid "Invoke command when data limit exceeded"
 msgstr "Kör kommando när angiven datagräns uppnåtts"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command_enabled->tooltip
+#. settings-schema.json->data_limit_command_enabled->tooltip
 msgid ""
 "Invoke a command when amount of data downloaded and uploaded exceeded the "
 "limit"
 msgstr ""
 "Anropa ett kommando när mängden ner- och uppladdad data uppnår angiven gräns"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command->description
+#. settings-schema.json->data_limit_command->description
 msgid "Command"
 msgstr "Kommando"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->data_limit_command->tooltip
+#. settings-schema.json->data_limit_command->tooltip
 msgid "A command to invoke"
 msgstr "Kommando att anropa"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->connections_start->description
+#. settings-schema.json->connections_start->description
 msgid "Connections"
 msgstr "Anslutningar"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->launch_terminal->description
+#. settings-schema.json->launch_terminal->description
 msgid "List current Internet connections on left mouse click"
 msgstr "Lista aktuella internetanslutningar vid vänsterklick"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->launch_terminal->tooltip
+#. settings-schema.json->launch_terminal->tooltip
 msgid ""
 "Open a terminal with a list of current connections on a left mouse click. "
 "The next click closes the terminal."
@@ -420,12 +502,10 @@ msgstr ""
 "Öppna ett terminalfönster med en lista över aktuella anslutningar, vid "
 "vänsterklick på panelikonen. Nästa klick stänger terminal igen."
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->list_connections_command->description
+#. settings-schema.json->list_connections_command->description
 msgid "Command "
 msgstr "Kommando"
 
-#. download-and-upload-speed@cardsurf->settings-
-#. schema.json->list_connections_command->tooltip
+#. settings-schema.json->list_connections_command->tooltip
 msgid "A command used to list current Internet connections"
 msgstr "Kommando som används för att lista nuvarande internetanslutningar"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/tr.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/tr.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# DOWNLOAD AND UPLOAD SPEED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <serkanonder@outlook.com>, 2020.
@@ -6,100 +6,178 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.6.5\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-24 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2020-06-16 14:18+0300\n"
+"Last-Translator: serkan önder <serkanonder@outlook.com>\n"
 "Language-Team: \n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
-"Last-Translator: serkan önder <serkanonder@outlook.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: tr\n"
 
-#: applet.js:427
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "Ağ arayüzleri"
 
-#: applet.js:496
+#. applet.js:507
 msgid "Total data start"
 msgstr "Toplam veri başlangıcı"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:503
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "Uygulamanın başlangıcı"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:504
+#. applet.js:515
 msgid "Today"
 msgstr "Bugün"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:505
+#. applet.js:516
 msgid "Yesterday"
 msgstr "Dün"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:506
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:507
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:508
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:509
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:510
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:511
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:512
+#. applet.js:523
 msgid "Custom date"
 msgstr "Özel tarih"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:549
+#. applet.js:560
 msgid "Gui"
 msgstr "Arayüz"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:549
+#. applet.js:560
 msgid "Compact"
 msgstr "Sıkışık"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:549
+#. applet.js:560
 msgid "Large"
 msgstr "Büyük"
 
-#: applet.js:815
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "Arayüz"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "Arayüz"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "Toplam indirme:"
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "Toplam yükleme:"
 
@@ -146,6 +224,25 @@ msgstr "Bit"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "Panelde gösterilen temel veri birimi"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "Ondalık"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -241,16 +338,24 @@ msgid "Download icon"
 msgstr "İndirme simgesi"
 
 #. settings-schema.json->gui_received_icon_filename->tooltip
-msgid "An icon displayed next to download speed in the panel"
-msgstr "Panelde indirme hızının yanında görüntülenen bir simge"
+msgid ""
+"An icon displayed next to download speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
 
 #. settings-schema.json->gui_sent_icon_filename->description
 msgid "Upload icon"
 msgstr "Yükleme simgesi"
 
 #. settings-schema.json->gui_sent_icon_filename->tooltip
-msgid "An icon displayed next to upload speed in the panel"
-msgstr "Panelde yükleme hızının yanında görüntülenen bir simge"
+msgid ""
+"An icon displayed next to upload speed in the panel.\n"
+"To display a symbolic icon make sure its name ends with '-symbolic.svg'."
+msgstr ""
+
+#. settings-schema.json->gui_symbolic_icon->description
+msgid "Show a default set of symbolic icons"
+msgstr ""
 
 #. settings-schema.json->hover_popup_text_css->description
 msgid "Popup text CSS"
@@ -341,10 +446,6 @@ msgstr ""
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
 msgstr "Veri limitleri"
-
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
 
 #. settings-schema.json->data_limit->description
 msgid "Data limit"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/zh_CN.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/zh_CN.po
@@ -1,13 +1,14 @@
 # Chinese translation for download-and-upload-speed@cardsurf.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# cardsurf, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 00:05+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-24 09:51+0200\n"
 "PO-Revision-Date: 2023-06-01 17:30+0800\n"
 "Last-Translator: Slinet6056 <slinet6056@gmail.com>\n"
 "Language-Team: \n"
@@ -18,88 +19,165 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.3.1\n"
 
-#: applet.js:437
+#. applet.js:438
 msgid "Network interfaces"
 msgstr "网络接口"
 
-#: applet.js:506
+#. applet.js:507
 msgid "Total data start"
 msgstr "总数据开始"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:513
+#. applet.js:514
 msgid "Launch of applet"
 msgstr "启动小程序"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:514
+#. applet.js:515
 msgid "Today"
 msgstr "今天"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:515
+#. applet.js:516
 msgid "Yesterday"
 msgstr "昨天"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:516
+#. applet.js:517
 msgid "3 days ago"
 msgstr "3 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:517
+#. applet.js:518
 msgid "5 days ago"
 msgstr "5 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:518
+#. applet.js:519
 msgid "7 days ago"
 msgstr "7 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:519
+#. applet.js:520
 msgid "10 days ago"
 msgstr "10 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:520
+#. applet.js:521
 msgid "14 days ago"
 msgstr "14 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:521
+#. applet.js:522
 msgid "30 days ago"
 msgstr "30 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#: applet.js:522
+#. applet.js:523
 msgid "Custom date"
 msgstr "自定义日期"
 
 #. settings-schema.json->gui_start->description
-#: applet.js:559
+#. applet.js:560
 msgid "Gui"
 msgstr "图形用户界面"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Compact"
 msgstr "小"
 
 #. settings-schema.json->gui_speed_type->options
-#: applet.js:559
+#. applet.js:560
 msgid "Large"
 msgstr "大"
 
-#: applet.js:825
+#. applet.js:796
+msgid "TiB"
+msgstr ""
+
+#. applet.js:799
+#, fuzzy
+msgid "GiB"
+msgstr "图形用户界面"
+
+#. applet.js:802
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#. applet.js:805
+msgid "kiB"
+msgstr ""
+
+#. applet.js:807 applet.js:821
+#, fuzzy
+msgid "B"
+msgstr "MB"
+
+#. applet.js:810
+msgid "TB"
+msgstr ""
+
+#. applet.js:813
+msgid "GB"
+msgstr ""
+
+#. settings-schema.json->data_limit->units
+#. applet.js:816
+msgid "MB"
+msgstr "MB"
+
+#. applet.js:819
+msgid "kB"
+msgstr ""
+
+#. applet.js:831
+msgid "Tib"
+msgstr ""
+
+#. applet.js:834
+#, fuzzy
+msgid "Gib"
+msgstr "图形用户界面"
+
+#. applet.js:837
+msgid "Mib"
+msgstr ""
+
+#. applet.js:840
+msgid "kib"
+msgstr ""
+
+#. applet.js:842 applet.js:856
 msgid "b"
 msgstr "b"
 
-#: appletGui.js:470
+#. applet.js:845
+#, fuzzy
+msgid "Tb"
+msgstr "b"
+
+#. applet.js:848
+#, fuzzy
+msgid "Gb"
+msgstr "b"
+
+#. applet.js:851
+#, fuzzy
+msgid "Mb"
+msgstr "b"
+
+#. applet.js:854
+#, fuzzy
+msgid "kb"
+msgstr "b"
+
+#. appletGui.js:478
 msgid "Total download:"
 msgstr "总下载："
 
-#: appletGui.js:471
+#. appletGui.js:479
 msgid "Total upload:"
 msgstr "总上传："
 
@@ -146,6 +224,25 @@ msgstr "比特"
 #. settings-schema.json->unit_type->tooltip
 msgid "Base data unit shown in the panel"
 msgstr "显示在面板中的基本数据单位"
+
+#. settings-schema.json->is_binary->description
+msgid "Decimal or binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->options
+#, fuzzy
+msgid "Decimal"
+msgstr "小数位"
+
+#. settings-schema.json->is_binary->options
+msgid "Binary"
+msgstr ""
+
+#. settings-schema.json->is_binary->tooltip
+msgid ""
+"Decimal: k, M, G, T\n"
+"Binary: ki, Mi, Gi, Ti"
+msgstr ""
 
 #. settings-schema.json->update_every->units
 #. settings-schema.json->update_available_interfaces_every->units
@@ -342,10 +439,6 @@ msgstr "将下载和上传的数据总量保存到文件的频率。0 表示不�
 msgid "Data limits"
 msgstr "数据限制"
 
-#. settings-schema.json->data_limit->units
-msgid "MB"
-msgstr "MB"
-
 #. settings-schema.json->data_limit->description
 msgid "Data limit"
 msgstr "数据限制"
@@ -413,9 +506,3 @@ msgstr "命令 "
 #. settings-schema.json->list_connections_command->tooltip
 msgid "A command used to list current Internet connections"
 msgstr "用来列出当前互联网连接的命令"
-
-#~ msgid "Settings for download-and-upload-speed@cardsurf"
-#~ msgstr "download-and-upload-speed@cardsurf的设置"
-
-#~ msgid "An icon displayed next to download speed in the panel"
-#~ msgstr "显示面板中下载速度旁边的图标"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/settings-schema.json
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/settings-schema.json
@@ -27,6 +27,16 @@
         },
         "tooltip" : "Base data unit shown in the panel"
     },
+    "is_binary" : {
+        "type": "combobox",
+        "default": false,
+        "description" : "Decimal or binary",
+        "options" : {
+            "Decimal" : false,
+            "Binary" : true
+        },
+        "tooltip" : "Decimal: k, M, G, T\nBinary: ki, Mi, Gi, Ti"
+    },
     "update_every": {
         "type": "spinbutton",
         "default": 1.0,


### PR DESCRIPTION
@cardsurf 

Binary or decimal units can now be selected in settings.

![image](https://github.com/user-attachments/assets/6a9dde68-6cd0-4583-9f01-2ce7ed039d0d)

![image](https://github.com/user-attachments/assets/f683f3a7-b485-4886-9957-54edc3c48d2a)

![image](https://github.com/user-attachments/assets/4fa2627b-f651-45f0-aca9-ca713dd61ce4)

![image](https://github.com/user-attachments/assets/39f6fc25-20ca-4a5c-ab1c-84c0ae94f1a4)

'Decimal' is the default.

Also, units are now translatable. French translation is provided.

I hope you'll like these changes.

Claudiux

N.B. I can do the same for disk-read-and-write-speed@cardsurf if you wish.

