### PR TITLE
Increase refreshInterval max value to 3600 seconds

### DIFF
--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/settings-schema.json
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/settings-schema.json
@@ -13,7 +13,7 @@
 		"type": "spinbutton",
 		"default": 10,
 		"min": 0,
-		"max": 60,
+		"max": 3600,
 		"step": 1,
 		"units": "seconds",
 		"description": "Refresh interval [0 for no refresh]"


### PR DESCRIPTION
Every 60s is too frequent for many uses of bash-sensors. Increasing the max value allows for more options.