### PR TITLE
[pin-unpin-panel@anaximeno] User can set panel pinned/unpinned at startup

### DIFF
--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/5.4/applet.js
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/5.4/applet.js
@@ -76,6 +76,11 @@ class PinUnpinPanelApplet extends Applet.IconApplet {
 				cb: this.on_applet_autohide_type_settings_changed,
 			},
 			{
+				key: 'pinned-at-startup',
+				value: 'pinned_at_startup',
+				cb: null,
+			},
+			{
 				key: 'use-custom-icons',
 				value: 'use_custom_icons',
 				cb: this.update_panel_applet_ui_state,
@@ -109,6 +114,13 @@ class PinUnpinPanelApplet extends Applet.IconApplet {
 
 	on_applet_clicked(event) {
 		this.toggle_panel_pin_state();
+	}
+
+	on_applet_added_to_panel(userEnabled) {
+		global.log(UUID+": instance "+this.instanceId);
+		if (this.pinned_at_startup !== 0 && (this.pinned_at_startup === 1) !== this.pinned) {
+			this.toggle_panel_pin_state();
+		}
 	}
 
 	on_applet_removed_from_panel(deleteConfig) {

--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/5.4/settings-schema.json
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/5.4/settings-schema.json
@@ -14,6 +14,17 @@
         }
     },
 
+    "pinned-at-startup": {
+        "type": "combobox",
+        "description": "At Startup",
+        "default": 0,
+        "options": {
+            "Leave the panel as it is": 0,
+            "Pin the panel": 1,
+            "Unpin the panel": 2
+        }
+    },
+
     "style": {
         "type": "section",
         "description": "Style"

--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/metadata.json
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/metadata.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.2",
+    "version": "0.2.3",
     "uuid": "pin-unpin-panel@anaximeno",
     "name": "Pin-Unpin the Panel",
     "multiversion": true,

--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/ca.po
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pin-unpin-panel@anaximeno 0.1.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-07 10:57-0100\n"
+"POT-Creation-Date: 2024-10-13 14:05+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Unpin the Panel"
 msgstr "Feu clic per fer el tauler plegable"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Pin the Panel"
 msgstr "Feu clic per fixar el tauler"
 
@@ -52,6 +52,24 @@ msgstr "Ocultació automàtica"
 #. 5.4->settings-schema.json->unpin-autohide-type->options
 msgid "Intelligent Hide"
 msgstr "Ocultació intel·ligent"
+
+#. 5.4->settings-schema.json->pinned-at-startup->description
+msgid "At Startup"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Leave the panel as it is"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Pin the panel"
+msgstr "Fixa o plega el tauler"
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Unpin the panel"
+msgstr "Fixa o plega el tauler"
 
 #. 5.4->settings-schema.json->style->description
 msgid "Style"

--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/es.po
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: pin-unpin-panel@anaximeno 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-07 10:57-0100\n"
+"POT-Creation-Date: 2024-10-13 14:05+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Unpin the Panel"
 msgstr "Haga clic para desanclar el panel"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Pin the Panel"
 msgstr "Haga clic para fijar el panel"
 
@@ -52,6 +52,24 @@ msgstr "Auto Ocultar"
 #. 5.4->settings-schema.json->unpin-autohide-type->options
 msgid "Intelligent Hide"
 msgstr "Ocultación inteligente"
+
+#. 5.4->settings-schema.json->pinned-at-startup->description
+msgid "At Startup"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Leave the panel as it is"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Pin the panel"
+msgstr "Fijar o desanclar el panel"
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Unpin the panel"
+msgstr "Fijar o desanclar el panel"
 
 #. 5.4->settings-schema.json->style->description
 msgid "Style"

--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/fr.po
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pin-unpin-panel@anaximeno 0.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-07 10:57-0100\n"
+"POT-Creation-Date: 2024-10-13 14:05+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -18,13 +18,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Unpin the Panel"
-msgstr "Cliquez pour désépingler le panneau"
+msgstr "Clic pour désépingler le panneau"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Pin the Panel"
-msgstr "Cliquez pour épingler le panneau"
+msgstr "Clic pour épingler le panneau"
 
 #. metadata.json->name
 msgid "Pin-Unpin the Panel"
@@ -53,6 +53,22 @@ msgstr "Masquage auto"
 #. 5.4->settings-schema.json->unpin-autohide-type->options
 msgid "Intelligent Hide"
 msgstr "Masquage intelligent"
+
+#. 5.4->settings-schema.json->pinned-at-startup->description
+msgid "At Startup"
+msgstr "Au démarrage"
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Leave the panel as it is"
+msgstr "Laisser le panneau tel quel"
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Pin the panel"
+msgstr "Épingler le panneau"
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Unpin the panel"
+msgstr "Désépingler le panneau"
 
 #. 5.4->settings-schema.json->style->description
 msgid "Style"

--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/hu.po
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pin-unpin-panel@anaximeno 0.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-07 10:57-0100\n"
+"POT-Creation-Date: 2024-10-13 14:05+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Unpin the Panel"
 msgstr "Kattintson a panel rögzítésének feloldásához"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Pin the Panel"
 msgstr "Kattintson a panel rögzítéséhez"
 
@@ -35,8 +35,8 @@ msgid ""
 "An applet that lets you pin or unpin the panel, making it fixed or "
 "collapsible."
 msgstr ""
-"Egy kisalkalmazás, amely lehetővé teszi a panel rögzítését vagy "
-"feloldását, így téve azt rögzítetté vagy összecsukhatóvá."
+"Egy kisalkalmazás, amely lehetővé teszi a panel rögzítését vagy feloldását, "
+"így téve azt rögzítetté vagy összecsukhatóvá."
 
 #. 5.4->settings-schema.json->general->description
 msgid "General"
@@ -53,6 +53,24 @@ msgstr "Automatikus elrejtés"
 #. 5.4->settings-schema.json->unpin-autohide-type->options
 msgid "Intelligent Hide"
 msgstr "Intelligens elrejtés"
+
+#. 5.4->settings-schema.json->pinned-at-startup->description
+msgid "At Startup"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Leave the panel as it is"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Pin the panel"
+msgstr "Panel rögzítése/feloldása"
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Unpin the panel"
+msgstr "Panel rögzítése/feloldása"
 
 #. 5.4->settings-schema.json->style->description
 msgid "Style"

--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/nl.po
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: pin-unpin-panel@anaximeno 0.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-07 10:57-0100\n"
+"POT-Creation-Date: 2024-10-13 14:05+0200\n"
 "PO-Revision-Date: 2024-09-11 12:33+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,11 +16,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Unpin the Panel"
 msgstr "Klik om het paneel los te koppelen"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Pin the Panel"
 msgstr "Klik om het paneel vast te koppelen"
 
@@ -51,6 +51,24 @@ msgstr "Automatisch verbergen"
 #. 5.4->settings-schema.json->unpin-autohide-type->options
 msgid "Intelligent Hide"
 msgstr "Intelligent verbergen"
+
+#. 5.4->settings-schema.json->pinned-at-startup->description
+msgid "At Startup"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Leave the panel as it is"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Pin the panel"
+msgstr "Paneel vast- of loskoppelen"
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Unpin the panel"
+msgstr "Paneel vast- of loskoppelen"
 
 #. 5.4->settings-schema.json->style->description
 msgid "Style"

--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/pin-unpin-panel@anaximeno.pot
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/pin-unpin-panel@anaximeno.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: pin-unpin-panel@anaximeno 0.2.0\n"
+"Project-Id-Version: pin-unpin-panel@anaximeno 0.2.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-07 10:57-0100\n"
+"POT-Creation-Date: 2024-10-13 14:05+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Unpin the Panel"
 msgstr ""
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Pin the Panel"
 msgstr ""
 
@@ -49,6 +49,22 @@ msgstr ""
 
 #. 5.4->settings-schema.json->unpin-autohide-type->options
 msgid "Intelligent Hide"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->description
+msgid "At Startup"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Leave the panel as it is"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Pin the panel"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Unpin the panel"
 msgstr ""
 
 #. 5.4->settings-schema.json->style->description

--- a/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/pt.po
+++ b/pin-unpin-panel@anaximeno/files/pin-unpin-panel@anaximeno/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pin-unpin-panel@anaximeno 0.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-07 10:57-0100\n"
+"POT-Creation-Date: 2024-10-13 14:05+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Unpin the Panel"
 msgstr "Clique para Desafixar o Painel"
 
-#. 5.4/applet.js:139
+#. 5.4/applet.js:155
 msgid "Click to Pin the Panel"
 msgstr "Clique para Fixar o Painel"
 
@@ -53,6 +53,24 @@ msgstr "Ocultação Automática"
 #. 5.4->settings-schema.json->unpin-autohide-type->options
 msgid "Intelligent Hide"
 msgstr "Ocultação Inteligente"
+
+#. 5.4->settings-schema.json->pinned-at-startup->description
+msgid "At Startup"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+msgid "Leave the panel as it is"
+msgstr ""
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Pin the panel"
+msgstr "Fixar-Desafixar o Painel"
+
+#. 5.4->settings-schema.json->pinned-at-startup->options
+#, fuzzy
+msgid "Unpin the panel"
+msgstr "Fixar-Desafixar o Painel"
 
 #. 5.4->settings-schema.json->style->description
 msgid "Style"


### PR DESCRIPTION
@anaximeno 

Hi,
I often forget to unpin a panel before closing my session and this annoys me.

So I'm proposing here that the user should be able to set the panel state when the applet starts up. Three states are available:

- Leave the panel as it is.
- Pin the panel.
- Unpin the panel.

I hope you'll like this.

Regards
claudiux