### PR TITLE
sound150@claudiux: Play volume change sound after changing volume via dragging slider

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/4.6/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/4.6/applet.js
@@ -134,6 +134,9 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
         this.tooltip = new Tooltips.Tooltip(this.actor, this.tooltipText);
 
         this.connect("value-changed", () => this._onValueChanged());
+        if (tooltip === _("Volume")) {
+            this.connect("drag-end", () => this._onDragEnd());
+        }
 
         this.app_icon = app_icon;
         if (this.app_icon == null) {
@@ -198,6 +201,12 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             this.applet._notifyVolumeChange(this.stream);
     }
 
+    _onDragEnd() {
+        if (this.stream) {
+            this.applet._notifyVolumeChange(this.stream);
+        }
+    }
+
     _onScrollEvent(actor, event) {
         let direction = event.get_scroll_direction();
 
@@ -227,7 +236,6 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             }
             this._slider.queue_repaint();
             this.emit('value-changed', this._value);
-            this.emit('drag-end');
             return true;
         }
         return false;

--- a/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
@@ -237,6 +237,9 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
         this.tooltip = new Tooltips.Tooltip(this.actor, this.tooltipText);
 
         this.connect("value-changed", () => this._onValueChanged());
+        if (tooltip === _("Volume")) {
+            this.connect("drag-end", () => this._onDragEnd());
+        }
 
         this.app_icon = app_icon;
         if (this.app_icon == null) {
@@ -349,6 +352,12 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             this.applet._notifyVolumeChange(this.stream);
     }
 
+    _onDragEnd() {
+        if (this.stream) {
+            this.applet._notifyVolumeChange(this.stream);
+        }
+    }
+
     _onScrollEvent(actor, event) {
         let direction = event.get_scroll_direction();
 
@@ -379,7 +388,6 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             }
             this._slider.queue_repaint();
             this.emit("value-changed", this._value);
-            this.emit("drag-end");
             return true;
         }
         return false;

--- a/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
@@ -237,6 +237,9 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
         this.tooltip = new Tooltips.Tooltip(this.actor, this.tooltipText);
 
         this.connect("value-changed", () => this._onValueChanged());
+        if (tooltip === _("Volume")) {
+            this.connect("drag-end", () => this._onDragEnd());
+        }
 
         this.app_icon = app_icon;
         if (this.app_icon == null) {
@@ -350,6 +353,12 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             this.applet._notifyVolumeChange(this.stream);
     }
 
+    _onDragEnd() {
+        if (this.stream) {
+            this.applet._notifyVolumeChange(this.stream);
+        }
+    }
+
     _onScrollEvent(actor, event) {
         let direction = event.get_scroll_direction();
 
@@ -380,7 +389,6 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             }
             this._slider.queue_repaint();
             this.emit("value-changed", this._value);
-            this.emit("drag-end");
             return true;
         }
         return false;


### PR DESCRIPTION
fixes https://github.com/linuxmint/cinnamon/issues/9472

Users migrating from other operating systems might expect that changing the volume slider would play an audible tone to indicate how loud the volume is. Right now, the only ways to get this tone to play from the applet are to use the keyboard or mouse scroll wheel. This adds another option for users who prefer to use mouse/touch screen or don't have a mouse wheel to hear how loud the volume is.

@claudiux 