### PR TITLE
[test-spice] Add applet reload after successful copy

### DIFF
--- a/test-spice
+++ b/test-spice
@@ -53,15 +53,7 @@ def reload_xlet(uuid):
     """
     Reloads the Spice via dbus-send.
     """
-    args = ['dbus-send', 
-        '--dest=org.Cinnamon',
-        '--print-reply',
-        '--type=method_call',
-        '/org/Cinnamon',
-        'org.Cinnamon.ReloadXlet',
-        f'string:{uuid}', 
-        'string:APPLET'
-        ]
+    args = ['/usr/bin/cinnamon-dbus-command', 'ReloadXlet', uuid, 'APPLET']
     out = subprocess.run(args, check=False, 
         stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
     )

--- a/test-spice
+++ b/test-spice
@@ -21,10 +21,12 @@ def validate_spice(uuid):
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if out.returncode != 0:
             print(out.stdout.decode('ascii') + '\nValidation failed!')
+            return False
+        return True
     except FileNotFoundError:
         print('Errors encountered! Please try running again from the top-level'
               ' directory of the repository.')
-
+        return False
 
 def copy_xlet(uuid):
     """
@@ -42,10 +44,29 @@ def copy_xlet(uuid):
             data['uuid'] = f"{DEV_PREFIX}{data['uuid']}"
             data['name'] = f"({DEV_PREFIX.replace('-', '')}) {data['name']}"
             json.dump(data, metadata, indent=4)
+        reload_xlet(f'{DEV_PREFIX}{uuid}')
     except (FileNotFoundError, KeyError):
         # metadata.json file not found or missing valid keys
         pass
 
+def reload_xlet(uuid):
+    """
+    Reloads the Spice via dbus-send.
+    """
+    args = ['dbus-send', 
+        '--dest=org.Cinnamon',
+        '--print-reply',
+        '--type=method_call',
+        '/org/Cinnamon',
+        'org.Cinnamon.ReloadXlet',
+        f'string:{uuid}', 
+        'string:APPLET'
+        ]
+    out = subprocess.run(args, check=False, 
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+    )
+    if out.returncode != 0:
+        print(out.stderr.decode('ascii') + '\nReload error!')
 
 def main():
     """
@@ -71,8 +92,8 @@ def main():
     elif args.skip and args.uuid:
         copy_xlet(args.uuid.rstrip('/'))
     elif args.uuid and not args.remove:
-        validate_spice(args.uuid.rstrip('/'))
-        copy_xlet(args.uuid.rstrip('/'))
+        if validate_spice(args.uuid.rstrip('/')):
+            copy_xlet(args.uuid.rstrip('/'))
     else:
         parser.print_help()
         sys.exit(2)


### PR DESCRIPTION
**Change:** 
Add automatic reload of applet after copying to DEVTEST path

**Rationale:** 
Currently, when a developer needs to test their applet, they need to run `./test-spice uuid`, followed up by explicitly entering the applet settings, and triggering a reload of the applet from the hamburger menu. In my tests, removing/re-adding the applet from the panel didn't trigger a reload in Cinnamon.

Now, when a developer runs `./test-spice uuid`, the script will tell Cinnamon to reload the applet using same method as the applet settings, making it easier for the developer to test their changes.

@rcalixte 