### PR TITLE
[MuteToggler@jebeaudet.com] Added new parameters for soundcard and input choice

### DIFF
--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -152,6 +152,7 @@ MyApplet.prototype = {
         }
 
         VERBOSE = this.verbose;
+        this.evaluate_soundcard();
     },
 
     refresh_loop: function() {

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -16,7 +16,7 @@ const APPNAME = "MuteToggler";
 const UUID = APPNAME + "@jebeaudet.com";
 const HOME_DIR = GLib.get_home_dir();
 
-var VERBOSE = false; // VERBOSE value will be changed according to this applet settings.
+var VERBOSE = true; // VERBOSE value will be changed according to this applet settings.
 
 const POTENTIAL_INPUTS = ["'Capture'", "'Mic'"];
 
@@ -116,8 +116,9 @@ MyApplet.prototype = {
             
             this.amixer = "amixer";
 
-            this.evaluate_soundcard();
- 
+            this.evaluate_soundcard(); 
+            this.evaluate_input();
+            
             const parameters = ["", " -D pulse"];
             for (let param of parameters) {
                 let cmd = this.amixer + param + " scontrols";
@@ -130,8 +131,6 @@ MyApplet.prototype = {
                     break;
                 }
             }
-
-            this.evaluate_input();
             
             this.applet_is_running = true;
             this.set_not_muted_icon();

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -218,7 +218,6 @@ MyApplet.prototype = {
           // per default use first soundcard 
           this.soundcard_id = "0";
           
-          let soundcard_list_cmd =  
           Util.spawn_async(["sh","-c","cat /proc/asound/cards"], (stdout) => {
             try {
               // Split the result into lines 

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -214,7 +214,7 @@ MyApplet.prototype = {
 
     evaluate_soundcard: function() {
       // only use specific soundcard if searchstring is not empty
-      if (this.soundcard.trim() !== '')
+      if (this.soundcard.trim().length > 0)
       {
         // per default use first soundcard 
         this.soundcard_id = "0";
@@ -224,7 +224,7 @@ MyApplet.prototype = {
 
         if (res) {
           // Split the result into lines 
-          let lines = stdout.toString().split('\n');
+          let lines = to_string(stdout).split('\n');
 
           // Filter lines that contain the soundcard search string
           let filteredLines = lines.filter(line => line.includes(this.soundcard)); 

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/settings-schema.json
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/settings-schema.json
@@ -1,4 +1,22 @@
 {
+  "section_soundcard": {
+    "type": "section",
+    "description": "Soundcard settings",
+    "keys": [
+      "soundcard",
+      "input"
+    ]
+  },
+  "soundcard": {
+    "type": "entry",
+    "description": "Soundcard identifier",
+    "default": "USB-Audio - USB"
+  },
+  "input": {
+    "type": "entry",
+    "description": "Input name (e.g. Capture, Mic, ...)",
+    "default": "Mic"
+  },
   "section_keybinding": {
     "type": "section",
     "description": "Keyboard shortcuts",

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/settings-schema.json
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/settings-schema.json
@@ -3,19 +3,13 @@
     "type": "section",
     "description": "Soundcard settings",
     "keys": [
-      "soundcard",
-      "input"
+      "soundcard"
     ]
   },
   "soundcard": {
     "type": "entry",
-    "description": "Soundcard identifier",
-    "default": "USB-Audio - USB"
-  },
-  "input": {
-    "type": "entry",
-    "description": "Input name (e.g. Capture, Mic, ...)",
-    "default": "Mic"
+    "description": "Soundcard search string in /proc/asound/cards (empty: deactivate)",
+    "default": ""
   },
   "section_keybinding": {
     "type": "section",


### PR DESCRIPTION
I am using a USB microphone (which is a soundcard by it's own).
The command 'amixer set Capture toggle' does not work in this environment.
In my case i need to select the soundcard as well and the control is not called 'Capture' but 'Mic'.
This extension let's you configure two strings that let you choose the device by a search string as it is displayed in 'cat /proc/asound/cards' and name control (Capture, Mic, ...).

Works fine for me, could also work fine for others...