### PR TITLE
Sensors@claudiux: add support for Nvidia SMI temperatures

### DIFF
--- a/Sensors@claudiux/files/Sensors@claudiux/applet.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/applet.js
@@ -402,7 +402,6 @@ class SensorsApplet extends Applet.TextApplet {
     }
 
     this.loopId = Mainloop.timeout_add(this.interval * 1000, () => this.reap_sensors());
-    this.nvidiaLoopId = Mainloop.timeout_add(this.interval * 1000, () => this.reap_nvidia_smi());
     return false
   }
 
@@ -1462,10 +1461,6 @@ class SensorsApplet extends Applet.TextApplet {
         Mainloop.source_remove(this.loopId);
         this.loopId = 0;
     }
-    if (this.nvidiaLoopId != undefined && this.nvidiaLoopId > 0) {
-      Mainloop.source_remove(this.nvidiaLoopId);
-      this.nvidiaLoopId = 0;
-    }
     this.detect_markup();
     this.isLooping = true;
     this.reap_sensors();
@@ -1487,10 +1482,6 @@ class SensorsApplet extends Applet.TextApplet {
     if ((this.loopId != undefined) && (this.loopId > 0)) {
       Mainloop.source_remove(this.loopId);
       this.loopId = 0;
-    }
-    if (this.nvidiaLoopId != undefined && this.nvidiaLoopId > 0) {
-      Mainloop.source_remove(this.nvidiaLoopId);
-      this.nvidiaLoopId = 0;
     }
 
     if (this.checkDepInterval && (this.checkDepInterval != 0)) {

--- a/Sensors@claudiux/files/Sensors@claudiux/applet.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/applet.js
@@ -257,6 +257,7 @@ class SensorsApplet extends Applet.TextApplet {
       this.strictly_positive_fan ? 1 : 0,
       this.strictly_positive_volt ? 1 : 0
     );
+    this.reaper.reap_nvidia_smi();
 
     // Events:
     this._connectIds = [];
@@ -395,11 +396,13 @@ class SensorsApplet extends Applet.TextApplet {
         this.strictly_positive_fan ? 1 : 0,
         this.strictly_positive_volt ? 1 : 0
       );
+      this.reaper.reap_nvidia_smi();
     } else {
       this.set_applet_label(_("Suspended"));
     }
 
     this.loopId = Mainloop.timeout_add(this.interval * 1000, () => this.reap_sensors());
+    this.nvidiaLoopId = Mainloop.timeout_add(this.interval * 1000, () => this.reap_nvidia_smi());
     return false
   }
 
@@ -1459,6 +1462,10 @@ class SensorsApplet extends Applet.TextApplet {
         Mainloop.source_remove(this.loopId);
         this.loopId = 0;
     }
+    if (this.nvidiaLoopId != undefined && this.nvidiaLoopId > 0) {
+      Mainloop.source_remove(this.nvidiaLoopId);
+      this.nvidiaLoopId = 0;
+    }
     this.detect_markup();
     this.isLooping = true;
     this.reap_sensors();
@@ -1480,6 +1487,10 @@ class SensorsApplet extends Applet.TextApplet {
     if ((this.loopId != undefined) && (this.loopId > 0)) {
       Mainloop.source_remove(this.loopId);
       this.loopId = 0;
+    }
+    if (this.nvidiaLoopId != undefined && this.nvidiaLoopId > 0) {
+      Mainloop.source_remove(this.nvidiaLoopId);
+      this.nvidiaLoopId = 0;
     }
 
     if (this.checkDepInterval && (this.checkDepInterval != 0)) {

--- a/Sensors@claudiux/files/Sensors@claudiux/lib/constants.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/lib/constants.js
@@ -9,6 +9,8 @@ const APPLET_DIR = HOME_DIR + "/.local/share/cinnamon/applets/" + UUID;
 const SCRIPTS_DIR = APPLET_DIR + "/scripts";
 const ICONS_DIR = APPLET_DIR + "/icons";
 
+const NVIDIA_SMI_VERSION_REGEX = /(?<=nvidia-smi version  : )\d+\.\d+\.\d+/gi;
+
 const versionCompare = (left, right) => {
   if (typeof left + typeof right != "stringstring")
     return false;
@@ -125,6 +127,7 @@ module.exports = {
   SCRIPTS_DIR,
   ICONS_DIR,
   XS_PATH,
+  NVIDIA_SMI_VERSION_REGEX,
   _,
   DEBUG,
   RELOAD,


### PR DESCRIPTION
Use the nvidia-smi tool (https://developer.nvidia.com/system-management-interface) to read GPU temperatures 

Spice author: @claudiux 
References: #6078 