### PR TITLE
Allow higher width for cpu in multicore-sys-monitor

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/6.0/prefsui.glade
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/6.0/prefsui.glade
@@ -4,7 +4,7 @@
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="cpuWidthAdjustment">
     <property name="lower">10</property>
-    <property name="upper">100</property>
+    <property name="upper">300</property>
     <property name="value">64</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>


### PR DESCRIPTION
With 16+ cores, the value 100 is very low.