### PR TITLE
Calender@ccprog version 1.3.0

### DIFF
--- a/calendar@ccprog/CHANGELOG.md
+++ b/calendar@ccprog/CHANGELOG.md
@@ -1,4 +1,12 @@
-###1.2.2
+### 1.3.0
+- Thanks for multiple translations: blogdron for Russian, qadzek for Dutch, Odyssey for Catalan
+- Multiple fixes merged from upstream calendar@cinnamon
+- Included custom tooltip formatting from upstream calendar@cinnamon
+- Bugfix: correctly check cache whenever data are needed
+- Support for holidays in Cyprus, Montenegro and El Salvador, and for regional holidays in Belgium.  
+  **Users from Belgium will need to check their regional settings!**
+
+### 1.2.2
 - Thanks to Kimmo Kujansuu for the finnish translation
 - fredcw added support for libsup 3
 - Support for Kosovo holidays

--- a/calendar@ccprog/files/calendar@ccprog/5.2/applet.js
+++ b/calendar@ccprog/files/calendar@ccprog/5.2/applet.js
@@ -38,6 +38,7 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
             this.settings.bind("show-events", "show_events", this._onSettingsChanged);
             this.settings.bind("use-custom-format", "use_custom_format", this._onSettingsChanged);
             this.settings.bind("custom-format", "custom_format", this._onSettingsChanged);
+            this.settings.bind("custom-tooltip-format", "custom_tooltip_format", this._onSettingsChanged);
             this.settings.bind("keyOpen", "keyOpen", this._setKeybinding);
             this._setKeybinding();
 
@@ -203,7 +204,7 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
     }
 
     on_custom_format_button_pressed() {
-        Util.spawnCommandLine("xdg-open http://www.foragoodstrftime.com/");
+        Util.spawnCommandLine("xdg-open https://cinnamon-spices.linuxmint.com/strftime.php");
     }
 
     _onLaunchSettings() {
@@ -267,13 +268,21 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
 
         this.set_applet_label(label_string);
 
-        let dateFormattedFull = this.clock.get_clock_for_format(DATE_FORMAT_FULL).capitalize();
+        let dateFormattedTooltip = this.clock.get_clock_for_format(DATE_FORMAT_FULL).capitalize();
+        if (this.use_custom_format) {
+            dateFormattedTooltip = this.clock.get_clock_for_format(this.custom_tooltip_format).capitalize();
+            if (!dateFormattedTooltip) {
+                global.logError("Calendar applet: bad tooltip time format string - check your string.");
+                dateFormattedTooltip = this.clock.get_clock_for_format("~CLOCK FORMAT ERROR~ %l:%M %p");
+            }
+        }
+
         let dateFormattedShort = this.clock.get_clock_for_format(DATE_FORMAT_SHORT).capitalize();
         let dayFormatted = this.clock.get_clock_for_format(DAY_FORMAT).capitalize();
 
         this._day.set_text(dayFormatted);
         this._date.set_text(dateFormattedShort);
-        this.set_applet_tooltip(dateFormattedFull);
+        this.set_applet_tooltip(dateFormattedTooltip);
 
         this.events_manager.select_date(this._calendar.getSelectedDate());
 

--- a/calendar@ccprog/files/calendar@ccprog/5.2/settings-schema.json
+++ b/calendar@ccprog/files/calendar@ccprog/5.2/settings-schema.json
@@ -41,6 +41,7 @@
                 "country",
                 "has_region",
                 "region_aus",
+                "region_bel",
                 "region_can",
                 "region_deu",
                 "region_esp",
@@ -134,8 +135,10 @@
             "China": "chn",
             "Colombia": "col",
             "Croatia": "hrv",
+            "Cyprus": "cyp",
             "Czech Republic": "cze",
             "Denmark": "dnk",
+            "El Salvador": "slv",
             "Estonia": "est",
             "Spain": "esp",
             "Finland": "fin",
@@ -156,6 +159,7 @@
             "Lithuania": "ltu",
             "Luxembourg": "lux",
             "Macedonia": "mkd",
+            "Montenegro": "mne",
             "Mexico": "mex",
             "Netherlands": "nld",
             "New Zealand": "nzl",
@@ -183,6 +187,7 @@
         "type": "generic",
         "default": [
             "aus",
+            "bel",
             "can",
             "deu",
             "esp",
@@ -208,6 +213,17 @@
             "Western Australia": "wa"
         },
         "dependency": "country=aus"
+    },
+    "region_bel": {
+        "type": "combobox",
+        "default": "bru",
+        "description": "Region",
+        "options": {
+            "Brussels": "bru",
+            "Flemish Region": "vlg",
+            "Walloon Region": "wal"
+        },
+        "dependency": "country=bel"
     },
     "region_can": {
         "type": "combobox",

--- a/calendar@ccprog/files/calendar@ccprog/5.2/settings-schema.json
+++ b/calendar@ccprog/files/calendar@ccprog/5.2/settings-schema.json
@@ -30,6 +30,7 @@
                 "weekend-length",
                 "use-custom-format",
                 "custom-format",
+                "custom-tooltip-format",
                 "format-button"
             ]
         },
@@ -100,6 +101,13 @@
         "indent": true,
         "dependency": "use-custom-format",
         "tooltip": "Set your custom format here."
+    },
+    "custom-tooltip-format" : {
+        "type" : "entry",
+        "default" : "%A, %B %e, %H:%M",
+        "description" : "Date format for tooltip",
+        "dependency" : "use-custom-format",
+        "tooltip" : "Set your custom tooltip format here."
     },
     "format-button": {
         "type": "button",

--- a/calendar@ccprog/files/calendar@ccprog/metadata.json
+++ b/calendar@ccprog/files/calendar@ccprog/metadata.json
@@ -3,6 +3,6 @@
     "name": "Calendar with public Holidays",
     "description": "Calendar applet with public holiday data provided by Enrico service",
     "max-instances": -1,
-    "version": "1.2.2",
+    "version": "1.3.0",
     "multiversion": true
 }

--- a/calendar@ccprog/files/calendar@ccprog/po/ca.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/ca.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR WITH PUBLIC HOLIDAYS
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# ccprog, 2020
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog 1.2.2\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2024-07-08 17:20+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,68 +19,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Començant d'aquí a uns minuts"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Començant en %d minuts"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Aquesta tarda"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Començant avui"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "En %d hora"
 msgstr[1] "En %d hores"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "No hi ha events"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "En procés"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Tot el dia"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Avui"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Configuració de data i hora"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Afegir una nova entrada"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Editar entrada"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +100,11 @@ msgstr "Editar entrada"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Regió"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Ciutat"
 
@@ -117,100 +118,1220 @@ msgstr ""
 "Miniaplicació de calendari amb informació de dies festius proveïda pel "
 "servei Enrico"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendari"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Rellotge mundial"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Visualitzar"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Obtenir els dies festius per a"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Dreceres del teclat"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Mostrar el rellotge mundial"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Mostrar esdeveniments del calendari"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Marqueu això per a mostrar esdeveniments al calendari."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Mostrar el número de les setmanes al calendari"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Marqueu això per a mostrar el número de la setmana al calendari."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Marcar com a dies de cap de setmana"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Assigneu quants dies de la setmana es consideren no feiners."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Un dia"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Dos dies"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Utilitzar un format personalitzat de data"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Marqueu això per a definir un format personalitzat per la data de la "
 "miniaplicació del calendari."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Format de la data"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Assigneu el vostre format personalitzat aquí."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Mostrar informació sobre la sintaxi per a la data"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr "Marqueu això per saber més sobre la sintaxi dels formats de data."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "País"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Austràlia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Àustria"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Bèlgica"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bòsnia i Herzegovina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Bielorússia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brasil"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Canadà"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Xile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "Xina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Colòmbia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Croàcia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "República Xeca"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Dinamarca"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estònia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "Espanya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finlàndia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "França"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Alemanya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Grècia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Hongria"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Islàndia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Irlanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Illa de Man"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Israel"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Itàlia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japó"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Corea del Sud"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr "kosovo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Letònia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Lituània"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxemburg"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Macedònia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Mèxic"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Països Baixos"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Nova Zelanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Noruega"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Perú"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Filipines"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Polònia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portugal"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Romania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Rússia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Sèrbia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapur"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Eslovàquia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Eslovènia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Sudàfrica"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Suècia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Suïssa"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Turquia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ucraïna"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Regne Unit"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "Estats Units d'Amèrica"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Territori de la capital d'Austràlia"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "Nova gal·les del sud"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Territori del nord"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Austràlia del sud"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmània"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Victòria"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Austràlia de l'oest"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "Columbia britànica"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "New Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Newfoundland and Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Territoris del nord-oest"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nova Escòcia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Illa del príncep Eduard"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Quebec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Württemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Bayern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlín"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandenburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Bremen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hamburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hessen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Niedersachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklenburg-Vorpommern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Nordrhein-Westfalen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Rheinland-Pfalz"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Saarland"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Sachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Sachsen-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Thüringen"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andalusia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragó"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Astúries"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Canàries"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Cantàbria"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Castella i Lleó"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Castella-La Manxa"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Catalunya"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Extremadura"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galícia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Illes Balears"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "La Rioja"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madrid"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Múrcia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarra"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "País Basc"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "València"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Bay of Plenty"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's Bay"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Northland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Southland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "Costa oest"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Chatham Islands Territory"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Banskobystrický kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Bratislavský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Košický kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Nitriansky kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Prešovský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Trnavský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Trenčiansky kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Žilinský kraj"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Aargau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Innerrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Ausserrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Basel-Landschaft"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Basel-Stadt"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Bern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Friburg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Gènova"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Glarus"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Grisons"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Luzern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "St. Gallen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Solothurn"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Thurgau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Ticino"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zúric"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "Anglaterra"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Irlanda del nord"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Escòcia"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Gal·les"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "Califòrnia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "District of Columbia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Florida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Geòrgia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "Nou Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "New Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "Nou Mèxic"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "Nova York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "Carolina del nord"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "Dakota del nord"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pensilvània"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Illa de Rodes"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "Carolina del sud"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "Dakota del sud"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virgínia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "Virgínia de l'oest"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Mostrar el calendari"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Assigneu dreceres del teclat per a mostrar el calendari."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Nom a mostrar"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Zona horària"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -222,347 +1343,17 @@ msgstr "Format de la data"
 msgid "Set your custom tooltip format here."
 msgstr "Assigneu el vostre format personalitzat aquí."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Mostrar informació sobre la sintaxi per a la data"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr "Marqueu això per saber més sobre la sintaxi dels formats de data."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "País"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Austràlia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Àustria"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Bèlgica"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bòsnia i Herzegovina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Bielorússia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brasil"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Canadà"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Xile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "Xina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Colòmbia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Croàcia"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "República Xeca"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Dinamarca"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estònia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "Espanya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finlàndia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "França"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Alemanya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Grècia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Hongria"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Islàndia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Irlanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Illa de Man"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Israel"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Itàlia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japó"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Corea del Sud"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr "kosovo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Letònia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Lituània"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxemburg"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Macedònia"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Mèxic"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Països Baixos"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Nova Zelanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Noruega"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Perú"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Filipines"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Polònia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portugal"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Romania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Rússia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Sèrbia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapur"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Eslovàquia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Eslovènia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Sudàfrica"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Suècia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Suïssa"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Turquia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ucraïna"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Regne Unit"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "Estats Units d'Amèrica"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Territori de la capital d'Austràlia"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "Nova gal·les del sud"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Territori del nord"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Austràlia del sud"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmània"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Victòria"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Austràlia de l'oest"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -577,793 +1368,3 @@ msgstr "Regió"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Regió"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "Columbia britànica"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "New Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Newfoundland and Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Territoris del nord-oest"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nova Escòcia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Illa del príncep Eduard"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Quebec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Württemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Bayern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlín"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandenburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Bremen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hamburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hessen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Niedersachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklenburg-Vorpommern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Nordrhein-Westfalen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Rheinland-Pfalz"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Saarland"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Sachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Sachsen-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Thüringen"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andalusia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragó"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Astúries"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Canàries"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Cantàbria"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Castella i Lleó"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Castella-La Manxa"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Catalunya"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Extremadura"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galícia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Illes Balears"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "La Rioja"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madrid"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Múrcia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarra"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "País Basc"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "València"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Bay of Plenty"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's Bay"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Northland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Southland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "Costa oest"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Chatham Islands Territory"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Banskobystrický kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Bratislavský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Košický kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Nitriansky kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Prešovský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Trnavský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Trenčiansky kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Žilinský kraj"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Aargau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Innerrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Ausserrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Basel-Landschaft"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Basel-Stadt"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Bern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Friburg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Gènova"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Glarus"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Grisons"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Luzern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "St. Gallen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Solothurn"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Thurgau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Ticino"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zúric"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "Anglaterra"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Irlanda del nord"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Escòcia"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Gal·les"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "Califòrnia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "District of Columbia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Florida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Geòrgia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "Nou Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "New Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "Nou Mèxic"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "Nova York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "Carolina del nord"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "Dakota del nord"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pensilvània"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Illa de Rodes"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "Carolina del sud"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "Dakota del sud"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virgínia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "Virgínia de l'oest"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Mostrar el calendari"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Assigneu dreceres del teclat per a mostrar el calendari."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Nom a mostrar"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Zona horària"

--- a/calendar@ccprog/files/calendar@ccprog/po/ca.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/ca.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog 1.2.2\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2024-07-08 17:20+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -19,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
@@ -47,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] "En %d hora"
 msgstr[1] "En %d hores"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "No hi ha events"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "En procés"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Tot el dia"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Avui"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Configuració de data i hora"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Afegir una nova entrada"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Editar entrada"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -90,20 +99,11 @@ msgstr "Editar entrada"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Regió"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Ciutat"
 
@@ -117,1217 +117,1253 @@ msgstr ""
 "Miniaplicació de calendari amb informació de dies festius proveïda pel "
 "servei Enrico"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendari"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Rellotge mundial"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Visualitzar"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Obtenir els dies festius per a"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Dreceres del teclat"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Mostrar el rellotge mundial"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Mostrar esdeveniments del calendari"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Marqueu això per a mostrar esdeveniments al calendari."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Mostrar el número de les setmanes al calendari"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Marqueu això per a mostrar el número de la setmana al calendari."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Marcar com a dies de cap de setmana"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Assigneu quants dies de la setmana es consideren no feiners."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Un dia"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Dos dies"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Utilitzar un format personalitzat de data"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
+#. 3.8->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Marqueu això per a definir un format personalitzat per la data de la "
 "miniaplicació del calendari."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Format de la data"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Assigneu el vostre format personalitzat aquí."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Format de la data"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Assigneu el vostre format personalitzat aquí."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Mostrar informació sobre la sintaxi per a la data"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr "Marqueu això per saber més sobre la sintaxi dels formats de data."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "País"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Austràlia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Àustria"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Bèlgica"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bòsnia i Herzegovina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Bielorússia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brasil"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Canadà"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Xile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "Xina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Colòmbia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Croàcia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "República Xeca"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Dinamarca"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estònia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "Espanya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finlàndia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "França"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Alemanya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Grècia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Hongria"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Islàndia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Irlanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Illa de Man"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Israel"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Itàlia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japó"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Corea del Sud"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr "kosovo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Letònia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Lituània"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Macedònia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Mèxic"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Països Baixos"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Nova Zelanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Noruega"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Perú"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Filipines"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Polònia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portugal"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Romania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Rússia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Sèrbia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapur"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Eslovàquia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Eslovènia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Sudàfrica"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Suècia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Suïssa"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Turquia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ucraïna"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Regne Unit"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Estats Units d'Amèrica"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Territori de la capital d'Austràlia"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "Nova gal·les del sud"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Territori del nord"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Austràlia del sud"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmània"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Victòria"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Austràlia de l'oest"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Regió"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Regió"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "Columbia britànica"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "New Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Newfoundland and Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Territoris del nord-oest"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nova Escòcia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Illa del príncep Eduard"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Quebec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Bayern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlín"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandenburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Bremen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hamburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hessen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Niedersachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklenburg-Vorpommern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Nordrhein-Westfalen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Rheinland-Pfalz"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Saarland"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Sachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Sachsen-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Thüringen"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andalusia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragó"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Astúries"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Canàries"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Cantàbria"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Castella i Lleó"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Castella-La Manxa"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Catalunya"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Extremadura"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galícia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Illes Balears"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "La Rioja"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madrid"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Múrcia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarra"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "País Basc"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "València"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Bay of Plenty"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's Bay"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Northland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Southland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "Costa oest"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Chatham Islands Territory"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Banskobystrický kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Bratislavský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Košický kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Nitriansky kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Prešovský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Trnavský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Trenčiansky kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Žilinský kraj"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Aargau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Innerrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Ausserrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Basel-Landschaft"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Basel-Stadt"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Bern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Friburg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Gènova"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Glarus"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Grisons"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Luzern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "St. Gallen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Solothurn"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Thurgau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Ticino"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zúric"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "Anglaterra"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Irlanda del nord"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Escòcia"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Gal·les"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "Califòrnia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Florida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Geòrgia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "Nou Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "Nou Mèxic"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "Nova York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "Carolina del nord"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "Dakota del nord"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pensilvània"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Illa de Rodes"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "Carolina del sud"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "Dakota del sud"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virgínia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "Virgínia de l'oest"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Mostrar el calendari"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Assigneu dreceres del teclat per a mostrar el calendari."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Nom a mostrar"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Zona horària"

--- a/calendar@ccprog/files/calendar@ccprog/po/calendar@ccprog.pot
+++ b/calendar@ccprog/files/calendar@ccprog/po/calendar@ccprog.pot
@@ -1,13 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# This file is put in the public domain.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: calendar@ccprog 1.2.2\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
@@ -45,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr ""
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr ""
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr ""
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr ""
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr ""
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr ""
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr ""
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -88,20 +99,11 @@ msgstr ""
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr ""
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr ""
 
@@ -113,1214 +115,1247 @@ msgstr ""
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr ""
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr ""
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr ""
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr ""
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr ""
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr ""
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr ""
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr ""
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr ""
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr ""
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr ""
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr ""
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr ""
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr ""
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
-msgid "Check this to define a custom format for the date in the calendar applet."
+#. 3.8->settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr ""
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr ""
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+msgid "Date format for tooltip"
+msgstr ""
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+msgid "Set your custom tooltip format here."
+msgstr ""
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr ""
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr ""
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Flemish Region"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Walloon Region"
+msgstr ""
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr ""
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr ""
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr ""
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr ""
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr ""

--- a/calendar@ccprog/files/calendar@ccprog/po/calendar@ccprog.pot
+++ b/calendar@ccprog/files/calendar@ccprog/po/calendar@ccprog.pot
@@ -1,85 +1,94 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# CALENDAR WITH PUBLIC HOLIDAYS
+# This file is put in the public domain.
+# ccprog, 2020
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: calendar@ccprog 1.3.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr ""
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr ""
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr ""
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr ""
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr ""
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr ""
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr ""
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr ""
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr ""
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr ""
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr ""
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +99,11 @@ msgstr ""
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr ""
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr ""
 
@@ -115,97 +115,1217 @@ msgstr ""
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr ""
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr ""
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr ""
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr ""
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr ""
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr ""
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr ""
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr ""
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr ""
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr ""
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr ""
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr ""
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr ""
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr ""
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr ""
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
+msgstr ""
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr ""
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr ""
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr ""
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr ""
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr ""
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
 msgstr ""
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
@@ -216,93 +1336,8 @@ msgstr ""
 msgid "Set your custom tooltip format here."
 msgstr ""
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr ""
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr ""
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
@@ -310,252 +1345,7 @@ msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
 msgstr ""
 
 #. 5.2->settings-schema.json->region_bel->options
@@ -568,794 +1358,4 @@ msgstr ""
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Walloon Region"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr ""
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr ""
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr ""
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr ""
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
 msgstr ""

--- a/calendar@ccprog/files/calendar@ccprog/po/da.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/da.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2022-10-26 17:45+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr "%A den %-e. %B %Y"
 
@@ -46,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] "Om %d time"
 msgstr[1] "Om %d timer"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Ingen begivenheder"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "I gang"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Hele dagen"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "I dag"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%-e. %B %Y"
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Indstillinger for dato og tid"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Tilføj ny indgang"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Redigér indgang"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -89,20 +99,11 @@ msgstr "Redigér indgang"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Region"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "By"
 
@@ -114,1214 +115,1253 @@ msgstr "Kalender med offentlige helligdage"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Kalender med offentlige helligdage leveret af Enrico"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Kalender"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Verdensure"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Fremvisning"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Hent offentlige helligdage for"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Tastaturgenveje"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Vis verdenstid"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Vis kalenderbegivenheder"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Aktivér denne for at få vist begivenheder i kalenderen."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Vis ugenumre i kalenderen"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Aktivér denne for at vise ugenumre i kalenderen."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Antal weekenddage"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Angiv hvor mange dage pr. uge som ikke er arbejdsdage."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "En dag"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "To dage"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Anvend et brugerdefineret datoformat"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
-msgid "Check this to define a custom format for the date in the calendar applet."
-msgstr "Aktivér denne for at angive et brugerdefineret format for datoen i kalenderpanelprogrammet."
+#. 3.8->settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+"Aktivér denne for at angive et brugerdefineret format for datoen i "
+"kalenderpanelprogrammet."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Datoformat"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Indstil dit brugerdefineret format her."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Datoformat"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Indstil dit brugerdefineret format her."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Vis information om syntaks for datoformat"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr "Tryk på denne knap for at lære mere om syntaksen for datoformater."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Land"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Australien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Østrig"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Belgien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosnien og Herzegovina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Belarus"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brasilien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Canada"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Chile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "Kina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Colombia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Kroatien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "Tjekkiet"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Danmark"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "Spanien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "Frankrig"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Tyskland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Grækenland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Ungarn"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Island"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Irland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Man"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Israel"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Italien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japan"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Sydkorea"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Letland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Litauen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxembourg"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Nordmakedonien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Mexico"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Nederlandene"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "New Zealand"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Norge"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Peru"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Filippinerne"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Polen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portugal"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Rumænien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Russiske føderation"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Serbien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapore"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Slovakiet"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Slovenien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Sydafrika"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Sverige"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Schweiz"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Tyrkiet"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukraine"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Storbritannien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "USA"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Australian Capital Territory"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "New South Wales"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Northern Territory"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "South Australia"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmanien"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Victoria"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Western Australia"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Region"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Region"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "Britisk Columbia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "New Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Newfoundland og Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Northwest Territories"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nova Scotia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Prince Edward Island"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Quebec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Bayern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlin"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandenburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Bremen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hamburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hessen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Niedersachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklenburg-Vorpommern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Nordrhein-Westfalen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Rheinland-Pfalz"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Saarland"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Sachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Sachsen-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Slesvig-holsten"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Thüringen"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andalucien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragón"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Asturias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Kanarieøerne"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Cantabrien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Castilla y León"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Castilla-La Mancha"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Catalonien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Extremadura"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galicien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Balearerne"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "La Rioja"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madrid"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Murcia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarra"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "País Vasco"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "Valencia"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Bay of Plenty"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's Bay"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Northland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Southland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "West Coast"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Chatham Islands Territory"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Banská Bystrica-regionen"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Bratislava-regionen"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Košický-regionen"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Nitra-regionen"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Prešov-regionen"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Trnava-regionen"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Trenčín-regionen"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Žilina-regionen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Aargau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Innerrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Ausserrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Basel-Landschaft"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Basel-Stadt"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Bern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Fribourg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Geneva"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Glarus"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Grisons"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Luzern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "St. Gallen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Solothurn"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Thurgau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Ticino"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zürich"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "England"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Nordirland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Skotland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Wales"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "Californien"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Florida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Georgia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "New Mexico"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "New York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "North Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "North Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "South Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "South Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Vis kalender"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Indstil tastegenveje til visning af kalenderen."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Vist navn"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Tidszone"

--- a/calendar@ccprog/files/calendar@ccprog/po/da.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/da.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR WITH PUBLIC HOLIDAYS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# ccprog, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2022-10-26 17:45+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,68 +19,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr "%A den %-e. %B %Y"
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Starter om få minutter"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Starter om %d minutter"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "I aften"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Starter senere i dag"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "Om %d time"
 msgstr[1] "Om %d timer"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Ingen begivenheder"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "I gang"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Hele dagen"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "I dag"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%-e. %B %Y"
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Indstillinger for dato og tid"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Tilføj ny indgang"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Redigér indgang"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +100,11 @@ msgstr "Redigér indgang"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Region"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "By"
 
@@ -115,100 +116,1220 @@ msgstr "Kalender med offentlige helligdage"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Kalender med offentlige helligdage leveret af Enrico"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Kalender"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Verdensure"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Fremvisning"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Hent offentlige helligdage for"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Tastaturgenveje"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Vis verdenstid"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Vis kalenderbegivenheder"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Aktivér denne for at få vist begivenheder i kalenderen."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Vis ugenumre i kalenderen"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Aktivér denne for at vise ugenumre i kalenderen."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Antal weekenddage"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Angiv hvor mange dage pr. uge som ikke er arbejdsdage."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "En dag"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "To dage"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Anvend et brugerdefineret datoformat"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Aktivér denne for at angive et brugerdefineret format for datoen i "
 "kalenderpanelprogrammet."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Datoformat"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Indstil dit brugerdefineret format her."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Vis information om syntaks for datoformat"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr "Tryk på denne knap for at lære mere om syntaksen for datoformater."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Land"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Australien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Østrig"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Belgien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosnien og Herzegovina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Belarus"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brasilien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Canada"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Chile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "Kina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Colombia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Kroatien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "Tjekkiet"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Danmark"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "Spanien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "Frankrig"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Tyskland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Grækenland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Ungarn"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Island"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Irland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Man"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Israel"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Italien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japan"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Sydkorea"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Letland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Litauen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxembourg"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Nordmakedonien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Mexico"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Nederlandene"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "New Zealand"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Norge"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Peru"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Filippinerne"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Polen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portugal"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Rumænien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Russiske føderation"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Serbien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapore"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Slovakiet"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Slovenien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Sydafrika"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Sverige"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Schweiz"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Tyrkiet"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ukraine"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Storbritannien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "USA"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Australian Capital Territory"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "New South Wales"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Northern Territory"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "South Australia"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmanien"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Victoria"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Western Australia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "Britisk Columbia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "New Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Newfoundland og Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Northwest Territories"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nova Scotia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Prince Edward Island"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Quebec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Württemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Bayern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlin"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandenburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Bremen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hamburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hessen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Niedersachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklenburg-Vorpommern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Nordrhein-Westfalen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Rheinland-Pfalz"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Saarland"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Sachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Sachsen-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Slesvig-holsten"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Thüringen"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andalucien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragón"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Asturias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Kanarieøerne"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Cantabrien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Castilla y León"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Castilla-La Mancha"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Catalonien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Extremadura"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galicien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Balearerne"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "La Rioja"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madrid"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Murcia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarra"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "País Vasco"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "Valencia"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Bay of Plenty"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's Bay"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Northland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Southland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "West Coast"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Chatham Islands Territory"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Banská Bystrica-regionen"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Bratislava-regionen"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Košický-regionen"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Nitra-regionen"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Prešov-regionen"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Trnava-regionen"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Trenčín-regionen"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Žilina-regionen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Aargau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Innerrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Ausserrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Basel-Landschaft"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Basel-Stadt"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Bern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Fribourg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Geneva"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Glarus"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Grisons"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Luzern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "St. Gallen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Solothurn"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Thurgau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Ticino"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zürich"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "England"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Nordirland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Skotland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Wales"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "Californien"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "District of Columbia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Florida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Georgia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "New Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "New Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "New Mexico"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "New York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "North Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "North Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pennsylvania"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rhode Island"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "South Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "South Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "West Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Vis kalender"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Indstil tastegenveje til visning af kalenderen."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Vist navn"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Tidszone"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -220,347 +1341,17 @@ msgstr "Datoformat"
 msgid "Set your custom tooltip format here."
 msgstr "Indstil dit brugerdefineret format her."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Vis information om syntaks for datoformat"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr "Tryk på denne knap for at lære mere om syntaksen for datoformater."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Land"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Australien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Østrig"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Belgien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosnien og Herzegovina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Belarus"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brasilien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Canada"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Chile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "Kina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Colombia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Kroatien"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "Tjekkiet"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Danmark"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "Spanien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "Frankrig"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Tyskland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Grækenland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Ungarn"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Island"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Irland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Man"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Israel"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Italien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japan"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Sydkorea"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Letland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Litauen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxembourg"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Nordmakedonien"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Mexico"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Nederlandene"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "New Zealand"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Norge"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Peru"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Filippinerne"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Polen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portugal"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Rumænien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Russiske føderation"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Serbien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapore"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Slovakiet"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Slovenien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Sydafrika"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Sverige"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Schweiz"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Tyrkiet"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ukraine"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Storbritannien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "USA"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Australian Capital Territory"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "New South Wales"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Northern Territory"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "South Australia"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmanien"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Victoria"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Western Australia"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -575,793 +1366,3 @@ msgstr "Region"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Region"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "Britisk Columbia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "New Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Newfoundland og Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Northwest Territories"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nova Scotia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Prince Edward Island"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Quebec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Württemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Bayern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlin"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandenburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Bremen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hamburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hessen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Niedersachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklenburg-Vorpommern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Nordrhein-Westfalen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Rheinland-Pfalz"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Saarland"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Sachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Sachsen-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Slesvig-holsten"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Thüringen"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andalucien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragón"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Asturias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Kanarieøerne"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Cantabrien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Castilla y León"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Castilla-La Mancha"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Catalonien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Extremadura"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galicien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Balearerne"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "La Rioja"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madrid"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Murcia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarra"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "País Vasco"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "Valencia"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Bay of Plenty"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's Bay"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Northland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Southland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "West Coast"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Chatham Islands Territory"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Banská Bystrica-regionen"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Bratislava-regionen"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Košický-regionen"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Nitra-regionen"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Prešov-regionen"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Trnava-regionen"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Trenčín-regionen"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Žilina-regionen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Aargau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Innerrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Ausserrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Basel-Landschaft"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Basel-Stadt"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Bern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Fribourg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Geneva"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Glarus"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Grisons"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Luzern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "St. Gallen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Solothurn"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Thurgau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Ticino"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zürich"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "England"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Nordirland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Skotland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Wales"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "Californien"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "District of Columbia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Florida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Georgia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "New Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "New Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "New Mexico"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "New York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "North Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "North Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pennsylvania"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rhode Island"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "South Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "South Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "West Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Vis kalender"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Indstil tastegenveje til visning af kalenderen."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Vist navn"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Tidszone"

--- a/calendar@ccprog/files/calendar@ccprog/po/de.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/de.po
@@ -2,8 +2,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog VERSION\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2024-11-20 18:59+0100\n"
 "Last-Translator: Claus Colloseus <ccprog@gmx.de>\n"
 "Language-Team: German\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
@@ -42,40 +42,50 @@ msgid_plural "In %d hours"
 msgstr[0] "In %d Stunde"
 msgstr[1] "In %d Stunden"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Keine Termine"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Zur Zeit"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Ganztägig"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Heute"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Datums- und Zeiteinstellungen"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Neuen Eintrag hinzufügen"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Eintrag bearbeiten"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -85,20 +95,11 @@ msgstr "Eintrag bearbeiten"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Region"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Stadt"
 
@@ -110,1214 +111,1253 @@ msgstr "Kalender mit Feiertagen"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Kalender-Applet mit Feiertagsinformationen vom Enrico Webservice"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Kalender"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Weltzeituhren"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Darstellung"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Nutze Feiertage für"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Tastenkombinationen"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Zeige Weltzeiten"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Kalendereinträge anzeigen"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Aktivieren, um Termine im Kalender anzuzeigen."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Wochennummern im Kalender anzeigen"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Aktivieren, um Wochennummern im Kalender anzuzeigen."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Markiere als Wochenende"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
-msgstr "Einstellen, wie viele Tage pro Woche als arbeitsfreie Tage markiert werden sollen."
+msgstr ""
+"Einstellen, wie viele Tage pro Woche als arbeitsfreie Tage markiert werden "
+"sollen."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Ein Tag"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Zwei Tage"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Ein benutzerdefiniertes Datumsformat verwenden"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
-msgid "Check this to define a custom format for the date in the calendar applet."
-msgstr "Aktivieren, um ein individuelles Datumsformat für die Kalenderanwendung festzulegen."
+#. 3.8->settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+"Aktivieren, um ein individuelles Datumsformat für die Kalenderanwendung "
+"festzulegen."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Datumsformat"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Hier können Sie Ihr eigenes Datumsformat festlegen."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+msgid "Date format for tooltip"
+msgstr "Datumsformat für Tooltip"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+msgid "Set your custom tooltip format here."
+msgstr "Hier können Sie Ihr eigenes Datumsformat für den Tooltip festlegen."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Angaben zum Datumsformat anzeigen"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
-msgstr "Auf diesen Knopf klicken, um mehr über die Schreibweise von Datumsformaten zu erfahren."
+msgstr ""
+"Auf diesen Knopf klicken, um mehr über die Schreibweise von Datumsformaten "
+"zu erfahren."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Staat"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Australien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Österreich"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Belgien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosnien und Herzogowina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Weißrussland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brasilien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Kanada"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Chile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "China"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Kolumbien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Kroatien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr "Zypern"
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "Tschechische Republik"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Dänemark"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr "El Salvador"
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "Spanien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finnland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "Frankreich"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Deutschland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Griechenland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hongkong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Ungarn"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Island"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Irland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Isle of Man"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Israel"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Italien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japan"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Südkorea"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr "Kosovo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Lettland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Litauen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Nordmazedonien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr "Montenegro"
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Mexiko"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Niederlande"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Neuseeland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Norwegen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Peru"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Philippinen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Polen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portugal"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Rumänien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Russische Föderation"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Serbien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapur"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Slowakei"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Slowenien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Südafrika"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Schweden"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Schweiz"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Türkei"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukraine"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Vereinigtes Königreich"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Vereinigte Staaten von Amerika"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Australisches Hauptstadt-Territorium"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "Neu-Süd-Wales"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Nördliches Territorium"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Südaustralien"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmanien"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Victoria"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Westaustralien"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr "Brüssel"
+
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Flemish Region"
+msgstr "Region Flandern"
+
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Walloon Region"
+msgstr "Region Wallonie"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "British Columbia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "New Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Neufundland und Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Nordwest-Territorien"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nova Scotia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Prinz-Edward-Insel"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Québec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Bayern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlin"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandenburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Bremen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hamburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hessen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Niedersachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklenburg-Vorpommern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Nordrhein-Westfalen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Rheinland-Pfalz"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Saarland"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Sachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Sachsen-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Thüringen"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andalusien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragonien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Asturien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Kanarische Inseln"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Kantabrien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Kastilien und León"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Kastilien-La Mancha"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Katalonien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Extremadura"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galizien"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Balearische Inseln"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "La Rioja"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madrid"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Murcia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarra"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "Baskenland"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "Valencia"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Bay of Plenty"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's Bay"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Northland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Southland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "West Coast"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Chatham Islands Territory"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Neusohler Kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Bratislavaer Kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Kaschauer Kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Neutraer Kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Eperieser Kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Tyrnauer Kreis"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Trentschiner Kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Silleiner Kraj"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Kanton Aargau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Kanton Appenzell Innerrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Kanton Appenzell Ausserrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Kanton Basel-Landschaft"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Kanton Basel-Stadt"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Kanton Bern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Kanton Freiburg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Kanton Genf"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Kanton Glarus"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Kanton Graubünden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Kanton Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Kanton Luzern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Kanton Neuenburg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Kanton Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Kanton Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "Kanton St. Gallen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Kanton Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Kanton Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Kanton Solothurn"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Kanton Thurgau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Kanton Tessin"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Kanton Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Kanton Wallis"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Kanton Waadt"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Kanton Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Kanton Zürich"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "England"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Nordirland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Schottland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Wales"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "Kalifornien"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Florida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Georgia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "New Mexico"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "New York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "North Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "North Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "South Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "South Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Kalender anzeigen"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Tastenkombination(en) festlegen, um den Kalender anzuzeigen."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Anzeigename"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Zeitzone"

--- a/calendar@ccprog/files/calendar@ccprog/po/de.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/de.po
@@ -2,8 +2,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2024-11-20 18:59+0100\n"
 "Last-Translator: Claus Colloseus <ccprog@gmx.de>\n"
 "Language-Team: German\n"
@@ -14,68 +15,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Beginnt in wenigen Minuten"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Wird in %d Minuten gestartet"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Heute Abend"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Beginnt heute später"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "In %d Stunde"
 msgstr[1] "In %d Stunden"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Keine Termine"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Zur Zeit"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Ganztägig"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Heute"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Datums- und Zeiteinstellungen"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Neuen Eintrag hinzufügen"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Eintrag bearbeiten"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -86,20 +96,11 @@ msgstr "Eintrag bearbeiten"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Region"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Stadt"
 
@@ -111,102 +112,1224 @@ msgstr "Kalender mit Feiertagen"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Kalender-Applet mit Feiertagsinformationen vom Enrico Webservice"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Kalender"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Weltzeituhren"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Darstellung"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Nutze Feiertage für"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Tastenkombinationen"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Zeige Weltzeiten"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Kalendereinträge anzeigen"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Aktivieren, um Termine im Kalender anzuzeigen."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Wochennummern im Kalender anzeigen"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Aktivieren, um Wochennummern im Kalender anzuzeigen."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Markiere als Wochenende"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 "Einstellen, wie viele Tage pro Woche als arbeitsfreie Tage markiert werden "
 "sollen."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Ein Tag"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Zwei Tage"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Ein benutzerdefiniertes Datumsformat verwenden"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Aktivieren, um ein individuelles Datumsformat für die Kalenderanwendung "
 "festzulegen."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Datumsformat"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Hier können Sie Ihr eigenes Datumsformat festlegen."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Angaben zum Datumsformat anzeigen"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"Auf diesen Knopf klicken, um mehr über die Schreibweise von Datumsformaten "
+"zu erfahren."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Staat"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Australien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Österreich"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Belgien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosnien und Herzogowina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Weißrussland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brasilien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Kanada"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Chile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "China"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Kolumbien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Kroatien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "Tschechische Republik"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Dänemark"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "Spanien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finnland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "Frankreich"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Deutschland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Griechenland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hongkong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Ungarn"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Island"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Irland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Isle of Man"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Israel"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Italien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japan"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Südkorea"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr "Kosovo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Lettland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Litauen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxemburg"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Nordmazedonien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Mexiko"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Niederlande"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Neuseeland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Norwegen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Peru"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Philippinen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Polen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portugal"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Rumänien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Russische Föderation"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Serbien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapur"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Slowakei"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Slowenien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Südafrika"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Schweden"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Schweiz"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Türkei"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ukraine"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Vereinigtes Königreich"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "Vereinigte Staaten von Amerika"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Australisches Hauptstadt-Territorium"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "Neu-Süd-Wales"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Nördliches Territorium"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Südaustralien"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmanien"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Victoria"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Westaustralien"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "British Columbia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "New Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Neufundland und Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Nordwest-Territorien"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nova Scotia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Prinz-Edward-Insel"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Québec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Württemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Bayern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlin"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandenburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Bremen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hamburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hessen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Niedersachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklenburg-Vorpommern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Nordrhein-Westfalen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Rheinland-Pfalz"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Saarland"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Sachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Sachsen-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Thüringen"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andalusien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragonien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Asturien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Kanarische Inseln"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Kantabrien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Kastilien und León"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Kastilien-La Mancha"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Katalonien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Extremadura"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galizien"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Balearische Inseln"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "La Rioja"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madrid"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Murcia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarra"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "Baskenland"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "Valencia"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Bay of Plenty"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's Bay"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Northland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Southland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "West Coast"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Chatham Islands Territory"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Neusohler Kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Bratislavaer Kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Kaschauer Kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Neutraer Kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Eperieser Kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Tyrnauer Kreis"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Trentschiner Kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Silleiner Kraj"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Kanton Aargau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Kanton Appenzell Innerrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Kanton Appenzell Ausserrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Kanton Basel-Landschaft"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Kanton Basel-Stadt"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Kanton Bern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Kanton Freiburg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Kanton Genf"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Kanton Glarus"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Kanton Graubünden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Kanton Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Kanton Luzern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Kanton Neuenburg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Kanton Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Kanton Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "Kanton St. Gallen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Kanton Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Kanton Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Kanton Solothurn"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Kanton Thurgau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Kanton Tessin"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Kanton Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Kanton Wallis"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Kanton Waadt"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Kanton Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Kanton Zürich"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "England"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Nordirland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Schottland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Wales"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "Kalifornien"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "District of Columbia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Florida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Georgia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "New Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "New Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "New Mexico"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "New York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "North Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "North Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pennsylvania"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rhode Island"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "South Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "South Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "West Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Kalender anzeigen"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Tastenkombination(en) festlegen, um den Kalender anzuzeigen."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Anzeigename"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Zeitzone"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 msgid "Date format for tooltip"
@@ -216,349 +1339,17 @@ msgstr "Datumsformat für Tooltip"
 msgid "Set your custom tooltip format here."
 msgstr "Hier können Sie Ihr eigenes Datumsformat für den Tooltip festlegen."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Angaben zum Datumsformat anzeigen"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-"Auf diesen Knopf klicken, um mehr über die Schreibweise von Datumsformaten "
-"zu erfahren."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Staat"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Australien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Österreich"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Belgien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosnien und Herzogowina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Weißrussland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brasilien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Kanada"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Chile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "China"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Kolumbien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Kroatien"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr "Zypern"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "Tschechische Republik"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Dänemark"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr "El Salvador"
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "Spanien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finnland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "Frankreich"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Deutschland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Griechenland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hongkong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Ungarn"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Island"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Irland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Isle of Man"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Israel"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Italien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japan"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Südkorea"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr "Kosovo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Lettland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Litauen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxemburg"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Nordmazedonien"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr "Montenegro"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Mexiko"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Niederlande"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Neuseeland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Norwegen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Peru"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Philippinen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Polen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portugal"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Rumänien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Russische Föderation"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Serbien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapur"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Slowakei"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Slowenien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Südafrika"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Schweden"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Schweiz"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Türkei"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ukraine"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Vereinigtes Königreich"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "Vereinigte Staaten von Amerika"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Australisches Hauptstadt-Territorium"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "Neu-Süd-Wales"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Nördliches Territorium"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Südaustralien"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmanien"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Victoria"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Westaustralien"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -571,793 +1362,3 @@ msgstr "Region Flandern"
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Walloon Region"
 msgstr "Region Wallonie"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "British Columbia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "New Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Neufundland und Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Nordwest-Territorien"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nova Scotia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Prinz-Edward-Insel"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Québec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Württemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Bayern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlin"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandenburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Bremen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hamburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hessen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Niedersachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklenburg-Vorpommern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Nordrhein-Westfalen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Rheinland-Pfalz"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Saarland"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Sachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Sachsen-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Thüringen"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andalusien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragonien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Asturien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Kanarische Inseln"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Kantabrien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Kastilien und León"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Kastilien-La Mancha"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Katalonien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Extremadura"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galizien"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Balearische Inseln"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "La Rioja"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madrid"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Murcia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarra"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "Baskenland"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "Valencia"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Bay of Plenty"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's Bay"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Northland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Southland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "West Coast"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Chatham Islands Territory"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Neusohler Kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Bratislavaer Kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Kaschauer Kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Neutraer Kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Eperieser Kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Tyrnauer Kreis"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Trentschiner Kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Silleiner Kraj"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Kanton Aargau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Kanton Appenzell Innerrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Kanton Appenzell Ausserrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Kanton Basel-Landschaft"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Kanton Basel-Stadt"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Kanton Bern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Kanton Freiburg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Kanton Genf"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Kanton Glarus"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Kanton Graubünden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Kanton Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Kanton Luzern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Kanton Neuenburg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Kanton Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Kanton Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "Kanton St. Gallen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Kanton Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Kanton Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Kanton Solothurn"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Kanton Thurgau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Kanton Tessin"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Kanton Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Kanton Wallis"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Kanton Waadt"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Kanton Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Kanton Zürich"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "England"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Nordirland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Schottland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Wales"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "Kalifornien"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "District of Columbia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Florida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Georgia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "New Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "New Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "New Mexico"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "New York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "North Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "North Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pennsylvania"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rhode Island"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "South Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "South Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "West Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Kalender anzeigen"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Tastenkombination(en) festlegen, um den Kalender anzuzeigen."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Anzeigename"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Zeitzone"

--- a/calendar@ccprog/files/calendar@ccprog/po/es.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/es.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2024-02-05 21:27-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
@@ -47,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] "En %d hora"
 msgstr[1] "En %d horas"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "No hay eventos"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "En curso"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Todo el día"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Hoy"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Configuración de Fecha y Hora"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Añadir nueva entrada"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Editar entrada"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -90,20 +99,11 @@ msgstr "Editar entrada"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Región"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Ciudad"
 
@@ -116,1220 +116,1256 @@ msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr ""
 "Applet de calendario con días festivos proporcionados por Enrico Sevice"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendario"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Reloj Mundial"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Visualizar"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Obtener días festivos para"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Atajos de teclado"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Mostrar Reloj Mundial"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Mostrar eventos del calendario"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Marque esto para mostrar los eventos del calendario."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Mostrar números de la semana en el calendario"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr ""
 "Marque esta opción para mostrar los números de la semana en el calendario."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Marcar como días de fin de semana"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Establezca cuántos días se marcan como días no laborables por semana."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Un día"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Dos días"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Utilizar un formato de fecha personalizado"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
+#. 3.8->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Marque esta opción para definir un formato personalizado para la fecha en el "
 "applet de calendario."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Formato de la fecha"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Configure su formato personalizado aquí."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Formato de la fecha"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Configure su formato personalizado aquí."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Mostrar información sobre la sintaxis del formato de fecha"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr ""
 "Haga clic en este botón para saber más sobre la sintaxis de los formatos de "
 "fecha."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "País"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Australia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Austria"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Bélgica"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosnia y Herzegovina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Bielorrusia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brasil"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Canadá"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Chile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "China"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Colombia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Croacia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "República Checa"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Dinamarca"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estonia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "España"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finlandia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "Francia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Alemania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Grecia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Hungría"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Islandia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Irlanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Isla de Man"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Israel"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Italia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japón"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Corea del Sur"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr "kosovo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Letonia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Lituania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Macedonia del Norte"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "México"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Países Bajos"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Nueva Zelanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Noruega"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Perú"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Filipinas"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Polonia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portugal"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Rumania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Rusia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Serbia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapore"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Eslovaquia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Eslovenia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Sudáfrica"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Suecia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Suiza"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Turquía"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ucrania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Reino Unido"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Estados Unidos"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Territorio de la Capital Australiana"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "Nueva Gales del Sur"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Territorio del Norte"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Australia Meridional"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmania"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Victoria"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Australia Occidental"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Región"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Región"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "Columbia Británica"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "Nuevo Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Terranova y Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Territorios del Noroeste"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nueva Escocia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Isla del Príncipe Eduardo"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Quebec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Territorio del Yucón"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Wurtemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Baviera"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlín"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandemburgo"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Bremen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hamburgo"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hesse"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Baja Sajonia"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklemburgo-Pomerania Occidental"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Renania del Norte-Westfalia"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Renania-Palatinado"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Sarre"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Sajonia"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Sajonia-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Turingia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andalucía"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragón"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Asturias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Canarias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Cantabria"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Castilla y León"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Castilla-La Mancha"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Cataluña"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Extremadura"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galicia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Islas Baleares"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "Islas Baleares"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madrid"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Murcia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarra"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "País Vasco"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "Valencia"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Región de Bay of Plenty"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's Bay"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Región de Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Northland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Southland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "West Coast"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Islas Chatham"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Región de Banská Bystrica"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Región de Bratislava"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Región de Košice"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Región de Nitra"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Región de Prešov"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Región de Trnava"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Región de Trenčín"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Región de Žilina"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Cantón de Argovia"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Rodas Interiores"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Rodas Exteriores"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Cantón de Basilea-Campiña"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Cantón de Basilea-Ciudad"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Berna"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Friburgo"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Ginebra"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Cantón de Glaris"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Cantón de los Grisones"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Cantón del Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Lucerna"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Cantón de Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Cantón de Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "San Galo"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Cantón de Soleura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Cantón de Turgovia"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Cantón del Tesino"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Cantón de Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Cantón del Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Cantón de Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zúrich"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "Inglaterra"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Irlanda del Norte"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Escocia"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Gales"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "California"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "Washington D. C"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Florida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Georgia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "Nuevo Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "Nueva Jersey​"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "Nuevo México"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "Nueva York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "Carolina del Norte"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "Dakota del Norte"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "Carolina del Sur"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "Dakota del Sur"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "Virginia Occidental"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Mostrar calendario"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Configurar las combinaciones de teclas para mostrar el calendario."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Nombre a mostrar"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Zona horaria"

--- a/calendar@ccprog/files/calendar@ccprog/po/es.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/es.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR WITH PUBLIC HOLIDAYS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# ccprog, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2024-02-05 21:27-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,68 +19,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Comenzará en unos minutos"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Comenzará en %d minutos"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Esta noche"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Comenzará hoy más tarde"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "En %d hora"
 msgstr[1] "En %d horas"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "No hay eventos"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "En curso"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Todo el día"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Hoy"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Configuración de Fecha y Hora"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Añadir nueva entrada"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Editar entrada"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +100,11 @@ msgstr "Editar entrada"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Región"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Ciudad"
 
@@ -116,101 +117,1223 @@ msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr ""
 "Applet de calendario con días festivos proporcionados por Enrico Sevice"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendario"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Reloj Mundial"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Visualizar"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Obtener días festivos para"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Atajos de teclado"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Mostrar Reloj Mundial"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Mostrar eventos del calendario"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Marque esto para mostrar los eventos del calendario."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Mostrar números de la semana en el calendario"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr ""
 "Marque esta opción para mostrar los números de la semana en el calendario."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Marcar como días de fin de semana"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Establezca cuántos días se marcan como días no laborables por semana."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Un día"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Dos días"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Utilizar un formato de fecha personalizado"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Marque esta opción para definir un formato personalizado para la fecha en el "
 "applet de calendario."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Formato de la fecha"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Configure su formato personalizado aquí."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Mostrar información sobre la sintaxis del formato de fecha"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"Haga clic en este botón para saber más sobre la sintaxis de los formatos de "
+"fecha."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "País"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Australia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Austria"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Bélgica"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosnia y Herzegovina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Bielorrusia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brasil"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Canadá"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Chile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "China"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Colombia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Croacia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "República Checa"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Dinamarca"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estonia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "España"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finlandia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "Francia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Alemania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Grecia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Hungría"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Islandia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Irlanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Isla de Man"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Israel"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Italia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japón"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Corea del Sur"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr "kosovo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Letonia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Lituania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxemburgo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Macedonia del Norte"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "México"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Países Bajos"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Nueva Zelanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Noruega"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Perú"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Filipinas"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Polonia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portugal"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Rumania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Rusia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Serbia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapore"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Eslovaquia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Eslovenia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Sudáfrica"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Suecia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Suiza"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Turquía"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ucrania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Reino Unido"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "Estados Unidos"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Territorio de la Capital Australiana"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "Nueva Gales del Sur"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Territorio del Norte"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Australia Meridional"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmania"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Victoria"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Australia Occidental"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "Columbia Británica"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "Nuevo Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Terranova y Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Territorios del Noroeste"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nueva Escocia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Isla del Príncipe Eduardo"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Quebec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Territorio del Yucón"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Wurtemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Baviera"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlín"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandemburgo"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Bremen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hamburgo"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hesse"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Baja Sajonia"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklemburgo-Pomerania Occidental"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Renania del Norte-Westfalia"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Renania-Palatinado"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Sarre"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Sajonia"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Sajonia-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Turingia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andalucía"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragón"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Asturias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Canarias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Cantabria"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Castilla y León"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Castilla-La Mancha"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Cataluña"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Extremadura"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galicia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Islas Baleares"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "Islas Baleares"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madrid"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Murcia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarra"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "País Vasco"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "Valencia"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Región de Bay of Plenty"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's Bay"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Región de Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Northland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Southland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "West Coast"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Islas Chatham"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Región de Banská Bystrica"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Región de Bratislava"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Región de Košice"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Región de Nitra"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Región de Prešov"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Región de Trnava"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Región de Trenčín"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Región de Žilina"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Cantón de Argovia"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Rodas Interiores"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Rodas Exteriores"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Cantón de Basilea-Campiña"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Cantón de Basilea-Ciudad"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Berna"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Friburgo"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Ginebra"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Cantón de Glaris"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Cantón de los Grisones"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Cantón del Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Lucerna"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Cantón de Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Cantón de Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "San Galo"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Cantón de Soleura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Cantón de Turgovia"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Cantón del Tesino"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Cantón de Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Cantón del Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Cantón de Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zúrich"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "Inglaterra"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Irlanda del Norte"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Escocia"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Gales"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "California"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "Washington D. C"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Florida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Georgia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "Nuevo Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "Nueva Jersey​"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "Nuevo México"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "Nueva York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "Carolina del Norte"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "Dakota del Norte"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pennsylvania"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rhode Island"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "Carolina del Sur"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "Dakota del Sur"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "Virginia Occidental"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Mostrar calendario"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Configurar las combinaciones de teclas para mostrar el calendario."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Nombre a mostrar"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Zona horaria"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -222,349 +1345,17 @@ msgstr "Formato de la fecha"
 msgid "Set your custom tooltip format here."
 msgstr "Configure su formato personalizado aquí."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Mostrar información sobre la sintaxis del formato de fecha"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-"Haga clic en este botón para saber más sobre la sintaxis de los formatos de "
-"fecha."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "País"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Australia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Austria"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Bélgica"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosnia y Herzegovina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Bielorrusia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brasil"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Canadá"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Chile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "China"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Colombia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Croacia"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "República Checa"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Dinamarca"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estonia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "España"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finlandia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "Francia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Alemania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Grecia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Hungría"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Islandia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Irlanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Isla de Man"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Israel"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Italia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japón"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Corea del Sur"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr "kosovo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Letonia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Lituania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxemburgo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Macedonia del Norte"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "México"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Países Bajos"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Nueva Zelanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Noruega"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Perú"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Filipinas"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Polonia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portugal"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Rumania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Rusia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Serbia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapore"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Eslovaquia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Eslovenia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Sudáfrica"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Suecia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Suiza"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Turquía"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ucrania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Reino Unido"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "Estados Unidos"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Territorio de la Capital Australiana"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "Nueva Gales del Sur"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Territorio del Norte"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Australia Meridional"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmania"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Victoria"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Australia Occidental"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -579,793 +1370,3 @@ msgstr "Región"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Región"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "Columbia Británica"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "Nuevo Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Terranova y Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Territorios del Noroeste"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nueva Escocia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Isla del Príncipe Eduardo"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Quebec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Territorio del Yucón"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Wurtemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Baviera"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlín"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandemburgo"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Bremen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hamburgo"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hesse"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Baja Sajonia"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklemburgo-Pomerania Occidental"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Renania del Norte-Westfalia"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Renania-Palatinado"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Sarre"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Sajonia"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Sajonia-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Turingia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andalucía"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragón"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Asturias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Canarias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Cantabria"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Castilla y León"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Castilla-La Mancha"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Cataluña"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Extremadura"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galicia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Islas Baleares"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "Islas Baleares"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madrid"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Murcia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarra"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "País Vasco"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "Valencia"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Región de Bay of Plenty"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's Bay"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Región de Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Northland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Southland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "West Coast"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Islas Chatham"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Región de Banská Bystrica"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Región de Bratislava"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Región de Košice"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Región de Nitra"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Región de Prešov"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Región de Trnava"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Región de Trenčín"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Región de Žilina"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Cantón de Argovia"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Rodas Interiores"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Rodas Exteriores"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Cantón de Basilea-Campiña"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Cantón de Basilea-Ciudad"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Berna"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Friburgo"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Ginebra"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Cantón de Glaris"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Cantón de los Grisones"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Cantón del Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Lucerna"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Cantón de Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Cantón de Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "San Galo"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Cantón de Soleura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Cantón de Turgovia"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Cantón del Tesino"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Cantón de Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Cantón del Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Cantón de Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zúrich"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "Inglaterra"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Irlanda del Norte"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Escocia"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Gales"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "California"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "Washington D. C"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Florida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Georgia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "Nuevo Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "Nueva Jersey​"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "Nuevo México"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "Nueva York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "Carolina del Norte"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "Dakota del Norte"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pennsylvania"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rhode Island"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "Carolina del Sur"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "Dakota del Sur"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "Virginia Occidental"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Mostrar calendario"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Configurar las combinaciones de teclas para mostrar el calendario."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Nombre a mostrar"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Zona horaria"

--- a/calendar@ccprog/files/calendar@ccprog/po/fi.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/fi.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2022-12-01 12:55+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
@@ -46,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] "%d tunti"
 msgstr[1] "%d tuntia"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Ei tapahtumia"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Meneillään"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Koko päivä"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Tänään"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Päivän ja ajan asetukset"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Lisää uusi kohde"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Muokkaa merkintää"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -89,20 +99,11 @@ msgstr "Muokkaa merkintää"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Maa"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Kaupunki"
 
@@ -114,1214 +115,1253 @@ msgstr "Kalenteri yleisillä merkkipäivillä"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Kalenterisovelma, jossa on Enrico-palvelun toimittamat merkkipäivät"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Kalenteri"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Maailmankellot"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Näyttö"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Hanki yleiset merkkipäivät"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Pikanäppäimet"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Näytä maailman aikoja"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Näytä kalenteritapahtumat"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Valitse näyttääksesi tapahtumat kalenterissa."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Näytä viikkonumerot kalenterissa"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Valitse näyttääksesi viikkonumerot kalenterissa."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Merkitse viikonloppuksi"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Aseta, kuinka monta päivää on viikonlopussa."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Yksi päivä"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Kaksi päivää"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Käytä mukautettua päiväyksen muotoa"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
-msgid "Check this to define a custom format for the date in the calendar applet."
-msgstr "Valitse jos haluat määrittää mukautetun muodon päivämäärälle kalenterissa."
+#. 3.8->settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+"Valitse jos haluat määrittää mukautetun muodon päivämäärälle kalenterissa."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Päiväyksen muoto"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Aseta mukautettu muoto tässä."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Päiväyksen muoto"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Aseta mukautettu muoto tässä."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Näytä tietoa päivämäärän muodon syntaksista"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
-msgstr "Napsauta painiketta saadaksesi lisätietoja päivämäärämuotojen syntaksista."
+msgstr ""
+"Napsauta painiketta saadaksesi lisätietoja päivämäärämuotojen syntaksista."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Maa"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Australia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Austria"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Belgium"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosnia and Herzegovina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Belarus"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brazil"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Canada"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Chile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "China"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Colombia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Croatia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "Czech Republic"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Denmark"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estonia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "Spain"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "France"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Germany"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Greece"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Hungary"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Iceland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Ireland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Isle of Man"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Israel"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Italy"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japan"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Korea (South)"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Latvia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Lithuania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxembourg"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Macedonia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Mexico"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Netherlands"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "New Zealand"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Norway"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Peru"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Philippines"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Poland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portugal"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Romania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Russian Federation"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Serbia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapore"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Slovakia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Slovenia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "South Africa"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Sweden"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Switzerland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Turkey"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukraine"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "United Kingdom"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "United States of America"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Australian Capital Territory"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "New South Wales"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Northern Territory"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "South Australia"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmania"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Victoria"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Western Australia"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Maa"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Maa"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "British Columbia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "New Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Newfoundland and Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Northwest Territories"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nova Scotia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Prince Edward Island"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Quebec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Bayern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlin"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandenburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Bremen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hamburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hessen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Niedersachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklenburg-Vorpommern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Nordrhein-Westfalen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Rheinland-Pfalz"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Saarland"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Sachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Sachsen-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Thüringen"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andalucía"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragón"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Asturias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Canarias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Cantabria"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Castilla y León"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Castilla-La Mancha"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Cataluña"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Extremadura"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galicia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Islas Baleares"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "La Rioja"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madrid"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Murcia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarra"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "País Vasco"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "Valencia"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Bay of Plenty"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's Bay"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Northland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Southland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "West Coast"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Chatham Islands Territory"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Banskobystrický kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Bratislavský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Košický kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Nitriansky kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Prešovský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Trnavský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Trenčiansky kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Žilinský kraj"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Aargau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Innerrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Ausserrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Basel-Landschaft"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Basel-Stadt"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Bern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Fribourg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Geneva"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Glarus"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Grisons"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Luzern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "St. Gallen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Solothurn"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Thurgau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Ticino"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zürich"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "England"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Northern Ireland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Scotland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Wales"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "California"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Florida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Georgia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "New Mexico"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "New York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "North Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "North Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "South Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "South Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Näytä kalenteri"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Aseta pikanäppäin näyttämään kalenteri."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Näyttönimi"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Aikavyöhyke"

--- a/calendar@ccprog/files/calendar@ccprog/po/fi.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/fi.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR WITH PUBLIC HOLIDAYS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# ccprog, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2022-12-01 12:55+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,68 +19,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Alkaa muutamassa minuutissa"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Alkaa %d minuutin kuluttua"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Tänä iltana"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Alkaa tänään myöhemmin"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "%d tunti"
 msgstr[1] "%d tuntia"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Ei tapahtumia"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Meneillään"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Koko päivä"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Tänään"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Päivän ja ajan asetukset"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Lisää uusi kohde"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Muokkaa merkintää"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +100,11 @@ msgstr "Muokkaa merkintää"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Maa"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Kaupunki"
 
@@ -115,99 +116,1220 @@ msgstr "Kalenteri yleisillä merkkipäivillä"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Kalenterisovelma, jossa on Enrico-palvelun toimittamat merkkipäivät"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Kalenteri"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Maailmankellot"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Näyttö"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Hanki yleiset merkkipäivät"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Pikanäppäimet"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Näytä maailman aikoja"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Näytä kalenteritapahtumat"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Valitse näyttääksesi tapahtumat kalenterissa."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Näytä viikkonumerot kalenterissa"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Valitse näyttääksesi viikkonumerot kalenterissa."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Merkitse viikonloppuksi"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Aseta, kuinka monta päivää on viikonlopussa."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Yksi päivä"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Kaksi päivää"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Käytä mukautettua päiväyksen muotoa"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Valitse jos haluat määrittää mukautetun muodon päivämäärälle kalenterissa."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Päiväyksen muoto"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Aseta mukautettu muoto tässä."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Näytä tietoa päivämäärän muodon syntaksista"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"Napsauta painiketta saadaksesi lisätietoja päivämäärämuotojen syntaksista."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Maa"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Australia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Austria"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Belgium"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosnia and Herzegovina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Belarus"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brazil"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Canada"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Chile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "China"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Colombia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Croatia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "Czech Republic"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Denmark"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estonia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "Spain"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "France"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Germany"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Greece"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Hungary"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Iceland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Ireland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Isle of Man"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Israel"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Italy"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japan"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Korea (South)"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Latvia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Lithuania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxembourg"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Macedonia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Mexico"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Netherlands"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "New Zealand"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Norway"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Peru"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Philippines"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Poland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portugal"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Romania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Russian Federation"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Serbia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapore"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Slovakia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Slovenia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "South Africa"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Sweden"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Switzerland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Turkey"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ukraine"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "United Kingdom"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "United States of America"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Australian Capital Territory"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "New South Wales"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Northern Territory"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "South Australia"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmania"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Victoria"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Western Australia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "British Columbia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "New Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Newfoundland and Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Northwest Territories"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nova Scotia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Prince Edward Island"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Quebec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Württemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Bayern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlin"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandenburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Bremen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hamburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hessen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Niedersachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklenburg-Vorpommern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Nordrhein-Westfalen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Rheinland-Pfalz"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Saarland"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Sachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Sachsen-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Thüringen"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andalucía"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragón"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Asturias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Canarias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Cantabria"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Castilla y León"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Castilla-La Mancha"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Cataluña"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Extremadura"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galicia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Islas Baleares"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "La Rioja"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madrid"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Murcia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarra"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "País Vasco"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "Valencia"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Bay of Plenty"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's Bay"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Northland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Southland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "West Coast"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Chatham Islands Territory"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Banskobystrický kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Bratislavský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Košický kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Nitriansky kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Prešovský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Trnavský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Trenčiansky kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Žilinský kraj"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Aargau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Innerrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Ausserrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Basel-Landschaft"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Basel-Stadt"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Bern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Fribourg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Geneva"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Glarus"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Grisons"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Luzern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "St. Gallen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Solothurn"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Thurgau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Ticino"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zürich"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "England"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Northern Ireland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Scotland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Wales"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "California"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "District of Columbia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Florida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Georgia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "New Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "New Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "New Mexico"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "New York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "North Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "North Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pennsylvania"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rhode Island"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "South Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "South Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "West Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Näytä kalenteri"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Aseta pikanäppäin näyttämään kalenteri."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Näyttönimi"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Aikavyöhyke"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -219,348 +1341,17 @@ msgstr "Päiväyksen muoto"
 msgid "Set your custom tooltip format here."
 msgstr "Aseta mukautettu muoto tässä."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Näytä tietoa päivämäärän muodon syntaksista"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-"Napsauta painiketta saadaksesi lisätietoja päivämäärämuotojen syntaksista."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Maa"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Australia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Austria"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Belgium"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosnia and Herzegovina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Belarus"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brazil"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Canada"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Chile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "China"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Colombia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Croatia"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "Czech Republic"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Denmark"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estonia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "Spain"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "France"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Germany"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Greece"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Hungary"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Iceland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Ireland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Isle of Man"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Israel"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Italy"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japan"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Korea (South)"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Latvia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Lithuania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxembourg"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Macedonia"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Mexico"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Netherlands"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "New Zealand"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Norway"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Peru"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Philippines"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Poland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portugal"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Romania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Russian Federation"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Serbia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapore"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Slovakia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Slovenia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "South Africa"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Sweden"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Switzerland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Turkey"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ukraine"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "United Kingdom"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "United States of America"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Australian Capital Territory"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "New South Wales"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Northern Territory"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "South Australia"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmania"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Victoria"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Western Australia"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -575,793 +1366,3 @@ msgstr "Maa"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Maa"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "British Columbia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "New Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Newfoundland and Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Northwest Territories"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nova Scotia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Prince Edward Island"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Quebec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Württemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Bayern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlin"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandenburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Bremen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hamburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hessen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Niedersachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklenburg-Vorpommern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Nordrhein-Westfalen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Rheinland-Pfalz"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Saarland"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Sachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Sachsen-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Thüringen"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andalucía"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragón"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Asturias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Canarias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Cantabria"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Castilla y León"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Castilla-La Mancha"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Cataluña"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Extremadura"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galicia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Islas Baleares"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "La Rioja"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madrid"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Murcia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarra"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "País Vasco"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "Valencia"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Bay of Plenty"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's Bay"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Northland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Southland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "West Coast"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Chatham Islands Territory"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Banskobystrický kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Bratislavský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Košický kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Nitriansky kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Prešovský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Trnavský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Trenčiansky kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Žilinský kraj"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Aargau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Innerrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Ausserrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Basel-Landschaft"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Basel-Stadt"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Bern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Fribourg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Geneva"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Glarus"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Grisons"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Luzern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "St. Gallen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Solothurn"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Thurgau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Ticino"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zürich"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "England"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Northern Ireland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Scotland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Wales"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "California"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "District of Columbia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Florida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Georgia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "New Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "New Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "New Mexico"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "New York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "North Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "North Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pennsylvania"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rhode Island"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "South Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "South Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "West Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Näytä kalenteri"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Aseta pikanäppäin näyttämään kalenteri."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Näyttönimi"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Aikavyöhyke"

--- a/calendar@ccprog/files/calendar@ccprog/po/fr.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/fr.po
@@ -2,9 +2,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog 1.1.6\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -15,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr "%A %-e %B %Y"
 
@@ -43,40 +42,50 @@ msgid_plural "In %d hours"
 msgstr[0] "Dans %d heure"
 msgstr[1] "Dans %d heures"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Aucun évènement"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "En cours"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Journée entière"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Aujourd'hui"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%-e %B %Y"
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Paramètres date et heure"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Ajouter une nouvelle entrée"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Modifier l'entrée sélectionnée"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -86,20 +95,11 @@ msgstr "Modifier l'entrée sélectionnée"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Région"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Ville"
 
@@ -113,1220 +113,1256 @@ msgstr ""
 "Applet de calendrier avec données de jours fériés fournies par le service "
 "Enrico"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendrier"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Horloges mondiales"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Affichage"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Obtenez les jours fériés pour"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Afficher les heures mondiales"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Afficher les évènements de calendrier"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Activez cette option pour afficher les évênements dans le calendrier."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Afficher les numéros de semaine dans le calendrier"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr ""
 "Cochez cette case pour afficher les numéros de semaine dans le calendrier."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Nombre de jour formant un weekend"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 "Définit le nombre de jours marqués comme jours non ouvrables par semaine."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Un jour"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Deux jours"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Utiliser un format de date personnalisé"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
+#. 3.8->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Cochez cette case pour définir votre propre format de date dans la barre des "
 "tâches."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Format de date"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Spécifiez votre format ici."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Format de date"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Spécifiez votre format ici."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Afficher des indications sur la syntaxe du format de date"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr ""
 "Cliquez sur ce bouton pour en savoir plus sur la syntaxe des formats de date."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Pays"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Australie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Autriche"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Belgique"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosnie-Herzégovine"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Biélorussie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brésil"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Canada"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Chili"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "Chine"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Colombie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Croatie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "République Tchèque"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Danemark"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estonie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "Espagne"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finlande"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "France"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Allemagne"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Grèce"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Hongrie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Islande"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Irlande"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Île de Man"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Israël"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Italie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japon"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Corée du Sud"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr "Kosovo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Lettonie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Lituanie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxembourg"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Macédoine"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Mexique"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Pays-Bas"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Nouvelle-Zélande"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Norvège"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Pérou"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Philippines"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Pologne"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portugal"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Roumanie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Fédération de Russie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Serbie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapour"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Slovaquie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Slovénie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Afrique du Sud"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Suède"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Suisse"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Turquie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukraine"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Royaume-Uni"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "États-Unis d'Amérique"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Territoire de la capitale australienne"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "Nouvelle-Galles du Sud"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Territoire du Nord"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Australie-Méridionale"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmanie"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Victoria"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Australie-Occidentale"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Région"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Région"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "Colombie-Britannique"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "Nouveau-Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Terre-Neuve-et-Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Territoires du Nord-Ouest"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nouvelle-Écosse"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Île-du-Prince-Édouard"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Québec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Bade-Wurtemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Bavière"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlin"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandebourg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Brême"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hambourg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hesse"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Basse-Saxe"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklembourg-Poméranie-Occidentale"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Rhénanie-du-Nord-Westphalie"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Rhénanie-Palatinat"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Sarre"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Saxe"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Saxe-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Thuringe"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andalousie"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragon"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Asturies"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Îles Canaries"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Cantabrie"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Castille-et-León"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Castille-La Manche"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Catalogne"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Estrémadure"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galice"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Îles Baléares"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "La Rioja"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madrid"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Murcie"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarre"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "Pays Basque"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "Valence"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Baie de l'Abondance"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's Bay"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Northland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Southland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "West Coast"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Îles Chatham"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Région de Banská Bystrica"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Région de Bratislava"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Région de Košice"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Région de Nitra"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Région de Prešov"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Région de Trnava"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Région de Trenčín"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Région de Žilina"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Argovie"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Rhodes-Intérieures"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Rhodes-Extérieures"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Bâle-Campagne"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Bâle-Ville"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Berne"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Fribourg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Genève"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Glaris"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Grisons"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Lucerne"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Nidwald"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Obwald"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "Saint-Gall"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhouse"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwytz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Soleure"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Thurgovie"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Tessin"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zoug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zurich"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "Angleterre"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Irlande du Nord"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Écosse"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Pays de Galles"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "Californie"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "District de Columbia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Floride"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Géorgie"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiane"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "Nouveau-Mexique"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "État de New York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "Caroline du Nord"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "Dakota du Nord"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pennsylvanie"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "Caroline du Sud"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "Dakota du Sud"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virginie"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "Virginie-Occidentale"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Afficher l'agenda"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Définir les raccourcis clavier pour afficher l'agenda."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Nom affiché"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Fuseau horaire"

--- a/calendar@ccprog/files/calendar@ccprog/po/fr.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/fr.po
@@ -2,8 +2,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog 1.1.6\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -14,68 +15,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr "%A %-e %B %Y"
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Commence dans quelques minutes"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Commence dans %d minutes"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Cet après-midi"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Commence plus tard aujourd'hui"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "Dans %d heure"
 msgstr[1] "Dans %d heures"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Aucun évènement"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "En cours"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Journée entière"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Aujourd'hui"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%-e %B %Y"
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Paramètres date et heure"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Ajouter une nouvelle entrée"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Modifier l'entrée sélectionnée"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -86,20 +96,11 @@ msgstr "Modifier l'entrée sélectionnée"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Région"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Ville"
 
@@ -113,102 +114,1223 @@ msgstr ""
 "Applet de calendrier avec données de jours fériés fournies par le service "
 "Enrico"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendrier"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Horloges mondiales"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Affichage"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Obtenez les jours fériés pour"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Afficher les heures mondiales"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Afficher les évènements de calendrier"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Activez cette option pour afficher les évênements dans le calendrier."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Afficher les numéros de semaine dans le calendrier"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr ""
 "Cochez cette case pour afficher les numéros de semaine dans le calendrier."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Nombre de jour formant un weekend"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 "Définit le nombre de jours marqués comme jours non ouvrables par semaine."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Un jour"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Deux jours"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Utiliser un format de date personnalisé"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Cochez cette case pour définir votre propre format de date dans la barre des "
 "tâches."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Format de date"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Spécifiez votre format ici."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Afficher des indications sur la syntaxe du format de date"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"Cliquez sur ce bouton pour en savoir plus sur la syntaxe des formats de date."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Pays"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Australie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Autriche"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Belgique"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosnie-Herzégovine"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Biélorussie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brésil"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Canada"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Chili"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "Chine"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Colombie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Croatie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "République Tchèque"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Danemark"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estonie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "Espagne"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finlande"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "France"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Allemagne"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Grèce"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Hongrie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Islande"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Irlande"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Île de Man"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Israël"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Italie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japon"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Corée du Sud"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr "Kosovo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Lettonie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Lituanie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxembourg"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Macédoine"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Mexique"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Pays-Bas"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Nouvelle-Zélande"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Norvège"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Pérou"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Philippines"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Pologne"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portugal"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Roumanie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Fédération de Russie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Serbie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapour"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Slovaquie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Slovénie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Afrique du Sud"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Suède"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Suisse"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Turquie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ukraine"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Royaume-Uni"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "États-Unis d'Amérique"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Territoire de la capitale australienne"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "Nouvelle-Galles du Sud"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Territoire du Nord"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Australie-Méridionale"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmanie"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Victoria"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Australie-Occidentale"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "Colombie-Britannique"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "Nouveau-Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Terre-Neuve-et-Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Territoires du Nord-Ouest"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nouvelle-Écosse"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Île-du-Prince-Édouard"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Québec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Bade-Wurtemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Bavière"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlin"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandebourg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Brême"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hambourg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hesse"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Basse-Saxe"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklembourg-Poméranie-Occidentale"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Rhénanie-du-Nord-Westphalie"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Rhénanie-Palatinat"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Sarre"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Saxe"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Saxe-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Thuringe"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andalousie"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragon"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Asturies"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Îles Canaries"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Cantabrie"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Castille-et-León"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Castille-La Manche"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Catalogne"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Estrémadure"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galice"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Îles Baléares"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "La Rioja"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madrid"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Murcie"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarre"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "Pays Basque"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "Valence"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Baie de l'Abondance"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's Bay"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Northland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Southland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "West Coast"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Îles Chatham"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Région de Banská Bystrica"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Région de Bratislava"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Région de Košice"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Région de Nitra"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Région de Prešov"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Région de Trnava"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Région de Trenčín"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Région de Žilina"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Argovie"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Rhodes-Intérieures"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Rhodes-Extérieures"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Bâle-Campagne"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Bâle-Ville"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Berne"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Fribourg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Genève"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Glaris"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Grisons"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Lucerne"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Nidwald"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Obwald"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "Saint-Gall"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhouse"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwytz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Soleure"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Thurgovie"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Tessin"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zoug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zurich"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "Angleterre"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Irlande du Nord"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Écosse"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Pays de Galles"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "Californie"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "District de Columbia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Floride"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Géorgie"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiane"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "New Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "New Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "Nouveau-Mexique"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "État de New York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "Caroline du Nord"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "Dakota du Nord"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pennsylvanie"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rhode Island"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "Caroline du Sud"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "Dakota du Sud"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virginie"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "Virginie-Occidentale"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Afficher l'agenda"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Définir les raccourcis clavier pour afficher l'agenda."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Nom affiché"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Fuseau horaire"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -220,348 +1342,17 @@ msgstr "Format de date"
 msgid "Set your custom tooltip format here."
 msgstr "Spécifiez votre format ici."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Afficher des indications sur la syntaxe du format de date"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-"Cliquez sur ce bouton pour en savoir plus sur la syntaxe des formats de date."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Pays"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Australie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Autriche"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Belgique"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosnie-Herzégovine"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Biélorussie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brésil"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Canada"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Chili"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "Chine"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Colombie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Croatie"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "République Tchèque"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Danemark"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estonie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "Espagne"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finlande"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "France"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Allemagne"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Grèce"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Hongrie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Islande"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Irlande"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Île de Man"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Israël"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Italie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japon"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Corée du Sud"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr "Kosovo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Lettonie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Lituanie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxembourg"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Macédoine"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Mexique"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Pays-Bas"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Nouvelle-Zélande"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Norvège"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Pérou"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Philippines"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Pologne"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portugal"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Roumanie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Fédération de Russie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Serbie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapour"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Slovaquie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Slovénie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Afrique du Sud"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Suède"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Suisse"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Turquie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ukraine"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Royaume-Uni"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "États-Unis d'Amérique"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Territoire de la capitale australienne"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "Nouvelle-Galles du Sud"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Territoire du Nord"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Australie-Méridionale"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmanie"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Victoria"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Australie-Occidentale"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -576,793 +1367,3 @@ msgstr "Région"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Région"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "Colombie-Britannique"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "Nouveau-Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Terre-Neuve-et-Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Territoires du Nord-Ouest"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nouvelle-Écosse"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Île-du-Prince-Édouard"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Québec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Bade-Wurtemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Bavière"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlin"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandebourg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Brême"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hambourg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hesse"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Basse-Saxe"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklembourg-Poméranie-Occidentale"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Rhénanie-du-Nord-Westphalie"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Rhénanie-Palatinat"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Sarre"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Saxe"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Saxe-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Thuringe"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andalousie"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragon"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Asturies"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Îles Canaries"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Cantabrie"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Castille-et-León"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Castille-La Manche"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Catalogne"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Estrémadure"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galice"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Îles Baléares"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "La Rioja"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madrid"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Murcie"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarre"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "Pays Basque"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "Valence"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Baie de l'Abondance"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's Bay"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Northland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Southland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "West Coast"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Îles Chatham"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Région de Banská Bystrica"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Région de Bratislava"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Région de Košice"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Région de Nitra"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Région de Prešov"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Région de Trnava"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Région de Trenčín"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Région de Žilina"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Argovie"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Rhodes-Intérieures"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Rhodes-Extérieures"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Bâle-Campagne"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Bâle-Ville"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Berne"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Fribourg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Genève"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Glaris"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Grisons"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Lucerne"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Nidwald"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Obwald"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "Saint-Gall"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhouse"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwytz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Soleure"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Thurgovie"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Tessin"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zoug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zurich"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "Angleterre"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Irlande du Nord"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Écosse"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Pays de Galles"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "Californie"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "District de Columbia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Floride"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Géorgie"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiane"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "New Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "New Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "Nouveau-Mexique"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "État de New York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "Caroline du Nord"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "Dakota du Nord"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pennsylvanie"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rhode Island"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "Caroline du Sud"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "Dakota du Sud"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virginie"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "Virginie-Occidentale"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Afficher l'agenda"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Définir les raccourcis clavier pour afficher l'agenda."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Nom affiché"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Fuseau horaire"

--- a/calendar@ccprog/files/calendar@ccprog/po/hu.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/hu.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2024-02-08 15:05+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -19,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr "%Y. %B %-e., %A"
 
@@ -47,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] "%d órán belül"
 msgstr[1] "%d órán belül"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Nincsenek események"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Folyamatban"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Egész nap"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Ma"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%Y. %B %-e."
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Dátum és idő beállítások"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Új bejegyzés hozzáadása"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Bejegyzés szerkesztése"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -90,20 +99,11 @@ msgstr "Bejegyzés szerkesztése"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Régió"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Város"
 
@@ -117,1218 +117,1254 @@ msgstr ""
 "Naptári kisalkalmazás munkaszüneti adatokkal, az Enrico szolgáltatás által "
 "biztosítva"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Naptár"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Világórák"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Megjelenítés"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Munkaszüneti napok a következőre"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Gyorsbillentyűk"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Időzónák megjelenítése"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Naptáresemények megjelenítése"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Válassza ki ezt az események a naptárban történő megjelenítéséhez."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Hetek számának megjelenítése a naptárban"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Válassza ki ezt a hetek számának megjelenítéséhez a naptárban."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Megjelölés hétvégeként"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 "Állítsa be, hogy egy héten hány nap legyen nem munkanapként megjelölve."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Egy nap"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Két nap"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Egyéni dátumformátum használata"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
+#. 3.8->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Válassza ki ezt a naptár kisalkalmazásban egyéni dátumformátum használatához."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Dátumformátum"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Egyéni dátumformátum megadása itt."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Dátumformátum"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Egyéni dátumformátum megadása itt."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Információk megjelenítése a dátumformátum szintaxisáról"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr ""
 "A dátumformátumok szintaxisáról többet megtudhat, ha erre a gombra kattint."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Ország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Ausztrália"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Ausztria"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Belgium"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosznia és Hercegovina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Fehéroroszország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brazília"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Kanada"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Chile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "Kína"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Kolumbia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Horvátország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "Cseh Köztársaság"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Dánia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Észtország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "Spanyolország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finnország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "Franciaország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Németország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Görögország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Magyarország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Izland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Írország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Man-sziget"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Izrael"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Olaszország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japán"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Dél-Korea"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr "koszovó"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Lettország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Litvánia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxembourg"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Észak-Macedónia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Mexikó"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Hollandia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Új Zéland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Norvégia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Peru"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Fülöp-szigetek"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Lengyelország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portugália"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Románia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Oroszország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Szerbia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Szingapúr"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Szlovákia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Szlovénia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Dél-afrikai Köztársaság"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Svédország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Svájc"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Törökország"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukrajna"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Egyesült Királyság"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Amerikai egyesült államok"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Ausztrál fővárosi terület"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "Új Dél-Wales"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Északi Terület"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Dél-Ausztrália"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmania"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Viktória"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Nyugat-Ausztrália"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Régió"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Régió"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "Brit Kolumbia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "New Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Új-Fundland és Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Északnyugati területek"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Új-Skócia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Prince Edward-sziget"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Quebec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Bajorország"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlin"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandenburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Bréma"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hamburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hessen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Alsó-Szászország"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklenburg-Elő-Pomeránia"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Észak-Rajna-Vesztfália"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Rajna-vidék-Pfalz"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Saar-vidék"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Szászország"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Szász-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Türingia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andalucía"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragón"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Asturias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Canarias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Cantabria"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Castilla y León"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Castilla-La Mancha"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Cataluña"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Extremadura"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galicia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Islas Baleares"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "La Rioja"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madrid"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Murcia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarra"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "País Vasco"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "Valencia"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Plenty-öböl"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's-öböl"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Northland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Southland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "Nyugati part"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Chatham-sziget terület"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Banskobystrický kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Bratislavský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Košický kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Nitriansky kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Prešovský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Trnavský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Trenčiansky kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Žilinský kraj"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Aargau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Innerrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Ausserrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Basel-Landschaft"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Basel-Stadt"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Bern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Fribourg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Genf"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Glarus"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Grisons"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Luzern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "St. Gallen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Solothurn"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Thurgau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Ticino"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zürich"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "Anglia"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Észak-Írország"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Skócia"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Wales"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaszka"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "Kalifornia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Florida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Georgia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "New Mexico"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "New York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "Észak-Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "Észak-Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "Dél-Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "Dél-Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "Nyugat-Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Naptár megjelenítése"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Állítsa be a billentyűkiosztás(oka)t a naptár megjelenítéséhez."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Név megjelenítése"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Időzóna"

--- a/calendar@ccprog/files/calendar@ccprog/po/hu.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/hu.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR WITH PUBLIC HOLIDAYS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# ccprog, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2024-02-08 15:05+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -18,68 +19,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr "%Y. %B %-e., %A"
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Perceken belül elindul"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "%d perc múlva elindul"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Ma reggel"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Mai nap folyamán kezdődik"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "%d órán belül"
 msgstr[1] "%d órán belül"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Nincsenek események"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Folyamatban"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Egész nap"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Ma"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%Y. %B %-e."
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Dátum és idő beállítások"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Új bejegyzés hozzáadása"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Bejegyzés szerkesztése"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +100,11 @@ msgstr "Bejegyzés szerkesztése"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Régió"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Város"
 
@@ -117,100 +118,1221 @@ msgstr ""
 "Naptári kisalkalmazás munkaszüneti adatokkal, az Enrico szolgáltatás által "
 "biztosítva"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Naptár"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Világórák"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Megjelenítés"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Munkaszüneti napok a következőre"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Gyorsbillentyűk"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Időzónák megjelenítése"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Naptáresemények megjelenítése"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Válassza ki ezt az események a naptárban történő megjelenítéséhez."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Hetek számának megjelenítése a naptárban"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Válassza ki ezt a hetek számának megjelenítéséhez a naptárban."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Megjelölés hétvégeként"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 "Állítsa be, hogy egy héten hány nap legyen nem munkanapként megjelölve."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Egy nap"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Két nap"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Egyéni dátumformátum használata"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Válassza ki ezt a naptár kisalkalmazásban egyéni dátumformátum használatához."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Dátumformátum"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Egyéni dátumformátum megadása itt."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Információk megjelenítése a dátumformátum szintaxisáról"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"A dátumformátumok szintaxisáról többet megtudhat, ha erre a gombra kattint."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Ország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Ausztrália"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Ausztria"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Belgium"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosznia és Hercegovina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Fehéroroszország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brazília"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Kanada"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Chile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "Kína"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Kolumbia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Horvátország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "Cseh Köztársaság"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Dánia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Észtország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "Spanyolország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finnország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "Franciaország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Németország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Görögország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Magyarország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Izland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Írország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Man-sziget"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Izrael"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Olaszország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japán"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Dél-Korea"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr "koszovó"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Lettország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Litvánia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxembourg"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Észak-Macedónia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Mexikó"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Hollandia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Új Zéland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Norvégia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Peru"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Fülöp-szigetek"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Lengyelország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portugália"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Románia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Oroszország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Szerbia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Szingapúr"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Szlovákia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Szlovénia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Dél-afrikai Köztársaság"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Svédország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Svájc"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Törökország"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ukrajna"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Egyesült Királyság"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "Amerikai egyesült államok"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Ausztrál fővárosi terület"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "Új Dél-Wales"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Északi Terület"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Dél-Ausztrália"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmania"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Viktória"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Nyugat-Ausztrália"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "Brit Kolumbia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "New Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Új-Fundland és Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Északnyugati területek"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Új-Skócia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Prince Edward-sziget"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Quebec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Württemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Bajorország"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlin"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandenburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Bréma"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hamburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hessen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Alsó-Szászország"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklenburg-Elő-Pomeránia"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Észak-Rajna-Vesztfália"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Rajna-vidék-Pfalz"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Saar-vidék"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Szászország"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Szász-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Türingia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andalucía"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragón"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Asturias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Canarias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Cantabria"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Castilla y León"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Castilla-La Mancha"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Cataluña"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Extremadura"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galicia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Islas Baleares"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "La Rioja"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madrid"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Murcia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarra"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "País Vasco"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "Valencia"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Plenty-öböl"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's-öböl"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Northland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Southland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "Nyugati part"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Chatham-sziget terület"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Banskobystrický kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Bratislavský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Košický kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Nitriansky kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Prešovský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Trnavský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Trenčiansky kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Žilinský kraj"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Aargau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Innerrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Ausserrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Basel-Landschaft"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Basel-Stadt"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Bern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Fribourg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Genf"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Glarus"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Grisons"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Luzern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "St. Gallen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Solothurn"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Thurgau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Ticino"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zürich"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "Anglia"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Észak-Írország"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Skócia"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Wales"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaszka"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "Kalifornia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "District of Columbia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Florida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Georgia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "New Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "New Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "New Mexico"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "New York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "Észak-Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "Észak-Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pennsylvania"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rhode Island"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "Dél-Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "Dél-Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "Nyugat-Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Naptár megjelenítése"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Állítsa be a billentyűkiosztás(oka)t a naptár megjelenítéséhez."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Név megjelenítése"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Időzóna"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -222,348 +1344,17 @@ msgstr "Dátumformátum"
 msgid "Set your custom tooltip format here."
 msgstr "Egyéni dátumformátum megadása itt."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Információk megjelenítése a dátumformátum szintaxisáról"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-"A dátumformátumok szintaxisáról többet megtudhat, ha erre a gombra kattint."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Ország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Ausztrália"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Ausztria"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Belgium"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosznia és Hercegovina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Fehéroroszország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brazília"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Kanada"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Chile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "Kína"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Kolumbia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Horvátország"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "Cseh Köztársaság"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Dánia"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Észtország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "Spanyolország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finnország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "Franciaország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Németország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Görögország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Magyarország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Izland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Írország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Man-sziget"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Izrael"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Olaszország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japán"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Dél-Korea"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr "koszovó"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Lettország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Litvánia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxembourg"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Észak-Macedónia"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Mexikó"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Hollandia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Új Zéland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Norvégia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Peru"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Fülöp-szigetek"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Lengyelország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portugália"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Románia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Oroszország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Szerbia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Szingapúr"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Szlovákia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Szlovénia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Dél-afrikai Köztársaság"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Svédország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Svájc"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Törökország"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ukrajna"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Egyesült Királyság"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "Amerikai egyesült államok"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Ausztrál fővárosi terület"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "Új Dél-Wales"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Északi Terület"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Dél-Ausztrália"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmania"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Viktória"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Nyugat-Ausztrália"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -578,793 +1369,3 @@ msgstr "Régió"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Régió"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "Brit Kolumbia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "New Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Új-Fundland és Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Északnyugati területek"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Új-Skócia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Prince Edward-sziget"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Quebec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Württemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Bajorország"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlin"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandenburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Bréma"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hamburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hessen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Alsó-Szászország"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklenburg-Elő-Pomeránia"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Észak-Rajna-Vesztfália"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Rajna-vidék-Pfalz"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Saar-vidék"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Szászország"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Szász-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Türingia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andalucía"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragón"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Asturias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Canarias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Cantabria"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Castilla y León"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Castilla-La Mancha"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Cataluña"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Extremadura"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galicia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Islas Baleares"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "La Rioja"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madrid"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Murcia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarra"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "País Vasco"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "Valencia"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Plenty-öböl"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's-öböl"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Northland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Southland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "Nyugati part"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Chatham-sziget terület"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Banskobystrický kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Bratislavský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Košický kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Nitriansky kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Prešovský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Trnavský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Trenčiansky kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Žilinský kraj"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Aargau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Innerrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Ausserrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Basel-Landschaft"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Basel-Stadt"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Bern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Fribourg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Genf"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Glarus"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Grisons"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Luzern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "St. Gallen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Solothurn"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Thurgau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Ticino"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zürich"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "Anglia"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Észak-Írország"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Skócia"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Wales"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaszka"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "Kalifornia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "District of Columbia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Florida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Georgia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "New Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "New Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "New Mexico"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "New York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "Észak-Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "Észak-Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pennsylvania"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rhode Island"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "Dél-Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "Dél-Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "Nyugat-Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Naptár megjelenítése"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Állítsa be a billentyűkiosztás(oka)t a naptár megjelenítéséhez."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Név megjelenítése"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Időzóna"

--- a/calendar@ccprog/files/calendar@ccprog/po/it.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/it.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR WITH PUBLIC HOLIDAYS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# ccprog, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2024-06-18 15:18+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,68 +19,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Tra pochi minuti"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Tra %d minuti"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Questa mattina"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "In giornata"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "Tra %d ora"
 msgstr[1] "Tra %d ore"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Nessun evento"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "In corso"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Tutto il giorno"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Oggi"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Impostazioni Data e Ora"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Aggiungi nuova voce"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Modifica voce"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +100,11 @@ msgstr "Modifica voce"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Regione"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Città"
 
@@ -115,102 +116,1224 @@ msgstr "Calendario con Giorni festivi"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Applet Calendario con giorni festivi forniti dal servizio Enrico"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendario"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Orologi del Mondo"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Mostra"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Ottieni Giorni Festivi per"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Scorciatoie da Tastiera"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Mostra i Tempi del Mondo"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Mostra eventi del calendario"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Seleziona questa opzione per visualizzare gli eventi nel calendario."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Mostra numeri della settimana nel calendario"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Seleziona questo per mostrare i numeri delle settimane nel calendario."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Contrassegna come giorni di fine settimana"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 "Imposta quanti giorni sono contrassegnati come giorni non lavorativi alla "
 "settimana."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Un giorno"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Due giorni"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Usa un formato data personalizzato"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Seleziona questa opzione per definire un formato personalizzato per la data "
 "nell'applet del calendario."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Formato data"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Imposta qui il tuo formato personalizzato."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Mostra le informazioni sulla sintassi del formato della data"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"Fare clic su questo pulsante per saperne di più sulla sintassi per i formati "
+"di data."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Paese"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Australia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Austria"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Belgio"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosnia e Erzegovina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Bielorussia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brasile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Canada"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Cile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "Cina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Colombia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Croazia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "Repubblica Ceca"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Danimarca"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estonia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "Spagna"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finlandia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "Francia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Germania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Grecia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Ungheria"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Islanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Irlanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Isola di Man"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Israele"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Italia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Giappone"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Korea (Sud)"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr "kosovo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Lettonia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Lituania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Lussemburgo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Macedonia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Messico"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Olanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Nuova Zelnda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Norvegia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Perù"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Filippine"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Polonia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portogallo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Romania"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Federazione Russa"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Serbia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapore"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Slovacchia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Slovenia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Sud Africa"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Svezia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Svizzera"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Turchia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ucraina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Regno Unito"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "Stati Uniti d'America"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Territorio della Capitale Australiana"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "Nuovo Galles del Sud"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Territori del Nord"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Australia Meridionale"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmania"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Victoria"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Australia Occidentale"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "Columbia Britannica"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "New Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Newfoundland and Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Territori del Nordovest"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nova Scotia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Prince Edward Island"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Quebec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Württemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Bayern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlino"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandeburgo"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Brema"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Amburgo"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hessen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Niedersachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklenburg-Vorpommern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Nordrhein-Westfalen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Rheinland-Pfalz"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Saarland"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Sachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Sachsen-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Thüringen"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andalucía"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragón"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Asturias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Canarias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Cantabria"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Castilla y León"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Castilla-La Mancha"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Cataluña"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Extremadura"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galizia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Islas Baleares"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "La Rioja"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madrid"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Murcia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarra"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "País Vasco"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "Valencia"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Bay of Plenty"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's Bay"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Northland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Southland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "West Coast"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Chatham Islands Territory"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Banskobystrický kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Bratislavský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Košický kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Nitriansky kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Prešovský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Trnavský kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Trenčiansky kraj"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Žilinský kraj"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Aargau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Innerrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Ausserrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Basel-Landschaft"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Basel-Stadt"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Bern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Fribourg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Ginevra"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Glarus"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Grisons"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Luzern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "St. Gallen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Solothurn"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Thurgau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Ticino"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zurigo"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "Inghilterra"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Irlanda del Nord"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Scozia"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Wales"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "California"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "District of Columbia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Florida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Georgia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "New Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "New Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "New Mexico"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "New York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "North Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "North Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pennsylvania"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rhode Island"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "South Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "South Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "West Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Mostra calendario"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Imposta tasto(i) di scelta rapida per mostrare il calendario."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Nome visualizzato"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Fuso Orario"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -222,349 +1345,17 @@ msgstr "Formato data"
 msgid "Set your custom tooltip format here."
 msgstr "Imposta qui il tuo formato personalizzato."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Mostra le informazioni sulla sintassi del formato della data"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-"Fare clic su questo pulsante per saperne di più sulla sintassi per i formati "
-"di data."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Paese"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Australia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Austria"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Belgio"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosnia e Erzegovina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Bielorussia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brasile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Canada"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Cile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "Cina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Colombia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Croazia"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "Repubblica Ceca"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Danimarca"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estonia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "Spagna"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finlandia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "Francia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Germania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Grecia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Ungheria"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Islanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Irlanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Isola di Man"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Israele"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Italia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Giappone"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Korea (Sud)"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr "kosovo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Lettonia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Lituania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Lussemburgo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Macedonia"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Messico"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Olanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Nuova Zelnda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Norvegia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Perù"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Filippine"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Polonia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portogallo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Romania"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Federazione Russa"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Serbia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapore"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Slovacchia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Slovenia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Sud Africa"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Svezia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Svizzera"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Turchia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ucraina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Regno Unito"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "Stati Uniti d'America"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Territorio della Capitale Australiana"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "Nuovo Galles del Sud"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Territori del Nord"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Australia Meridionale"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmania"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Victoria"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Australia Occidentale"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -579,793 +1370,3 @@ msgstr "Regione"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Regione"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "Columbia Britannica"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "New Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Newfoundland and Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Territori del Nordovest"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nova Scotia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Prince Edward Island"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Quebec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Württemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Bayern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlino"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandeburgo"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Brema"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Amburgo"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hessen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Niedersachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklenburg-Vorpommern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Nordrhein-Westfalen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Rheinland-Pfalz"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Saarland"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Sachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Sachsen-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Thüringen"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andalucía"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragón"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Asturias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Canarias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Cantabria"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Castilla y León"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Castilla-La Mancha"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Cataluña"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Extremadura"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galizia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Islas Baleares"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "La Rioja"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madrid"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Murcia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarra"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "País Vasco"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "Valencia"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Bay of Plenty"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's Bay"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Northland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Southland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "West Coast"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Chatham Islands Territory"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Banskobystrický kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Bratislavský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Košický kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Nitriansky kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Prešovský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Trnavský kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Trenčiansky kraj"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Žilinský kraj"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Aargau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Innerrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Ausserrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Basel-Landschaft"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Basel-Stadt"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Bern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Fribourg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Ginevra"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Glarus"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Grisons"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Luzern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "St. Gallen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Solothurn"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Thurgau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Ticino"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zurigo"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "Inghilterra"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Irlanda del Nord"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Scozia"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Wales"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "California"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "District of Columbia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Florida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Georgia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "New Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "New Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "New Mexico"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "New York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "North Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "North Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pennsylvania"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rhode Island"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "South Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "South Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "West Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Mostra calendario"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Imposta tasto(i) di scelta rapida per mostrare il calendario."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Nome visualizzato"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Fuso Orario"

--- a/calendar@ccprog/files/calendar@ccprog/po/it.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/it.po
@@ -6,9 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2024-06-18 15:18+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
@@ -47,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] "Tra %d ora"
 msgstr[1] "Tra %d ore"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Nessun evento"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "In corso"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Tutto il giorno"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Oggi"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Impostazioni Data e Ora"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Aggiungi nuova voce"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Modifica voce"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -90,20 +99,11 @@ msgstr "Modifica voce"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Regione"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Città"
 
@@ -115,1221 +115,1257 @@ msgstr "Calendario con Giorni festivi"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Applet Calendario con giorni festivi forniti dal servizio Enrico"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendario"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Orologi del Mondo"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Mostra"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Ottieni Giorni Festivi per"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Scorciatoie da Tastiera"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Mostra i Tempi del Mondo"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Mostra eventi del calendario"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Seleziona questa opzione per visualizzare gli eventi nel calendario."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Mostra numeri della settimana nel calendario"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Seleziona questo per mostrare i numeri delle settimane nel calendario."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Contrassegna come giorni di fine settimana"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 "Imposta quanti giorni sono contrassegnati come giorni non lavorativi alla "
 "settimana."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Un giorno"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Due giorni"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Usa un formato data personalizzato"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
+#. 3.8->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Seleziona questa opzione per definire un formato personalizzato per la data "
 "nell'applet del calendario."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Formato data"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Imposta qui il tuo formato personalizzato."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Formato data"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Imposta qui il tuo formato personalizzato."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Mostra le informazioni sulla sintassi del formato della data"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr ""
 "Fare clic su questo pulsante per saperne di più sulla sintassi per i formati "
 "di data."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Paese"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Australia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Austria"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Belgio"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosnia e Erzegovina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Bielorussia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brasile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Canada"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Cile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "Cina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Colombia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Croazia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "Repubblica Ceca"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Danimarca"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estonia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "Spagna"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finlandia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "Francia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Germania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Grecia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Ungheria"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Islanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Irlanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Isola di Man"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Israele"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Italia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Giappone"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Korea (Sud)"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr "kosovo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Lettonia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Lituania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Lussemburgo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Macedonia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Messico"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Olanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Nuova Zelnda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Norvegia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Perù"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Filippine"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Polonia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portogallo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Romania"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Federazione Russa"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Serbia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapore"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Slovacchia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Slovenia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Sud Africa"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Svezia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Svizzera"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Turchia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ucraina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Regno Unito"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Stati Uniti d'America"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Territorio della Capitale Australiana"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "Nuovo Galles del Sud"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Territori del Nord"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Australia Meridionale"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmania"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Victoria"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Australia Occidentale"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Regione"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Regione"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "Columbia Britannica"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "New Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Newfoundland and Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Territori del Nordovest"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nova Scotia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Prince Edward Island"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Quebec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Bayern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlino"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandeburgo"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Brema"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Amburgo"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hessen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Niedersachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklenburg-Vorpommern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Nordrhein-Westfalen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Rheinland-Pfalz"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Saarland"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Sachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Sachsen-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Thüringen"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andalucía"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragón"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Asturias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Canarias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Cantabria"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Castilla y León"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Castilla-La Mancha"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Cataluña"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Extremadura"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galizia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Islas Baleares"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "La Rioja"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madrid"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Murcia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarra"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "País Vasco"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "Valencia"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Bay of Plenty"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's Bay"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Northland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Southland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "West Coast"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Chatham Islands Territory"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Banskobystrický kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Bratislavský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Košický kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Nitriansky kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Prešovský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Trnavský kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Trenčiansky kraj"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Žilinský kraj"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Aargau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Innerrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Ausserrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Basel-Landschaft"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Basel-Stadt"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Bern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Fribourg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Ginevra"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Glarus"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Grisons"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Luzern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "St. Gallen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Solothurn"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Thurgau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Ticino"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zurigo"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "Inghilterra"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Irlanda del Nord"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Scozia"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Wales"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "California"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Florida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Georgia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "New Mexico"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "New York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "North Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "North Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "South Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "South Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Mostra calendario"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Imposta tasto(i) di scelta rapida per mostrare il calendario."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Nome visualizzato"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Fuso Orario"

--- a/calendar@ccprog/files/calendar@ccprog/po/nl.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/nl.po
@@ -1,12 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR WITH PUBLIC HOLIDAYS
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# ccprog, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog 1.2.2\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2024-04-22 18:34+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,68 +17,77 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Begint over enkele minuten"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Begint over %d minuten"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Vanavond"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Start later vandaag"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "Over %d uur"
 msgstr[1] "Over %d uren"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Geen evenementen"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Bezig"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Hele dag"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Vandaag"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Instellingen voor datum en tijd"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Nieuwe invoer toevoegen"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Invoer bewerken"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -88,20 +98,11 @@ msgstr "Invoer bewerken"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Regio"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Stad"
 
@@ -115,100 +116,1221 @@ msgstr ""
 "Kalender applet met gegevens over openbare feestdagen verstrekt door de "
 "Enrico-service"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Kalender"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Wereldklokken"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Weergave"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Openbare feestdagen krijgen voor"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Sneltoetsen"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Wereldtijden tonen"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Kalenderevenementen weergeven"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Vink dit aan om evenementen in de kalender weer te geven."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Weeknummers tonen in kalender"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Vink dit aan om weeknummers in de kalender weer te geven."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Aanduiden als weekenddagen"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Stel in hoeveel dagen per week als niet-werkdagen worden aangemerkt."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Eén dag"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Twee dagen"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Gebruik een aangepast datumformaat"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Vink dit aan om een aangepast formaat voor de datum in de kalender-applet te "
 "definiëren."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Datumformaat"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Stel hier uw aangepaste formaat in."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Informatie over de syntaxis van het datumformaat tonen"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"Klik op deze knop voor meer informatie over de syntaxis van datumformaten."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Land"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Australië"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Oostenrijk"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "België"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosnië en Herzegovina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Wit-Rusland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brazilië"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Canada"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Chili"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "China"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Colombia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Kroatië"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "Tsjechië"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Denemarken"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "Spanje"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "Frankrijk"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Duitsland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Griekenland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Hongarije"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "IJsland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Ierland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Isle of Man"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Israël"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Italië"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japan"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Korea (Zuid)"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr "Kosovo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Letland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Litouwen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxemburg"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Macedonië"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Mexico"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Nederland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Nieuw-Zeeland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Noorwegen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Peru"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Filippijnen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Polen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portugal"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Roemenië"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Russische Federatie"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Servië"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapore"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Slowakije"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Slovenië"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Zuid-Afrika"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Zweden"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Zwitserland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Turkije"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Oekraïne"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Verenigd Koninkrijk"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "Verenigde Staten van Amerika"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Australisch Hoofdstedelijk Territorium"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "New South Wales"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Noordelijk Territorium"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Zuid-Australië"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmanië"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Victoria"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "West-Australië"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "Brits-Columbia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "New Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Newfoundland en Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Northwest Territories"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nova Scotia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Prins Edwardeiland"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Québec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Württemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Beieren"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlijn"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandenburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Bremen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hamburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hessen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Nedersaksen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklenburg-Voor-Pommeren"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Noordrijn-Westfalen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Rijnland-Palts"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Saarland"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Saksen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Saksen-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Thüringen"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andalusië"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragón"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Asturië"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Canarische Eilanden"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Cantabrië"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Castilla y León"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Castilla-La Mancha"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Catalonië"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Extremadura"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galicië"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Balearen"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "La Rioja"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madrid"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Murcia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarra"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "Baskenland"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "Valencia"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Bay of Plenty"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's Bay"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Noordland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Zuidland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "West Coast"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Chatham Islands Territory"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Banská Bystrica"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Bratislava"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Košice"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Nitra"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Prešov"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Trnava"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Trenčín"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Žilina"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Aargau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Innerrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Ausserrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Basel-Landschaft"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Bazel-Stad"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Bern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Fribourg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Genève"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Glarus"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Grisons"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Luzern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "St. Gallen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Solothurn"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Thurgau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Ticino"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zürich"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "Engeland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Noord-Ierland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Schotland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Wales"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "Californië"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "District of Columbia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Florida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Georgia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "New Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "New Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "New Mexico"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "New York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "North Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "North Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pennsylvania"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rhode Island"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "South Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "South Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "West Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Kalender tonen"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Stel sneltoets(en) in om de kalender weer te geven."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Weergavenaam"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Tijdzone"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -220,348 +1342,17 @@ msgstr "Datumformaat"
 msgid "Set your custom tooltip format here."
 msgstr "Stel hier uw aangepaste formaat in."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Informatie over de syntaxis van het datumformaat tonen"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-"Klik op deze knop voor meer informatie over de syntaxis van datumformaten."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Land"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Australië"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Oostenrijk"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "België"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosnië en Herzegovina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Wit-Rusland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brazilië"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Canada"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Chili"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "China"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Colombia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Kroatië"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "Tsjechië"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Denemarken"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "Spanje"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "Frankrijk"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Duitsland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Griekenland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Hongarije"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "IJsland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Ierland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Isle of Man"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Israël"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Italië"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japan"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Korea (Zuid)"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr "Kosovo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Letland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Litouwen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxemburg"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Macedonië"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Mexico"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Nederland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Nieuw-Zeeland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Noorwegen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Peru"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Filippijnen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Polen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portugal"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Roemenië"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Russische Federatie"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Servië"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapore"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Slowakije"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Slovenië"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Zuid-Afrika"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Zweden"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Zwitserland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Turkije"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Oekraïne"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Verenigd Koninkrijk"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "Verenigde Staten van Amerika"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Australisch Hoofdstedelijk Territorium"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "New South Wales"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Noordelijk Territorium"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Zuid-Australië"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmanië"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Victoria"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "West-Australië"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -576,793 +1367,3 @@ msgstr "Regio"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Regio"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "Brits-Columbia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "New Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Newfoundland en Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Northwest Territories"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nova Scotia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Prins Edwardeiland"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Québec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Württemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Beieren"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlijn"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandenburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Bremen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hamburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hessen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Nedersaksen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklenburg-Voor-Pommeren"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Noordrijn-Westfalen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Rijnland-Palts"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Saarland"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Saksen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Saksen-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Thüringen"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andalusië"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragón"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Asturië"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Canarische Eilanden"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Cantabrië"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Castilla y León"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Castilla-La Mancha"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Catalonië"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Extremadura"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galicië"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Balearen"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "La Rioja"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madrid"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Murcia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarra"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "Baskenland"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "Valencia"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Bay of Plenty"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's Bay"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Noordland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Zuidland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "West Coast"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Chatham Islands Territory"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Banská Bystrica"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Bratislava"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Košice"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Nitra"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Prešov"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Trnava"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Trenčín"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Žilina"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Aargau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Innerrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Ausserrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Basel-Landschaft"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Bazel-Stad"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Bern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Fribourg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Genève"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Glarus"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Grisons"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Luzern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "St. Gallen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Solothurn"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Thurgau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Ticino"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zürich"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "Engeland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Noord-Ierland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Schotland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Wales"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "Californië"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "District of Columbia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Florida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Georgia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "New Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "New Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "New Mexico"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "New York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "North Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "North Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pennsylvania"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rhode Island"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "South Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "South Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "West Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Kalender tonen"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Stel sneltoets(en) in om de kalender weer te geven."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Weergavenaam"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Tijdzone"

--- a/calendar@ccprog/files/calendar@ccprog/po/nl.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/nl.po
@@ -5,9 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog 1.2.2\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2024-04-22 18:34+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -17,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr "%A, %B %-e, %Y"
 
@@ -45,40 +44,50 @@ msgid_plural "In %d hours"
 msgstr[0] "Over %d uur"
 msgstr[1] "Over %d uren"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Geen evenementen"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Bezig"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Hele dag"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Vandaag"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr "%B %-e, %Y"
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Instellingen voor datum en tijd"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Nieuwe invoer toevoegen"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Invoer bewerken"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -88,20 +97,11 @@ msgstr "Invoer bewerken"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Regio"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Stad"
 
@@ -115,1218 +115,1254 @@ msgstr ""
 "Kalender applet met gegevens over openbare feestdagen verstrekt door de "
 "Enrico-service"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Kalender"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Wereldklokken"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Weergave"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Openbare feestdagen krijgen voor"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Sneltoetsen"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Wereldtijden tonen"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Kalenderevenementen weergeven"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Vink dit aan om evenementen in de kalender weer te geven."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Weeknummers tonen in kalender"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Vink dit aan om weeknummers in de kalender weer te geven."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Aanduiden als weekenddagen"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Stel in hoeveel dagen per week als niet-werkdagen worden aangemerkt."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Eén dag"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Twee dagen"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Gebruik een aangepast datumformaat"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
+#. 3.8->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Vink dit aan om een aangepast formaat voor de datum in de kalender-applet te "
 "definiëren."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Datumformaat"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Stel hier uw aangepaste formaat in."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Datumformaat"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Stel hier uw aangepaste formaat in."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Informatie over de syntaxis van het datumformaat tonen"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr ""
 "Klik op deze knop voor meer informatie over de syntaxis van datumformaten."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Land"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Australië"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Oostenrijk"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "België"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosnië en Herzegovina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Wit-Rusland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brazilië"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Canada"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Chili"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "China"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Colombia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Kroatië"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "Tsjechië"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Denemarken"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "Spanje"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "Frankrijk"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Duitsland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Griekenland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Hongarije"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "IJsland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Ierland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Isle of Man"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Israël"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Italië"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japan"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Korea (Zuid)"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr "Kosovo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Letland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Litouwen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Macedonië"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Mexico"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Nederland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Nieuw-Zeeland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Noorwegen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Peru"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Filippijnen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Polen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portugal"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Roemenië"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Russische Federatie"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Servië"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapore"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Slowakije"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Slovenië"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Zuid-Afrika"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Zweden"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Zwitserland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Turkije"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Oekraïne"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Verenigd Koninkrijk"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Verenigde Staten van Amerika"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Australisch Hoofdstedelijk Territorium"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "New South Wales"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Noordelijk Territorium"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Zuid-Australië"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmanië"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Victoria"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "West-Australië"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Regio"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Regio"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "Brits-Columbia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "New Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Newfoundland en Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Northwest Territories"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nova Scotia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Prins Edwardeiland"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Québec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Beieren"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlijn"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandenburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Bremen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hamburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hessen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Nedersaksen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklenburg-Voor-Pommeren"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Noordrijn-Westfalen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Rijnland-Palts"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Saarland"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Saksen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Saksen-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Thüringen"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andalusië"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragón"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Asturië"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Canarische Eilanden"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Cantabrië"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Castilla y León"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Castilla-La Mancha"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Catalonië"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Extremadura"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galicië"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Balearen"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "La Rioja"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madrid"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Murcia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarra"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "Baskenland"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "Valencia"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Bay of Plenty"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's Bay"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Noordland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Zuidland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "West Coast"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Chatham Islands Territory"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Banská Bystrica"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Bratislava"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Košice"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Nitra"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Prešov"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Trnava"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Trenčín"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Žilina"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Aargau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Innerrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Ausserrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Basel-Landschaft"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Bazel-Stad"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Bern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Fribourg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Genève"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Glarus"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Grisons"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Luzern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "St. Gallen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Solothurn"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Thurgau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Ticino"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zürich"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "Engeland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Noord-Ierland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Schotland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Wales"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "Californië"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Florida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Georgia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "New Mexico"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "New York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "North Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "North Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "South Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "South Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Kalender tonen"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Stel sneltoets(en) in om de kalender weer te geven."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Weergavenaam"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Tijdzone"

--- a/calendar@ccprog/files/calendar@ccprog/po/pt_BR.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/pt_BR.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR WITH PUBLIC HOLIDAYS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Vinícius Queiroz <viniciusqueiroz.voq@gmail.com>, 2021.
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2021-10-02 18:47-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -18,68 +19,77 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Começando em alguns minutos"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Começando em %d minutos"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Esta noite"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Começando mais tarde hoje"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "Em %d hora"
 msgstr[1] "Em %d horas"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Sem eventos"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Em andamento"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Todo dia"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Hoje"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Configurações de Data e Hora"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Adicionar novo relógio"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Editar relógio"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +100,11 @@ msgstr "Editar relógio"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Região"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Cidade"
 
@@ -117,100 +118,1221 @@ msgstr ""
 "Applet de calendário que exibe os próximos feriados. Dados fornecidos pelo "
 "serviço Enrico"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendário"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Relógios Mundiais"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Exibição"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Obter Feriados para"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Atalhos de Teclado"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Mostrar Relógios Mundiais"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Mostrar eventos do calendário"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Marque esta opção para exibir eventos no calendário."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Mostrar números da semana no calendário"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Marque isso para mostrar números das semanas no calendário."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Considerar quantos dias de fim de semana"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Defina quantos dias não são marcados como dias úteis em uma semana."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Um dia"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Dois dias"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Usar um formato de data personalizado"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Marque esta opção para definir um formato de data personalizado no applet de "
 "calendário."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Formato da Data"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Defina seu formato personalizado aqui."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Saiba mais sobre a sintaxe do formato de data"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"Clique neste botão para saber mais sobre a sintaxe dos formatos de data."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "País"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Austrália"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Áustria"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Bélgica"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bósnia e Herzegovina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr "Bielorrússia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brasil"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Canadá"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Chile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "China"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Colômbia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Croácia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "Tchéquia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Dinamarca"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estônia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr "Espanha"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finlândia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "França"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Alemanha"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Grécia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Hungria"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Islândia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Irlanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Ilha de Man"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "Israel"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Itália"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japão"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Coreia do Sul"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Letônia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Lituânia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxemburgo"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Macedônia do Norte"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "México"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Países Baixos"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Nova Zelândia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Noruega"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Peru"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Filipinas"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Polônia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portugal"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Romênia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Rússia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Sérvia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapura"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Eslováquia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Eslovênia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "África do Sul"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Suécia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Suíça"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Turquia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ucrânia"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Reino Unido"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "Estados Unidos da América"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Território da Capital Australiana"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "Nova Gales do Sul"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Território do Norte"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Austrália do Sul"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmânia"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Vitória"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Austrália Ocidental"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "Colúmbia Britânica"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "Nova Brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Terra Nova e Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Territórios do Noroeste"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nova Escócia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontário"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Ilha do Príncipe Eduardo"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Quebec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Württemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Baviera"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlim"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandemburgo"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Bremen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hamburgo"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hessen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Baixa Saxônia"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklemburgo-Pomerânia Ocidental"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Renânia do Norte-Vestfália"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Renânia-Palatinado"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Sarre"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Saxônia"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Saxônia-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Turíngia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr "Andaluzia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr "Aragão"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr "Astúrias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr "Ilhas Canárias"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr "Cantábria"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr "Castela e Leão"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr "Castilla-La Mancha"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr "Catalunha"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr "Ceuta"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr "Extremadura"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr "Galícia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr "Ilhas Baleares"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr "La Rioja"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr "Madri"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr "Melilla"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr "Múrcia"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr "Navarra"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr "País Basco"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr "Valência"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Baía de Plenty"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Baía de Hawke"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Northland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Southland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "Costa Oeste"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Ilhas Chatham"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Banská Bystrica"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Bratislava"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Košice"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Nitra"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Prešov"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Trnava"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Trenčín"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Žilina"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Aargau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Innerrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Ausserrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Basileia-Campo"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Basileia-Cidade"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Berna"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Friburgo"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Genebra"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Glarus"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Grisões"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Lucerna"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "St. Gallen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Solothurn"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Thurgau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Ticino"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zurique"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "Inglaterra"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Irlanda do Norte"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Escócia"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "País de Gales"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alasca"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "Califórnia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Colorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "Distrito de Colúmbia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Flórida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Geórgia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Havaí"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Indiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "Nova Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "Nova Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "Novo México"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "Nova York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "Carolina do Norte"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "Dakota do Norte"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pensilvânia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rhode Island"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "Carolina do Sul"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "Dakota do Sul"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virgínia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "Virgínia Ocidental"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Mostrar calendário"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Defina os atalhos de teclado para mostrar o calendário."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Nome em exibição"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Fuso horário"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -222,348 +1344,17 @@ msgstr "Formato da Data"
 msgid "Set your custom tooltip format here."
 msgstr "Defina seu formato personalizado aqui."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Saiba mais sobre a sintaxe do formato de data"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-"Clique neste botão para saber mais sobre a sintaxe dos formatos de data."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "País"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Austrália"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Áustria"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Bélgica"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bósnia e Herzegovina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr "Bielorrússia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brasil"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Canadá"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Chile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "China"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Colômbia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Croácia"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "Tchéquia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Dinamarca"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estônia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr "Espanha"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finlândia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "França"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Alemanha"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Grécia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Hungria"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Islândia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Irlanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Ilha de Man"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "Israel"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Itália"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japão"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Coreia do Sul"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Letônia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Lituânia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxemburgo"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Macedônia do Norte"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "México"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Países Baixos"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Nova Zelândia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Noruega"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Peru"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Filipinas"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Polônia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portugal"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Romênia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Rússia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Sérvia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapura"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Eslováquia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Eslovênia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "África do Sul"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Suécia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Suíça"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Turquia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ucrânia"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Reino Unido"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "Estados Unidos da América"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Território da Capital Australiana"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "Nova Gales do Sul"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Território do Norte"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Austrália do Sul"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmânia"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Vitória"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Austrália Ocidental"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -578,793 +1369,3 @@ msgstr "Região"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Região"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "Colúmbia Britânica"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "Nova Brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Terra Nova e Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Territórios do Noroeste"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nova Escócia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontário"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Ilha do Príncipe Eduardo"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Quebec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Württemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Baviera"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlim"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandemburgo"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Bremen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hamburgo"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hessen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Baixa Saxônia"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklemburgo-Pomerânia Ocidental"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Renânia do Norte-Vestfália"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Renânia-Palatinado"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Sarre"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Saxônia"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Saxônia-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Turíngia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr "Andaluzia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr "Aragão"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr "Astúrias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr "Ilhas Canárias"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr "Cantábria"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr "Castela e Leão"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr "Castilla-La Mancha"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr "Catalunha"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr "Ceuta"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr "Extremadura"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr "Galícia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr "Ilhas Baleares"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr "La Rioja"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr "Madri"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr "Melilla"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr "Múrcia"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr "Navarra"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr "País Basco"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr "Valência"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Baía de Plenty"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Baía de Hawke"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Northland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Southland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "Costa Oeste"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Ilhas Chatham"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Banská Bystrica"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Bratislava"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Košice"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Nitra"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Prešov"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Trnava"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Trenčín"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Žilina"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Aargau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Innerrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Ausserrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Basileia-Campo"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Basileia-Cidade"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Berna"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Friburgo"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Genebra"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Glarus"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Grisões"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Lucerna"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "St. Gallen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Solothurn"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Thurgau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Ticino"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zurique"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "Inglaterra"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Irlanda do Norte"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Escócia"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "País de Gales"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alasca"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "Califórnia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Colorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "Distrito de Colúmbia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Flórida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Geórgia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Havaí"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Indiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "Nova Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "Nova Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "Novo México"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "Nova York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "Carolina do Norte"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "Dakota do Norte"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pensilvânia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rhode Island"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "Carolina do Sul"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "Dakota do Sul"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virgínia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "Virgínia Ocidental"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Mostrar calendário"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Defina os atalhos de teclado para mostrar o calendário."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Nome em exibição"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Fuso horário"

--- a/calendar@ccprog/files/calendar@ccprog/po/pt_BR.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/pt_BR.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2021-10-02 18:47-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
@@ -46,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] "Em %d hora"
 msgstr[1] "Em %d horas"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Sem eventos"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Em andamento"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Todo dia"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Hoje"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Configurações de Data e Hora"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Adicionar novo relógio"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Editar relógio"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -89,20 +99,11 @@ msgstr "Editar relógio"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Região"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Cidade"
 
@@ -112,1216 +113,1258 @@ msgstr "Calendário com feriados"
 
 #. metadata.json->description
 msgid "Calendar applet with public holiday data provided by Enrico service"
-msgstr "Applet de calendário que exibe os próximos feriados. Dados fornecidos pelo serviço Enrico"
+msgstr ""
+"Applet de calendário que exibe os próximos feriados. Dados fornecidos pelo "
+"serviço Enrico"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Calendário"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Relógios Mundiais"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Exibição"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Obter Feriados para"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Atalhos de Teclado"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Mostrar Relógios Mundiais"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Mostrar eventos do calendário"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Marque esta opção para exibir eventos no calendário."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Mostrar números da semana no calendário"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Marque isso para mostrar números das semanas no calendário."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Considerar quantos dias de fim de semana"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Defina quantos dias não são marcados como dias úteis em uma semana."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Um dia"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Dois dias"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Usar um formato de data personalizado"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
-msgid "Check this to define a custom format for the date in the calendar applet."
-msgstr "Marque esta opção para definir um formato de data personalizado no applet de calendário."
+#. 3.8->settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+"Marque esta opção para definir um formato de data personalizado no applet de "
+"calendário."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Formato da Data"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Defina seu formato personalizado aqui."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Formato da Data"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Defina seu formato personalizado aqui."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Saiba mais sobre a sintaxe do formato de data"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
-msgstr "Clique neste botão para saber mais sobre a sintaxe dos formatos de data."
+msgstr ""
+"Clique neste botão para saber mais sobre a sintaxe dos formatos de data."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "País"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Austrália"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Áustria"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Bélgica"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bósnia e Herzegovina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr "Bielorrússia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brasil"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Canadá"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Chile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "China"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Colômbia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Croácia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "Tchéquia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Dinamarca"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estônia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr "Espanha"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finlândia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "França"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Alemanha"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Grécia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Hungria"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Islândia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Irlanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Ilha de Man"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "Israel"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Itália"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japão"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Coreia do Sul"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Letônia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Lituânia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Macedônia do Norte"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "México"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Países Baixos"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Nova Zelândia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Noruega"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Peru"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Filipinas"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Polônia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portugal"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Romênia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Rússia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Sérvia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapura"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Eslováquia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Eslovênia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "África do Sul"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Suécia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Suíça"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Turquia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ucrânia"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Reino Unido"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Estados Unidos da América"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Território da Capital Australiana"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "Nova Gales do Sul"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Território do Norte"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Austrália do Sul"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmânia"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Vitória"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Austrália Ocidental"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Região"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Região"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "Colúmbia Britânica"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "Nova Brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Terra Nova e Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Territórios do Noroeste"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nova Escócia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontário"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Ilha do Príncipe Eduardo"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Quebec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Baviera"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlim"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandemburgo"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Bremen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hamburgo"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hessen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Baixa Saxônia"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklemburgo-Pomerânia Ocidental"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Renânia do Norte-Vestfália"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Renânia-Palatinado"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Sarre"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Saxônia"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Saxônia-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Turíngia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr "Andaluzia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr "Aragão"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr "Astúrias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr "Ilhas Canárias"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr "Cantábria"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr "Castela e Leão"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr "Castilla-La Mancha"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr "Catalunha"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr "Ceuta"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr "Extremadura"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr "Galícia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr "Ilhas Baleares"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr "La Rioja"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr "Madri"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr "Melilla"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr "Múrcia"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr "Navarra"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr "País Basco"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr "Valência"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Baía de Plenty"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Baía de Hawke"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Northland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Southland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "Costa Oeste"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Ilhas Chatham"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Banská Bystrica"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Bratislava"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Košice"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Nitra"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Prešov"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Trnava"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Trenčín"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Žilina"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Aargau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Innerrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Ausserrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Basileia-Campo"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Basileia-Cidade"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Berna"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Friburgo"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Genebra"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Glarus"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Grisões"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Lucerna"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "St. Gallen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Solothurn"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Thurgau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Ticino"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zurique"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "Inglaterra"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Irlanda do Norte"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Escócia"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "País de Gales"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alasca"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "Califórnia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Colorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "Distrito de Colúmbia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Flórida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Geórgia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Havaí"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Indiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "Nova Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "Nova Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "Novo México"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "Nova York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "Carolina do Norte"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "Dakota do Norte"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pensilvânia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "Carolina do Sul"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "Dakota do Sul"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virgínia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "Virgínia Ocidental"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Mostrar calendário"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Defina os atalhos de teclado para mostrar o calendário."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Nome em exibição"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Fuso horário"

--- a/calendar@ccprog/files/calendar@ccprog/po/ru.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/ru.po
@@ -2,8 +2,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -11,10 +11,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 3.4.1\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
@@ -43,40 +44,50 @@ msgstr[0] "В %d час"
 msgstr[1] "В %d часа"
 msgstr[2] "В %d часов"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Нет событий"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Уже"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Все дни"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Сегодня"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Настройка Времени и Даты"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Добавить новый элемент"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Редактировать элемент"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -86,20 +97,11 @@ msgstr "Редактировать элемент"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Регион"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Город"
 
@@ -111,1214 +113,1251 @@ msgstr "Календарь Праздничных Дней (Calendar with public
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Календарь праздничных дней по информации из сервиса Enrico"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Календарь"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Мировые Часы"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Отображать"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Получить список праздников для"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Клавиатурные сочетания"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Показать Мировое Время"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Показать события календаря"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Отображать события на календаре."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Показывать номера недель на календаре"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Нажмите, чтобы отображать номера недель на панели в апплете календаря."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Сколько выходных в неделе"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Укажите, сколько нерабочих дней в неделе."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Один день"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Два дня"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Задать свой формат даты"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
-msgid "Check this to define a custom format for the date in the calendar applet."
+#. 3.8->settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
 msgstr "Задать пользовательский формат даты в апплете календаря."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Формат даты"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Задайте ваш формат здесь."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Формат даты"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Задайте ваш формат здесь."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Справка по формату даты"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr "Нажмите, чтобы узнать, как указать свой формат даты."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Страна"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Регион"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Регион"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr ""
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Показать календарь"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Клавиатурное сочетания для показа календаря."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr ""
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Часовой пояс"

--- a/calendar@ccprog/files/calendar@ccprog/po/ru.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/ru.po
@@ -2,8 +2,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -11,32 +12,32 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 3.4.1\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Начало через несколько минут"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Начало через %d минут"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Этим вечером"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Начало сегодня"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
@@ -44,40 +45,49 @@ msgstr[0] "В %d час"
 msgstr[1] "В %d часа"
 msgstr[2] "В %d часов"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Нет событий"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Уже"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Все дни"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Сегодня"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Настройка Времени и Даты"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Добавить новый элемент"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Редактировать элемент"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -88,20 +98,11 @@ msgstr "Редактировать элемент"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Регион"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Город"
 
@@ -113,98 +114,1218 @@ msgstr "Календарь Праздничных Дней (Calendar with public
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Календарь праздничных дней по информации из сервиса Enrico"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Календарь"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Мировые Часы"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Отображать"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Получить список праздников для"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Клавиатурные сочетания"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Показать Мировое Время"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Показать события календаря"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Отображать события на календаре."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Показывать номера недель на календаре"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Нажмите, чтобы отображать номера недель на панели в апплете календаря."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Сколько выходных в неделе"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Укажите, сколько нерабочих дней в неделе."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Один день"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Два дня"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Задать свой формат даты"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr "Задать пользовательский формат даты в апплете календаря."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Формат даты"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Задайте ваш формат здесь."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Справка по формату даты"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr "Нажмите, чтобы узнать, как указать свой формат даты."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Страна"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr ""
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Показать календарь"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Клавиатурное сочетания для показа календаря."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr ""
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Часовой пояс"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -216,93 +1337,8 @@ msgstr "Формат даты"
 msgid "Set your custom tooltip format here."
 msgstr "Задайте ваш формат здесь."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Справка по формату даты"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr "Нажмите, чтобы узнать, как указать свой формат даты."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Страна"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr ""
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
@@ -310,252 +1346,7 @@ msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
 msgstr ""
 
 #. 5.2->settings-schema.json->region_bel->options
@@ -571,793 +1362,3 @@ msgstr "Регион"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Регион"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr ""
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Показать календарь"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Клавиатурное сочетания для показа календаря."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr ""
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Часовой пояс"

--- a/calendar@ccprog/files/calendar@ccprog/po/sv.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/sv.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2021-02-27 16:18+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -18,68 +19,77 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Startar om några minuter"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "Startar om %d minuter"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Ikväll"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Senare idag"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "Om %d timme"
 msgstr[1] "Om %d timmar"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Inga händelser"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Pågår"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Hela dagen"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Idag"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr ""
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr ""
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr ""
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +100,11 @@ msgstr ""
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Region"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr ""
 
@@ -115,99 +116,1220 @@ msgstr "Kalender med allmänna helgdagar"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Kalenderprogram med helgdagsuppgifter från Enrico-tjänsten"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr ""
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Världsklockor"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr ""
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Hämta allmänna helgdagar för"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Visa världstider"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Visa kalenderhändelser"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Välj detta för att visa händelser i kalendern"
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr ""
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr ""
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Markera som helgdagar"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr ""
 "Ange hur många dagar som skall markeras som icke arbetsdagar, varje vecka."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "En dag"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Två dagar"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr ""
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr ""
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr ""
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr ""
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Land"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Australien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Österrike"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Belgien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosnien och Herzegovina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brasilien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Kanada"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "Kina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Kroatien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "Tjeckien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Danmark"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "Frankrike"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Tyskland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Grekland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Ungern"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "Island"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "Irland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "Italien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Korea (Syd)"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Lettland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Litauen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Luxemburg"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Makedonien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Mexiko"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Nederländerna"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Nya Zeeland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Norge"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Fillipinerna"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Polen"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Rumänien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Ryssland"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Serbien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapor"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Slovakien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Slovenien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Sydafrika"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "Sverige"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "Schweiz"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ukraina"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Storbritannien"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "Amerikas förenta stater"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Australiska huvudstadsområde"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Södra Australien"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tasmanien"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Västra Australien"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+#, fuzzy
+msgid "Canarias"
+msgstr "Kanada"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Genev"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "URI"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Nordirland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "Skottland"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "Kalifornien"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr ""
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Visa kalender"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Ange snabbtangent(er) för att visa kalendern."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Visningsnamn"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Tidszon"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 msgid "Date format for tooltip"
@@ -217,347 +1339,17 @@ msgstr ""
 msgid "Set your custom tooltip format here."
 msgstr ""
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr ""
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Land"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Australien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Österrike"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Belgien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosnien och Herzegovina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brasilien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Kanada"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "Kina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Kroatien"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "Tjeckien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Danmark"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "Frankrike"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Tyskland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Grekland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Ungern"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "Island"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "Irland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "Italien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Korea (Syd)"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Lettland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Litauen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Luxemburg"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Makedonien"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Mexiko"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Nederländerna"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Nya Zeeland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Norge"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Fillipinerna"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Polen"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Rumänien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Ryssland"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Serbien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapor"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Slovakien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Slovenien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Sydafrika"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "Sverige"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "Schweiz"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ukraina"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Storbritannien"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "Amerikas förenta stater"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Australiska huvudstadsområde"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Södra Australien"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tasmanien"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Västra Australien"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -572,794 +1364,3 @@ msgstr "Region"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Region"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-#, fuzzy
-msgid "Canarias"
-msgstr "Kanada"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Genev"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "URI"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Nordirland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "Skottland"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "Kalifornien"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr ""
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Visa kalender"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Ange snabbtangent(er) för att visa kalendern."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Visningsnamn"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Tidszon"

--- a/calendar@ccprog/files/calendar@ccprog/po/sv.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/sv.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2021-02-27 16:18+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
@@ -46,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] "Om %d timme"
 msgstr[1] "Om %d timmar"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Inga händelser"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Pågår"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Hela dagen"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Idag"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr ""
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr ""
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr ""
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -89,20 +99,11 @@ msgstr ""
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Region"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr ""
 
@@ -114,1215 +115,1251 @@ msgstr "Kalender med allmänna helgdagar"
 msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr "Kalenderprogram med helgdagsuppgifter från Enrico-tjänsten"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr ""
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Världsklockor"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr ""
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Hämta allmänna helgdagar för"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Visa världstider"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Visa kalenderhändelser"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Välj detta för att visa händelser i kalendern"
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr ""
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr ""
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Markera som helgdagar"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
-msgstr "Ange hur många dagar som skall markeras som icke arbetsdagar, varje vecka."
+msgstr ""
+"Ange hur många dagar som skall markeras som icke arbetsdagar, varje vecka."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "En dag"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Två dagar"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr ""
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
-msgid "Check this to define a custom format for the date in the calendar applet."
+#. 3.8->settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr ""
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr ""
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+msgid "Date format for tooltip"
+msgstr ""
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+msgid "Set your custom tooltip format here."
+msgstr ""
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr ""
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
 msgstr ""
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Land"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Australien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Österrike"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Belgien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosnien och Herzegovina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brasilien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Kanada"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "Kina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Kroatien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "Tjeckien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Danmark"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "Frankrike"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Tyskland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Grekland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Ungern"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "Island"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "Irland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "Italien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Korea (Syd)"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Lettland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Litauen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Makedonien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Mexiko"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Nederländerna"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Nya Zeeland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Norge"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Fillipinerna"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Polen"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Rumänien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Ryssland"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Serbien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapor"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Slovakien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Slovenien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Sydafrika"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "Sverige"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Schweiz"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukraina"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Storbritannien"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Amerikas förenta stater"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Australiska huvudstadsområde"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Södra Australien"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tasmanien"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Västra Australien"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Region"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Region"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 #, fuzzy
 msgid "Canarias"
 msgstr "Kanada"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Genev"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "URI"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Nordirland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "Skottland"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "Kalifornien"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr ""
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Visa kalender"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Ange snabbtangent(er) för att visa kalendern."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Visningsnamn"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Tidszon"

--- a/calendar@ccprog/files/calendar@ccprog/po/tr.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/tr.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR WITH PUBLIC HOLIDAYS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Serkan ÖNDER <serkanonder@outlook.com>, 2021.
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog 1.1.6\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 22:50+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-11-22 17:45-0500\n"
 "PO-Revision-Date: 2021-07-05 18:36+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
@@ -18,68 +19,77 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
+#. eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
-#: eventView.js:65 5.2/eventView.js:67
+#. eventView.js:65 5.2/eventView.js:67
 msgid "Starting in a few minutes"
 msgstr "Bir kaç dakika içinde başlayacak"
 
-#: eventView.js:69 5.2/eventView.js:71
+#. eventView.js:69 5.2/eventView.js:71
 #, javascript-format
 msgid "Starting in %d minutes"
 msgstr "%d dakika içinde başlayacak"
 
-#: eventView.js:79 5.2/eventView.js:81
+#. eventView.js:79 5.2/eventView.js:81
 msgid "This evening"
 msgstr "Bu akşam"
 
-#: eventView.js:82 5.2/eventView.js:84
+#. eventView.js:82 5.2/eventView.js:84
 msgid "Starting later today"
 msgstr "Bugün, gün içinde başlayacak"
 
-#: eventView.js:85 5.2/eventView.js:87
+#. eventView.js:85 5.2/eventView.js:87
 #, javascript-format
 msgid "In %d hour"
 msgid_plural "In %d hours"
 msgstr[0] "%d saat içinde"
 msgstr[1] "%d saat içinde"
 
-#: eventView.js:664 5.2/eventView.js:693
+#. eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Olay Yok"
 
-#: eventView.js:925 5.2/eventView.js:966
+#. eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Devam ediyor"
 
-#: eventView.js:946 5.2/eventView.js:987
+#. eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Tüm gün"
 
-#: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
-#: 5.2/eventView.js:1097
+#. eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
+#. 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#. 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Bugün"
 
-#: 5.2/applet.js:21 3.8/applet.js:21
+#. 3.8/applet.js:21 5.2/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 5.2/applet.js:138 3.8/applet.js:131
+#. 3.8/applet.js:131 5.2/applet.js:138
 msgid "Date and Time Settings"
 msgstr "Tarih ve Zaman Ayarları"
 
-#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
+#. 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Yeni girdi ekle"
 
-#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
+#. 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Girdiyi düzenle"
 
+#. 3.8->settings-schema.json->region_aus->description
+#. 3.8->settings-schema.json->region_can->description
+#. 3.8->settings-schema.json->region_deu->description
+#. 3.8->settings-schema.json->region_esp->description
+#. 3.8->settings-schema.json->region_nzl->description
+#. 3.8->settings-schema.json->region_svk->description
+#. 3.8->settings-schema.json->region_che->description
+#. 3.8->settings-schema.json->region_gbr->description
+#. 3.8->settings-schema.json->region_usa->description
 #. 5.2->settings-schema.json->region_aus->description
 #. 5.2->settings-schema.json->region_bel->description
 #. 5.2->settings-schema.json->region_can->description
@@ -90,20 +100,11 @@ msgstr "Girdiyi düzenle"
 #. 5.2->settings-schema.json->region_che->description
 #. 5.2->settings-schema.json->region_gbr->description
 #. 5.2->settings-schema.json->region_usa->description
-#. 3.8->settings-schema.json->region_aus->description
-#. 3.8->settings-schema.json->region_can->description
-#. 3.8->settings-schema.json->region_deu->description
-#. 3.8->settings-schema.json->region_esp->description
-#. 3.8->settings-schema.json->region_nzl->description
-#. 3.8->settings-schema.json->region_svk->description
-#. 3.8->settings-schema.json->region_che->description
-#. 3.8->settings-schema.json->region_gbr->description
-#. 3.8->settings-schema.json->region_usa->description
-#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
+#. 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
 msgid "Region"
 msgstr "Bölge"
 
-#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
+#. 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
 msgid "City"
 msgstr "Şehir"
 
@@ -116,100 +117,1222 @@ msgid "Calendar applet with public holiday data provided by Enrico service"
 msgstr ""
 "Enrico hizmeti tarafından sağlanan resmi tatil verileriyle takvim uygulaması"
 
-#. 5.2->settings-schema.json->page1->title
 #. 3.8->settings-schema.json->page1->title
+#. 5.2->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Takvim"
 
-#. 5.2->settings-schema.json->page2->title
-#. 5.2->settings-schema.json->worldclocks->description
 #. 3.8->settings-schema.json->page2->title
 #. 3.8->settings-schema.json->worldclocks->description
+#. 5.2->settings-schema.json->page2->title
+#. 5.2->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Dünya Saatleri"
 
-#. 5.2->settings-schema.json->section1->title
 #. 3.8->settings-schema.json->section1->title
+#. 5.2->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Görüntüleme"
 
-#. 5.2->settings-schema.json->section2->title
 #. 3.8->settings-schema.json->section2->title
+#. 5.2->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Resmi Tatilleri Alın"
 
-#. 5.2->settings-schema.json->section3->title
 #. 3.8->settings-schema.json->section3->title
+#. 5.2->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Klavye Kısayolları"
 
-#. 5.2->settings-schema.json->section4->title
 #. 3.8->settings-schema.json->section4->title
+#. 5.2->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Dünya Tarihlerini Göster"
 
-#. 5.2->settings-schema.json->show-events->description
 #. 3.8->settings-schema.json->show-events->description
+#. 5.2->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Takvim olaylarını göster"
 
-#. 5.2->settings-schema.json->show-events->tooltip
 #. 3.8->settings-schema.json->show-events->tooltip
+#. 5.2->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Takvimdeki olayları görüntülemek için bunu etkinleştirin."
 
-#. 5.2->settings-schema.json->show-week-numbers->description
 #. 3.8->settings-schema.json->show-week-numbers->description
+#. 5.2->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Takvimde hafta numarasını göster"
 
-#. 5.2->settings-schema.json->show-week-numbers->tooltip
 #. 3.8->settings-schema.json->show-week-numbers->tooltip
+#. 5.2->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Takvimde hafta numarası gösterimi için burayı işaretleyiniz."
 
-#. 5.2->settings-schema.json->weekend-length->description
 #. 3.8->settings-schema.json->weekend-length->description
+#. 5.2->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Hafta sonu günleri olarak işaretle"
 
-#. 5.2->settings-schema.json->weekend-length->tooltip
 #. 3.8->settings-schema.json->weekend-length->tooltip
+#. 5.2->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Haftada kaç günün çalışma dışı gün olarak işaretleneceğini ayarlayın."
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Bir gün"
 
-#. 5.2->settings-schema.json->weekend-length->options
 #. 3.8->settings-schema.json->weekend-length->options
+#. 5.2->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "İki gün"
 
-#. 5.2->settings-schema.json->use-custom-format->description
 #. 3.8->settings-schema.json->use-custom-format->description
+#. 5.2->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Özel bir tarih biçimi kullan"
 
-#. 5.2->settings-schema.json->use-custom-format->tooltip
 #. 3.8->settings-schema.json->use-custom-format->tooltip
+#. 5.2->settings-schema.json->use-custom-format->tooltip
 msgid ""
 "Check this to define a custom format for the date in the calendar applet."
 msgstr ""
 "Takvim uygulamacığında, özel bir tarih biçimi tanımlamak için bunu kontrol "
 "edin."
 
-#. 5.2->settings-schema.json->custom-format->description
 #. 3.8->settings-schema.json->custom-format->description
+#. 5.2->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Tarih biçimi"
 
-#. 5.2->settings-schema.json->custom-format->tooltip
 #. 3.8->settings-schema.json->custom-format->tooltip
+#. 5.2->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Buradan özelleştirilmiş bir tarih biçimi ayarlayabilirsiniz."
+
+#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Tarih biçimi sözdizimi için bilgi göster"
+
+#. 3.8->settings-schema.json->format-button->tooltip
+#. 5.2->settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"Tarih formatı için sözdilimi hakkında daha fazla bilgi için bu düğmeyi "
+"tıklayınız."
+
+#. 3.8->settings-schema.json->country->description
+#. 5.2->settings-schema.json->country->description
+msgid "Country"
+msgstr "Ülke"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Angola"
+msgstr "Angola"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Australia"
+msgstr "Avustralya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Austria"
+msgstr "Avusturya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belgium"
+msgstr "Belçika"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Bosnia and Herzegovina"
+msgstr "Bosna Hersek"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Belarus"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Brazil"
+msgstr "Brezilya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Canada"
+msgstr "Kanada"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Chile"
+msgstr "Chile"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "China"
+msgstr "Çin"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Colombia"
+msgstr "Kolombiya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Croatia"
+msgstr "Hırvatistan"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Czech Republic"
+msgstr "Çek Cumhuriyeti"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Denmark"
+msgstr "Danimarka"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Estonia"
+msgstr "Estonya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Spain"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Finland"
+msgstr "Finlandiya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "France"
+msgstr "Fransa"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Germany"
+msgstr "Almanya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Greece"
+msgstr "Yunanistan"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hong Kong"
+msgstr "Hong Kong"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Hungary"
+msgstr "Macaristan"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Iceland"
+msgstr "İzlanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ireland"
+msgstr "İrlanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Isle of Man"
+msgstr "Man Adası"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Israel"
+msgstr "İsrail"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Italy"
+msgstr "İtalya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Japan"
+msgstr "Japonya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Korea (South)"
+msgstr "Kore (Güney)"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "kosovo"
+msgstr ""
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Latvia"
+msgstr "Letonya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Lithuania"
+msgstr "Litvanya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Luxembourg"
+msgstr "Lüksemburg"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Macedonia"
+msgstr "Makedonya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Mexico"
+msgstr "Meksika"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Netherlands"
+msgstr "Hollanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "New Zealand"
+msgstr "Yeni Zelanda"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Norway"
+msgstr "Norveç"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Peru"
+msgstr "Peru"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Philippines"
+msgstr "Filipinler"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Poland"
+msgstr "Polonya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Portugal"
+msgstr "Portekiz"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Romania"
+msgstr "Romanya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Russian Federation"
+msgstr "Rusya Federasyonu"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Serbia"
+msgstr "Sırbistan"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Singapore"
+msgstr "Singapur"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovakia"
+msgstr "Slovakya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Slovenia"
+msgstr "Slovenya"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "South Africa"
+msgstr "Güney Afrika"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Sweden"
+msgstr "İsveç"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Switzerland"
+msgstr "İsviçre"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Türkiye"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "Ukraine"
+msgstr "Ukrayna"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United Kingdom"
+msgstr "Birleşik Kırallık"
+
+#. 3.8->settings-schema.json->country->options
+#. 5.2->settings-schema.json->country->options
+msgid "United States of America"
+msgstr "Amerika Birleşik Devletleri"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Australian Capital Territory"
+msgstr "Avustralya Başkent Bölgesi"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Queensland"
+msgstr "Queensland"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "New South Wales"
+msgstr "Yeni Güney Galler"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Northern Territory"
+msgstr "Kuzey Bölgesi"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "South Australia"
+msgstr "Güney Avustralya"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Tasmania"
+msgstr "Tazmanya"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Victoria"
+msgstr "Victoria"
+
+#. 3.8->settings-schema.json->region_aus->options
+#. 5.2->settings-schema.json->region_aus->options
+msgid "Western Australia"
+msgstr "Batı Avustralya"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Alberta"
+msgstr "Alberta"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "British Columbia"
+msgstr "Britanya Kolombiyası"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Manitoba"
+msgstr "Manitoba"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "New Brunswick"
+msgstr "Yeni brunswick"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Newfoundland and Labrador"
+msgstr "Newfoundland ve Labrador"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Northwest Territories"
+msgstr "Kuzeybatı bölgesi"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nova Scotia"
+msgstr "Nova Scotia"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Nunavut"
+msgstr "Nunavut"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Ontario"
+msgstr "Ontario"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Prince Edward Island"
+msgstr "Prens Edward Adası"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Quebec"
+msgstr "Quebec"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Saskatchewan"
+msgstr "Saskatchewan"
+
+#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_can->options
+msgid "Yukon"
+msgstr "Yukon"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Baden-Württemberg"
+msgstr "Baden-Württemberg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bayern"
+msgstr "Bayern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Berlin"
+msgstr "Berlin"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Brandenburg"
+msgstr "Brandenburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Bremen"
+msgstr "Bremen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hamburg"
+msgstr "Hamburg"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Hessen"
+msgstr "Hessen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Niedersachsen"
+msgstr "Niedersachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Mecklenburg-Vorpommern"
+msgstr "Mecklenburg-Vorpommern"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Nordrhein-Westfalen"
+msgstr "Nordrhein-Westfalen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Rheinland-Pfalz"
+msgstr "Rheinland-Pfalz"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Saarland"
+msgstr "Saarland"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen"
+msgstr "Sachsen"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Sachsen-Anhalt"
+msgstr "Sachsen-Anhalt"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Schleswig-Holstein"
+msgstr "Schleswig-Holstein"
+
+#. 3.8->settings-schema.json->region_deu->options
+#. 5.2->settings-schema.json->region_deu->options
+msgid "Thüringen"
+msgstr "Thüringen"
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Andalucía"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Aragón"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Asturias"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Canarias"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cantabria"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla y León"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Castilla-La Mancha"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Cataluña"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Ceuta"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Extremadura"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Galicia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Islas Baleares"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "La Rioja"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Madrid"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Melilla"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Murcia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Navarra"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "País Vasco"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_esp->options
+#. 5.2->settings-schema.json->region_esp->options
+msgid "Valencia"
+msgstr ""
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Auckland"
+msgstr "Auckland"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Bay of Plenty"
+msgstr "Bay of Plenty"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Canterbury"
+msgstr "Canterbury"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Gisborne"
+msgstr "Gisborne"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Hawke's Bay"
+msgstr "Hawke's Bay"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Marlborough"
+msgstr "Marlborough"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Manawatu-Wanganui"
+msgstr "Manawatu-Wanganui"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Nelson"
+msgstr "Nelson"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Northland"
+msgstr "Kuzey bölgesi"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Otago"
+msgstr "Otago"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Southland"
+msgstr "Güney bölgesi"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Tasman"
+msgstr "Tasman"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Taranaki"
+msgstr "Taranaki"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Waikato"
+msgstr "Waikato"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Wellington"
+msgstr "Wellington"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "West Coast"
+msgstr "Batı Kıyısı"
+
+#. 3.8->settings-schema.json->region_nzl->options
+#. 5.2->settings-schema.json->region_nzl->options
+msgid "Chatham Islands Territory"
+msgstr "Chatham Adaları Bölgesi"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Banskobystrický kraj"
+msgstr "Banska Bystrica Bölgesi"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Bratislavský kraj"
+msgstr "Bratislava Bölgesi"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Košický kraj"
+msgstr "Kösice bölgesi"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Nitriansky kraj"
+msgstr "Nitra bölgesi"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Prešovský kraj"
+msgstr "Prešov Bölgesi"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trnavský kraj"
+msgstr "Trnava bölgesi"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Trenčiansky kraj"
+msgstr "Trencin Bölgesi"
+
+#. 3.8->settings-schema.json->region_svk->options
+#. 5.2->settings-schema.json->region_svk->options
+msgid "Žilinský kraj"
+msgstr "Žilina Bölgesi"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Aargau"
+msgstr "Aargau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Innerrhoden"
+msgstr "Appenzell Innerrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Appenzell Ausserrhoden"
+msgstr "Appenzell Ausserrhoden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Landschaft"
+msgstr "Basel-Ülke"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Basel-Stadt"
+msgstr "Basel şehri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Bern"
+msgstr "Bern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Fribourg"
+msgstr "Fribourg"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Geneva"
+msgstr "Cenevre"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Glarus"
+msgstr "Glarus"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Grisons"
+msgstr "Grisons"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Jura"
+msgstr "Jura"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Luzern"
+msgstr "Luzern"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Neuchâtel"
+msgstr "Neuchâtel"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Nidwalden"
+msgstr "Nidwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Obwalden"
+msgstr "Obwalden"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "St. Gallen"
+msgstr "Aziz Gallen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schaffhausen"
+msgstr "Schaffhausen"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Schwyz"
+msgstr "Schwyz"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Solothurn"
+msgstr "Solothurn"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Thurgau"
+msgstr "Thurgau"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Ticino"
+msgstr "Ticino"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Uri"
+msgstr "Uri"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Valais"
+msgstr "Valais"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Vaud"
+msgstr "Vaud"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zug"
+msgstr "Zug"
+
+#. 3.8->settings-schema.json->region_che->options
+#. 5.2->settings-schema.json->region_che->options
+msgid "Zürich"
+msgstr "Zürih"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "England"
+msgstr "İngiltere"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Northern Ireland"
+msgstr "Kuzey Irlanda"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Scotland"
+msgstr "İskoçya"
+
+#. 3.8->settings-schema.json->region_gbr->options
+#. 5.2->settings-schema.json->region_gbr->options
+msgid "Wales"
+msgstr "Wales"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alabama"
+msgstr "Alabama"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Alaska"
+msgstr "Alaska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arizona"
+msgstr "Arizona"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Arkansas"
+msgstr "Arkansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "California"
+msgstr "California"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Colorado"
+msgstr "Kolorado"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Connecticut"
+msgstr "Connecticut"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Delaware"
+msgstr "Delaware"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "District of Columbia"
+msgstr "Kolombia Bölgesi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Florida"
+msgstr "Florida"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Georgia"
+msgstr "Gürcistan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Hawaii"
+msgstr "Hawaii"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Idaho"
+msgstr "Idaho"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Illinois"
+msgstr "Illinois"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Indiana"
+msgstr "Hindistan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Iowa"
+msgstr "Iowa"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kansas"
+msgstr "Kansas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Kentucky"
+msgstr "Kentucky"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Louisiana"
+msgstr "Louisiana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maine"
+msgstr "Maine"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Maryland"
+msgstr "Maryland"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Massachusetts"
+msgstr "Massachusetts"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Michigan"
+msgstr "Michigan"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Minnesota"
+msgstr "Minnesota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Mississippi"
+msgstr "Mississippi"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Missouri"
+msgstr "Missouri"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Montana"
+msgstr "Montana"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nebraska"
+msgstr "Nebraska"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Nevada"
+msgstr "Nevada"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Hampshire"
+msgstr "New Hampshire"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Jersey"
+msgstr "New Jersey"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New Mexico"
+msgstr "New Mexico"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "New York"
+msgstr "New York"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Carolina"
+msgstr "Kuzey Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "North Dakota"
+msgstr "Kuzey Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Ohio"
+msgstr "Ohio"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oklahoma"
+msgstr "Oklahoma"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Oregon"
+msgstr "Oregon"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Pennsylvania"
+msgstr "Pennsylvania"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Rhode Island"
+msgstr "Rodos Adası"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Carolina"
+msgstr "Güney Carolina"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "South Dakota"
+msgstr "Güney Dakota"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Tennessee"
+msgstr "Tennessee"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Texas"
+msgstr "Texas"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Utah"
+msgstr "Utah"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Vermont"
+msgstr "Vermont"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Virginia"
+msgstr "Virjinya"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Washington"
+msgstr "Washington"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "West Virginia"
+msgstr "Batı Virginia"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wisconsin"
+msgstr "Wisconsin"
+
+#. 3.8->settings-schema.json->region_usa->options
+#. 5.2->settings-schema.json->region_usa->options
+msgid "Wyoming"
+msgstr "Wyoming"
+
+#. 3.8->settings-schema.json->keyOpen->description
+#. 5.2->settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Takvimi göster"
+
+#. 3.8->settings-schema.json->keyOpen->tooltip
+#. 5.2->settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Takvimi göstermek için tuş kısayolunu ayarlayın."
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Görünüm Adı"
+
+#. 3.8->settings-schema.json->worldclocks->columns->title
+#. 5.2->settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Zaman dilimi"
 
 #. 5.2->settings-schema.json->custom-tooltip-format->description
 #, fuzzy
@@ -221,349 +1344,17 @@ msgstr "Tarih biçimi"
 msgid "Set your custom tooltip format here."
 msgstr "Buradan özelleştirilmiş bir tarih biçimi ayarlayabilirsiniz."
 
-#. 5.2->settings-schema.json->format-button->description
-#. 3.8->settings-schema.json->format-button->description
-msgid "Show information on date format syntax"
-msgstr "Tarih biçimi sözdizimi için bilgi göster"
-
-#. 5.2->settings-schema.json->format-button->tooltip
-#. 3.8->settings-schema.json->format-button->tooltip
-msgid "Click this button to know more about the syntax for date formats."
-msgstr ""
-"Tarih formatı için sözdilimi hakkında daha fazla bilgi için bu düğmeyi "
-"tıklayınız."
-
-#. 5.2->settings-schema.json->country->description
-#. 3.8->settings-schema.json->country->description
-msgid "Country"
-msgstr "Ülke"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Angola"
-msgstr "Angola"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Australia"
-msgstr "Avustralya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Austria"
-msgstr "Avusturya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belgium"
-msgstr "Belçika"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Bosnia and Herzegovina"
-msgstr "Bosna Hersek"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Belarus"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Brazil"
-msgstr "Brezilya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Canada"
-msgstr "Kanada"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Chile"
-msgstr "Chile"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "China"
-msgstr "Çin"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Colombia"
-msgstr "Kolombiya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Croatia"
-msgstr "Hırvatistan"
-
 #. 5.2->settings-schema.json->country->options
 msgid "Cyprus"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Czech Republic"
-msgstr "Çek Cumhuriyeti"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Denmark"
-msgstr "Danimarka"
 
 #. 5.2->settings-schema.json->country->options
 msgid "El Salvador"
 msgstr ""
 
 #. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Estonia"
-msgstr "Estonya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Spain"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Finland"
-msgstr "Finlandiya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "France"
-msgstr "Fransa"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Germany"
-msgstr "Almanya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Greece"
-msgstr "Yunanistan"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hong Kong"
-msgstr "Hong Kong"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Hungary"
-msgstr "Macaristan"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Iceland"
-msgstr "İzlanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ireland"
-msgstr "İrlanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Isle of Man"
-msgstr "Man Adası"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Israel"
-msgstr "İsrail"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Italy"
-msgstr "İtalya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Japan"
-msgstr "Japonya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Korea (South)"
-msgstr "Kore (Güney)"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "kosovo"
-msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Latvia"
-msgstr "Letonya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Lithuania"
-msgstr "Litvanya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Luxembourg"
-msgstr "Lüksemburg"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Macedonia"
-msgstr "Makedonya"
-
-#. 5.2->settings-schema.json->country->options
 msgid "Montenegro"
 msgstr ""
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Mexico"
-msgstr "Meksika"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Netherlands"
-msgstr "Hollanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "New Zealand"
-msgstr "Yeni Zelanda"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Norway"
-msgstr "Norveç"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Peru"
-msgstr "Peru"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Philippines"
-msgstr "Filipinler"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Poland"
-msgstr "Polonya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Portugal"
-msgstr "Portekiz"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Romania"
-msgstr "Romanya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Russian Federation"
-msgstr "Rusya Federasyonu"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Serbia"
-msgstr "Sırbistan"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Singapore"
-msgstr "Singapur"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovakia"
-msgstr "Slovakya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Slovenia"
-msgstr "Slovenya"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "South Africa"
-msgstr "Güney Afrika"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Sweden"
-msgstr "İsveç"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Switzerland"
-msgstr "İsviçre"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Turkey"
-msgstr "Türkiye"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "Ukraine"
-msgstr "Ukrayna"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United Kingdom"
-msgstr "Birleşik Kırallık"
-
-#. 5.2->settings-schema.json->country->options
-#. 3.8->settings-schema.json->country->options
-msgid "United States of America"
-msgstr "Amerika Birleşik Devletleri"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Australian Capital Territory"
-msgstr "Avustralya Başkent Bölgesi"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Queensland"
-msgstr "Queensland"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "New South Wales"
-msgstr "Yeni Güney Galler"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Northern Territory"
-msgstr "Kuzey Bölgesi"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "South Australia"
-msgstr "Güney Avustralya"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Tasmania"
-msgstr "Tazmanya"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Victoria"
-msgstr "Victoria"
-
-#. 5.2->settings-schema.json->region_aus->options
-#. 3.8->settings-schema.json->region_aus->options
-msgid "Western Australia"
-msgstr "Batı Avustralya"
 
 #. 5.2->settings-schema.json->region_bel->options
 msgid "Brussels"
@@ -578,793 +1369,3 @@ msgstr "Bölge"
 #, fuzzy
 msgid "Walloon Region"
 msgstr "Bölge"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Alberta"
-msgstr "Alberta"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "British Columbia"
-msgstr "Britanya Kolombiyası"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Manitoba"
-msgstr "Manitoba"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "New Brunswick"
-msgstr "Yeni brunswick"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Newfoundland and Labrador"
-msgstr "Newfoundland ve Labrador"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Northwest Territories"
-msgstr "Kuzeybatı bölgesi"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nova Scotia"
-msgstr "Nova Scotia"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Nunavut"
-msgstr "Nunavut"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Ontario"
-msgstr "Ontario"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Prince Edward Island"
-msgstr "Prens Edward Adası"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Quebec"
-msgstr "Quebec"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Saskatchewan"
-msgstr "Saskatchewan"
-
-#. 5.2->settings-schema.json->region_can->options
-#. 3.8->settings-schema.json->region_can->options
-msgid "Yukon"
-msgstr "Yukon"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Baden-Württemberg"
-msgstr "Baden-Württemberg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bayern"
-msgstr "Bayern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Berlin"
-msgstr "Berlin"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Brandenburg"
-msgstr "Brandenburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Bremen"
-msgstr "Bremen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hamburg"
-msgstr "Hamburg"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Hessen"
-msgstr "Hessen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Niedersachsen"
-msgstr "Niedersachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Mecklenburg-Vorpommern"
-msgstr "Mecklenburg-Vorpommern"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Nordrhein-Westfalen"
-msgstr "Nordrhein-Westfalen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Rheinland-Pfalz"
-msgstr "Rheinland-Pfalz"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Saarland"
-msgstr "Saarland"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen"
-msgstr "Sachsen"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Sachsen-Anhalt"
-msgstr "Sachsen-Anhalt"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Schleswig-Holstein"
-msgstr "Schleswig-Holstein"
-
-#. 5.2->settings-schema.json->region_deu->options
-#. 3.8->settings-schema.json->region_deu->options
-msgid "Thüringen"
-msgstr "Thüringen"
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Andalucía"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Aragón"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Asturias"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Canarias"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cantabria"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla y León"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Castilla-La Mancha"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Cataluña"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Ceuta"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Extremadura"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Galicia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Islas Baleares"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "La Rioja"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Madrid"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Melilla"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Murcia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Navarra"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "País Vasco"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_esp->options
-#. 3.8->settings-schema.json->region_esp->options
-msgid "Valencia"
-msgstr ""
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Auckland"
-msgstr "Auckland"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Bay of Plenty"
-msgstr "Bay of Plenty"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Canterbury"
-msgstr "Canterbury"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Gisborne"
-msgstr "Gisborne"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Hawke's Bay"
-msgstr "Hawke's Bay"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Marlborough"
-msgstr "Marlborough"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Manawatu-Wanganui"
-msgstr "Manawatu-Wanganui"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Nelson"
-msgstr "Nelson"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Northland"
-msgstr "Kuzey bölgesi"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Otago"
-msgstr "Otago"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Southland"
-msgstr "Güney bölgesi"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Tasman"
-msgstr "Tasman"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Taranaki"
-msgstr "Taranaki"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Waikato"
-msgstr "Waikato"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Wellington"
-msgstr "Wellington"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "West Coast"
-msgstr "Batı Kıyısı"
-
-#. 5.2->settings-schema.json->region_nzl->options
-#. 3.8->settings-schema.json->region_nzl->options
-msgid "Chatham Islands Territory"
-msgstr "Chatham Adaları Bölgesi"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Banskobystrický kraj"
-msgstr "Banska Bystrica Bölgesi"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Bratislavský kraj"
-msgstr "Bratislava Bölgesi"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Košický kraj"
-msgstr "Kösice bölgesi"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Nitriansky kraj"
-msgstr "Nitra bölgesi"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Prešovský kraj"
-msgstr "Prešov Bölgesi"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trnavský kraj"
-msgstr "Trnava bölgesi"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Trenčiansky kraj"
-msgstr "Trencin Bölgesi"
-
-#. 5.2->settings-schema.json->region_svk->options
-#. 3.8->settings-schema.json->region_svk->options
-msgid "Žilinský kraj"
-msgstr "Žilina Bölgesi"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Aargau"
-msgstr "Aargau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Innerrhoden"
-msgstr "Appenzell Innerrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Appenzell Ausserrhoden"
-msgstr "Appenzell Ausserrhoden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Landschaft"
-msgstr "Basel-Ülke"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Basel-Stadt"
-msgstr "Basel şehri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Bern"
-msgstr "Bern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Fribourg"
-msgstr "Fribourg"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Geneva"
-msgstr "Cenevre"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Glarus"
-msgstr "Glarus"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Grisons"
-msgstr "Grisons"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Jura"
-msgstr "Jura"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Luzern"
-msgstr "Luzern"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Neuchâtel"
-msgstr "Neuchâtel"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Nidwalden"
-msgstr "Nidwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Obwalden"
-msgstr "Obwalden"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "St. Gallen"
-msgstr "Aziz Gallen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schaffhausen"
-msgstr "Schaffhausen"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Schwyz"
-msgstr "Schwyz"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Solothurn"
-msgstr "Solothurn"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Thurgau"
-msgstr "Thurgau"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Ticino"
-msgstr "Ticino"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Uri"
-msgstr "Uri"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Valais"
-msgstr "Valais"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Vaud"
-msgstr "Vaud"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zug"
-msgstr "Zug"
-
-#. 5.2->settings-schema.json->region_che->options
-#. 3.8->settings-schema.json->region_che->options
-msgid "Zürich"
-msgstr "Zürih"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "England"
-msgstr "İngiltere"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Northern Ireland"
-msgstr "Kuzey Irlanda"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Scotland"
-msgstr "İskoçya"
-
-#. 5.2->settings-schema.json->region_gbr->options
-#. 3.8->settings-schema.json->region_gbr->options
-msgid "Wales"
-msgstr "Wales"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alabama"
-msgstr "Alabama"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Alaska"
-msgstr "Alaska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arizona"
-msgstr "Arizona"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Arkansas"
-msgstr "Arkansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "California"
-msgstr "California"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Colorado"
-msgstr "Kolorado"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Connecticut"
-msgstr "Connecticut"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Delaware"
-msgstr "Delaware"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "District of Columbia"
-msgstr "Kolombia Bölgesi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Florida"
-msgstr "Florida"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Georgia"
-msgstr "Gürcistan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Hawaii"
-msgstr "Hawaii"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Idaho"
-msgstr "Idaho"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Illinois"
-msgstr "Illinois"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Indiana"
-msgstr "Hindistan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Iowa"
-msgstr "Iowa"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kansas"
-msgstr "Kansas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Kentucky"
-msgstr "Kentucky"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Louisiana"
-msgstr "Louisiana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maine"
-msgstr "Maine"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Maryland"
-msgstr "Maryland"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Massachusetts"
-msgstr "Massachusetts"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Michigan"
-msgstr "Michigan"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Minnesota"
-msgstr "Minnesota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Mississippi"
-msgstr "Mississippi"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Missouri"
-msgstr "Missouri"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Montana"
-msgstr "Montana"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nebraska"
-msgstr "Nebraska"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Nevada"
-msgstr "Nevada"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Hampshire"
-msgstr "New Hampshire"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Jersey"
-msgstr "New Jersey"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New Mexico"
-msgstr "New Mexico"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "New York"
-msgstr "New York"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Carolina"
-msgstr "Kuzey Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "North Dakota"
-msgstr "Kuzey Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Ohio"
-msgstr "Ohio"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oklahoma"
-msgstr "Oklahoma"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Oregon"
-msgstr "Oregon"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Pennsylvania"
-msgstr "Pennsylvania"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Rhode Island"
-msgstr "Rodos Adası"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Carolina"
-msgstr "Güney Carolina"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "South Dakota"
-msgstr "Güney Dakota"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Tennessee"
-msgstr "Tennessee"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Texas"
-msgstr "Texas"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Utah"
-msgstr "Utah"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Vermont"
-msgstr "Vermont"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Virginia"
-msgstr "Virjinya"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Washington"
-msgstr "Washington"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "West Virginia"
-msgstr "Batı Virginia"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wisconsin"
-msgstr "Wisconsin"
-
-#. 5.2->settings-schema.json->region_usa->options
-#. 3.8->settings-schema.json->region_usa->options
-msgid "Wyoming"
-msgstr "Wyoming"
-
-#. 5.2->settings-schema.json->keyOpen->description
-#. 3.8->settings-schema.json->keyOpen->description
-msgid "Show calendar"
-msgstr "Takvimi göster"
-
-#. 5.2->settings-schema.json->keyOpen->tooltip
-#. 3.8->settings-schema.json->keyOpen->tooltip
-msgid "Set keybinding(s) to show the calendar."
-msgstr "Takvimi göstermek için tuş kısayolunu ayarlayın."
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Görünüm Adı"
-
-#. 5.2->settings-schema.json->worldclocks->columns->title
-#. 3.8->settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Zaman dilimi"

--- a/calendar@ccprog/files/calendar@ccprog/po/tr.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/tr.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog 1.1.6\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2024-02-05 14:47-0500\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-22 22:50+0100\n"
 "PO-Revision-Date: 2021-07-05 18:36+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: eventView.js:26 3.8/applet.js:22 5.2/applet.js:22 5.2/eventView.js:27
+#: eventView.js:26 5.2/applet.js:22 5.2/eventView.js:27 3.8/applet.js:22
 msgid "%A, %B %-e, %Y"
 msgstr ""
 
@@ -46,40 +46,50 @@ msgid_plural "In %d hours"
 msgstr[0] "%d saat içinde"
 msgstr[1] "%d saat içinde"
 
-#: eventView.js:664 5.2/eventView.js:683
+#: eventView.js:664 5.2/eventView.js:693
 msgid "No Events"
 msgstr "Olay Yok"
 
-#: eventView.js:925 5.2/eventView.js:944
+#: eventView.js:925 5.2/eventView.js:966
 msgid "In progress"
 msgstr "Devam ediyor"
 
-#: eventView.js:946 5.2/eventView.js:965
+#: eventView.js:946 5.2/eventView.js:987
 msgid "All day"
 msgstr "Tüm gün"
 
 #: eventView.js:971 eventView.js:994 eventView.js:1032 eventView.js:1054
-#: 5.2/eventView.js:992 5.2/eventView.js:1015 5.2/eventView.js:1053
-#: 5.2/eventView.js:1075
+#: 5.2/eventView.js:1014 5.2/eventView.js:1037 5.2/eventView.js:1075
+#: 5.2/eventView.js:1097
 msgid "Today"
 msgstr "Bugün"
 
-#: 3.8/applet.js:21 5.2/applet.js:21
+#: 5.2/applet.js:21 3.8/applet.js:21
 msgid "%B %-e, %Y"
 msgstr ""
 
-#: 3.8/applet.js:131 5.2/applet.js:137
+#: 5.2/applet.js:138 3.8/applet.js:131
 msgid "Date and Time Settings"
 msgstr "Tarih ve Zaman Ayarları"
 
-#: 3.8/settings_widgets.py:95 5.2/settings_widgets.py:95
+#: 5.2/settings_widgets.py:95 3.8/settings_widgets.py:95
 msgid "Add new entry"
 msgstr "Yeni girdi ekle"
 
-#: 3.8/settings_widgets.py:99 5.2/settings_widgets.py:99
+#: 5.2/settings_widgets.py:99 3.8/settings_widgets.py:99
 msgid "Edit entry"
 msgstr "Girdiyi düzenle"
 
+#. 5.2->settings-schema.json->region_aus->description
+#. 5.2->settings-schema.json->region_bel->description
+#. 5.2->settings-schema.json->region_can->description
+#. 5.2->settings-schema.json->region_deu->description
+#. 5.2->settings-schema.json->region_esp->description
+#. 5.2->settings-schema.json->region_nzl->description
+#. 5.2->settings-schema.json->region_svk->description
+#. 5.2->settings-schema.json->region_che->description
+#. 5.2->settings-schema.json->region_gbr->description
+#. 5.2->settings-schema.json->region_usa->description
 #. 3.8->settings-schema.json->region_aus->description
 #. 3.8->settings-schema.json->region_can->description
 #. 3.8->settings-schema.json->region_deu->description
@@ -89,20 +99,11 @@ msgstr "Girdiyi düzenle"
 #. 3.8->settings-schema.json->region_che->description
 #. 3.8->settings-schema.json->region_gbr->description
 #. 3.8->settings-schema.json->region_usa->description
-#. 5.2->settings-schema.json->region_aus->description
-#. 5.2->settings-schema.json->region_can->description
-#. 5.2->settings-schema.json->region_deu->description
-#. 5.2->settings-schema.json->region_esp->description
-#. 5.2->settings-schema.json->region_nzl->description
-#. 5.2->settings-schema.json->region_svk->description
-#. 5.2->settings-schema.json->region_che->description
-#. 5.2->settings-schema.json->region_gbr->description
-#. 5.2->settings-schema.json->region_usa->description
-#: 3.8/settings_widgets.py:122 5.2/settings_widgets.py:122
+#: 5.2/settings_widgets.py:122 3.8/settings_widgets.py:122
 msgid "Region"
 msgstr "Bölge"
 
-#: 3.8/settings_widgets.py:123 5.2/settings_widgets.py:123
+#: 5.2/settings_widgets.py:123 3.8/settings_widgets.py:123
 msgid "City"
 msgstr "Şehir"
 
@@ -112,1216 +113,1258 @@ msgstr "Resmi Tatiller ile Takvim"
 
 #. metadata.json->description
 msgid "Calendar applet with public holiday data provided by Enrico service"
-msgstr "Enrico hizmeti tarafından sağlanan resmi tatil verileriyle takvim uygulaması"
+msgstr ""
+"Enrico hizmeti tarafından sağlanan resmi tatil verileriyle takvim uygulaması"
 
-#. 3.8->settings-schema.json->page1->title
 #. 5.2->settings-schema.json->page1->title
+#. 3.8->settings-schema.json->page1->title
 msgid "Calendar"
 msgstr "Takvim"
 
-#. 3.8->settings-schema.json->page2->title
-#. 3.8->settings-schema.json->worldclocks->description
 #. 5.2->settings-schema.json->page2->title
 #. 5.2->settings-schema.json->worldclocks->description
+#. 3.8->settings-schema.json->page2->title
+#. 3.8->settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Dünya Saatleri"
 
-#. 3.8->settings-schema.json->section1->title
 #. 5.2->settings-schema.json->section1->title
+#. 3.8->settings-schema.json->section1->title
 msgid "Display"
 msgstr "Görüntüleme"
 
-#. 3.8->settings-schema.json->section2->title
 #. 5.2->settings-schema.json->section2->title
+#. 3.8->settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Resmi Tatilleri Alın"
 
-#. 3.8->settings-schema.json->section3->title
 #. 5.2->settings-schema.json->section3->title
+#. 3.8->settings-schema.json->section3->title
 msgid "Keyboard shortcuts"
 msgstr "Klavye Kısayolları"
 
-#. 3.8->settings-schema.json->section4->title
 #. 5.2->settings-schema.json->section4->title
+#. 3.8->settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Dünya Tarihlerini Göster"
 
-#. 3.8->settings-schema.json->show-events->description
 #. 5.2->settings-schema.json->show-events->description
+#. 3.8->settings-schema.json->show-events->description
 msgid "Show calendar events"
 msgstr "Takvim olaylarını göster"
 
-#. 3.8->settings-schema.json->show-events->tooltip
 #. 5.2->settings-schema.json->show-events->tooltip
+#. 3.8->settings-schema.json->show-events->tooltip
 msgid "Check this to display events in the calendar."
 msgstr "Takvimdeki olayları görüntülemek için bunu etkinleştirin."
 
-#. 3.8->settings-schema.json->show-week-numbers->description
 #. 5.2->settings-schema.json->show-week-numbers->description
+#. 3.8->settings-schema.json->show-week-numbers->description
 msgid "Show week numbers in calendar"
 msgstr "Takvimde hafta numarasını göster"
 
-#. 3.8->settings-schema.json->show-week-numbers->tooltip
 #. 5.2->settings-schema.json->show-week-numbers->tooltip
+#. 3.8->settings-schema.json->show-week-numbers->tooltip
 msgid "Check this to show week numbers in the calendar."
 msgstr "Takvimde hafta numarası gösterimi için burayı işaretleyiniz."
 
-#. 3.8->settings-schema.json->weekend-length->description
 #. 5.2->settings-schema.json->weekend-length->description
+#. 3.8->settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
 msgstr "Hafta sonu günleri olarak işaretle"
 
-#. 3.8->settings-schema.json->weekend-length->tooltip
 #. 5.2->settings-schema.json->weekend-length->tooltip
+#. 3.8->settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
 msgstr "Haftada kaç günün çalışma dışı gün olarak işaretleneceğini ayarlayın."
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "One day"
 msgstr "Bir gün"
 
-#. 3.8->settings-schema.json->weekend-length->options
 #. 5.2->settings-schema.json->weekend-length->options
+#. 3.8->settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "İki gün"
 
-#. 3.8->settings-schema.json->use-custom-format->description
 #. 5.2->settings-schema.json->use-custom-format->description
+#. 3.8->settings-schema.json->use-custom-format->description
 msgid "Use a custom date format"
 msgstr "Özel bir tarih biçimi kullan"
 
-#. 3.8->settings-schema.json->use-custom-format->tooltip
 #. 5.2->settings-schema.json->use-custom-format->tooltip
-msgid "Check this to define a custom format for the date in the calendar applet."
-msgstr "Takvim uygulamacığında, özel bir tarih biçimi tanımlamak için bunu kontrol edin."
+#. 3.8->settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+"Takvim uygulamacığında, özel bir tarih biçimi tanımlamak için bunu kontrol "
+"edin."
 
-#. 3.8->settings-schema.json->custom-format->description
 #. 5.2->settings-schema.json->custom-format->description
+#. 3.8->settings-schema.json->custom-format->description
 msgid "Date format"
 msgstr "Tarih biçimi"
 
-#. 3.8->settings-schema.json->custom-format->tooltip
 #. 5.2->settings-schema.json->custom-format->tooltip
+#. 3.8->settings-schema.json->custom-format->tooltip
 msgid "Set your custom format here."
 msgstr "Buradan özelleştirilmiş bir tarih biçimi ayarlayabilirsiniz."
 
-#. 3.8->settings-schema.json->format-button->description
+#. 5.2->settings-schema.json->custom-tooltip-format->description
+#, fuzzy
+msgid "Date format for tooltip"
+msgstr "Tarih biçimi"
+
+#. 5.2->settings-schema.json->custom-tooltip-format->tooltip
+#, fuzzy
+msgid "Set your custom tooltip format here."
+msgstr "Buradan özelleştirilmiş bir tarih biçimi ayarlayabilirsiniz."
+
 #. 5.2->settings-schema.json->format-button->description
+#. 3.8->settings-schema.json->format-button->description
 msgid "Show information on date format syntax"
 msgstr "Tarih biçimi sözdizimi için bilgi göster"
 
-#. 3.8->settings-schema.json->format-button->tooltip
 #. 5.2->settings-schema.json->format-button->tooltip
+#. 3.8->settings-schema.json->format-button->tooltip
 msgid "Click this button to know more about the syntax for date formats."
-msgstr "Tarih formatı için sözdilimi hakkında daha fazla bilgi için bu düğmeyi tıklayınız."
+msgstr ""
+"Tarih formatı için sözdilimi hakkında daha fazla bilgi için bu düğmeyi "
+"tıklayınız."
 
-#. 3.8->settings-schema.json->country->description
 #. 5.2->settings-schema.json->country->description
+#. 3.8->settings-schema.json->country->description
 msgid "Country"
 msgstr "Ülke"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Angola"
 msgstr "Angola"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Australia"
 msgstr "Avustralya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Austria"
 msgstr "Avusturya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belgium"
 msgstr "Belçika"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Bosnia and Herzegovina"
 msgstr "Bosna Hersek"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Belarus"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Brazil"
 msgstr "Brezilya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Canada"
 msgstr "Kanada"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Chile"
 msgstr "Chile"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "China"
 msgstr "Çin"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Colombia"
 msgstr "Kolombiya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Croatia"
 msgstr "Hırvatistan"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Cyprus"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Czech Republic"
 msgstr "Çek Cumhuriyeti"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Denmark"
 msgstr "Danimarka"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "El Salvador"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Estonia"
 msgstr "Estonya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Spain"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Finland"
 msgstr "Finlandiya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "France"
 msgstr "Fransa"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Germany"
 msgstr "Almanya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Greece"
 msgstr "Yunanistan"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Hungary"
 msgstr "Macaristan"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Iceland"
 msgstr "İzlanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ireland"
 msgstr "İrlanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Isle of Man"
 msgstr "Man Adası"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Israel"
 msgstr "İsrail"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Italy"
 msgstr "İtalya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Japan"
 msgstr "Japonya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Korea (South)"
 msgstr "Kore (Güney)"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "kosovo"
 msgstr ""
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Latvia"
 msgstr "Letonya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Lithuania"
 msgstr "Litvanya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Luxembourg"
 msgstr "Lüksemburg"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Macedonia"
 msgstr "Makedonya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+msgid "Montenegro"
+msgstr ""
+
+#. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Mexico"
 msgstr "Meksika"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Netherlands"
 msgstr "Hollanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "New Zealand"
 msgstr "Yeni Zelanda"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Norway"
 msgstr "Norveç"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Peru"
 msgstr "Peru"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Philippines"
 msgstr "Filipinler"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Poland"
 msgstr "Polonya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Portugal"
 msgstr "Portekiz"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Romania"
 msgstr "Romanya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Russian Federation"
 msgstr "Rusya Federasyonu"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Serbia"
 msgstr "Sırbistan"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Singapore"
 msgstr "Singapur"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovakia"
 msgstr "Slovakya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Slovenia"
 msgstr "Slovenya"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "South Africa"
 msgstr "Güney Afrika"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Sweden"
 msgstr "İsveç"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "İsviçre"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Turkey"
 msgstr "Türkiye"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukrayna"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United Kingdom"
 msgstr "Birleşik Kırallık"
 
-#. 3.8->settings-schema.json->country->options
 #. 5.2->settings-schema.json->country->options
+#. 3.8->settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Amerika Birleşik Devletleri"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
 msgstr "Avustralya Başkent Bölgesi"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Queensland"
 msgstr "Queensland"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "New South Wales"
 msgstr "Yeni Güney Galler"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Northern Territory"
 msgstr "Kuzey Bölgesi"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "South Australia"
 msgstr "Güney Avustralya"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Tasmania"
 msgstr "Tazmanya"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Victoria"
 msgstr "Victoria"
 
-#. 3.8->settings-schema.json->region_aus->options
 #. 5.2->settings-schema.json->region_aus->options
+#. 3.8->settings-schema.json->region_aus->options
 msgid "Western Australia"
 msgstr "Batı Avustralya"
 
-#. 3.8->settings-schema.json->region_can->options
+#. 5.2->settings-schema.json->region_bel->options
+msgid "Brussels"
+msgstr ""
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Flemish Region"
+msgstr "Bölge"
+
+#. 5.2->settings-schema.json->region_bel->options
+#, fuzzy
+msgid "Walloon Region"
+msgstr "Bölge"
+
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Alberta"
 msgstr "Alberta"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "British Columbia"
 msgstr "Britanya Kolombiyası"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Manitoba"
 msgstr "Manitoba"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "New Brunswick"
 msgstr "Yeni brunswick"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
 msgstr "Newfoundland ve Labrador"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Northwest Territories"
 msgstr "Kuzeybatı bölgesi"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nova Scotia"
 msgstr "Nova Scotia"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Nunavut"
 msgstr "Nunavut"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Ontario"
 msgstr "Ontario"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Prince Edward Island"
 msgstr "Prens Edward Adası"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Quebec"
 msgstr "Quebec"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-#. 3.8->settings-schema.json->region_can->options
 #. 5.2->settings-schema.json->region_can->options
+#. 3.8->settings-schema.json->region_can->options
 msgid "Yukon"
 msgstr "Yukon"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bayern"
 msgstr "Bayern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Berlin"
 msgstr "Berlin"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Brandenburg"
 msgstr "Brandenburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Bremen"
 msgstr "Bremen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hamburg"
 msgstr "Hamburg"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Hessen"
 msgstr "Hessen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Niedersachsen"
 msgstr "Niedersachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklenburg-Vorpommern"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Nordrhein-Westfalen"
 msgstr "Nordrhein-Westfalen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
 msgstr "Rheinland-Pfalz"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Saarland"
 msgstr "Saarland"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen"
 msgstr "Sachsen"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
 msgstr "Sachsen-Anhalt"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
 msgstr "Schleswig-Holstein"
 
-#. 3.8->settings-schema.json->region_deu->options
 #. 5.2->settings-schema.json->region_deu->options
+#. 3.8->settings-schema.json->region_deu->options
 msgid "Thüringen"
 msgstr "Thüringen"
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Andalucía"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Aragón"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Asturias"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Canarias"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cantabria"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla y León"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Castilla-La Mancha"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Cataluña"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Ceuta"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Extremadura"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Galicia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Islas Baleares"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "La Rioja"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Madrid"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Melilla"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Murcia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Navarra"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "País Vasco"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_esp->options
 #. 5.2->settings-schema.json->region_esp->options
+#. 3.8->settings-schema.json->region_esp->options
 msgid "Valencia"
 msgstr ""
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Auckland"
 msgstr "Auckland"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
 msgstr "Bay of Plenty"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Canterbury"
 msgstr "Canterbury"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Gisborne"
 msgstr "Gisborne"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
 msgstr "Hawke's Bay"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Marlborough"
 msgstr "Marlborough"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
 msgstr "Manawatu-Wanganui"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Nelson"
 msgstr "Nelson"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Northland"
 msgstr "Kuzey bölgesi"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Otago"
 msgstr "Otago"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Southland"
 msgstr "Güney bölgesi"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Tasman"
 msgstr "Tasman"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Taranaki"
 msgstr "Taranaki"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Waikato"
 msgstr "Waikato"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Wellington"
 msgstr "Wellington"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "West Coast"
 msgstr "Batı Kıyısı"
 
-#. 3.8->settings-schema.json->region_nzl->options
 #. 5.2->settings-schema.json->region_nzl->options
+#. 3.8->settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
 msgstr "Chatham Adaları Bölgesi"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
 msgstr "Banska Bystrica Bölgesi"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
 msgstr "Bratislava Bölgesi"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Košický kraj"
 msgstr "Kösice bölgesi"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
 msgstr "Nitra bölgesi"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
 msgstr "Prešov Bölgesi"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
 msgstr "Trnava bölgesi"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
 msgstr "Trencin Bölgesi"
 
-#. 3.8->settings-schema.json->region_svk->options
 #. 5.2->settings-schema.json->region_svk->options
+#. 3.8->settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
 msgstr "Žilina Bölgesi"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Aargau"
 msgstr "Aargau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
 msgstr "Appenzell Innerrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
 msgstr "Appenzell Ausserrhoden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
 msgstr "Basel-Ülke"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Basel-Stadt"
 msgstr "Basel şehri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Bern"
 msgstr "Bern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Fribourg"
 msgstr "Fribourg"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Geneva"
 msgstr "Cenevre"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Glarus"
 msgstr "Glarus"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Grisons"
 msgstr "Grisons"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Jura"
 msgstr "Jura"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Luzern"
 msgstr "Luzern"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Nidwalden"
 msgstr "Nidwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Obwalden"
 msgstr "Obwalden"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "St. Gallen"
 msgstr "Aziz Gallen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schaffhausen"
 msgstr "Schaffhausen"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Schwyz"
 msgstr "Schwyz"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Solothurn"
 msgstr "Solothurn"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Thurgau"
 msgstr "Thurgau"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Ticino"
 msgstr "Ticino"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Uri"
 msgstr "Uri"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Valais"
 msgstr "Valais"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Vaud"
 msgstr "Vaud"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zug"
 msgstr "Zug"
 
-#. 3.8->settings-schema.json->region_che->options
 #. 5.2->settings-schema.json->region_che->options
+#. 3.8->settings-schema.json->region_che->options
 msgid "Zürich"
 msgstr "Zürih"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "England"
 msgstr "İngiltere"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
 msgstr "Kuzey Irlanda"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Scotland"
 msgstr "İskoçya"
 
-#. 3.8->settings-schema.json->region_gbr->options
 #. 5.2->settings-schema.json->region_gbr->options
+#. 3.8->settings-schema.json->region_gbr->options
 msgid "Wales"
 msgstr "Wales"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alabama"
 msgstr "Alabama"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Alaska"
 msgstr "Alaska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arizona"
 msgstr "Arizona"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "California"
 msgstr "California"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Colorado"
 msgstr "Kolorado"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Delaware"
 msgstr "Delaware"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "District of Columbia"
 msgstr "Kolombia Bölgesi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Florida"
 msgstr "Florida"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Georgia"
 msgstr "Gürcistan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Hawaii"
 msgstr "Hawaii"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Idaho"
 msgstr "Idaho"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Illinois"
 msgstr "Illinois"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Indiana"
 msgstr "Hindistan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Iowa"
 msgstr "Iowa"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kansas"
 msgstr "Kansas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maine"
 msgstr "Maine"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Maryland"
 msgstr "Maryland"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Michigan"
 msgstr "Michigan"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Minnesota"
 msgstr "Minnesota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Mississippi"
 msgstr "Mississippi"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Missouri"
 msgstr "Missouri"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Montana"
 msgstr "Montana"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Nevada"
 msgstr "Nevada"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Jersey"
 msgstr "New Jersey"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New Mexico"
 msgstr "New Mexico"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "New York"
 msgstr "New York"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Carolina"
 msgstr "Kuzey Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "North Dakota"
 msgstr "Kuzey Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Ohio"
 msgstr "Ohio"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Oregon"
 msgstr "Oregon"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Rhode Island"
 msgstr "Rodos Adası"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Carolina"
 msgstr "Güney Carolina"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "South Dakota"
 msgstr "Güney Dakota"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Texas"
 msgstr "Texas"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Utah"
 msgstr "Utah"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Vermont"
 msgstr "Vermont"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Virginia"
 msgstr "Virjinya"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Washington"
 msgstr "Washington"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "West Virginia"
 msgstr "Batı Virginia"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#. 3.8->settings-schema.json->region_usa->options
 #. 5.2->settings-schema.json->region_usa->options
+#. 3.8->settings-schema.json->region_usa->options
 msgid "Wyoming"
 msgstr "Wyoming"
 
-#. 3.8->settings-schema.json->keyOpen->description
 #. 5.2->settings-schema.json->keyOpen->description
+#. 3.8->settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Takvimi göster"
 
-#. 3.8->settings-schema.json->keyOpen->tooltip
 #. 5.2->settings-schema.json->keyOpen->tooltip
+#. 3.8->settings-schema.json->keyOpen->tooltip
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Takvimi göstermek için tuş kısayolunu ayarlayın."
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Görünüm Adı"
 
-#. 3.8->settings-schema.json->worldclocks->columns->title
 #. 5.2->settings-schema.json->worldclocks->columns->title
+#. 3.8->settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Zaman dilimi"


### PR DESCRIPTION
- Thanks for multiple translations: blogdron for Russian, qadzek for Dutch, Odyssey for Catalan
- Multiple fixes merged from upstream calendar@cinnamon
- Included custom tooltip formatting from upstream calendar@cinnamon
- Bugfix: correctly check cache whenever data are needed
- Support for holidays in Cyprus, Montenegro and El Salvador, and for regional holidays in Belgium.  
  **Users from Belgium will need to check their regional settings!**

Resolves #6587
