### PR TITLE
[sound150@claudiux] v7.1.0 - Option to try to avoid loud cracking sound at shutdown

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
@@ -338,7 +338,7 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
         let icon = Gio.Icon.new_for_string(this._volumeToIcon(this._value));
 
         if (this.applet.showOSD) {
-            Main.osdWindowManager.show(-1, icon, Math.round(volume/this.applet._volumeNorm * 100), null);
+            Main.osdWindowManager.show(-1, icon, ""+Math.round(volume/this.applet._volumeNorm * 100), null);
         }
 
 
@@ -1806,6 +1806,7 @@ class Sound150Applet extends Applet.TextIconApplet {
         this.settings.bind("tooltipShowArtistTitle", "tooltipShowArtistTitle", this.on_settings_changed);
 
         this.settings.bind("alwaysCanChangeMic", "alwaysCanChangeMic", this.on_settings_changed);
+        this.settings.bind("avoidCrackingAtShutdown", "avoidCrackingAtShutdown", null);
 
         this._sounds_settings = new Gio.Settings({ schema_id: CINNAMON_DESKTOP_SOUNDS });
         this.settings.setValue("volumeSoundFile", this._sounds_settings.get_string(VOLUME_SOUND_FILE_KEY));
@@ -2206,6 +2207,11 @@ class Sound150Applet extends Applet.TextIconApplet {
     }
 
     on_applet_removed_from_panel() {
+        if (this.avoidCrackingAtShutdown && this._output && !this._output.is_muted) {
+            let old_volume = this.volume;
+            this._toggle_out_mute();
+            this.volume = old_volume;
+        }
         Main.keybindingManager.removeHotKey("sound-open-" + this.instance_id);
         Main.keybindingManager.removeHotKey("switch-player-" + this.instance_id);
         try {
@@ -2414,8 +2420,8 @@ class Sound150Applet extends Applet.TextIconApplet {
             this.set_applet_icon_symbolic_name(icon_name);
             if (this.showOSD) {
                 //~ Main.osdWindowManager.hideAll();
-                Main.osdWindowManager.show(-1, icon, volume, null);
-                //Main.osdWindowManager.show(0, icon, volume, true);
+                Main.osdWindowManager.show(-1, icon, ""+volume, null);
+                //Main.osdWindowManager.show(0, icon, ""+volume, true);
             }
             var intervalId = null;
             intervalId = Util.setInterval(() => {

--- a/sound150@claudiux/files/sound150@claudiux/5.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/settings-schema.json
@@ -99,7 +99,8 @@
         "stepVolume",
         "magneticOn",
         "magnetic25On",
-        "alwaysCanChangeMic"
+        "alwaysCanChangeMic",
+        "avoidCrackingAtShutdown"
       ]
     },
     "sectionSound2": {
@@ -360,6 +361,11 @@
     "description": "Always allow microphone to be reactivated",
     "tooltip": "Always show the 'Mute input' switch in the context menu.",
     "default": true
+  },
+  "avoidCrackingAtShutdown": {
+    "type": "switch",
+    "description": "Try to avoid loud cracking sound at shutdown",
+    "default": false
   },
   "showMediaKeysOSD": {
     "type": "combobox",

--- a/sound150@claudiux/files/sound150@claudiux/5.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/settings-schema.json
@@ -365,7 +365,7 @@
   "avoidCrackingAtShutdown": {
     "type": "switch",
     "description": "Try to avoid loud cracking sound at shutdown",
-    "default": false
+    "default": true
   },
   "showMediaKeysOSD": {
     "type": "combobox",

--- a/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
@@ -1808,6 +1808,7 @@ class Sound150Applet extends Applet.TextIconApplet {
         this.settings.bind("tooltipShowArtistTitle", "tooltipShowArtistTitle", this.on_settings_changed);
 
         this.settings.bind("alwaysCanChangeMic", "alwaysCanChangeMic", this.on_settings_changed);
+        this.settings.bind("avoidCrackingAtShutdown", "avoidCrackingAtShutdown", null);
 
         this._sounds_settings = new Gio.Settings({ schema_id: CINNAMON_DESKTOP_SOUNDS });
         this.settings.setValue("volumeSoundFile", this._sounds_settings.get_string(VOLUME_SOUND_FILE_KEY));
@@ -2230,6 +2231,11 @@ class Sound150Applet extends Applet.TextIconApplet {
     }
 
     on_applet_removed_from_panel() {
+        if (this.avoidCrackingAtShutdown && this._output && !this._output.is_muted) {
+            let old_volume = this.volume;
+            this._toggle_out_mute();
+            this.volume = old_volume;
+        }
         Main.keybindingManager.removeHotKey("sound-open-" + this.instance_id);
         Main.keybindingManager.removeHotKey("switch-player-" + this.instance_id);
         try {

--- a/sound150@claudiux/files/sound150@claudiux/6.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/settings-schema.json
@@ -101,7 +101,8 @@
         "stepVolume",
         "magneticOn",
         "magnetic25On",
-        "alwaysCanChangeMic"
+        "alwaysCanChangeMic",
+        "avoidCrackingAtShutdown"
       ]
     },
     "sectionSound2": {
@@ -375,6 +376,11 @@
     "type": "switch",
     "description": "Always allow microphone to be reactivated",
     "tooltip": "Always show the 'Mute input' switch in the context menu.",
+    "default": true
+  },
+  "avoidCrackingAtShutdown": {
+    "type": "switch",
+    "description": "Try to avoid loud cracking sound at shutdown",
     "default": true
   },
   "showMediaKeysOSD": {

--- a/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v7.1.0~20241013
+  * Option to try to avoid loud cracking sound at shutdown.
+  * Fixes https://github.com/linuxmint/cinnamon/issues/12446.
+
 ### v7.0.0~20241011
   * Compatible with Cinnamon 6.4.
 

--- a/sound150@claudiux/files/sound150@claudiux/metadata.json
+++ b/sound150@claudiux/files/sound150@claudiux/metadata.json
@@ -5,7 +5,7 @@
   "max-instances": "1",
   "description": "Enhanced sound applet",
   "hide-configuration": false,
-  "version": "7.0.0",
+  "version": "7.1.0",
   "cinnamon-version": [
     "2.8",
     "3.0",


### PR DESCRIPTION
Try to solve https://github.com/linuxmint/cinnamon/issues/12446

How it works: When new option is checked, the output is muted at shutdown.