### PR TITLE
[Exit@claudiux] v1.3.0 - New option: Screen Off

### DIFF
--- a/Exit@claudiux/files/Exit@claudiux/5.4/settings-schema.json
+++ b/Exit@claudiux/files/Exit@claudiux/5.4/settings-schema.json
@@ -50,6 +50,23 @@
     "type": "label",
     "description": "All the menu options below may be managed by the system.\nIf they are, you can't see them."
   },
+  "showScreenOff": {
+    "type": "switch",
+    "default": true,
+    "description": "Show the Screen Off option"
+  },
+  "mouse-deactivation-duration": {
+    "type": "scale",
+    "dependency": "showScreenOff",
+    "default": 5,
+    "min": 1,
+    "max": 15,
+    "step": 1,
+    "units": "seconds",
+    "show-value": true,
+    "description": "Duration of deactivation of the mouse",
+    "tooltip": "To prevent the monitor from turning on too soon after turning it off, the mouse will be disabled for the number of seconds set here."
+  },
   "showLockscreen": {
     "type": "switch",
     "dependency": "displayLockScreenSetting",

--- a/Exit@claudiux/files/Exit@claudiux/CHANGELOG.md
+++ b/Exit@claudiux/files/Exit@claudiux/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.3.0~20241114
+
+* New option: Screen Off. You can also set the mouse deactivation time to prevent the screen from turning on too soon after you've turned it off.
+
 ### v1.2.0~20240929
 
 * Allows hibernation using root user rights.

--- a/Exit@claudiux/files/Exit@claudiux/README.md
+++ b/Exit@claudiux/files/Exit@claudiux/README.md
@@ -7,6 +7,7 @@ This is a simple, configurable applet for displaying an Exit menu on your panel.
 ## Available Menu options
 
   * Restart Cinnamon
+  * Screen Off
   * Lock Screen
   * Switch user
   * Log Out
@@ -37,6 +38,7 @@ These include `disable-lock-screen`, `disable-log-out` and `disable-switching-us
 For now, these menu options are not available using a **wayland** session:
 
 * Restart Cinnamon
+* Screen Off
 * Lock Screen
 * Switch User
 

--- a/Exit@claudiux/files/Exit@claudiux/metadata.json
+++ b/Exit@claudiux/files/Exit@claudiux/metadata.json
@@ -1,8 +1,8 @@
 {
-    "description": "Restart Cinnamon, lock the screen, switch users, log out, suspend, hibernate, reboot or shut down the computer",
+    "description": "Restart Cinnamon, turn off the screen, lock the screen, switch users, log out, suspend, hibernate, reboot or shut down the computer",
     "uuid": "Exit@claudiux",
     "name": "Exit",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "max-instances": -1,
     "author": "claudiux"
 }

--- a/Exit@claudiux/files/Exit@claudiux/po/Exit@claudiux.pot
+++ b/Exit@claudiux/files/Exit@claudiux/po/Exit@claudiux.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Exit@claudiux 1.2.0\n"
+"Project-Id-Version: Exit@claudiux 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-29 21:43+0200\n"
+"POT-Creation-Date: 2024-11-14 23:59+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,42 +17,46 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 5.4/applet.js:110
+#. 5.4/applet.js:126
 msgid "Restart Cinnamon"
 msgstr ""
 
-#. 5.4/applet.js:122
+#. 5.4/applet.js:138
+msgid "Screen Off"
+msgstr ""
+
+#. 5.4/applet.js:163
 msgid "Lock Screen"
 msgstr ""
 
-#. 5.4/applet.js:145 5.4/applet.js:155 5.4/applet.js:164
+#. 5.4/applet.js:190 5.4/applet.js:200 5.4/applet.js:209
 msgid "Switch User"
 msgstr ""
 
-#. 5.4/applet.js:180
+#. 5.4/applet.js:225
 msgid "Log Out"
 msgstr ""
 
-#. 5.4/applet.js:192
+#. 5.4/applet.js:237
 msgid "Suspend"
 msgstr ""
 
-#. 5.4/applet.js:201
+#. 5.4/applet.js:246
 msgid "Hibernate"
 msgstr ""
 
-#. 5.4/applet.js:216
+#. 5.4/applet.js:261
 msgid "Restart"
 msgstr ""
 
-#. 5.4/applet.js:225
+#. 5.4/applet.js:270
 msgid "Power Off"
 msgstr ""
 
 #. metadata.json->description
 msgid ""
-"Restart Cinnamon, lock the screen, switch users, log out, suspend, "
-"hibernate, reboot or shut down the computer"
+"Restart Cinnamon, turn off the screen, lock the screen, switch users, log "
+"out, suspend, hibernate, reboot or shut down the computer"
 msgstr ""
 
 #. metadata.json->name
@@ -103,6 +107,24 @@ msgstr ""
 msgid ""
 "All the menu options below may be managed by the system.\n"
 "If they are, you can't see them."
+msgstr ""
+
+#. 5.4->settings-schema.json->showScreenOff->description
+msgid "Show the Screen Off option"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
 msgstr ""
 
 #. 5.4->settings-schema.json->showLockscreen->description

--- a/Exit@claudiux/files/Exit@claudiux/po/ca.po
+++ b/Exit@claudiux/files/Exit@claudiux/po/ca.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-29 21:43+0200\n"
+"POT-Creation-Date: 2024-11-14 23:59+0100\n"
 "PO-Revision-Date: 2024-10-01 03:01+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -19,42 +19,47 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 5.4/applet.js:110
+#. 5.4/applet.js:126
 msgid "Restart Cinnamon"
 msgstr "Reiniciar Cinnamon"
 
-#. 5.4/applet.js:122
+#. 5.4/applet.js:138
+msgid "Screen Off"
+msgstr ""
+
+#. 5.4/applet.js:163
 msgid "Lock Screen"
 msgstr "Bloquejar la pantalla"
 
-#. 5.4/applet.js:145 5.4/applet.js:155 5.4/applet.js:164
+#. 5.4/applet.js:190 5.4/applet.js:200 5.4/applet.js:209
 msgid "Switch User"
 msgstr "Canviar d'usuari"
 
-#. 5.4/applet.js:180
+#. 5.4/applet.js:225
 msgid "Log Out"
 msgstr "Tancar la sessió"
 
-#. 5.4/applet.js:192
+#. 5.4/applet.js:237
 msgid "Suspend"
 msgstr "Suspendre"
 
-#. 5.4/applet.js:201
+#. 5.4/applet.js:246
 msgid "Hibernate"
 msgstr "Hivernar"
 
-#. 5.4/applet.js:216
+#. 5.4/applet.js:261
 msgid "Restart"
 msgstr "Reiniciar"
 
-#. 5.4/applet.js:225
+#. 5.4/applet.js:270
 msgid "Power Off"
 msgstr "Apagar"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Restart Cinnamon, lock the screen, switch users, log out, suspend, "
-"hibernate, reboot or shut down the computer"
+"Restart Cinnamon, turn off the screen, lock the screen, switch users, log "
+"out, suspend, hibernate, reboot or shut down the computer"
 msgstr ""
 "Reinicia Cinnamon, bloqueja la pantalla, canvia d'usuari, tanca la sessió, "
 "suspèn, hiverna, reinicia o apaga l'ordinador"
@@ -111,6 +116,25 @@ msgstr ""
 "És possible que el sistema administri algunes o totes les opcions llistades "
 "a continuació.\n"
 "En cas afirmatiu, no les podreu veure."
+
+#. 5.4->settings-schema.json->showScreenOff->description
+#, fuzzy
+msgid "Show the Screen Off option"
+msgstr "Mostrar la opció del bloqueig de pantalla"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
 
 #. 5.4->settings-schema.json->showLockscreen->description
 msgid "Show the Lock Screen option"

--- a/Exit@claudiux/files/Exit@claudiux/po/de.po
+++ b/Exit@claudiux/files/Exit@claudiux/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-29 21:43+0200\n"
+"POT-Creation-Date: 2024-11-14 23:59+0100\n"
 "PO-Revision-Date: 2024-02-14 22:09+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,42 +19,47 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. 5.4/applet.js:110
+#. 5.4/applet.js:126
 msgid "Restart Cinnamon"
 msgstr "Starte Cinnamon neu"
 
-#. 5.4/applet.js:122
+#. 5.4/applet.js:138
+msgid "Screen Off"
+msgstr ""
+
+#. 5.4/applet.js:163
 msgid "Lock Screen"
 msgstr "Bildschirm sperren"
 
-#. 5.4/applet.js:145 5.4/applet.js:155 5.4/applet.js:164
+#. 5.4/applet.js:190 5.4/applet.js:200 5.4/applet.js:209
 msgid "Switch User"
 msgstr "Benutzer wechseln"
 
-#. 5.4/applet.js:180
+#. 5.4/applet.js:225
 msgid "Log Out"
 msgstr "Abmelden"
 
-#. 5.4/applet.js:192
+#. 5.4/applet.js:237
 msgid "Suspend"
 msgstr "Bereitschaft"
 
-#. 5.4/applet.js:201
+#. 5.4/applet.js:246
 msgid "Hibernate"
 msgstr "Ruhezustand"
 
-#. 5.4/applet.js:216
+#. 5.4/applet.js:261
 msgid "Restart"
 msgstr "Neustart"
 
-#. 5.4/applet.js:225
+#. 5.4/applet.js:270
 msgid "Power Off"
 msgstr "Ausschalten"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Restart Cinnamon, lock the screen, switch users, log out, suspend, "
-"hibernate, reboot or shut down the computer"
+"Restart Cinnamon, turn off the screen, lock the screen, switch users, log "
+"out, suspend, hibernate, reboot or shut down the computer"
 msgstr ""
 "Cinnamon neu starten, Bildschirm sperren, Benutzer wechseln, Abmelden, "
 "Bereitschaft, Ruhezustand, den Computer neu starten oder herunterfahren"
@@ -110,6 +115,25 @@ msgid ""
 msgstr ""
 "Alle nachstehenden Menüoptionen werden möglicherweise vom System verwaltet.\n"
 "Wenn dies der Fall ist, können Sie sie nicht sehen."
+
+#. 5.4->settings-schema.json->showScreenOff->description
+#, fuzzy
+msgid "Show the Screen Off option"
+msgstr "Die Option \"Bildschirm sperren\" anzeigen"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
 
 #. 5.4->settings-schema.json->showLockscreen->description
 msgid "Show the Lock Screen option"

--- a/Exit@claudiux/files/Exit@claudiux/po/es.po
+++ b/Exit@claudiux/files/Exit@claudiux/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-29 21:43+0200\n"
+"POT-Creation-Date: 2024-11-14 23:59+0100\n"
 "PO-Revision-Date: 2024-09-30 10:53-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,42 +18,47 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 5.4/applet.js:110
+#. 5.4/applet.js:126
 msgid "Restart Cinnamon"
 msgstr "Reiniciar Cinnamon"
 
-#. 5.4/applet.js:122
+#. 5.4/applet.js:138
+msgid "Screen Off"
+msgstr ""
+
+#. 5.4/applet.js:163
 msgid "Lock Screen"
 msgstr "Bloquear pantalla"
 
-#. 5.4/applet.js:145 5.4/applet.js:155 5.4/applet.js:164
+#. 5.4/applet.js:190 5.4/applet.js:200 5.4/applet.js:209
 msgid "Switch User"
 msgstr "Cambiar de usuario"
 
-#. 5.4/applet.js:180
+#. 5.4/applet.js:225
 msgid "Log Out"
 msgstr "Cerrar sesión"
 
-#. 5.4/applet.js:192
+#. 5.4/applet.js:237
 msgid "Suspend"
 msgstr "Suspender"
 
-#. 5.4/applet.js:201
+#. 5.4/applet.js:246
 msgid "Hibernate"
 msgstr "Hibernar"
 
-#. 5.4/applet.js:216
+#. 5.4/applet.js:261
 msgid "Restart"
 msgstr "Reiniciar"
 
-#. 5.4/applet.js:225
+#. 5.4/applet.js:270
 msgid "Power Off"
 msgstr "Apagar"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Restart Cinnamon, lock the screen, switch users, log out, suspend, "
-"hibernate, reboot or shut down the computer"
+"Restart Cinnamon, turn off the screen, lock the screen, switch users, log "
+"out, suspend, hibernate, reboot or shut down the computer"
 msgstr ""
 "Reiniciar Cinnamon, bloquear la pantalla, cambiar de usuario, cerrar sesión, "
 "suspender, hibernar, reiniciar o apagar el ordenador"
@@ -110,6 +115,25 @@ msgstr ""
 "Todas las opciones de menú que aparecen a continuación pueden estar "
 "gestionadas por el sistema.\n"
 "Si lo están, no podrá verlas."
+
+#. 5.4->settings-schema.json->showScreenOff->description
+#, fuzzy
+msgid "Show the Screen Off option"
+msgstr "Mostrar la opción Bloquear pantalla"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
 
 #. 5.4->settings-schema.json->showLockscreen->description
 msgid "Show the Lock Screen option"

--- a/Exit@claudiux/files/Exit@claudiux/po/fi.po
+++ b/Exit@claudiux/files/Exit@claudiux/po/fi.po
@@ -7,53 +7,58 @@ msgstr ""
 "Project-Id-Version: Exit@claudiux 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-29 21:43+0200\n"
+"POT-Creation-Date: 2024-11-14 23:59+0100\n"
 "PO-Revision-Date: \n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
-#. 5.4/applet.js:110
+#. 5.4/applet.js:126
 msgid "Restart Cinnamon"
 msgstr "Käynnistä Cinnamon"
 
-#. 5.4/applet.js:122
+#. 5.4/applet.js:138
+msgid "Screen Off"
+msgstr ""
+
+#. 5.4/applet.js:163
 msgid "Lock Screen"
 msgstr "Lukitse näyttö"
 
-#. 5.4/applet.js:145 5.4/applet.js:155 5.4/applet.js:164
+#. 5.4/applet.js:190 5.4/applet.js:200 5.4/applet.js:209
 msgid "Switch User"
 msgstr "Vaihda käyttäjä"
 
-#. 5.4/applet.js:180
+#. 5.4/applet.js:225
 msgid "Log Out"
 msgstr "Kirjaudu ulos"
 
-#. 5.4/applet.js:192
+#. 5.4/applet.js:237
 msgid "Suspend"
 msgstr "Valmiustila"
 
-#. 5.4/applet.js:201
+#. 5.4/applet.js:246
 msgid "Hibernate"
 msgstr "Lepotila"
 
-#. 5.4/applet.js:216
+#. 5.4/applet.js:261
 msgid "Restart"
 msgstr "Käynnistä uudelleen"
 
-#. 5.4/applet.js:225
+#. 5.4/applet.js:270
 msgid "Power Off"
 msgstr "Sammuta"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Restart Cinnamon, lock the screen, switch users, log out, suspend, "
-"hibernate, reboot or shut down the computer"
+"Restart Cinnamon, turn off the screen, lock the screen, switch users, log "
+"out, suspend, hibernate, reboot or shut down the computer"
 msgstr ""
 "Käynnistä Cinnamon uudelleen, lukitse näyttö, vaihda käyttäjä, kirjaudu "
 "ulos, valmiustila, lepotila, käynnistä uudelleen tai sammuta tietokone"
@@ -109,6 +114,25 @@ msgid ""
 msgstr ""
 "Järjestelmä hallinnoi kaikkia alla olevia valikon vaihtoehtoja.\n"
 "Jos ne ovat, et näe niitä."
+
+#. 5.4->settings-schema.json->showScreenOff->description
+#, fuzzy
+msgid "Show the Screen Off option"
+msgstr "Näytä Lukitse näyttö"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
 
 #. 5.4->settings-schema.json->showLockscreen->description
 msgid "Show the Lock Screen option"

--- a/Exit@claudiux/files/Exit@claudiux/po/fr.po
+++ b/Exit@claudiux/files/Exit@claudiux/po/fr.po
@@ -7,8 +7,8 @@ msgstr ""
 "Project-Id-Version: 1.2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-29 21:43+0200\n"
-"PO-Revision-Date: 2024-09-29 21:44+0200\n"
+"POT-Creation-Date: 2024-11-14 23:59+0100\n"
+"PO-Revision-Date: 2024-11-15 00:02+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -18,45 +18,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 5.4/applet.js:110
+#. 5.4/applet.js:126
 msgid "Restart Cinnamon"
 msgstr "Redémarrer Cinnamon"
 
-#. 5.4/applet.js:122
+#. 5.4/applet.js:138
+msgid "Screen Off"
+msgstr "Éteindre l'écran"
+
+#. 5.4/applet.js:163
 msgid "Lock Screen"
 msgstr "Verrouiller l'écran"
 
-#. 5.4/applet.js:145 5.4/applet.js:155 5.4/applet.js:164
+#. 5.4/applet.js:190 5.4/applet.js:200 5.4/applet.js:209
 msgid "Switch User"
 msgstr "Changer d'utilisateur"
 
-#. 5.4/applet.js:180
+#. 5.4/applet.js:225
 msgid "Log Out"
 msgstr "Se déconnecter"
 
-#. 5.4/applet.js:192
+#. 5.4/applet.js:237
 msgid "Suspend"
 msgstr "Mettre en veille"
 
-#. 5.4/applet.js:201
+#. 5.4/applet.js:246
 msgid "Hibernate"
 msgstr "Hiberner"
 
-#. 5.4/applet.js:216
+#. 5.4/applet.js:261
 msgid "Restart"
 msgstr "Redémarrer l'ordinateur"
 
-#. 5.4/applet.js:225
+#. 5.4/applet.js:270
 msgid "Power Off"
 msgstr "Arrêter l'ordinateur"
 
 #. metadata.json->description
 msgid ""
-"Restart Cinnamon, lock the screen, switch users, log out, suspend, "
-"hibernate, reboot or shut down the computer"
+"Restart Cinnamon, turn off the screen, lock the screen, switch users, log "
+"out, suspend, hibernate, reboot or shut down the computer"
 msgstr ""
-"Redémarrer Cinnamon, verrouiller l'écran, changer d'utilisateur, se "
-"déconnecter, mettre en veille, hiberner, redémarrer ou arrêter l'ordinateur"
+"Redémarrer Cinnamon, éteindre l'écran, verrouiller l'écran, changer "
+"d'utilisateur, se déconnecter, mettre en veille, hiberner, redémarrer ou "
+"arrêter l'ordinateur"
 
 #. metadata.json->name
 msgid "Exit"
@@ -109,6 +114,26 @@ msgid ""
 msgstr ""
 "Toutes les options de menu ci-dessous peuvent être gérées par le système.\n"
 "Si c'est le cas, vous ne pouvez pas les voir."
+
+#. 5.4->settings-schema.json->showScreenOff->description
+msgid "Show the Screen Off option"
+msgstr "Afficher l'option Éteindre l'écran"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr " secondes"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr "Durée de désactivation de la souris"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
+"Pour éviter que l'écran ne se rallume trop tôt après l'avoir éteint, la "
+"souris sera désactivée pendant le nombre de secondes défini ici."
 
 #. 5.4->settings-schema.json->showLockscreen->description
 msgid "Show the Lock Screen option"

--- a/Exit@claudiux/files/Exit@claudiux/po/hu.po
+++ b/Exit@claudiux/files/Exit@claudiux/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-29 21:43+0200\n"
+"POT-Creation-Date: 2024-11-14 23:59+0100\n"
 "PO-Revision-Date: 2024-10-02 16:31+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,42 +19,47 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 5.4/applet.js:110
+#. 5.4/applet.js:126
 msgid "Restart Cinnamon"
 msgstr "Cinnamon újraindítása"
 
-#. 5.4/applet.js:122
+#. 5.4/applet.js:138
+msgid "Screen Off"
+msgstr ""
+
+#. 5.4/applet.js:163
 msgid "Lock Screen"
 msgstr "Képernyő zárolása"
 
-#. 5.4/applet.js:145 5.4/applet.js:155 5.4/applet.js:164
+#. 5.4/applet.js:190 5.4/applet.js:200 5.4/applet.js:209
 msgid "Switch User"
 msgstr "Felhasználó váltás"
 
-#. 5.4/applet.js:180
+#. 5.4/applet.js:225
 msgid "Log Out"
 msgstr "Kijelentkezés"
 
-#. 5.4/applet.js:192
+#. 5.4/applet.js:237
 msgid "Suspend"
 msgstr "Felfüggesztés"
 
-#. 5.4/applet.js:201
+#. 5.4/applet.js:246
 msgid "Hibernate"
 msgstr "Hibernálás"
 
-#. 5.4/applet.js:216
+#. 5.4/applet.js:261
 msgid "Restart"
 msgstr "Újraindítás"
 
-#. 5.4/applet.js:225
+#. 5.4/applet.js:270
 msgid "Power Off"
 msgstr "Kikapcsolás"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Restart Cinnamon, lock the screen, switch users, log out, suspend, "
-"hibernate, reboot or shut down the computer"
+"Restart Cinnamon, turn off the screen, lock the screen, switch users, log "
+"out, suspend, hibernate, reboot or shut down the computer"
 msgstr ""
 "A Cinnamon újraindítása, a képernyő zárolása, felhasználóváltás, "
 "kijelentkezés, felfüggesztés, hibernálás, újraindítás vagy a számítógép "
@@ -111,6 +116,25 @@ msgid ""
 msgstr ""
 "Az alábbi menü opciók mindegyikét a rendszer kezelheti.\n"
 "Ha igen, akkor nem láthatja őket."
+
+#. 5.4->settings-schema.json->showScreenOff->description
+#, fuzzy
+msgid "Show the Screen Off option"
+msgstr "A Zárolási képernyő opció megjelenítése"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
 
 #. 5.4->settings-schema.json->showLockscreen->description
 msgid "Show the Lock Screen option"

--- a/Exit@claudiux/files/Exit@claudiux/po/it.po
+++ b/Exit@claudiux/files/Exit@claudiux/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-29 21:43+0200\n"
+"POT-Creation-Date: 2024-11-14 23:59+0100\n"
 "PO-Revision-Date: 2024-06-18 14:35+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,42 +19,47 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. 5.4/applet.js:110
+#. 5.4/applet.js:126
 msgid "Restart Cinnamon"
 msgstr "Riavvia Cinnamon"
 
-#. 5.4/applet.js:122
+#. 5.4/applet.js:138
+msgid "Screen Off"
+msgstr ""
+
+#. 5.4/applet.js:163
 msgid "Lock Screen"
 msgstr "Blocca lo schermo"
 
-#. 5.4/applet.js:145 5.4/applet.js:155 5.4/applet.js:164
+#. 5.4/applet.js:190 5.4/applet.js:200 5.4/applet.js:209
 msgid "Switch User"
 msgstr "Cambia utente"
 
-#. 5.4/applet.js:180
+#. 5.4/applet.js:225
 msgid "Log Out"
 msgstr "Abbandona sessione"
 
-#. 5.4/applet.js:192
+#. 5.4/applet.js:237
 msgid "Suspend"
 msgstr "Sospendi"
 
-#. 5.4/applet.js:201
+#. 5.4/applet.js:246
 msgid "Hibernate"
 msgstr "Iberna"
 
-#. 5.4/applet.js:216
+#. 5.4/applet.js:261
 msgid "Restart"
 msgstr "Riavvia"
 
-#. 5.4/applet.js:225
+#. 5.4/applet.js:270
 msgid "Power Off"
 msgstr "Spegni"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Restart Cinnamon, lock the screen, switch users, log out, suspend, "
-"hibernate, reboot or shut down the computer"
+"Restart Cinnamon, turn off the screen, lock the screen, switch users, log "
+"out, suspend, hibernate, reboot or shut down the computer"
 msgstr ""
 "Riavvia Cinnamon, blocca lo schermo, cambia utente, disconnettiti, sospendi, "
 "iberna, riavvia o spegni il computer"
@@ -111,6 +116,25 @@ msgstr ""
 "Tutte le opzioni del menù sottostanti potrebbero essere gestite dal "
 "sistema.\n"
 "In tal caso, non puoi vederle."
+
+#. 5.4->settings-schema.json->showScreenOff->description
+#, fuzzy
+msgid "Show the Screen Off option"
+msgstr "Mostra l'opzione Schermata di blocco"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
 
 #. 5.4->settings-schema.json->showLockscreen->description
 msgid "Show the Lock Screen option"

--- a/Exit@claudiux/files/Exit@claudiux/po/nl.po
+++ b/Exit@claudiux/files/Exit@claudiux/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-29 21:43+0200\n"
+"POT-Creation-Date: 2024-11-14 23:59+0100\n"
 "PO-Revision-Date: 2024-04-20 11:02+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -17,42 +17,47 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 5.4/applet.js:110
+#. 5.4/applet.js:126
 msgid "Restart Cinnamon"
 msgstr "Herstart Cinnamon"
 
-#. 5.4/applet.js:122
+#. 5.4/applet.js:138
+msgid "Screen Off"
+msgstr ""
+
+#. 5.4/applet.js:163
 msgid "Lock Screen"
 msgstr "Vergrendel scherm"
 
-#. 5.4/applet.js:145 5.4/applet.js:155 5.4/applet.js:164
+#. 5.4/applet.js:190 5.4/applet.js:200 5.4/applet.js:209
 msgid "Switch User"
 msgstr "Gebruiker wisselen"
 
-#. 5.4/applet.js:180
+#. 5.4/applet.js:225
 msgid "Log Out"
 msgstr "Afmelden"
 
-#. 5.4/applet.js:192
+#. 5.4/applet.js:237
 msgid "Suspend"
 msgstr "Slaapstand"
 
-#. 5.4/applet.js:201
+#. 5.4/applet.js:246
 msgid "Hibernate"
 msgstr "Slaapstand naar schijf"
 
-#. 5.4/applet.js:216
+#. 5.4/applet.js:261
 msgid "Restart"
 msgstr "Herstart"
 
-#. 5.4/applet.js:225
+#. 5.4/applet.js:270
 msgid "Power Off"
 msgstr "Uitschakelen"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Restart Cinnamon, lock the screen, switch users, log out, suspend, "
-"hibernate, reboot or shut down the computer"
+"Restart Cinnamon, turn off the screen, lock the screen, switch users, log "
+"out, suspend, hibernate, reboot or shut down the computer"
 msgstr ""
 "Herstart Cinnamon, vergrendel het scherm, wissel van gebruiker, meld je af, "
 "zet de computer in slaapstand (al dan niet naar schijf), herstart of schakel "
@@ -109,6 +114,25 @@ msgid ""
 msgstr ""
 "Alle onderstaande menuopties kunnen worden beheerd door het systeem.\n"
 " Als dat het geval is, dan kun je ze niet zien."
+
+#. 5.4->settings-schema.json->showScreenOff->description
+#, fuzzy
+msgid "Show the Screen Off option"
+msgstr "Toon de optie Scherm vergrendelen"
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr ""
+
+#. 5.4->settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
 
 #. 5.4->settings-schema.json->showLockscreen->description
 msgid "Show the Lock Screen option"


### PR DESCRIPTION
New option: Screen Off. Also you can set the duration of deactivation of the mouse to prevent the screen to turning on too soon after turning it off.

Idea from https://github.com/orgs/linuxmint/discussions/676.