### PR TITLE
[sound150@claudiux] v7.1.1 - Avoids loud cracking sound at shutdown

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
@@ -1806,7 +1806,6 @@ class Sound150Applet extends Applet.TextIconApplet {
         this.settings.bind("tooltipShowArtistTitle", "tooltipShowArtistTitle", this.on_settings_changed);
 
         this.settings.bind("alwaysCanChangeMic", "alwaysCanChangeMic", this.on_settings_changed);
-        this.settings.bind("avoidCrackingAtShutdown", "avoidCrackingAtShutdown", null);
 
         this._sounds_settings = new Gio.Settings({ schema_id: CINNAMON_DESKTOP_SOUNDS });
         this.settings.setValue("volumeSoundFile", this._sounds_settings.get_string(VOLUME_SOUND_FILE_KEY));
@@ -2207,7 +2206,7 @@ class Sound150Applet extends Applet.TextIconApplet {
     }
 
     on_applet_removed_from_panel() {
-        if (this.avoidCrackingAtShutdown && this._output && !this._output.is_muted) {
+        if (this._output && !this._output.is_muted) {
             let old_volume = this.volume;
             this._toggle_out_mute();
             this.volume = old_volume;

--- a/sound150@claudiux/files/sound150@claudiux/5.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/settings-schema.json
@@ -99,8 +99,7 @@
         "stepVolume",
         "magneticOn",
         "magnetic25On",
-        "alwaysCanChangeMic",
-        "avoidCrackingAtShutdown"
+        "alwaysCanChangeMic"
       ]
     },
     "sectionSound2": {
@@ -360,11 +359,6 @@
     "type": "switch",
     "description": "Always allow microphone to be reactivated",
     "tooltip": "Always show the 'Mute input' switch in the context menu.",
-    "default": true
-  },
-  "avoidCrackingAtShutdown": {
-    "type": "switch",
-    "description": "Try to avoid loud cracking sound at shutdown",
     "default": true
   },
   "showMediaKeysOSD": {

--- a/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
@@ -1808,7 +1808,6 @@ class Sound150Applet extends Applet.TextIconApplet {
         this.settings.bind("tooltipShowArtistTitle", "tooltipShowArtistTitle", this.on_settings_changed);
 
         this.settings.bind("alwaysCanChangeMic", "alwaysCanChangeMic", this.on_settings_changed);
-        this.settings.bind("avoidCrackingAtShutdown", "avoidCrackingAtShutdown", null);
 
         this._sounds_settings = new Gio.Settings({ schema_id: CINNAMON_DESKTOP_SOUNDS });
         this.settings.setValue("volumeSoundFile", this._sounds_settings.get_string(VOLUME_SOUND_FILE_KEY));
@@ -2231,7 +2230,7 @@ class Sound150Applet extends Applet.TextIconApplet {
     }
 
     on_applet_removed_from_panel() {
-        if (this.avoidCrackingAtShutdown && this._output && !this._output.is_muted) {
+        if (this._output && !this._output.is_muted) {
             let old_volume = this.volume;
             this._toggle_out_mute();
             this.volume = old_volume;

--- a/sound150@claudiux/files/sound150@claudiux/6.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/settings-schema.json
@@ -101,8 +101,7 @@
         "stepVolume",
         "magneticOn",
         "magnetic25On",
-        "alwaysCanChangeMic",
-        "avoidCrackingAtShutdown"
+        "alwaysCanChangeMic"
       ]
     },
     "sectionSound2": {
@@ -376,11 +375,6 @@
     "type": "switch",
     "description": "Always allow microphone to be reactivated",
     "tooltip": "Always show the 'Mute input' switch in the context menu.",
-    "default": true
-  },
-  "avoidCrackingAtShutdown": {
-    "type": "switch",
-    "description": "Try to avoid loud cracking sound at shutdown",
     "default": true
   },
   "showMediaKeysOSD": {

--- a/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v7.1.1~20241016
+  * Avoids loud cracking sound at shutdown.
+  * Option removed. This is basic now.
+
+
 ### v7.1.0~20241013
   * Option to try to avoid loud cracking sound at shutdown.
   * Fixes https://github.com/linuxmint/cinnamon/issues/12446.

--- a/sound150@claudiux/files/sound150@claudiux/README.md
+++ b/sound150@claudiux/files/sound150@claudiux/README.md
@@ -8,6 +8,8 @@ This *sound150@claudiux* applet is an enhancement of the Cinnamon system sound a
 
 **It can display icons indicating that the microphone is muted or activated.**
 
+**It avoids loud cracking sound at shutdown.**
+
 **Sound volume:**
 
   * **The volume step can be redefined** (from 1% to 10%).
@@ -32,7 +34,7 @@ From 131 to 150%: red icon (by default).
 
 **You can redefine multimedia key bindings.**
 
-Successfully tested on Cinnamon versions 2.8 to 6.2 (Linux Mint 17.3 to 22). Does not work on Cinnamon prior to version 2.8 (Linux Mint prior to 17.3).
+Successfully tested on Cinnamon versions 2.8 to 6.4 (Linux Mint 17.3 to 22.1). Does not work on Cinnamon prior to version 2.8 (Linux Mint prior to 17.3).
 
 ## Dependencies
 

--- a/sound150@claudiux/files/sound150@claudiux/metadata.json
+++ b/sound150@claudiux/files/sound150@claudiux/metadata.json
@@ -5,7 +5,7 @@
   "max-instances": "1",
   "description": "Enhanced sound applet",
   "hide-configuration": false,
-  "version": "7.1.0",
+  "version": "7.1.1",
   "cinnamon-version": [
     "2.8",
     "3.0",

--- a/sound150@claudiux/files/sound150@claudiux/po/ca.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux 6.16.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2024-07-31 18:45+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -45,11 +45,11 @@ msgstr "Tancar el reproductor"
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr "Artista desconegut"
 
@@ -60,10 +60,10 @@ msgid "Unknown Album"
 msgstr "Àlbum desconegut"
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr "Títol desconegut"
 
@@ -154,19 +154,19 @@ msgstr "Micròfon"
 msgid "Input device"
 msgstr "Dispositiu d'entrada"
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr "Escollir els controls del reproductor"
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr "Iniciar reproductor"
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr "Volum"
 
@@ -175,8 +175,8 @@ msgstr "Volum"
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr "Opcions de so"
 
@@ -197,23 +197,23 @@ msgstr "Pulse Effects"
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Segur que voleu eliminar '%s'?"
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr "Es necessita el paquet 'playerctl'!"
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr "Si us plau, seleccioneu 'Instal·la playerctl' en aquest menú"
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr "Refresca aquesta miniaplicació"
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr "Elimina la miniaplicació"
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr "Instal·la playerctl"
 

--- a/sound150@claudiux/files/sound150@claudiux/po/da.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux v1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2023-12-25 11:24+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Dansk-gruppen <dansk@dansk-gruppen.dk>\n"
@@ -46,11 +46,11 @@ msgstr "Afslut afspiller"
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr "Ukendt kunstner"
 
@@ -61,10 +61,10 @@ msgid "Unknown Album"
 msgstr "Ukendt album"
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr "Ukendt titel"
 
@@ -155,19 +155,19 @@ msgstr "Mikrofon"
 msgid "Input device"
 msgstr "Inputenhed"
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr "Vælg kontrolelementer til afspiller"
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr "Start afspiller"
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr "Lydstyrke"
 
@@ -176,8 +176,8 @@ msgstr "Lydstyrke"
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr "Lydindstillinger"
 
@@ -198,23 +198,23 @@ msgstr ""
 msgid "Are you sure you want to remove '%s'?"
 msgstr ""
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr ""
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr ""
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr ""
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr ""
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr ""
 

--- a/sound150@claudiux/files/sound150@claudiux/po/es.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux v2.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2024-10-12 13:31-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -46,11 +46,11 @@ msgstr "Salir del reproductor"
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr "Artista desconocido"
 
@@ -61,10 +61,10 @@ msgid "Unknown Album"
 msgstr "Álbum desconocido"
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr "Título desconocido"
 
@@ -155,19 +155,19 @@ msgstr "Micrófono"
 msgid "Input device"
 msgstr "Dispositivo de entrada"
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr "Elegir los controles del reproductor"
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr "Iniciar reproductor"
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr "Volumen"
 
@@ -176,8 +176,8 @@ msgstr "Volumen"
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr "Ajustes de sonido"
 
@@ -198,23 +198,23 @@ msgstr "Efectos Pulse"
 msgid "Are you sure you want to remove '%s'?"
 msgstr "¿Estás seguro de que quieres eliminar '%s'?"
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr "¡Se necesita el paquete \"playerctl\"!"
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr "Seleccione 'Instalar playerctl' en este menú"
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr "Recargar este applet"
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr "Quitar el applet de sonido"
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr "Instalar playerctl"
 

--- a/sound150@claudiux/files/sound150@claudiux/po/fi.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux v2.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2022-11-30 10:35+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -46,11 +46,11 @@ msgstr "Lopeta soitin"
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr "Tuntematon esittäjä"
 
@@ -61,10 +61,10 @@ msgid "Unknown Album"
 msgstr "Tuntematon albumi"
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr "Tuntematon nimi"
 
@@ -155,19 +155,19 @@ msgstr "Mikrofoni"
 msgid "Input device"
 msgstr "Sisääntulon laite"
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr "Valitse soittimen säätimet"
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr "Käynnistä soitin"
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr "Voimakkuus"
 
@@ -176,8 +176,8 @@ msgstr "Voimakkuus"
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr "Ääniasetukset"
 
@@ -198,23 +198,23 @@ msgstr ""
 msgid "Are you sure you want to remove '%s'?"
 msgstr ""
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr ""
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr ""
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr ""
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr ""
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr ""
 

--- a/sound150@claudiux/files/sound150@claudiux/po/fr.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2024-10-12 16:35+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -46,11 +46,11 @@ msgstr "Fermer le lecteur"
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr "Artiste inconnu"
 
@@ -61,10 +61,10 @@ msgid "Unknown Album"
 msgstr "Album inconnu"
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr "Titre inconnu"
 
@@ -155,19 +155,19 @@ msgstr "Micro"
 msgid "Input device"
 msgstr "Périphérique d'entrée"
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr "Choisissez les contrôles du lecteur"
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr "Lancer le lecteur"
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr "Volume"
 
@@ -176,8 +176,8 @@ msgstr "Volume"
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr "Paramètres du son"
 
@@ -198,23 +198,23 @@ msgstr "Pulse Effects"
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Êtes-vous sûr de vouloir retirer \"%s\" ?"
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr "Le paquet \"playerctl\" est nécessaire !"
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr "Veuillez utiliser l'option \"Installer playerctl\" dans ce menu"
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr "Recharger cette applet"
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr "Retirer l'applet Son de Cinnamon"
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr "Installer playerctl"
 

--- a/sound150@claudiux/files/sound150@claudiux/po/hu.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux 6.16.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2024-10-02 19:04+0200\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -45,11 +45,11 @@ msgstr "Lejátszó bezárása"
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr "Ismeretlen előadó"
 
@@ -60,10 +60,10 @@ msgid "Unknown Album"
 msgstr "Ismeretlen album"
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr "Ismeretlen cím"
 
@@ -154,19 +154,19 @@ msgstr "Mikrofon"
 msgid "Input device"
 msgstr "Bemeneti eszköz"
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr "Médialejátszó vezérlőelemek kiválasztása"
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr "Lejátszó indítása"
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr "Hangerő"
 
@@ -175,8 +175,8 @@ msgstr "Hangerő"
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr "Hangbeállítások"
 
@@ -197,23 +197,23 @@ msgstr "Pulse Effects"
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Biztosan eltávolítja a következőt: '%s'?"
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr "A 'playerctl' csomag szükséges!"
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr "Kérem válassza a 'A playerctl telepítése'-t a menüben"
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr "Kisalkalmazás újratöltése"
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr "Távolítsa el a hangkisalkalmazást"
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr "A playerctl telepítése"
 

--- a/sound150@claudiux/files/sound150@claudiux/po/it.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux v1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2024-06-18 15:56+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -46,11 +46,11 @@ msgstr "Chiudi Player"
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr "Artista Sconosciuto"
 
@@ -61,10 +61,10 @@ msgid "Unknown Album"
 msgstr "Album Sconosciuto"
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr "Titolo Sconosciuto"
 
@@ -155,19 +155,19 @@ msgstr "Microfono"
 msgid "Input device"
 msgstr "Dispositivo di ingresso"
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr "Scegli i controlli del player"
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr "Avvia player"
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr "Volume"
 
@@ -176,8 +176,8 @@ msgstr "Volume"
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr "Impostazioni del Suono"
 
@@ -199,23 +199,23 @@ msgstr "Effetti semplici"
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Rimuovere '%s'?"
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr "È richiesto il pacchetto 'playerctl'!"
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr "Seleziona \"Installa playerctl\" in questo menù"
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr "Ricarica questa applet"
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr "Rimuovi l'applet audio"
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr "Installa playerctl"
 

--- a/sound150@claudiux/files/sound150@claudiux/po/nl.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux 6.8.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2024-09-11 12:35+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -43,11 +43,11 @@ msgstr "Speler afsluiten"
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr "Onbekende Artiest"
 
@@ -58,10 +58,10 @@ msgid "Unknown Album"
 msgstr "Onbekend Album"
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr "Onbekende Titel"
 
@@ -152,19 +152,19 @@ msgstr "Microfoon"
 msgid "Input device"
 msgstr "Invoerapparaat"
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr "Bedieningsknoppen kiezen"
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr "Speler openen"
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr "Volume"
 
@@ -173,8 +173,8 @@ msgstr "Volume"
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr "Geluidsinstellingen"
 
@@ -195,23 +195,23 @@ msgstr "Pulserende Effecten"
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Weet je zeker dat je '%s' wilt verwijderen?"
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr "Het 'playerctl'-pakket is vereist!"
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr "Selecteer 'Installeer playerctl' in dit menu alstublieft"
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr "Herlaad deze applet"
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr "Verwijder geluidsapplet"
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr "Installeer playerctl"
 

--- a/sound150@claudiux/files/sound150@claudiux/po/ru.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux-ru.po\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2022-12-26 15:25-0500\n"
 "Last-Translator: GNOU <bitmask1980@gmail.com>\n"
 "Language-Team: \n"
@@ -46,11 +46,11 @@ msgstr ""
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr ""
 
@@ -61,10 +61,10 @@ msgid "Unknown Album"
 msgstr ""
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr ""
 
@@ -155,19 +155,19 @@ msgstr ""
 msgid "Input device"
 msgstr ""
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr ""
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr ""
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr ""
 
@@ -176,8 +176,8 @@ msgstr ""
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr ""
 
@@ -198,23 +198,23 @@ msgstr ""
 msgid "Are you sure you want to remove '%s'?"
 msgstr ""
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr ""
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr ""
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr ""
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr ""
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr ""
 

--- a/sound150@claudiux/files/sound150@claudiux/po/sound150@claudiux.pot
+++ b/sound150@claudiux/files/sound150@claudiux/po/sound150@claudiux.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: sound150@claudiux 7.0.0\n"
+"Project-Id-Version: sound150@claudiux 7.1.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -44,11 +44,11 @@ msgstr ""
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr ""
 
@@ -59,10 +59,10 @@ msgid "Unknown Album"
 msgstr ""
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr ""
 
@@ -153,19 +153,19 @@ msgstr ""
 msgid "Input device"
 msgstr ""
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr ""
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr ""
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr ""
 
@@ -174,8 +174,8 @@ msgstr ""
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr ""
 
@@ -196,23 +196,23 @@ msgstr ""
 msgid "Are you sure you want to remove '%s'?"
 msgstr ""
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr ""
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr ""
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr ""
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 msgid "Remove sound applet"
 msgstr ""
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr ""
 

--- a/sound150@claudiux/files/sound150@claudiux/po/sv.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/sv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux v1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-12 16:33+0200\n"
+"POT-Creation-Date: 2024-10-16 16:13+0200\n"
 "PO-Revision-Date: 2024-03-04 05:52+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -46,11 +46,11 @@ msgstr "Avsluta spelare"
 
 #. 4.4/applet.js:591 4.4/applet.js:723 4.4/applet.js:727 5.4/applet.js:1102
 #. 5.4/applet.js:1385 5.4/applet.js:1388 5.4/applet.js:1391 5.4/applet.js:1425
-#. 5.4/applet.js:1434 5.4/applet.js:2644 5.4/applet.js:2678 4.6/applet.js:592
+#. 5.4/applet.js:1434 5.4/applet.js:2649 5.4/applet.js:2683 4.6/applet.js:592
 #. 4.6/applet.js:719 4.6/applet.js:723 2.8/applet.js:529 2.8/applet.js:761
 #. 2.8/applet.js:765 6.4/applet.js:1103 6.4/applet.js:1386 6.4/applet.js:1389
-#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2670
-#. 6.4/applet.js:2704 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
+#. 6.4/applet.js:1392 6.4/applet.js:1426 6.4/applet.js:1435 6.4/applet.js:2675
+#. 6.4/applet.js:2709 3.4/applet.js:534 3.4/applet.js:766 3.4/applet.js:770
 msgid "Unknown Artist"
 msgstr "Okänd artist"
 
@@ -61,10 +61,10 @@ msgid "Unknown Album"
 msgstr "Okänt album"
 
 #. 4.4/applet.js:593 4.4/applet.js:739 5.4/applet.js:1104 5.4/applet.js:1419
-#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2681
+#. 5.4/applet.js:1428 5.4/applet.js:1431 5.4/applet.js:1439 5.4/applet.js:2686
 #. 4.6/applet.js:594 4.6/applet.js:735 2.8/applet.js:531 2.8/applet.js:777
 #. 6.4/applet.js:1105 6.4/applet.js:1420 6.4/applet.js:1429 6.4/applet.js:1432
-#. 6.4/applet.js:1440 6.4/applet.js:2707 3.4/applet.js:536 3.4/applet.js:782
+#. 6.4/applet.js:1440 6.4/applet.js:2712 3.4/applet.js:536 3.4/applet.js:782
 msgid "Unknown Title"
 msgstr "Okänd låt"
 
@@ -155,19 +155,19 @@ msgstr "Mikrofon"
 msgid "Input device"
 msgstr "Indataenhet"
 
-#. 4.4/applet.js:1392 5.4/applet.js:2824 4.6/applet.js:1414 2.8/applet.js:1639
-#. 6.4/applet.js:2850 3.4/applet.js:1566
+#. 4.4/applet.js:1392 5.4/applet.js:2829 4.6/applet.js:1414 2.8/applet.js:1639
+#. 6.4/applet.js:2855 3.4/applet.js:1566
 msgid "Choose player controls"
 msgstr "Välj spelarkontroller"
 
-#. 4.4/applet.js:1397 5.4/applet.js:2819 4.6/applet.js:1409 2.8/applet.js:1644
-#. 6.4/applet.js:2845 3.4/applet.js:1571
+#. 4.4/applet.js:1397 5.4/applet.js:2824 4.6/applet.js:1409 2.8/applet.js:1644
+#. 6.4/applet.js:2850 3.4/applet.js:1571
 msgid "Launch player"
 msgstr "Starta spelare"
 
-#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2671 5.4/applet.js:2831
+#. 4.4/applet.js:1403 4.4/applet.js:1497 5.4/applet.js:2676 5.4/applet.js:2836
 #. 4.6/applet.js:1420 4.6/applet.js:1515 2.8/applet.js:1650 2.8/applet.js:1735
-#. 6.4/applet.js:2697 6.4/applet.js:2857 3.4/applet.js:1577 3.4/applet.js:1662
+#. 6.4/applet.js:2702 6.4/applet.js:2862 3.4/applet.js:1577 3.4/applet.js:1662
 msgid "Volume"
 msgstr "Volym"
 
@@ -176,8 +176,8 @@ msgstr "Volym"
 #. 4.6->settings-schema.json->section3->description
 #. 6.4->settings-schema.json->sectionSound1->title
 #. 3.4->settings-schema.json->section3->description
-#. 4.4/applet.js:1409 5.4/applet.js:2839 4.6/applet.js:1426 2.8/applet.js:1657
-#. 6.4/applet.js:2865 3.4/applet.js:1584
+#. 4.4/applet.js:1409 5.4/applet.js:2844 4.6/applet.js:1426 2.8/applet.js:1657
+#. 6.4/applet.js:2870 3.4/applet.js:1584
 msgid "Sound Settings"
 msgstr "Ljudinställningar"
 
@@ -199,24 +199,24 @@ msgstr "Lätta effekter"
 msgid "Are you sure you want to remove '%s'?"
 msgstr ""
 
-#. 5.4/applet.js:2687 6.4/applet.js:2713
+#. 5.4/applet.js:2692 6.4/applet.js:2718
 msgid "The 'playerctl' package is required!"
 msgstr "Paketet \"playerctl\" krävs!"
 
-#. 5.4/applet.js:2688 6.4/applet.js:2714
+#. 5.4/applet.js:2693 6.4/applet.js:2719
 msgid "Please select 'Install playerctl' in this menu"
 msgstr "Välj \"Installera playerctl\" i den här menyn"
 
-#. 5.4/applet.js:2844 6.4/applet.js:2870
+#. 5.4/applet.js:2849 6.4/applet.js:2875
 msgid "Reload this applet"
 msgstr "Ladda om det här panelprogrammet"
 
-#. 5.4/applet.js:2850 6.4/applet.js:2876
+#. 5.4/applet.js:2855 6.4/applet.js:2881
 #, fuzzy
 msgid "Remove sound applet"
 msgstr "Ladda om det här panelprogrammet"
 
-#. 5.4/applet.js:2859 6.4/applet.js:2885
+#. 5.4/applet.js:2864 6.4/applet.js:2890
 msgid "Install playerctl"
 msgstr "Installera playerctl"
 


### PR DESCRIPTION
This is now the default, with no options.

Related to https://github.com/linuxmint/cinnamon/issues/12446