### PR TITLE
[CassiaWindowList@klangman] 2.3.7 new scroll-wheel options and fixes

### DIFF
--- a/CassiaWindowList@klangman/CHANGELOG.md
+++ b/CassiaWindowList@klangman/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.3.7
+
+* Added scroll-wheel options, cycle all window-list windows and cycle group/pool windows
+* The "active" class (window-list button underline in MintY theme) is now used as an active window highlight when pinning is disabled
+* Fixed bug preventing pinned buttons from being removed after disabling the pinned buttons support ("Pinning of window list buttons" -> "Disabled")
+* The window-list mouse scroll-wheel action will apply when the Thumbnail menu is open and the Thumbnail menu scroll-wheel setting is "Disabled"
+* If the active window changes when the Thumbnail menu is open, the outlined Thumbnail menu item will change if the new active window is one of the menu items
+
 ## 2.3.6
 
 * Added context menu options to close all/other windows for the buttons application (when button is not grouped)

--- a/CassiaWindowList@klangman/README.md
+++ b/CassiaWindowList@klangman/README.md
@@ -2,6 +2,7 @@ This is a Cinnamon window list and panel launcher applet based on CobiWindowList
 
 Recent new features (Aug 2023 - Oct 2024):
 
+* Added scroll-wheel options, cycle all window-list windows and cycle group/pool windows
 * Added context menu options to close all/other windows for the buttons application
 * Saves new default thumbnail window sizes (adjusted using the mouse scroll-wheel) across cinnamon restarts
 * Now uses application specific thumbnail windows sizes across all workspaces

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -709,6 +709,8 @@
       "Change windows workspace": 2,
       "Change windows monitor": 3,
       "Change window tiling": 4,
+      "Cycle all window-list button windows": 5,
+      "Cycle grouped/pooled button windows": 6,
       "Do nothing": 0
     },
     "description": "Scroll wheel action",

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
@@ -709,6 +709,8 @@
       "Change windows workspace": 2,
       "Change windows monitor": 3,
       "Change window tiling": 4,
+      "Cycle all window-list button windows": 5,
+      "Cycle grouped/pooled button windows": 6,
       "Do nothing": 0
     },
     "description": "Scroll wheel action",

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
@@ -5,6 +5,6 @@
     "max-instances": -1,
     "multiversion": true,
     "role": "panellauncher",
-    "version": "2.3.6",
+    "version": "2.3.7",
     "author": "klangman"
 }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CassiaWindowList@klangman 2.3.6\n"
+"Project-Id-Version: CassiaWindowList@klangman 2.3.7\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-20 09:59-0400\n"
+"POT-Creation-Date: 2024-10-30 20:53-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,32 +17,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 4.0/applet.js:581 6.0/applet.js:581
+#. 4.0/applet.js:584 6.0/applet.js:584
 msgid "all buttons"
 msgstr ""
 
-#. 4.0/applet.js:3172 6.0/applet.js:3172
+#. 4.0/applet.js:3258 6.0/applet.js:3258
 msgid "Applet Preferences"
 msgstr ""
 
-#. 4.0/applet.js:3176 6.0/applet.js:3176
+#. 4.0/applet.js:3262 6.0/applet.js:3262
 msgid "About..."
 msgstr ""
 
-#. 4.0/applet.js:3180 6.0/applet.js:3180
+#. 4.0/applet.js:3266 6.0/applet.js:3266
 msgid "Configure..."
 msgstr ""
 
-#. 4.0/applet.js:3184 6.0/applet.js:3184
+#. 4.0/applet.js:3270 6.0/applet.js:3270
 msgid "Website"
 msgstr ""
 
-#. 4.0/applet.js:3188 6.0/applet.js:3188
+#. 4.0/applet.js:3274 6.0/applet.js:3274
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#. 4.0/applet.js:3190 6.0/applet.js:3190
+#. 4.0/applet.js:3276 6.0/applet.js:3276
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -58,75 +58,75 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3199 6.0/applet.js:3199
+#. 4.0/applet.js:3285 6.0/applet.js:3285
 msgid "Open new window"
 msgstr ""
 
-#. 4.0/applet.js:3207 6.0/applet.js:3207
+#. 4.0/applet.js:3293 6.0/applet.js:3293
 msgid "Remove from panel"
 msgstr ""
 
-#. 4.0/applet.js:3209 6.0/applet.js:3209
+#. 4.0/applet.js:3295 6.0/applet.js:3295
 msgid "Remove from this workspace"
 msgstr ""
 
-#. 4.0/applet.js:3215 6.0/applet.js:3215
+#. 4.0/applet.js:3301 6.0/applet.js:3301
 msgid "Pin to panel"
 msgstr ""
 
-#. 4.0/applet.js:3217 6.0/applet.js:3217
+#. 4.0/applet.js:3303 6.0/applet.js:3303
 msgid "Pin to this workspace"
 msgstr ""
 
-#. 4.0/applet.js:3258 6.0/applet.js:3258
+#. 4.0/applet.js:3344 6.0/applet.js:3344
 msgid "Pin to other workspaces"
 msgstr ""
 
-#. 4.0/applet.js:3279 6.0/applet.js:3279
+#. 4.0/applet.js:3365 6.0/applet.js:3365
 msgid "Pin to all workspaces"
 msgstr ""
 
-#. 4.0/applet.js:3297 6.0/applet.js:3297
+#. 4.0/applet.js:3383 6.0/applet.js:3383
 msgid "Pin to launcher"
 msgstr ""
 
-#. 4.0/applet.js:3315 4.0/applet.js:3520 6.0/applet.js:3315 6.0/applet.js:3520
+#. 4.0/applet.js:3401 4.0/applet.js:3606 6.0/applet.js:3401 6.0/applet.js:3606
 msgid "Add new Hotkey for"
 msgstr ""
 
-#. 4.0/applet.js:3329 6.0/applet.js:3329
+#. 4.0/applet.js:3415 6.0/applet.js:3415
 msgid "Recent files"
 msgstr ""
 
-#. 4.0/applet.js:3353 6.0/applet.js:3353
+#. 4.0/applet.js:3439 6.0/applet.js:3439
 msgid "Places"
 msgstr ""
 
-#. 4.0/applet.js:3396 6.0/applet.js:3396
+#. 4.0/applet.js:3482 6.0/applet.js:3482
 msgid "Always on top"
 msgstr ""
 
-#. 4.0/applet.js:3408 6.0/applet.js:3408
+#. 4.0/applet.js:3494 6.0/applet.js:3494
 msgid "Only on this workspace"
 msgstr ""
 
-#. 4.0/applet.js:3410 6.0/applet.js:3410
+#. 4.0/applet.js:3496 6.0/applet.js:3496
 msgid "Visible on all workspaces"
 msgstr ""
 
-#. 4.0/applet.js:3411 6.0/applet.js:3411
+#. 4.0/applet.js:3497 6.0/applet.js:3497
 msgid "Move to another workspace"
 msgstr ""
 
-#. 4.0/applet.js:3420 6.0/applet.js:3420
+#. 4.0/applet.js:3506 6.0/applet.js:3506
 msgid " (this workspace)"
 msgstr ""
 
-#. 4.0/applet.js:3433 6.0/applet.js:3433
+#. 4.0/applet.js:3519 6.0/applet.js:3519
 msgid "Move to another monitor"
 msgstr ""
 
-#. 4.0/applet.js:3441 6.0/applet.js:3441
+#. 4.0/applet.js:3527 6.0/applet.js:3527
 msgid "Monitor"
 msgstr ""
 
@@ -142,47 +142,47 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3458 6.0/applet.js:3458
+#. 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Move window here"
 msgstr ""
 
-#. 4.0/applet.js:3475 6.0/applet.js:3475
+#. 4.0/applet.js:3561 6.0/applet.js:3561
 msgid "unassigned"
 msgstr ""
 
-#. 4.0/applet.js:3486 4.0/applet.js:3517 6.0/applet.js:3486 6.0/applet.js:3517
+#. 4.0/applet.js:3572 4.0/applet.js:3603 6.0/applet.js:3572 6.0/applet.js:3603
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#. 4.0/applet.js:3540 6.0/applet.js:3540
+#. 4.0/applet.js:3626 6.0/applet.js:3626
 msgid "Change application label contents"
 msgstr ""
 
-#. 4.0/applet.js:3543 6.0/applet.js:3543
+#. 4.0/applet.js:3629 6.0/applet.js:3629
 msgid "Remove custom setting"
 msgstr ""
 
-#. 4.0/applet.js:3550 6.0/applet.js:3550
+#. 4.0/applet.js:3636 6.0/applet.js:3636
 msgid "Use window title"
 msgstr ""
 
-#. 4.0/applet.js:3557 6.0/applet.js:3557
+#. 4.0/applet.js:3643 6.0/applet.js:3643
 msgid "Use application name"
 msgstr ""
 
-#. 4.0/applet.js:3564 6.0/applet.js:3564
+#. 4.0/applet.js:3650 6.0/applet.js:3650
 msgid "No label"
 msgstr ""
 
-#. 4.0/applet.js:3575 6.0/applet.js:3575
+#. 4.0/applet.js:3661 6.0/applet.js:3661
 msgid "Ungroup application windows"
 msgstr ""
 
-#. 4.0/applet.js:3583 6.0/applet.js:3583
+#. 4.0/applet.js:3669 6.0/applet.js:3669
 msgid "Group application windows"
 msgstr ""
 
-#. 4.0/applet.js:3596 6.0/applet.js:3596
+#. 4.0/applet.js:3682 6.0/applet.js:3682
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -198,39 +198,39 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3624 6.0/applet.js:3624
+#. 4.0/applet.js:3710 6.0/applet.js:3710
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#. 4.0/applet.js:3629 6.0/applet.js:3629
+#. 4.0/applet.js:3715 6.0/applet.js:3715
 msgid "Restore"
 msgstr ""
 
-#. 4.0/applet.js:3633 6.0/applet.js:3633
+#. 4.0/applet.js:3719 6.0/applet.js:3719
 msgid "Minimize"
 msgstr ""
 
-#. 4.0/applet.js:3639 6.0/applet.js:3639
+#. 4.0/applet.js:3725 6.0/applet.js:3725
 msgid "Unmaximize"
 msgstr ""
 
-#. 4.0/applet.js:3647 6.0/applet.js:3647
+#. 4.0/applet.js:3733 6.0/applet.js:3733
 msgid "Close others"
 msgstr ""
 
-#. 4.0/applet.js:3649 6.0/applet.js:3649
+#. 4.0/applet.js:3735 6.0/applet.js:3735
 msgid "Close other windows for application"
 msgstr ""
 
-#. 4.0/applet.js:3670 6.0/applet.js:3670
+#. 4.0/applet.js:3756 6.0/applet.js:3756
 msgid "Close all"
 msgstr ""
 
-#. 4.0/applet.js:3672 6.0/applet.js:3672
+#. 4.0/applet.js:3758 6.0/applet.js:3758
 msgid "Close all windows for application"
 msgstr ""
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688
+#. 4.0/applet.js:3774 6.0/applet.js:3774
 msgid "Close"
 msgstr ""
 
@@ -1598,6 +1598,16 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Change window tiling"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Cycle all window-list button windows"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+msgid "Cycle grouped/pooled button windows"
 msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-scroll->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ca.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-20 09:59-0400\n"
+"POT-Creation-Date: 2024-10-30 20:53-0400\n"
 "PO-Revision-Date: 2024-10-28 02:42+0100\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,32 +18,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 4.0/applet.js:581 6.0/applet.js:581
+#. 4.0/applet.js:584 6.0/applet.js:584
 msgid "all buttons"
 msgstr "tots els botons"
 
-#. 4.0/applet.js:3172 6.0/applet.js:3172
+#. 4.0/applet.js:3258 6.0/applet.js:3258
 msgid "Applet Preferences"
 msgstr "Preferències de la miniaplicació"
 
-#. 4.0/applet.js:3176 6.0/applet.js:3176
+#. 4.0/applet.js:3262 6.0/applet.js:3262
 msgid "About..."
 msgstr "Quant a..."
 
-#. 4.0/applet.js:3180 6.0/applet.js:3180
+#. 4.0/applet.js:3266 6.0/applet.js:3266
 msgid "Configure..."
 msgstr "Configura..."
 
-#. 4.0/applet.js:3184 6.0/applet.js:3184
+#. 4.0/applet.js:3270 6.0/applet.js:3270
 msgid "Website"
 msgstr "Lloc web"
 
-#. 4.0/applet.js:3188 6.0/applet.js:3188
+#. 4.0/applet.js:3274 6.0/applet.js:3274
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#. 4.0/applet.js:3190 6.0/applet.js:3190
+#. 4.0/applet.js:3276 6.0/applet.js:3276
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Segur que voleu eliminar aquesta instància de la Llista de Finestres Cassia?"
@@ -60,75 +60,75 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3199 6.0/applet.js:3199
+#. 4.0/applet.js:3285 6.0/applet.js:3285
 msgid "Open new window"
 msgstr "Obre una nova finestra"
 
-#. 4.0/applet.js:3207 6.0/applet.js:3207
+#. 4.0/applet.js:3293 6.0/applet.js:3293
 msgid "Remove from panel"
 msgstr "Elimina del tauler"
 
-#. 4.0/applet.js:3209 6.0/applet.js:3209
+#. 4.0/applet.js:3295 6.0/applet.js:3295
 msgid "Remove from this workspace"
 msgstr "Elimina d'aquest espai de treball"
 
-#. 4.0/applet.js:3215 6.0/applet.js:3215
+#. 4.0/applet.js:3301 6.0/applet.js:3301
 msgid "Pin to panel"
 msgstr "Fixar al tauler"
 
-#. 4.0/applet.js:3217 6.0/applet.js:3217
+#. 4.0/applet.js:3303 6.0/applet.js:3303
 msgid "Pin to this workspace"
 msgstr "Fixar a aquest espai de treball"
 
-#. 4.0/applet.js:3258 6.0/applet.js:3258
+#. 4.0/applet.js:3344 6.0/applet.js:3344
 msgid "Pin to other workspaces"
 msgstr "Fixar a altres espais de treball"
 
-#. 4.0/applet.js:3279 6.0/applet.js:3279
+#. 4.0/applet.js:3365 6.0/applet.js:3365
 msgid "Pin to all workspaces"
 msgstr "Fixar a tots els espais de treball"
 
-#. 4.0/applet.js:3297 6.0/applet.js:3297
+#. 4.0/applet.js:3383 6.0/applet.js:3383
 msgid "Pin to launcher"
 msgstr "Fixar al llançador"
 
-#. 4.0/applet.js:3315 4.0/applet.js:3520 6.0/applet.js:3315 6.0/applet.js:3520
+#. 4.0/applet.js:3401 4.0/applet.js:3606 6.0/applet.js:3401 6.0/applet.js:3606
 msgid "Add new Hotkey for"
 msgstr "Afegir nova drecera per a"
 
-#. 4.0/applet.js:3329 6.0/applet.js:3329
+#. 4.0/applet.js:3415 6.0/applet.js:3415
 msgid "Recent files"
 msgstr "Fitxers recents"
 
-#. 4.0/applet.js:3353 6.0/applet.js:3353
+#. 4.0/applet.js:3439 6.0/applet.js:3439
 msgid "Places"
 msgstr "Llocs"
 
-#. 4.0/applet.js:3396 6.0/applet.js:3396
+#. 4.0/applet.js:3482 6.0/applet.js:3482
 msgid "Always on top"
 msgstr "Sempre en primer pla"
 
-#. 4.0/applet.js:3408 6.0/applet.js:3408
+#. 4.0/applet.js:3494 6.0/applet.js:3494
 msgid "Only on this workspace"
 msgstr "Només en aquest espai de treball"
 
-#. 4.0/applet.js:3410 6.0/applet.js:3410
+#. 4.0/applet.js:3496 6.0/applet.js:3496
 msgid "Visible on all workspaces"
 msgstr "Visible a tots els espais de treball"
 
-#. 4.0/applet.js:3411 6.0/applet.js:3411
+#. 4.0/applet.js:3497 6.0/applet.js:3497
 msgid "Move to another workspace"
 msgstr "Moure a un altre espai de treball"
 
-#. 4.0/applet.js:3420 6.0/applet.js:3420
+#. 4.0/applet.js:3506 6.0/applet.js:3506
 msgid " (this workspace)"
 msgstr " (aquest espai de treball)"
 
-#. 4.0/applet.js:3433 6.0/applet.js:3433
+#. 4.0/applet.js:3519 6.0/applet.js:3519
 msgid "Move to another monitor"
 msgstr "Moure a un altre monitor"
 
-#. 4.0/applet.js:3441 6.0/applet.js:3441
+#. 4.0/applet.js:3527 6.0/applet.js:3527
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -144,47 +144,47 @@ msgstr "Monitor"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3458 6.0/applet.js:3458
+#. 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Move window here"
 msgstr "Moure finestra aquí"
 
-#. 4.0/applet.js:3475 6.0/applet.js:3475
+#. 4.0/applet.js:3561 6.0/applet.js:3561
 msgid "unassigned"
 msgstr "sense assignar"
 
-#. 4.0/applet.js:3486 4.0/applet.js:3517 6.0/applet.js:3486 6.0/applet.js:3517
+#. 4.0/applet.js:3572 4.0/applet.js:3603 6.0/applet.js:3572 6.0/applet.js:3603
 msgid "Assign window to a hotkey"
 msgstr "Assignar finestra a una drecera"
 
-#. 4.0/applet.js:3540 6.0/applet.js:3540
+#. 4.0/applet.js:3626 6.0/applet.js:3626
 msgid "Change application label contents"
 msgstr "Canviar el contingut de l'etiqueta de l'aplicació"
 
-#. 4.0/applet.js:3543 6.0/applet.js:3543
+#. 4.0/applet.js:3629 6.0/applet.js:3629
 msgid "Remove custom setting"
 msgstr "Eliminar preferència personalitzada"
 
-#. 4.0/applet.js:3550 6.0/applet.js:3550
+#. 4.0/applet.js:3636 6.0/applet.js:3636
 msgid "Use window title"
 msgstr "Utilitzar el títol de la finestra"
 
-#. 4.0/applet.js:3557 6.0/applet.js:3557
+#. 4.0/applet.js:3643 6.0/applet.js:3643
 msgid "Use application name"
 msgstr "Utilitzar el nom de l'aplicació"
 
-#. 4.0/applet.js:3564 6.0/applet.js:3564
+#. 4.0/applet.js:3650 6.0/applet.js:3650
 msgid "No label"
 msgstr "Sense etiqueta"
 
-#. 4.0/applet.js:3575 6.0/applet.js:3575
+#. 4.0/applet.js:3661 6.0/applet.js:3661
 msgid "Ungroup application windows"
 msgstr "Desagrupar les finestres de l'aplicació"
 
-#. 4.0/applet.js:3583 6.0/applet.js:3583
+#. 4.0/applet.js:3669 6.0/applet.js:3669
 msgid "Group application windows"
 msgstr "Agrupar les finestres de l'aplicació"
 
-#. 4.0/applet.js:3596 6.0/applet.js:3596
+#. 4.0/applet.js:3682 6.0/applet.js:3682
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupar/Desagrupar automàticament"
 
@@ -200,39 +200,39 @@ msgstr "Agrupar/Desagrupar automàticament"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3624 6.0/applet.js:3624
+#. 4.0/applet.js:3710 6.0/applet.js:3710
 msgid "Move titlebar on to screen"
 msgstr "Moure la barra del títol a la pantalla"
 
-#. 4.0/applet.js:3629 6.0/applet.js:3629
+#. 4.0/applet.js:3715 6.0/applet.js:3715
 msgid "Restore"
 msgstr "Restaurar"
 
-#. 4.0/applet.js:3633 6.0/applet.js:3633
+#. 4.0/applet.js:3719 6.0/applet.js:3719
 msgid "Minimize"
 msgstr "Minimitzar"
 
-#. 4.0/applet.js:3639 6.0/applet.js:3639
+#. 4.0/applet.js:3725 6.0/applet.js:3725
 msgid "Unmaximize"
 msgstr "Desmaximitzar"
 
-#. 4.0/applet.js:3647 6.0/applet.js:3647
+#. 4.0/applet.js:3733 6.0/applet.js:3733
 msgid "Close others"
 msgstr "Tancar altres"
 
-#. 4.0/applet.js:3649 6.0/applet.js:3649
+#. 4.0/applet.js:3735 6.0/applet.js:3735
 msgid "Close other windows for application"
 msgstr "Tancar altres finestres de l'aplicació"
 
-#. 4.0/applet.js:3670 6.0/applet.js:3670
+#. 4.0/applet.js:3756 6.0/applet.js:3756
 msgid "Close all"
 msgstr "Tancar totes"
 
-#. 4.0/applet.js:3672 6.0/applet.js:3672
+#. 4.0/applet.js:3758 6.0/applet.js:3758
 msgid "Close all windows for application"
 msgstr "Tancar totes les finestres de l'aplicació"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688
+#. 4.0/applet.js:3774 6.0/applet.js:3774
 msgid "Close"
 msgstr "Tancar"
 
@@ -1716,6 +1716,18 @@ msgstr "Canviar el monitor de les finestres"
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Change window tiling"
 msgstr "Canviar el mosaic de les finestres"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle all window-list button windows"
+msgstr "Desplaçar-se per les finestres de l'aplicació"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle grouped/pooled button windows"
+msgstr "Desplaçar-se per les finestres de l'aplicació"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->description
 #. 6.0->settings-schema.json->mouse-action-scroll->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-20 09:59-0400\n"
+"POT-Creation-Date: 2024-10-30 20:53-0400\n"
 "PO-Revision-Date: 2024-01-01 10:11+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -14,32 +14,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. 4.0/applet.js:581 6.0/applet.js:581
+#. 4.0/applet.js:584 6.0/applet.js:584
 msgid "all buttons"
 msgstr "alle knapper"
 
-#. 4.0/applet.js:3172 6.0/applet.js:3172
+#. 4.0/applet.js:3258 6.0/applet.js:3258
 msgid "Applet Preferences"
 msgstr "Indstillinger"
 
-#. 4.0/applet.js:3176 6.0/applet.js:3176
+#. 4.0/applet.js:3262 6.0/applet.js:3262
 msgid "About..."
 msgstr "Om …"
 
-#. 4.0/applet.js:3180 6.0/applet.js:3180
+#. 4.0/applet.js:3266 6.0/applet.js:3266
 msgid "Configure..."
 msgstr "Konfigurér …"
 
-#. 4.0/applet.js:3184 6.0/applet.js:3184
+#. 4.0/applet.js:3270 6.0/applet.js:3270
 msgid "Website"
 msgstr ""
 
-#. 4.0/applet.js:3188 6.0/applet.js:3188
+#. 4.0/applet.js:3274 6.0/applet.js:3274
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Fjern “%s”"
 
-#. 4.0/applet.js:3190 6.0/applet.js:3190
+#. 4.0/applet.js:3276 6.0/applet.js:3276
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 
@@ -55,76 +55,76 @@ msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3199 6.0/applet.js:3199
+#. 4.0/applet.js:3285 6.0/applet.js:3285
 msgid "Open new window"
 msgstr "Åbn nyt vindue"
 
-#. 4.0/applet.js:3207 6.0/applet.js:3207
+#. 4.0/applet.js:3293 6.0/applet.js:3293
 msgid "Remove from panel"
 msgstr "Fjern fra panel"
 
-#. 4.0/applet.js:3209 6.0/applet.js:3209
+#. 4.0/applet.js:3295 6.0/applet.js:3295
 msgid "Remove from this workspace"
 msgstr "Fjern fra dette arbejdsområde"
 
-#. 4.0/applet.js:3215 6.0/applet.js:3215
+#. 4.0/applet.js:3301 6.0/applet.js:3301
 msgid "Pin to panel"
 msgstr "Fastgør til panel"
 
-#. 4.0/applet.js:3217 6.0/applet.js:3217
+#. 4.0/applet.js:3303 6.0/applet.js:3303
 msgid "Pin to this workspace"
 msgstr "Fastgør til dette arbejdsområde"
 
-#. 4.0/applet.js:3258 6.0/applet.js:3258
+#. 4.0/applet.js:3344 6.0/applet.js:3344
 msgid "Pin to other workspaces"
 msgstr "Fastgør til andre arbejdsområder"
 
-#. 4.0/applet.js:3279 6.0/applet.js:3279
+#. 4.0/applet.js:3365 6.0/applet.js:3365
 msgid "Pin to all workspaces"
 msgstr "Fastgør til alle arbejdsområder"
 
-#. 4.0/applet.js:3297 6.0/applet.js:3297
+#. 4.0/applet.js:3383 6.0/applet.js:3383
 msgid "Pin to launcher"
 msgstr "Fastgør til programstarter"
 
-#. 4.0/applet.js:3315 4.0/applet.js:3520 6.0/applet.js:3315 6.0/applet.js:3520
+#. 4.0/applet.js:3401 4.0/applet.js:3606 6.0/applet.js:3401 6.0/applet.js:3606
 msgid "Add new Hotkey for"
 msgstr "Tilføj ny genvejstast til"
 
-#. 4.0/applet.js:3329 6.0/applet.js:3329
+#. 4.0/applet.js:3415 6.0/applet.js:3415
 msgid "Recent files"
 msgstr "Seneste filer"
 
-#. 4.0/applet.js:3353 6.0/applet.js:3353
+#. 4.0/applet.js:3439 6.0/applet.js:3439
 msgid "Places"
 msgstr "Steder"
 
-#. 4.0/applet.js:3396 6.0/applet.js:3396
+#. 4.0/applet.js:3482 6.0/applet.js:3482
 #, fuzzy
 msgid "Always on top"
 msgstr "Altid"
 
-#. 4.0/applet.js:3408 6.0/applet.js:3408
+#. 4.0/applet.js:3494 6.0/applet.js:3494
 msgid "Only on this workspace"
 msgstr "Kun på dette arbejdsområde"
 
-#. 4.0/applet.js:3410 6.0/applet.js:3410
+#. 4.0/applet.js:3496 6.0/applet.js:3496
 msgid "Visible on all workspaces"
 msgstr "Synlig på alle arbejdsområder"
 
-#. 4.0/applet.js:3411 6.0/applet.js:3411
+#. 4.0/applet.js:3497 6.0/applet.js:3497
 msgid "Move to another workspace"
 msgstr "Flyt til et andet arbejdsområde"
 
-#. 4.0/applet.js:3420 6.0/applet.js:3420
+#. 4.0/applet.js:3506 6.0/applet.js:3506
 msgid " (this workspace)"
 msgstr " (dette arbejdsområde)"
 
-#. 4.0/applet.js:3433 6.0/applet.js:3433
+#. 4.0/applet.js:3519 6.0/applet.js:3519
 msgid "Move to another monitor"
 msgstr "Flyt til en anden skærm"
 
-#. 4.0/applet.js:3441 6.0/applet.js:3441
+#. 4.0/applet.js:3527 6.0/applet.js:3527
 msgid "Monitor"
 msgstr "Skærm"
 
@@ -140,48 +140,48 @@ msgstr "Skærm"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3458 6.0/applet.js:3458
+#. 4.0/applet.js:3544 6.0/applet.js:3544
 #, fuzzy
 msgid "Move window here"
 msgstr "Luk vindue"
 
-#. 4.0/applet.js:3475 6.0/applet.js:3475
+#. 4.0/applet.js:3561 6.0/applet.js:3561
 msgid "unassigned"
 msgstr "ikke tildelt"
 
-#. 4.0/applet.js:3486 4.0/applet.js:3517 6.0/applet.js:3486 6.0/applet.js:3517
+#. 4.0/applet.js:3572 4.0/applet.js:3603 6.0/applet.js:3572 6.0/applet.js:3603
 msgid "Assign window to a hotkey"
 msgstr "Tildel en genvejstast til vindue"
 
-#. 4.0/applet.js:3540 6.0/applet.js:3540
+#. 4.0/applet.js:3626 6.0/applet.js:3626
 msgid "Change application label contents"
 msgstr "Ændr indholdet af programetiket"
 
-#. 4.0/applet.js:3543 6.0/applet.js:3543
+#. 4.0/applet.js:3629 6.0/applet.js:3629
 msgid "Remove custom setting"
 msgstr "Fjern brugerdefineret indstilling"
 
-#. 4.0/applet.js:3550 6.0/applet.js:3550
+#. 4.0/applet.js:3636 6.0/applet.js:3636
 msgid "Use window title"
 msgstr "Brug vinduestitel"
 
-#. 4.0/applet.js:3557 6.0/applet.js:3557
+#. 4.0/applet.js:3643 6.0/applet.js:3643
 msgid "Use application name"
 msgstr "Brug programnavn"
 
-#. 4.0/applet.js:3564 6.0/applet.js:3564
+#. 4.0/applet.js:3650 6.0/applet.js:3650
 msgid "No label"
 msgstr "Ingen etiket"
 
-#. 4.0/applet.js:3575 6.0/applet.js:3575
+#. 4.0/applet.js:3661 6.0/applet.js:3661
 msgid "Ungroup application windows"
 msgstr "Opsplit gruppen af programmervinduer"
 
-#. 4.0/applet.js:3583 6.0/applet.js:3583
+#. 4.0/applet.js:3669 6.0/applet.js:3669
 msgid "Group application windows"
 msgstr "Gruppér programvinduer"
 
-#. 4.0/applet.js:3596 6.0/applet.js:3596
+#. 4.0/applet.js:3682 6.0/applet.js:3682
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisk gruppering/opsplitning af gruppe"
 
@@ -197,41 +197,41 @@ msgstr "Automatisk gruppering/opsplitning af gruppe"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3624 6.0/applet.js:3624
+#. 4.0/applet.js:3710 6.0/applet.js:3710
 msgid "Move titlebar on to screen"
 msgstr "Flyt titellinje til skærm"
 
-#. 4.0/applet.js:3629 6.0/applet.js:3629
+#. 4.0/applet.js:3715 6.0/applet.js:3715
 msgid "Restore"
 msgstr "Gendan"
 
-#. 4.0/applet.js:3633 6.0/applet.js:3633
+#. 4.0/applet.js:3719 6.0/applet.js:3719
 msgid "Minimize"
 msgstr "Minimér"
 
-#. 4.0/applet.js:3639 6.0/applet.js:3639
+#. 4.0/applet.js:3725 6.0/applet.js:3725
 msgid "Unmaximize"
 msgstr "Gendan"
 
-#. 4.0/applet.js:3647 6.0/applet.js:3647
+#. 4.0/applet.js:3733 6.0/applet.js:3733
 msgid "Close others"
 msgstr "Luk andre"
 
-#. 4.0/applet.js:3649 6.0/applet.js:3649
+#. 4.0/applet.js:3735 6.0/applet.js:3735
 #, fuzzy
 msgid "Close other windows for application"
 msgstr "Vis miniaturer for alle vinduer i en programpulje"
 
-#. 4.0/applet.js:3670 6.0/applet.js:3670
+#. 4.0/applet.js:3756 6.0/applet.js:3756
 msgid "Close all"
 msgstr "Luk alle"
 
-#. 4.0/applet.js:3672 6.0/applet.js:3672
+#. 4.0/applet.js:3758 6.0/applet.js:3758
 #, fuzzy
 msgid "Close all windows for application"
 msgstr "Vis miniaturer for alle vinduer i en programpulje"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688
+#. 4.0/applet.js:3774 6.0/applet.js:3774
 msgid "Close"
 msgstr "Luk"
 
@@ -1687,6 +1687,18 @@ msgstr ""
 #, fuzzy
 msgid "Change window tiling"
 msgstr "Brug vinduestitel"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle all window-list button windows"
+msgstr "Bladr gennem programvinduer"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle grouped/pooled button windows"
+msgstr "Bladr gennem programvinduer"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->description
 #. 6.0->settings-schema.json->mouse-action-scroll->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-20 09:59-0400\n"
+"POT-Creation-Date: 2024-10-30 20:53-0400\n"
 "PO-Revision-Date: 2024-10-21 15:32-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,32 +18,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 4.0/applet.js:581 6.0/applet.js:581
+#. 4.0/applet.js:584 6.0/applet.js:584
 msgid "all buttons"
 msgstr "todos los botones"
 
-#. 4.0/applet.js:3172 6.0/applet.js:3172
+#. 4.0/applet.js:3258 6.0/applet.js:3258
 msgid "Applet Preferences"
 msgstr "Preferencias del applet"
 
-#. 4.0/applet.js:3176 6.0/applet.js:3176
+#. 4.0/applet.js:3262 6.0/applet.js:3262
 msgid "About..."
 msgstr "Acerca de..."
 
-#. 4.0/applet.js:3180 6.0/applet.js:3180
+#. 4.0/applet.js:3266 6.0/applet.js:3266
 msgid "Configure..."
 msgstr "Configurar..."
 
-#. 4.0/applet.js:3184 6.0/applet.js:3184
+#. 4.0/applet.js:3270 6.0/applet.js:3270
 msgid "Website"
 msgstr "Sitio web"
 
-#. 4.0/applet.js:3188 6.0/applet.js:3188
+#. 4.0/applet.js:3274 6.0/applet.js:3274
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#. 4.0/applet.js:3190 6.0/applet.js:3190
+#. 4.0/applet.js:3276 6.0/applet.js:3276
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 
@@ -59,75 +59,75 @@ msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3199 6.0/applet.js:3199
+#. 4.0/applet.js:3285 6.0/applet.js:3285
 msgid "Open new window"
 msgstr "Abrir nueva ventana"
 
-#. 4.0/applet.js:3207 6.0/applet.js:3207
+#. 4.0/applet.js:3293 6.0/applet.js:3293
 msgid "Remove from panel"
 msgstr "Quitar del panel"
 
-#. 4.0/applet.js:3209 6.0/applet.js:3209
+#. 4.0/applet.js:3295 6.0/applet.js:3295
 msgid "Remove from this workspace"
 msgstr "Eliminar de este espacio de trabajo"
 
-#. 4.0/applet.js:3215 6.0/applet.js:3215
+#. 4.0/applet.js:3301 6.0/applet.js:3301
 msgid "Pin to panel"
 msgstr "Anclar al panel"
 
-#. 4.0/applet.js:3217 6.0/applet.js:3217
+#. 4.0/applet.js:3303 6.0/applet.js:3303
 msgid "Pin to this workspace"
 msgstr "Anclar a este espacio de trabajo"
 
-#. 4.0/applet.js:3258 6.0/applet.js:3258
+#. 4.0/applet.js:3344 6.0/applet.js:3344
 msgid "Pin to other workspaces"
 msgstr "Anclar a otros espacios de trabajo"
 
-#. 4.0/applet.js:3279 6.0/applet.js:3279
+#. 4.0/applet.js:3365 6.0/applet.js:3365
 msgid "Pin to all workspaces"
 msgstr "Anclar a todos los espacios de trabajo"
 
-#. 4.0/applet.js:3297 6.0/applet.js:3297
+#. 4.0/applet.js:3383 6.0/applet.js:3383
 msgid "Pin to launcher"
 msgstr "Anclar al lanzador"
 
-#. 4.0/applet.js:3315 4.0/applet.js:3520 6.0/applet.js:3315 6.0/applet.js:3520
+#. 4.0/applet.js:3401 4.0/applet.js:3606 6.0/applet.js:3401 6.0/applet.js:3606
 msgid "Add new Hotkey for"
 msgstr "Añadir nueva tecla de acceso rápido para"
 
-#. 4.0/applet.js:3329 6.0/applet.js:3329
+#. 4.0/applet.js:3415 6.0/applet.js:3415
 msgid "Recent files"
 msgstr "Archivos recientes"
 
-#. 4.0/applet.js:3353 6.0/applet.js:3353
+#. 4.0/applet.js:3439 6.0/applet.js:3439
 msgid "Places"
 msgstr "Lugares"
 
-#. 4.0/applet.js:3396 6.0/applet.js:3396
+#. 4.0/applet.js:3482 6.0/applet.js:3482
 msgid "Always on top"
 msgstr "Siempre arriba"
 
-#. 4.0/applet.js:3408 6.0/applet.js:3408
+#. 4.0/applet.js:3494 6.0/applet.js:3494
 msgid "Only on this workspace"
 msgstr "Sólo en este espacio de trabajo"
 
-#. 4.0/applet.js:3410 6.0/applet.js:3410
+#. 4.0/applet.js:3496 6.0/applet.js:3496
 msgid "Visible on all workspaces"
 msgstr "Visible en todos los espacios de trabajo"
 
-#. 4.0/applet.js:3411 6.0/applet.js:3411
+#. 4.0/applet.js:3497 6.0/applet.js:3497
 msgid "Move to another workspace"
 msgstr "Mover a otro espacio de trabajo"
 
-#. 4.0/applet.js:3420 6.0/applet.js:3420
+#. 4.0/applet.js:3506 6.0/applet.js:3506
 msgid " (this workspace)"
 msgstr " (este espacio de trabajo)"
 
-#. 4.0/applet.js:3433 6.0/applet.js:3433
+#. 4.0/applet.js:3519 6.0/applet.js:3519
 msgid "Move to another monitor"
 msgstr "Mover a otro monitor"
 
-#. 4.0/applet.js:3441 6.0/applet.js:3441
+#. 4.0/applet.js:3527 6.0/applet.js:3527
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -143,47 +143,47 @@ msgstr "Monitor"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3458 6.0/applet.js:3458
+#. 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Move window here"
 msgstr "Mover la ventana aquí"
 
-#. 4.0/applet.js:3475 6.0/applet.js:3475
+#. 4.0/applet.js:3561 6.0/applet.js:3561
 msgid "unassigned"
 msgstr "no asignado"
 
-#. 4.0/applet.js:3486 4.0/applet.js:3517 6.0/applet.js:3486 6.0/applet.js:3517
+#. 4.0/applet.js:3572 4.0/applet.js:3603 6.0/applet.js:3572 6.0/applet.js:3603
 msgid "Assign window to a hotkey"
 msgstr "Asignar ventana a una tecla de acceso rápido"
 
-#. 4.0/applet.js:3540 6.0/applet.js:3540
+#. 4.0/applet.js:3626 6.0/applet.js:3626
 msgid "Change application label contents"
 msgstr "Cambiar el contenido de la etiqueta de la aplicación"
 
-#. 4.0/applet.js:3543 6.0/applet.js:3543
+#. 4.0/applet.js:3629 6.0/applet.js:3629
 msgid "Remove custom setting"
 msgstr "Eliminar configuración personalizada"
 
-#. 4.0/applet.js:3550 6.0/applet.js:3550
+#. 4.0/applet.js:3636 6.0/applet.js:3636
 msgid "Use window title"
 msgstr "Utilizar título de ventana"
 
-#. 4.0/applet.js:3557 6.0/applet.js:3557
+#. 4.0/applet.js:3643 6.0/applet.js:3643
 msgid "Use application name"
 msgstr "Utilizar nombre de aplicación"
 
-#. 4.0/applet.js:3564 6.0/applet.js:3564
+#. 4.0/applet.js:3650 6.0/applet.js:3650
 msgid "No label"
 msgstr "Sin etiqueta"
 
-#. 4.0/applet.js:3575 6.0/applet.js:3575
+#. 4.0/applet.js:3661 6.0/applet.js:3661
 msgid "Ungroup application windows"
 msgstr "Ventanas de aplicaciones separadas"
 
-#. 4.0/applet.js:3583 6.0/applet.js:3583
+#. 4.0/applet.js:3669 6.0/applet.js:3669
 msgid "Group application windows"
 msgstr "Ventanas de aplicaciones agrupadas"
 
-#. 4.0/applet.js:3596 6.0/applet.js:3596
+#. 4.0/applet.js:3682 6.0/applet.js:3682
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupación/desagrupación automática"
 
@@ -199,39 +199,39 @@ msgstr "Agrupación/desagrupación automática"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3624 6.0/applet.js:3624
+#. 4.0/applet.js:3710 6.0/applet.js:3710
 msgid "Move titlebar on to screen"
 msgstr "Mover la barra de título a la pantalla"
 
-#. 4.0/applet.js:3629 6.0/applet.js:3629
+#. 4.0/applet.js:3715 6.0/applet.js:3715
 msgid "Restore"
 msgstr "Restaurar"
 
-#. 4.0/applet.js:3633 6.0/applet.js:3633
+#. 4.0/applet.js:3719 6.0/applet.js:3719
 msgid "Minimize"
 msgstr "Minimizar"
 
-#. 4.0/applet.js:3639 6.0/applet.js:3639
+#. 4.0/applet.js:3725 6.0/applet.js:3725
 msgid "Unmaximize"
 msgstr "Desmaximizar"
 
-#. 4.0/applet.js:3647 6.0/applet.js:3647
+#. 4.0/applet.js:3733 6.0/applet.js:3733
 msgid "Close others"
 msgstr "Cerrar otros"
 
-#. 4.0/applet.js:3649 6.0/applet.js:3649
+#. 4.0/applet.js:3735 6.0/applet.js:3735
 msgid "Close other windows for application"
 msgstr "Cerrar otras ventanas para la aplicación"
 
-#. 4.0/applet.js:3670 6.0/applet.js:3670
+#. 4.0/applet.js:3756 6.0/applet.js:3756
 msgid "Close all"
 msgstr "Cerrar todo"
 
-#. 4.0/applet.js:3672 6.0/applet.js:3672
+#. 4.0/applet.js:3758 6.0/applet.js:3758
 msgid "Close all windows for application"
 msgstr "Cerrar todas las ventanas para la aplicación"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688
+#. 4.0/applet.js:3774 6.0/applet.js:3774
 msgid "Close"
 msgstr "Cerrar"
 
@@ -1731,6 +1731,18 @@ msgstr "Cambiar monitor de ventanas"
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Change window tiling"
 msgstr "Cambiar mosaico de ventana"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle all window-list button windows"
+msgstr "Desplazarse por las ventanas de la aplicación"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle grouped/pooled button windows"
+msgstr "Desplazarse por las ventanas de la aplicación"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->description
 #. 6.0->settings-schema.json->mouse-action-scroll->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-20 09:59-0400\n"
+"POT-Creation-Date: 2024-10-30 20:53-0400\n"
 "PO-Revision-Date: 2024-10-02 21:39+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -19,32 +19,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 4.0/applet.js:581 6.0/applet.js:581
+#. 4.0/applet.js:584 6.0/applet.js:584
 msgid "all buttons"
 msgstr "tous les boutons"
 
-#. 4.0/applet.js:3172 6.0/applet.js:3172
+#. 4.0/applet.js:3258 6.0/applet.js:3258
 msgid "Applet Preferences"
 msgstr "Préférences"
 
-#. 4.0/applet.js:3176 6.0/applet.js:3176
+#. 4.0/applet.js:3262 6.0/applet.js:3262
 msgid "About..."
 msgstr "À propos..."
 
-#. 4.0/applet.js:3180 6.0/applet.js:3180
+#. 4.0/applet.js:3266 6.0/applet.js:3266
 msgid "Configure..."
 msgstr "Configurer..."
 
-#. 4.0/applet.js:3184 6.0/applet.js:3184
+#. 4.0/applet.js:3270 6.0/applet.js:3270
 msgid "Website"
 msgstr "Site web"
 
-#. 4.0/applet.js:3188 6.0/applet.js:3188
+#. 4.0/applet.js:3274 6.0/applet.js:3274
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Supprimer '%s'"
 
-#. 4.0/applet.js:3190 6.0/applet.js:3190
+#. 4.0/applet.js:3276 6.0/applet.js:3276
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 
@@ -60,75 +60,75 @@ msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3199 6.0/applet.js:3199
+#. 4.0/applet.js:3285 6.0/applet.js:3285
 msgid "Open new window"
 msgstr "Ouvrir une nouvelle fenêtre"
 
-#. 4.0/applet.js:3207 6.0/applet.js:3207
+#. 4.0/applet.js:3293 6.0/applet.js:3293
 msgid "Remove from panel"
 msgstr "Retirer du panneau"
 
-#. 4.0/applet.js:3209 6.0/applet.js:3209
+#. 4.0/applet.js:3295 6.0/applet.js:3295
 msgid "Remove from this workspace"
 msgstr "Retirer de cet espace de travail"
 
-#. 4.0/applet.js:3215 6.0/applet.js:3215
+#. 4.0/applet.js:3301 6.0/applet.js:3301
 msgid "Pin to panel"
 msgstr "Épingler au panneau"
 
-#. 4.0/applet.js:3217 6.0/applet.js:3217
+#. 4.0/applet.js:3303 6.0/applet.js:3303
 msgid "Pin to this workspace"
 msgstr "Épingler à cet espace de travail"
 
-#. 4.0/applet.js:3258 6.0/applet.js:3258
+#. 4.0/applet.js:3344 6.0/applet.js:3344
 msgid "Pin to other workspaces"
 msgstr "Épingler aux autres espaces de travail"
 
-#. 4.0/applet.js:3279 6.0/applet.js:3279
+#. 4.0/applet.js:3365 6.0/applet.js:3365
 msgid "Pin to all workspaces"
 msgstr "Épingler à tous les espaces de travail"
 
-#. 4.0/applet.js:3297 6.0/applet.js:3297
+#. 4.0/applet.js:3383 6.0/applet.js:3383
 msgid "Pin to launcher"
 msgstr "Épingler au lanceur"
 
-#. 4.0/applet.js:3315 4.0/applet.js:3520 6.0/applet.js:3315 6.0/applet.js:3520
+#. 4.0/applet.js:3401 4.0/applet.js:3606 6.0/applet.js:3401 6.0/applet.js:3606
 msgid "Add new Hotkey for"
 msgstr "Ajouter un nouveau raccourci clavier pour"
 
-#. 4.0/applet.js:3329 6.0/applet.js:3329
+#. 4.0/applet.js:3415 6.0/applet.js:3415
 msgid "Recent files"
 msgstr "Fichiers récents"
 
-#. 4.0/applet.js:3353 6.0/applet.js:3353
+#. 4.0/applet.js:3439 6.0/applet.js:3439
 msgid "Places"
 msgstr "Emplacements"
 
-#. 4.0/applet.js:3396 6.0/applet.js:3396
+#. 4.0/applet.js:3482 6.0/applet.js:3482
 msgid "Always on top"
 msgstr "Toujours au-dessus"
 
-#. 4.0/applet.js:3408 6.0/applet.js:3408
+#. 4.0/applet.js:3494 6.0/applet.js:3494
 msgid "Only on this workspace"
 msgstr "Seulement sur cet espace de travail"
 
-#. 4.0/applet.js:3410 6.0/applet.js:3410
+#. 4.0/applet.js:3496 6.0/applet.js:3496
 msgid "Visible on all workspaces"
 msgstr "Visible sur tous les espaces de travail"
 
-#. 4.0/applet.js:3411 6.0/applet.js:3411
+#. 4.0/applet.js:3497 6.0/applet.js:3497
 msgid "Move to another workspace"
 msgstr "Déplacer vers un autre espace de travail"
 
-#. 4.0/applet.js:3420 6.0/applet.js:3420
+#. 4.0/applet.js:3506 6.0/applet.js:3506
 msgid " (this workspace)"
 msgstr " (cet espace de travail)"
 
-#. 4.0/applet.js:3433 6.0/applet.js:3433
+#. 4.0/applet.js:3519 6.0/applet.js:3519
 msgid "Move to another monitor"
 msgstr "Déplacer vers un autre moniteur"
 
-#. 4.0/applet.js:3441 6.0/applet.js:3441
+#. 4.0/applet.js:3527 6.0/applet.js:3527
 msgid "Monitor"
 msgstr "Moniteur"
 
@@ -144,47 +144,47 @@ msgstr "Moniteur"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3458 6.0/applet.js:3458
+#. 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Move window here"
 msgstr "Déplacer la fenêtre ici"
 
-#. 4.0/applet.js:3475 6.0/applet.js:3475
+#. 4.0/applet.js:3561 6.0/applet.js:3561
 msgid "unassigned"
 msgstr "non attribué"
 
-#. 4.0/applet.js:3486 4.0/applet.js:3517 6.0/applet.js:3486 6.0/applet.js:3517
+#. 4.0/applet.js:3572 4.0/applet.js:3603 6.0/applet.js:3572 6.0/applet.js:3603
 msgid "Assign window to a hotkey"
 msgstr "Attribuer une fenêtre à un raccourci clavier"
 
-#. 4.0/applet.js:3540 6.0/applet.js:3540
+#. 4.0/applet.js:3626 6.0/applet.js:3626
 msgid "Change application label contents"
 msgstr "Modifier le libellé de l'étiquette de l'application"
 
-#. 4.0/applet.js:3543 6.0/applet.js:3543
+#. 4.0/applet.js:3629 6.0/applet.js:3629
 msgid "Remove custom setting"
 msgstr "Supprimer le paramètre personnalisé"
 
-#. 4.0/applet.js:3550 6.0/applet.js:3550
+#. 4.0/applet.js:3636 6.0/applet.js:3636
 msgid "Use window title"
 msgstr "Utiliser le titre de fenêtre"
 
-#. 4.0/applet.js:3557 6.0/applet.js:3557
+#. 4.0/applet.js:3643 6.0/applet.js:3643
 msgid "Use application name"
 msgstr "Utiliser le nom de l'application"
 
-#. 4.0/applet.js:3564 6.0/applet.js:3564
+#. 4.0/applet.js:3650 6.0/applet.js:3650
 msgid "No label"
 msgstr "Sans étiquette"
 
-#. 4.0/applet.js:3575 6.0/applet.js:3575
+#. 4.0/applet.js:3661 6.0/applet.js:3661
 msgid "Ungroup application windows"
 msgstr "Dégrouper les fenêtres de l'application"
 
-#. 4.0/applet.js:3583 6.0/applet.js:3583
+#. 4.0/applet.js:3669 6.0/applet.js:3669
 msgid "Group application windows"
 msgstr "Grouper les fenêtres par application"
 
-#. 4.0/applet.js:3596 6.0/applet.js:3596
+#. 4.0/applet.js:3682 6.0/applet.js:3682
 msgid "Automatic grouping/ungrouping"
 msgstr "Regrouper/dégrouper automatiquement"
 
@@ -200,45 +200,45 @@ msgstr "Regrouper/dégrouper automatiquement"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3624 6.0/applet.js:3624
+#. 4.0/applet.js:3710 6.0/applet.js:3710
 msgid "Move titlebar on to screen"
 msgstr "Déplacer la barre de titre sur l'écran"
 
-#. 4.0/applet.js:3629 6.0/applet.js:3629
+#. 4.0/applet.js:3715 6.0/applet.js:3715
 msgid "Restore"
 msgstr "Restaurer"
 
-#. 4.0/applet.js:3633 6.0/applet.js:3633
+#. 4.0/applet.js:3719 6.0/applet.js:3719
 msgid "Minimize"
 msgstr "Minimiser"
 
-#. 4.0/applet.js:3639 6.0/applet.js:3639
+#. 4.0/applet.js:3725 6.0/applet.js:3725
 msgid "Unmaximize"
 msgstr "Démaximiser"
 
-#. 4.0/applet.js:3647 6.0/applet.js:3647
+#. 4.0/applet.js:3733 6.0/applet.js:3733
 msgid "Close others"
 msgstr "Fermer les autres"
 
-#. 4.0/applet.js:3649 6.0/applet.js:3649
+#. 4.0/applet.js:3735 6.0/applet.js:3735
 #, fuzzy
 msgid "Close other windows for application"
 msgstr ""
 "Afficher les miniatures de toutes les fenêtre d'un groupement pour une "
 "application"
 
-#. 4.0/applet.js:3670 6.0/applet.js:3670
+#. 4.0/applet.js:3756 6.0/applet.js:3756
 msgid "Close all"
 msgstr "Tout fermer"
 
-#. 4.0/applet.js:3672 6.0/applet.js:3672
+#. 4.0/applet.js:3758 6.0/applet.js:3758
 #, fuzzy
 msgid "Close all windows for application"
 msgstr ""
 "Afficher les miniatures de toutes les fenêtre d'un groupement pour une "
 "application"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688
+#. 4.0/applet.js:3774 6.0/applet.js:3774
 msgid "Close"
 msgstr "Fermer"
 
@@ -1749,6 +1749,18 @@ msgstr "Déplacer les fenêtres vers un autre écran"
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Change window tiling"
 msgstr "Modifier la juxtaposition des fenêtres"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle all window-list button windows"
+msgstr "Cycle des fenêtres d'applications"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle grouped/pooled button windows"
+msgstr "Cycle des fenêtres d'applications"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->description
 #. 6.0->settings-schema.json->mouse-action-scroll->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.3.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-20 09:59-0400\n"
+"POT-Creation-Date: 2024-10-30 20:53-0400\n"
 "PO-Revision-Date: 2024-07-28 07:47-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,32 +18,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. 4.0/applet.js:581 6.0/applet.js:581
+#. 4.0/applet.js:584 6.0/applet.js:584
 msgid "all buttons"
 msgstr "minden gomb"
 
-#. 4.0/applet.js:3172 6.0/applet.js:3172
+#. 4.0/applet.js:3258 6.0/applet.js:3258
 msgid "Applet Preferences"
 msgstr "Kisalkalmazás beállítások"
 
-#. 4.0/applet.js:3176 6.0/applet.js:3176
+#. 4.0/applet.js:3262 6.0/applet.js:3262
 msgid "About..."
 msgstr "Névjegy…"
 
-#. 4.0/applet.js:3180 6.0/applet.js:3180
+#. 4.0/applet.js:3266 6.0/applet.js:3266
 msgid "Configure..."
 msgstr "Beállítások…"
 
-#. 4.0/applet.js:3184 6.0/applet.js:3184
+#. 4.0/applet.js:3270 6.0/applet.js:3270
 msgid "Website"
 msgstr "Weboldal"
 
-#. 4.0/applet.js:3188 6.0/applet.js:3188
+#. 4.0/applet.js:3274 6.0/applet.js:3274
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eltávolítás: „%s”"
 
-#. 4.0/applet.js:3190 6.0/applet.js:3190
+#. 4.0/applet.js:3276 6.0/applet.js:3276
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példányát?"
 
@@ -59,75 +59,75 @@ msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példány
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3199 6.0/applet.js:3199
+#. 4.0/applet.js:3285 6.0/applet.js:3285
 msgid "Open new window"
 msgstr "Új ablak megnyitása"
 
-#. 4.0/applet.js:3207 6.0/applet.js:3207
+#. 4.0/applet.js:3293 6.0/applet.js:3293
 msgid "Remove from panel"
 msgstr "Eltávolítás a panelról"
 
-#. 4.0/applet.js:3209 6.0/applet.js:3209
+#. 4.0/applet.js:3295 6.0/applet.js:3295
 msgid "Remove from this workspace"
 msgstr "Eltávolítás erről a munkaterületről"
 
-#. 4.0/applet.js:3215 6.0/applet.js:3215
+#. 4.0/applet.js:3301 6.0/applet.js:3301
 msgid "Pin to panel"
 msgstr "Panelhez rögzítés"
 
-#. 4.0/applet.js:3217 6.0/applet.js:3217
+#. 4.0/applet.js:3303 6.0/applet.js:3303
 msgid "Pin to this workspace"
 msgstr "Erre a munkaterületre rögzítés"
 
-#. 4.0/applet.js:3258 6.0/applet.js:3258
+#. 4.0/applet.js:3344 6.0/applet.js:3344
 msgid "Pin to other workspaces"
 msgstr "Más munkaterületre rögzítés"
 
-#. 4.0/applet.js:3279 6.0/applet.js:3279
+#. 4.0/applet.js:3365 6.0/applet.js:3365
 msgid "Pin to all workspaces"
 msgstr "Az összes munkaterületre rögzítés"
 
-#. 4.0/applet.js:3297 6.0/applet.js:3297
+#. 4.0/applet.js:3383 6.0/applet.js:3383
 msgid "Pin to launcher"
 msgstr "Alkalmazásindítóhoz rögzítés"
 
-#. 4.0/applet.js:3315 4.0/applet.js:3520 6.0/applet.js:3315 6.0/applet.js:3520
+#. 4.0/applet.js:3401 4.0/applet.js:3606 6.0/applet.js:3401 6.0/applet.js:3606
 msgid "Add new Hotkey for"
 msgstr "Új gyorsbillentyű hozzáadása ehhez"
 
-#. 4.0/applet.js:3329 6.0/applet.js:3329
+#. 4.0/applet.js:3415 6.0/applet.js:3415
 msgid "Recent files"
 msgstr "Nemrég használt fájlok"
 
-#. 4.0/applet.js:3353 6.0/applet.js:3353
+#. 4.0/applet.js:3439 6.0/applet.js:3439
 msgid "Places"
 msgstr "Helyek"
 
-#. 4.0/applet.js:3396 6.0/applet.js:3396
+#. 4.0/applet.js:3482 6.0/applet.js:3482
 msgid "Always on top"
 msgstr "Mindig felül"
 
-#. 4.0/applet.js:3408 6.0/applet.js:3408
+#. 4.0/applet.js:3494 6.0/applet.js:3494
 msgid "Only on this workspace"
 msgstr "Csak ezen a munkaterületen"
 
-#. 4.0/applet.js:3410 6.0/applet.js:3410
+#. 4.0/applet.js:3496 6.0/applet.js:3496
 msgid "Visible on all workspaces"
 msgstr "Minden munkaterületen látható"
 
-#. 4.0/applet.js:3411 6.0/applet.js:3411
+#. 4.0/applet.js:3497 6.0/applet.js:3497
 msgid "Move to another workspace"
 msgstr "Áthelyezés másik munkaterületre"
 
-#. 4.0/applet.js:3420 6.0/applet.js:3420
+#. 4.0/applet.js:3506 6.0/applet.js:3506
 msgid " (this workspace)"
 msgstr " (ez a munkaterület)"
 
-#. 4.0/applet.js:3433 6.0/applet.js:3433
+#. 4.0/applet.js:3519 6.0/applet.js:3519
 msgid "Move to another monitor"
 msgstr "Áthelyezés a másik kijelzőre"
 
-#. 4.0/applet.js:3441 6.0/applet.js:3441
+#. 4.0/applet.js:3527 6.0/applet.js:3527
 msgid "Monitor"
 msgstr "Kijelző"
 
@@ -143,47 +143,47 @@ msgstr "Kijelző"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3458 6.0/applet.js:3458
+#. 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Move window here"
 msgstr "Ablak mozdítása ide"
 
-#. 4.0/applet.js:3475 6.0/applet.js:3475
+#. 4.0/applet.js:3561 6.0/applet.js:3561
 msgid "unassigned"
 msgstr "nincs társítva"
 
-#. 4.0/applet.js:3486 4.0/applet.js:3517 6.0/applet.js:3486 6.0/applet.js:3517
+#. 4.0/applet.js:3572 4.0/applet.js:3603 6.0/applet.js:3572 6.0/applet.js:3603
 msgid "Assign window to a hotkey"
 msgstr "Az ablak hozzárendelése egy gyorsbillentyűhöz"
 
-#. 4.0/applet.js:3540 6.0/applet.js:3540
+#. 4.0/applet.js:3626 6.0/applet.js:3626
 msgid "Change application label contents"
 msgstr "Az alkalmazáscímke tartalmának módosítása"
 
-#. 4.0/applet.js:3543 6.0/applet.js:3543
+#. 4.0/applet.js:3629 6.0/applet.js:3629
 msgid "Remove custom setting"
 msgstr "Egyéni beállítás eltávolítása"
 
-#. 4.0/applet.js:3550 6.0/applet.js:3550
+#. 4.0/applet.js:3636 6.0/applet.js:3636
 msgid "Use window title"
 msgstr "Ablakcím használata"
 
-#. 4.0/applet.js:3557 6.0/applet.js:3557
+#. 4.0/applet.js:3643 6.0/applet.js:3643
 msgid "Use application name"
 msgstr "Alkalmazásnév használata"
 
-#. 4.0/applet.js:3564 6.0/applet.js:3564
+#. 4.0/applet.js:3650 6.0/applet.js:3650
 msgid "No label"
 msgstr "Nincs címke"
 
-#. 4.0/applet.js:3575 6.0/applet.js:3575
+#. 4.0/applet.js:3661 6.0/applet.js:3661
 msgid "Ungroup application windows"
 msgstr "Ablakokat ne csoportosítsa alkalmazás szerint"
 
-#. 4.0/applet.js:3583 6.0/applet.js:3583
+#. 4.0/applet.js:3669 6.0/applet.js:3669
 msgid "Group application windows"
 msgstr "Alkalmazás ablakok csoportosítása"
 
-#. 4.0/applet.js:3596 6.0/applet.js:3596
+#. 4.0/applet.js:3682 6.0/applet.js:3682
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 
@@ -199,41 +199,41 @@ msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3624 6.0/applet.js:3624
+#. 4.0/applet.js:3710 6.0/applet.js:3710
 msgid "Move titlebar on to screen"
 msgstr "Címsor mozgatása a kijelzőre"
 
-#. 4.0/applet.js:3629 6.0/applet.js:3629
+#. 4.0/applet.js:3715 6.0/applet.js:3715
 msgid "Restore"
 msgstr "Visszaállítás"
 
-#. 4.0/applet.js:3633 6.0/applet.js:3633
+#. 4.0/applet.js:3719 6.0/applet.js:3719
 msgid "Minimize"
 msgstr "Minimalizálás"
 
-#. 4.0/applet.js:3639 6.0/applet.js:3639
+#. 4.0/applet.js:3725 6.0/applet.js:3725
 msgid "Unmaximize"
 msgstr "Eredeti méret"
 
-#. 4.0/applet.js:3647 6.0/applet.js:3647
+#. 4.0/applet.js:3733 6.0/applet.js:3733
 msgid "Close others"
 msgstr "Többi bezárása"
 
-#. 4.0/applet.js:3649 6.0/applet.js:3649
+#. 4.0/applet.js:3735 6.0/applet.js:3735
 #, fuzzy
 msgid "Close other windows for application"
 msgstr "Bélyegképek megjelenítése egy alkalmazáskészlet összes ablakához"
 
-#. 4.0/applet.js:3670 6.0/applet.js:3670
+#. 4.0/applet.js:3756 6.0/applet.js:3756
 msgid "Close all"
 msgstr "Minden bezárása"
 
-#. 4.0/applet.js:3672 6.0/applet.js:3672
+#. 4.0/applet.js:3758 6.0/applet.js:3758
 #, fuzzy
 msgid "Close all windows for application"
 msgstr "Bélyegképek megjelenítése egy alkalmazáskészlet összes ablakához"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688
+#. 4.0/applet.js:3774 6.0/applet.js:3774
 msgid "Close"
 msgstr "Bezárás"
 
@@ -1712,6 +1712,18 @@ msgstr "Ablakok monitor megváltoztatása"
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Change window tiling"
 msgstr "Ablak csempézés módosítása"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle all window-list button windows"
+msgstr "Alkalmazási ablakok ciklusa"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle grouped/pooled button windows"
+msgstr "Alkalmazási ablakok ciklusa"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->description
 #. 6.0->settings-schema.json->mouse-action-scroll->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-20 09:59-0400\n"
+"POT-Creation-Date: 2024-10-30 20:53-0400\n"
 "PO-Revision-Date: 2024-07-25 10:03+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,32 +19,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. 4.0/applet.js:581 6.0/applet.js:581
+#. 4.0/applet.js:584 6.0/applet.js:584
 msgid "all buttons"
 msgstr "tutti i pulsanti"
 
-#. 4.0/applet.js:3172 6.0/applet.js:3172
+#. 4.0/applet.js:3258 6.0/applet.js:3258
 msgid "Applet Preferences"
 msgstr "Preferenze Applet"
 
-#. 4.0/applet.js:3176 6.0/applet.js:3176
+#. 4.0/applet.js:3262 6.0/applet.js:3262
 msgid "About..."
 msgstr "Informazioni su..."
 
-#. 4.0/applet.js:3180 6.0/applet.js:3180
+#. 4.0/applet.js:3266 6.0/applet.js:3266
 msgid "Configure..."
 msgstr "Configura..."
 
-#. 4.0/applet.js:3184 6.0/applet.js:3184
+#. 4.0/applet.js:3270 6.0/applet.js:3270
 msgid "Website"
 msgstr "Sito web"
 
-#. 4.0/applet.js:3188 6.0/applet.js:3188
+#. 4.0/applet.js:3274 6.0/applet.js:3274
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Rimuovi '%s'"
 
-#. 4.0/applet.js:3190 6.0/applet.js:3190
+#. 4.0/applet.js:3276 6.0/applet.js:3276
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 
@@ -60,75 +60,75 @@ msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3199 6.0/applet.js:3199
+#. 4.0/applet.js:3285 6.0/applet.js:3285
 msgid "Open new window"
 msgstr "Apri una nuova finestra"
 
-#. 4.0/applet.js:3207 6.0/applet.js:3207
+#. 4.0/applet.js:3293 6.0/applet.js:3293
 msgid "Remove from panel"
 msgstr "Rimuovi dal pannello"
 
-#. 4.0/applet.js:3209 6.0/applet.js:3209
+#. 4.0/applet.js:3295 6.0/applet.js:3295
 msgid "Remove from this workspace"
 msgstr "Rimuovi da questa area di lavoro"
 
-#. 4.0/applet.js:3215 6.0/applet.js:3215
+#. 4.0/applet.js:3301 6.0/applet.js:3301
 msgid "Pin to panel"
 msgstr "Appunta al pannello"
 
-#. 4.0/applet.js:3217 6.0/applet.js:3217
+#. 4.0/applet.js:3303 6.0/applet.js:3303
 msgid "Pin to this workspace"
 msgstr "Appunta a questo spazio di lavoro"
 
-#. 4.0/applet.js:3258 6.0/applet.js:3258
+#. 4.0/applet.js:3344 6.0/applet.js:3344
 msgid "Pin to other workspaces"
 msgstr "Appunta ad altre aree di lavoro"
 
-#. 4.0/applet.js:3279 6.0/applet.js:3279
+#. 4.0/applet.js:3365 6.0/applet.js:3365
 msgid "Pin to all workspaces"
 msgstr "Appunta in tutte le aree di lavoro"
 
-#. 4.0/applet.js:3297 6.0/applet.js:3297
+#. 4.0/applet.js:3383 6.0/applet.js:3383
 msgid "Pin to launcher"
 msgstr "Appunta al launcher"
 
-#. 4.0/applet.js:3315 4.0/applet.js:3520 6.0/applet.js:3315 6.0/applet.js:3520
+#. 4.0/applet.js:3401 4.0/applet.js:3606 6.0/applet.js:3401 6.0/applet.js:3606
 msgid "Add new Hotkey for"
 msgstr "Aggiungi un nuovo tasto di scelta rapida per"
 
-#. 4.0/applet.js:3329 6.0/applet.js:3329
+#. 4.0/applet.js:3415 6.0/applet.js:3415
 msgid "Recent files"
 msgstr "Recenti"
 
-#. 4.0/applet.js:3353 6.0/applet.js:3353
+#. 4.0/applet.js:3439 6.0/applet.js:3439
 msgid "Places"
 msgstr "Posizioni"
 
-#. 4.0/applet.js:3396 6.0/applet.js:3396
+#. 4.0/applet.js:3482 6.0/applet.js:3482
 msgid "Always on top"
 msgstr "Sempre in primo piano"
 
-#. 4.0/applet.js:3408 6.0/applet.js:3408
+#. 4.0/applet.js:3494 6.0/applet.js:3494
 msgid "Only on this workspace"
 msgstr "Solo su questo spazio di lavoro"
 
-#. 4.0/applet.js:3410 6.0/applet.js:3410
+#. 4.0/applet.js:3496 6.0/applet.js:3496
 msgid "Visible on all workspaces"
 msgstr "Visibile su tutte le aree di lavoro"
 
-#. 4.0/applet.js:3411 6.0/applet.js:3411
+#. 4.0/applet.js:3497 6.0/applet.js:3497
 msgid "Move to another workspace"
 msgstr "Sposta su un'altra area di lavoro"
 
-#. 4.0/applet.js:3420 6.0/applet.js:3420
+#. 4.0/applet.js:3506 6.0/applet.js:3506
 msgid " (this workspace)"
 msgstr " (questa area di lavoro)"
 
-#. 4.0/applet.js:3433 6.0/applet.js:3433
+#. 4.0/applet.js:3519 6.0/applet.js:3519
 msgid "Move to another monitor"
 msgstr "Sposta su un altro schermo"
 
-#. 4.0/applet.js:3441 6.0/applet.js:3441
+#. 4.0/applet.js:3527 6.0/applet.js:3527
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -144,47 +144,47 @@ msgstr "Monitor"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3458 6.0/applet.js:3458
+#. 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Move window here"
 msgstr "Sposta la finestra qui"
 
-#. 4.0/applet.js:3475 6.0/applet.js:3475
+#. 4.0/applet.js:3561 6.0/applet.js:3561
 msgid "unassigned"
 msgstr "non assegnato"
 
-#. 4.0/applet.js:3486 4.0/applet.js:3517 6.0/applet.js:3486 6.0/applet.js:3517
+#. 4.0/applet.js:3572 4.0/applet.js:3603 6.0/applet.js:3572 6.0/applet.js:3603
 msgid "Assign window to a hotkey"
 msgstr "Assegna finestra ad un tasto di scelta rapida"
 
-#. 4.0/applet.js:3540 6.0/applet.js:3540
+#. 4.0/applet.js:3626 6.0/applet.js:3626
 msgid "Change application label contents"
 msgstr "Cambia il contenuto dell'etichetta dell'applicazione"
 
-#. 4.0/applet.js:3543 6.0/applet.js:3543
+#. 4.0/applet.js:3629 6.0/applet.js:3629
 msgid "Remove custom setting"
 msgstr "Rimuovi impostazioni personalizzate"
 
-#. 4.0/applet.js:3550 6.0/applet.js:3550
+#. 4.0/applet.js:3636 6.0/applet.js:3636
 msgid "Use window title"
 msgstr "Usa il titolo della finestra"
 
-#. 4.0/applet.js:3557 6.0/applet.js:3557
+#. 4.0/applet.js:3643 6.0/applet.js:3643
 msgid "Use application name"
 msgstr "Usa il nome dell'applicazione"
 
-#. 4.0/applet.js:3564 6.0/applet.js:3564
+#. 4.0/applet.js:3650 6.0/applet.js:3650
 msgid "No label"
 msgstr "Nessuna etichetta"
 
-#. 4.0/applet.js:3575 6.0/applet.js:3575
+#. 4.0/applet.js:3661 6.0/applet.js:3661
 msgid "Ungroup application windows"
 msgstr "Separa le finestre dell'applicazione"
 
-#. 4.0/applet.js:3583 6.0/applet.js:3583
+#. 4.0/applet.js:3669 6.0/applet.js:3669
 msgid "Group application windows"
 msgstr "Raggruppa le finestre dell'applicazione"
 
-#. 4.0/applet.js:3596 6.0/applet.js:3596
+#. 4.0/applet.js:3682 6.0/applet.js:3682
 msgid "Automatic grouping/ungrouping"
 msgstr "Raggruppamento/separazione automatica"
 
@@ -200,41 +200,41 @@ msgstr "Raggruppamento/separazione automatica"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3624 6.0/applet.js:3624
+#. 4.0/applet.js:3710 6.0/applet.js:3710
 msgid "Move titlebar on to screen"
 msgstr "Sposta la barra del titolo sullo schermo"
 
-#. 4.0/applet.js:3629 6.0/applet.js:3629
+#. 4.0/applet.js:3715 6.0/applet.js:3715
 msgid "Restore"
 msgstr "Ripristina"
 
-#. 4.0/applet.js:3633 6.0/applet.js:3633
+#. 4.0/applet.js:3719 6.0/applet.js:3719
 msgid "Minimize"
 msgstr "Minimizza"
 
-#. 4.0/applet.js:3639 6.0/applet.js:3639
+#. 4.0/applet.js:3725 6.0/applet.js:3725
 msgid "Unmaximize"
 msgstr "De-massimizza"
 
-#. 4.0/applet.js:3647 6.0/applet.js:3647
+#. 4.0/applet.js:3733 6.0/applet.js:3733
 msgid "Close others"
 msgstr "Chiudi altri"
 
-#. 4.0/applet.js:3649 6.0/applet.js:3649
+#. 4.0/applet.js:3735 6.0/applet.js:3735
 #, fuzzy
 msgid "Close other windows for application"
 msgstr "Mostra le miniature per tutte le finestre di un pool di applicazioni"
 
-#. 4.0/applet.js:3670 6.0/applet.js:3670
+#. 4.0/applet.js:3756 6.0/applet.js:3756
 msgid "Close all"
 msgstr "Chiudi tutto"
 
-#. 4.0/applet.js:3672 6.0/applet.js:3672
+#. 4.0/applet.js:3758 6.0/applet.js:3758
 #, fuzzy
 msgid "Close all windows for application"
 msgstr "Mostra le miniature per tutte le finestre di un pool di applicazioni"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688
+#. 4.0/applet.js:3774 6.0/applet.js:3774
 msgid "Close"
 msgstr "Chiudi"
 
@@ -1742,6 +1742,18 @@ msgstr "Cambia il monitor delle finestre"
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Change window tiling"
 msgstr "Cambia la piastrellatura delle finestre"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle all window-list button windows"
+msgstr "Scorri le finestre dell'applicazione"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle grouped/pooled button windows"
+msgstr "Scorri le finestre dell'applicazione"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->description
 #. 6.0->settings-schema.json->mouse-action-scroll->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-20 09:59-0400\n"
+"POT-Creation-Date: 2024-10-30 20:53-0400\n"
 "PO-Revision-Date: 2024-07-24 00:36+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,32 +16,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 4.0/applet.js:581 6.0/applet.js:581
+#. 4.0/applet.js:584 6.0/applet.js:584
 msgid "all buttons"
 msgstr "alle knoppen"
 
-#. 4.0/applet.js:3172 6.0/applet.js:3172
+#. 4.0/applet.js:3258 6.0/applet.js:3258
 msgid "Applet Preferences"
 msgstr "Applet Voorkeuren"
 
-#. 4.0/applet.js:3176 6.0/applet.js:3176
+#. 4.0/applet.js:3262 6.0/applet.js:3262
 msgid "About..."
 msgstr "Over..."
 
-#. 4.0/applet.js:3180 6.0/applet.js:3180
+#. 4.0/applet.js:3266 6.0/applet.js:3266
 msgid "Configure..."
 msgstr "Configureren..."
 
-#. 4.0/applet.js:3184 6.0/applet.js:3184
+#. 4.0/applet.js:3270 6.0/applet.js:3270
 msgid "Website"
 msgstr "Website"
 
-#. 4.0/applet.js:3188 6.0/applet.js:3188
+#. 4.0/applet.js:3274 6.0/applet.js:3274
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Verwijder '%s'"
 
-#. 4.0/applet.js:3190 6.0/applet.js:3190
+#. 4.0/applet.js:3276 6.0/applet.js:3276
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Weet u zeker dat u deze instantie van CassiaWindowList wilt verwijderen?"
@@ -58,75 +58,75 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3199 6.0/applet.js:3199
+#. 4.0/applet.js:3285 6.0/applet.js:3285
 msgid "Open new window"
 msgstr "Open een nieuw venster"
 
-#. 4.0/applet.js:3207 6.0/applet.js:3207
+#. 4.0/applet.js:3293 6.0/applet.js:3293
 msgid "Remove from panel"
 msgstr "Verwijderen van paneel"
 
-#. 4.0/applet.js:3209 6.0/applet.js:3209
+#. 4.0/applet.js:3295 6.0/applet.js:3295
 msgid "Remove from this workspace"
 msgstr "Verwijderen van deze werkruimte"
 
-#. 4.0/applet.js:3215 6.0/applet.js:3215
+#. 4.0/applet.js:3301 6.0/applet.js:3301
 msgid "Pin to panel"
 msgstr "Vastmaken aan paneel"
 
-#. 4.0/applet.js:3217 6.0/applet.js:3217
+#. 4.0/applet.js:3303 6.0/applet.js:3303
 msgid "Pin to this workspace"
 msgstr "Vastmaken aan deze werkruimte"
 
-#. 4.0/applet.js:3258 6.0/applet.js:3258
+#. 4.0/applet.js:3344 6.0/applet.js:3344
 msgid "Pin to other workspaces"
 msgstr "Vastmaken aan andere werkruimtes"
 
-#. 4.0/applet.js:3279 6.0/applet.js:3279
+#. 4.0/applet.js:3365 6.0/applet.js:3365
 msgid "Pin to all workspaces"
 msgstr "Vastmaken aan alle werkruimtes"
 
-#. 4.0/applet.js:3297 6.0/applet.js:3297
+#. 4.0/applet.js:3383 6.0/applet.js:3383
 msgid "Pin to launcher"
 msgstr "Vastmaken aan launcher"
 
-#. 4.0/applet.js:3315 4.0/applet.js:3520 6.0/applet.js:3315 6.0/applet.js:3520
+#. 4.0/applet.js:3401 4.0/applet.js:3606 6.0/applet.js:3401 6.0/applet.js:3606
 msgid "Add new Hotkey for"
 msgstr "Voeg nieuwe sneltoets toe voor"
 
-#. 4.0/applet.js:3329 6.0/applet.js:3329
+#. 4.0/applet.js:3415 6.0/applet.js:3415
 msgid "Recent files"
 msgstr "Recente bestanden"
 
-#. 4.0/applet.js:3353 6.0/applet.js:3353
+#. 4.0/applet.js:3439 6.0/applet.js:3439
 msgid "Places"
 msgstr "Locaties"
 
-#. 4.0/applet.js:3396 6.0/applet.js:3396
+#. 4.0/applet.js:3482 6.0/applet.js:3482
 msgid "Always on top"
 msgstr "Altijd bovenop"
 
-#. 4.0/applet.js:3408 6.0/applet.js:3408
+#. 4.0/applet.js:3494 6.0/applet.js:3494
 msgid "Only on this workspace"
 msgstr "Alleen op deze werkruimte"
 
-#. 4.0/applet.js:3410 6.0/applet.js:3410
+#. 4.0/applet.js:3496 6.0/applet.js:3496
 msgid "Visible on all workspaces"
 msgstr "Zichtbaar op alle werkruimtes"
 
-#. 4.0/applet.js:3411 6.0/applet.js:3411
+#. 4.0/applet.js:3497 6.0/applet.js:3497
 msgid "Move to another workspace"
 msgstr "Verplaatsen naar een andere werkruimte"
 
-#. 4.0/applet.js:3420 6.0/applet.js:3420
+#. 4.0/applet.js:3506 6.0/applet.js:3506
 msgid " (this workspace)"
 msgstr " (deze werkruimte)"
 
-#. 4.0/applet.js:3433 6.0/applet.js:3433
+#. 4.0/applet.js:3519 6.0/applet.js:3519
 msgid "Move to another monitor"
 msgstr "Verplaatsen naar een ander beeldscherm"
 
-#. 4.0/applet.js:3441 6.0/applet.js:3441
+#. 4.0/applet.js:3527 6.0/applet.js:3527
 msgid "Monitor"
 msgstr "Beeldscherm"
 
@@ -142,47 +142,47 @@ msgstr "Beeldscherm"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3458 6.0/applet.js:3458
+#. 4.0/applet.js:3544 6.0/applet.js:3544
 msgid "Move window here"
 msgstr "Verplaats venster hierheen"
 
-#. 4.0/applet.js:3475 6.0/applet.js:3475
+#. 4.0/applet.js:3561 6.0/applet.js:3561
 msgid "unassigned"
 msgstr "niet toegewezen"
 
-#. 4.0/applet.js:3486 4.0/applet.js:3517 6.0/applet.js:3486 6.0/applet.js:3517
+#. 4.0/applet.js:3572 4.0/applet.js:3603 6.0/applet.js:3572 6.0/applet.js:3603
 msgid "Assign window to a hotkey"
 msgstr "Wijs venster toe aan een sneltoets"
 
-#. 4.0/applet.js:3540 6.0/applet.js:3540
+#. 4.0/applet.js:3626 6.0/applet.js:3626
 msgid "Change application label contents"
 msgstr "Wijzig inhoud van applicatielabel"
 
-#. 4.0/applet.js:3543 6.0/applet.js:3543
+#. 4.0/applet.js:3629 6.0/applet.js:3629
 msgid "Remove custom setting"
 msgstr "Verwijder aangepaste instelling"
 
-#. 4.0/applet.js:3550 6.0/applet.js:3550
+#. 4.0/applet.js:3636 6.0/applet.js:3636
 msgid "Use window title"
 msgstr "Gebruik venstertitel"
 
-#. 4.0/applet.js:3557 6.0/applet.js:3557
+#. 4.0/applet.js:3643 6.0/applet.js:3643
 msgid "Use application name"
 msgstr "Gebruik applicatienaam"
 
-#. 4.0/applet.js:3564 6.0/applet.js:3564
+#. 4.0/applet.js:3650 6.0/applet.js:3650
 msgid "No label"
 msgstr "Geen label"
 
-#. 4.0/applet.js:3575 6.0/applet.js:3575
+#. 4.0/applet.js:3661 6.0/applet.js:3661
 msgid "Ungroup application windows"
 msgstr "Applicatie-vensters niet groeperen"
 
-#. 4.0/applet.js:3583 6.0/applet.js:3583
+#. 4.0/applet.js:3669 6.0/applet.js:3669
 msgid "Group application windows"
 msgstr "Applicatie-vensters groeperen"
 
-#. 4.0/applet.js:3596 6.0/applet.js:3596
+#. 4.0/applet.js:3682 6.0/applet.js:3682
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisch groeperen/ongroeperen"
 
@@ -198,41 +198,41 @@ msgstr "Automatisch groeperen/ongroeperen"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3624 6.0/applet.js:3624
+#. 4.0/applet.js:3710 6.0/applet.js:3710
 msgid "Move titlebar on to screen"
 msgstr "Verplaats titelbalk naar het scherm"
 
-#. 4.0/applet.js:3629 6.0/applet.js:3629
+#. 4.0/applet.js:3715 6.0/applet.js:3715
 msgid "Restore"
 msgstr "Herstellen"
 
-#. 4.0/applet.js:3633 6.0/applet.js:3633
+#. 4.0/applet.js:3719 6.0/applet.js:3719
 msgid "Minimize"
 msgstr "Minimaliseren"
 
-#. 4.0/applet.js:3639 6.0/applet.js:3639
+#. 4.0/applet.js:3725 6.0/applet.js:3725
 msgid "Unmaximize"
 msgstr "Ontmaximaliseren"
 
-#. 4.0/applet.js:3647 6.0/applet.js:3647
+#. 4.0/applet.js:3733 6.0/applet.js:3733
 msgid "Close others"
 msgstr "Sluit anderen"
 
-#. 4.0/applet.js:3649 6.0/applet.js:3649
+#. 4.0/applet.js:3735 6.0/applet.js:3735
 #, fuzzy
 msgid "Close other windows for application"
 msgstr "Miniaturen weergeven voor alle vensters van een applicatiepool"
 
-#. 4.0/applet.js:3670 6.0/applet.js:3670
+#. 4.0/applet.js:3756 6.0/applet.js:3756
 msgid "Close all"
 msgstr "Sluit alle"
 
-#. 4.0/applet.js:3672 6.0/applet.js:3672
+#. 4.0/applet.js:3758 6.0/applet.js:3758
 #, fuzzy
 msgid "Close all windows for application"
 msgstr "Miniaturen weergeven voor alle vensters van een applicatiepool"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688
+#. 4.0/applet.js:3774 6.0/applet.js:3774
 msgid "Close"
 msgstr "Sluiten"
 
@@ -1731,6 +1731,18 @@ msgstr "Verander monitor van vensters"
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 msgid "Change window tiling"
 msgstr "Verander venstertegelen"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle all window-list button windows"
+msgstr "Vensters van applicaties wisselen"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle grouped/pooled button windows"
+msgstr "Vensters van applicaties wisselen"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->description
 #. 6.0->settings-schema.json->mouse-action-scroll->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-20 09:59-0400\n"
+"POT-Creation-Date: 2024-10-30 20:53-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -14,32 +14,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.1\n"
 
-#. 4.0/applet.js:581 6.0/applet.js:581
+#. 4.0/applet.js:584 6.0/applet.js:584
 msgid "all buttons"
 msgstr "все кнопки"
 
-#. 4.0/applet.js:3172 6.0/applet.js:3172
+#. 4.0/applet.js:3258 6.0/applet.js:3258
 msgid "Applet Preferences"
 msgstr "Настройки Апплета"
 
-#. 4.0/applet.js:3176 6.0/applet.js:3176
+#. 4.0/applet.js:3262 6.0/applet.js:3262
 msgid "About..."
 msgstr "О Апплете..."
 
-#. 4.0/applet.js:3180 6.0/applet.js:3180
+#. 4.0/applet.js:3266 6.0/applet.js:3266
 msgid "Configure..."
 msgstr "Настроить..."
 
-#. 4.0/applet.js:3184 6.0/applet.js:3184
+#. 4.0/applet.js:3270 6.0/applet.js:3270
 msgid "Website"
 msgstr ""
 
-#. 4.0/applet.js:3188 6.0/applet.js:3188
+#. 4.0/applet.js:3274 6.0/applet.js:3274
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Удалить '%s'"
 
-#. 4.0/applet.js:3190 6.0/applet.js:3190
+#. 4.0/applet.js:3276 6.0/applet.js:3276
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Вы действительно хотите удалить этот экземпляр CassiaWindowList?"
 
@@ -55,77 +55,77 @@ msgstr "Вы действительно хотите удалить этот э�
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3199 6.0/applet.js:3199
+#. 4.0/applet.js:3285 6.0/applet.js:3285
 msgid "Open new window"
 msgstr "Открыть новое окно"
 
-#. 4.0/applet.js:3207 6.0/applet.js:3207
+#. 4.0/applet.js:3293 6.0/applet.js:3293
 msgid "Remove from panel"
 msgstr "Удалить с панели"
 
-#. 4.0/applet.js:3209 6.0/applet.js:3209
+#. 4.0/applet.js:3295 6.0/applet.js:3295
 msgid "Remove from this workspace"
 msgstr "Удалить из этого рабочего стола"
 
-#. 4.0/applet.js:3215 6.0/applet.js:3215
+#. 4.0/applet.js:3301 6.0/applet.js:3301
 msgid "Pin to panel"
 msgstr "Закрепить на панели"
 
-#. 4.0/applet.js:3217 6.0/applet.js:3217
+#. 4.0/applet.js:3303 6.0/applet.js:3303
 msgid "Pin to this workspace"
 msgstr "Закрепить на этом рабочем столе"
 
-#. 4.0/applet.js:3258 6.0/applet.js:3258
+#. 4.0/applet.js:3344 6.0/applet.js:3344
 msgid "Pin to other workspaces"
 msgstr "Закрепить на другом рабочем столе"
 
-#. 4.0/applet.js:3279 6.0/applet.js:3279
+#. 4.0/applet.js:3365 6.0/applet.js:3365
 msgid "Pin to all workspaces"
 msgstr "Закрепить на всех рабочих столах"
 
-#. 4.0/applet.js:3297 6.0/applet.js:3297
+#. 4.0/applet.js:3383 6.0/applet.js:3383
 msgid "Pin to launcher"
 msgstr "Закрепить в лаунчере"
 
-#. 4.0/applet.js:3315 4.0/applet.js:3520 6.0/applet.js:3315 6.0/applet.js:3520
+#. 4.0/applet.js:3401 4.0/applet.js:3606 6.0/applet.js:3401 6.0/applet.js:3606
 msgid "Add new Hotkey for"
 msgstr "Добавить новую горячую клавишу для"
 
-#. 4.0/applet.js:3329 6.0/applet.js:3329
+#. 4.0/applet.js:3415 6.0/applet.js:3415
 msgid "Recent files"
 msgstr "Недавние файлы"
 
-#. 4.0/applet.js:3353 6.0/applet.js:3353
+#. 4.0/applet.js:3439 6.0/applet.js:3439
 msgid "Places"
 msgstr "Места"
 
-#. 4.0/applet.js:3396 6.0/applet.js:3396
+#. 4.0/applet.js:3482 6.0/applet.js:3482
 #, fuzzy
 msgid "Always on top"
 msgstr "Всегда"
 
-#. 4.0/applet.js:3408 6.0/applet.js:3408
+#. 4.0/applet.js:3494 6.0/applet.js:3494
 msgid "Only on this workspace"
 msgstr "Только на этом рабочем столе"
 
-#. 4.0/applet.js:3410 6.0/applet.js:3410
+#. 4.0/applet.js:3496 6.0/applet.js:3496
 msgid "Visible on all workspaces"
 msgstr "Видно на всех рабочих столах"
 
-#. 4.0/applet.js:3411 6.0/applet.js:3411
+#. 4.0/applet.js:3497 6.0/applet.js:3497
 msgid "Move to another workspace"
 msgstr "Переместить на другой рабочий стол"
 
-#. 4.0/applet.js:3420 6.0/applet.js:3420
+#. 4.0/applet.js:3506 6.0/applet.js:3506
 #, fuzzy
 msgid " (this workspace)"
 msgstr "Закрепить на этом рабочем столе"
 
-#. 4.0/applet.js:3433 6.0/applet.js:3433
+#. 4.0/applet.js:3519 6.0/applet.js:3519
 msgid "Move to another monitor"
 msgstr "Переместить на другой монитор"
 
-#. 4.0/applet.js:3441 6.0/applet.js:3441
+#. 4.0/applet.js:3527 6.0/applet.js:3527
 msgid "Monitor"
 msgstr "Монитор"
 
@@ -141,48 +141,48 @@ msgstr "Монитор"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3458 6.0/applet.js:3458
+#. 4.0/applet.js:3544 6.0/applet.js:3544
 #, fuzzy
 msgid "Move window here"
 msgstr "Закрой окно"
 
-#. 4.0/applet.js:3475 6.0/applet.js:3475
+#. 4.0/applet.js:3561 6.0/applet.js:3561
 msgid "unassigned"
 msgstr "не назначено"
 
-#. 4.0/applet.js:3486 4.0/applet.js:3517 6.0/applet.js:3486 6.0/applet.js:3517
+#. 4.0/applet.js:3572 4.0/applet.js:3603 6.0/applet.js:3572 6.0/applet.js:3603
 msgid "Assign window to a hotkey"
 msgstr "Назначить окно горячей клавише"
 
-#. 4.0/applet.js:3540 6.0/applet.js:3540
+#. 4.0/applet.js:3626 6.0/applet.js:3626
 msgid "Change application label contents"
 msgstr "Изменить текст названия приложения"
 
-#. 4.0/applet.js:3543 6.0/applet.js:3543
+#. 4.0/applet.js:3629 6.0/applet.js:3629
 msgid "Remove custom setting"
 msgstr "Удалить свои настройки"
 
-#. 4.0/applet.js:3550 6.0/applet.js:3550
+#. 4.0/applet.js:3636 6.0/applet.js:3636
 msgid "Use window title"
 msgstr "Использовать заголовок окон"
 
-#. 4.0/applet.js:3557 6.0/applet.js:3557
+#. 4.0/applet.js:3643 6.0/applet.js:3643
 msgid "Use application name"
 msgstr "Использовать названия программ"
 
-#. 4.0/applet.js:3564 6.0/applet.js:3564
+#. 4.0/applet.js:3650 6.0/applet.js:3650
 msgid "No label"
 msgstr "Без названий"
 
-#. 4.0/applet.js:3575 6.0/applet.js:3575
+#. 4.0/applet.js:3661 6.0/applet.js:3661
 msgid "Ungroup application windows"
 msgstr "Не группировать окна приложений"
 
-#. 4.0/applet.js:3583 6.0/applet.js:3583
+#. 4.0/applet.js:3669 6.0/applet.js:3669
 msgid "Group application windows"
 msgstr "Группировать окна приложений"
 
-#. 4.0/applet.js:3596 6.0/applet.js:3596
+#. 4.0/applet.js:3682 6.0/applet.js:3682
 msgid "Automatic grouping/ungrouping"
 msgstr "Автоматически группировать/разгруппировать"
 
@@ -198,41 +198,41 @@ msgstr "Автоматически группировать/разгруппир
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3624 6.0/applet.js:3624
+#. 4.0/applet.js:3710 6.0/applet.js:3710
 msgid "Move titlebar on to screen"
 msgstr "Переместить на другой экран"
 
-#. 4.0/applet.js:3629 6.0/applet.js:3629
+#. 4.0/applet.js:3715 6.0/applet.js:3715
 msgid "Restore"
 msgstr "Восстановить"
 
-#. 4.0/applet.js:3633 6.0/applet.js:3633
+#. 4.0/applet.js:3719 6.0/applet.js:3719
 msgid "Minimize"
 msgstr "Свернуть"
 
-#. 4.0/applet.js:3639 6.0/applet.js:3639
+#. 4.0/applet.js:3725 6.0/applet.js:3725
 msgid "Unmaximize"
 msgstr "Обычный размер"
 
-#. 4.0/applet.js:3647 6.0/applet.js:3647
+#. 4.0/applet.js:3733 6.0/applet.js:3733
 msgid "Close others"
 msgstr "Закрыть другие"
 
-#. 4.0/applet.js:3649 6.0/applet.js:3649
+#. 4.0/applet.js:3735 6.0/applet.js:3735
 #, fuzzy
 msgid "Close other windows for application"
 msgstr "Показать миниатюры для всех окон пула приложений"
 
-#. 4.0/applet.js:3670 6.0/applet.js:3670
+#. 4.0/applet.js:3756 6.0/applet.js:3756
 msgid "Close all"
 msgstr "Закрыть всё"
 
-#. 4.0/applet.js:3672 6.0/applet.js:3672
+#. 4.0/applet.js:3758 6.0/applet.js:3758
 #, fuzzy
 msgid "Close all windows for application"
 msgstr "Показать миниатюры для всех окон пула приложений"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688
+#. 4.0/applet.js:3774 6.0/applet.js:3774
 msgid "Close"
 msgstr "Закрыть"
 
@@ -1689,6 +1689,18 @@ msgstr ""
 #, fuzzy
 msgid "Change window tiling"
 msgstr "Использовать заголовок окон"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle all window-list button windows"
+msgstr "Циклическое переключение окон"
+
+#. 4.0->settings-schema.json->mouse-action-scroll->options
+#. 6.0->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle grouped/pooled button windows"
+msgstr "Циклическое переключение окон"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->description
 #. 6.0->settings-schema.json->mouse-action-scroll->description


### PR DESCRIPTION
* Added scroll-wheel options, cycle all window-list windows and cycle group/pool windows
* The "active" class (window-list button underline in MintY theme) is now used as an active window highlight when pinning is disabled
* Fixed bug preventing pinned buttons from being removed after disabling the pinned buttons support ("Pinning of window list buttons" -> "Disabled")
* The window-list mouse scroll-wheel action will apply when the Thumbnail menu is open and the Thumbnail menu scroll-wheel setting is "Disabled"
* If the active window changes when the Thumbnail menu is open, the outlined Thumbnail menu item will change if the new active window is one of the menu items