### PR TITLE
[gpaste-reloaded@feuerfuchs.eu] Add option to hide tray icon

### DIFF
--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/applet.js
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/applet.js
@@ -167,6 +167,7 @@ GPasteApplet.prototype = {
 
             this._appletSettings = new Settings.AppletSettings(this, uuid, instance_id);
 
+            this._appletSettings.bind("always-show-icon",      "alwaysShowIcon",      this._onDisplaySettingsUpdated);
             this._appletSettings.bind("display-track-switch",  "displayTrackSwitch",  this._onDisplaySettingsUpdated);
             this._appletSettings.bind("display-new-item",      "displayNewItem",      this._onDisplaySettingsUpdated);
             this._appletSettings.bind("display-searchbar",     "displaySearchBar",    this._onDisplaySettingsUpdated);
@@ -229,10 +230,14 @@ GPasteApplet.prototype = {
                     if (this.displaySearchBar) {
                         global.stage.set_key_focus(this.mitemSearch.entry);
                     }
+                    this.actor.visible = true;
                 } else {
                     this.mitemSearch.reset();
+                    this.actor.visible = this.alwaysShowIcon;
                 }
             }));
+            
+            global.settings.connect('changed::panel-edit-mode', () => this._on_panel_edit_mode_changed());
         }
         catch (e) {
             global.logError(e);
@@ -265,6 +270,7 @@ GPasteApplet.prototype = {
     _onDisplaySettingsUpdated: function() {
         this.mitemSearch.reset();
 
+        this.actor.visible = this.alwaysShowIcon;
         this.mitemTrack.actor.visible        = this.displayTrackSwitch;
         this.msepTop.actor.visible           = this.displayTrackSwitch;
         this.mitemSearch.actor.visible       = this.displaySearchBar;
@@ -611,5 +617,12 @@ GPasteApplet.prototype = {
      */
     on_applet_clicked: function(event) {
         this.menu.toggle();
+    },
+
+    /*
+     * Panel edit mode has been toggled
+     */
+    _on_panel_edit_mode_changed() {
+        this.actor.visible = global.settings.get_boolean('panel-edit-mode') || this.alwaysShowIcon;
     }
 };

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/bg.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/bg.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-28 14:57+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2017-11-28 14:58+0200\n"
 "Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
@@ -18,65 +19,19 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:55
-msgid "[GPaste is not installed]"
-msgstr "[GPaste не е инсталиран]"
-
-#: applet.js:91
-msgid "GPaste clipboard"
-msgstr "GPaste клипборд"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->gpaste-
-#. settings->description
-#: applet.js:97 applet.js:135
-msgid "GPaste Main Program"
-msgstr "GPaste основна програма"
-
-#: applet.js:102
-msgid "Select History"
-msgstr "Избор на история"
-
-#: applet.js:111
-msgid "Track clipboard changes"
-msgstr "Проследяване на промените в историята"
-
-#: applet.js:119
-msgid "(Empty)"
-msgstr "(Празно)"
-
-#: applet.js:122
-msgid "(No results)"
-msgstr "(Няма резултати)"
-
-#: applet.js:127
-msgid "New item"
-msgstr "Нов запис"
-
-#: applet.js:130
-msgid "Empty history"
-msgstr "Изчистване на историята"
-
-#: applet.js:447
-msgid "Do you really want to empty the current history?"
-msgstr "Наистина ли искате да изчистите историята?"
-
-#: GPasteNewItemDialog.js:48
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Моля въведете текста, който искате да добавите в историята:"
 
-#: GPasteNewItemDialog.js:54 GPasteNotInstalledDialog.js:27
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "Ок"
 
-#: GPasteNewItemDialog.js:58
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Отказ"
 
-#: GPasteSearchItem.js:29
-msgid "Type to search..."
-msgstr "Пишете за да търсите..."
-
-#: GPasteNotInstalledDialog.js:22
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -84,55 +39,95 @@ msgstr ""
 "GPaste не е инсталиран. Моля инсталирайте нужните пакети и рестартирайте "
 "Cinnamon, за да може аплета да работи."
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->name
+#. GPasteSearchItem.js:34
+msgid "Type to search..."
+msgstr "Пишете за да търсите..."
+
+#. applet.js:73
+msgid "[GPaste is not installed]"
+msgstr "[GPaste не е инсталиран]"
+
+#. applet.js:109
+msgid "GPaste clipboard"
+msgstr "GPaste клипборд"
+
+#. settings-schema.json->gpaste-settings->description
+#. applet.js:115 applet.js:153
+msgid "GPaste Main Program"
+msgstr "GPaste основна програма"
+
+#. applet.js:120
+msgid "Select History"
+msgstr "Избор на история"
+
+#. applet.js:129
+msgid "Track clipboard changes"
+msgstr "Проследяване на промените в историята"
+
+#. applet.js:137
+msgid "(Empty)"
+msgstr "(Празно)"
+
+#. applet.js:140
+msgid "(No results)"
+msgstr "(Няма резултати)"
+
+#. applet.js:145
+msgid "New item"
+msgstr "Нов запис"
+
+#. applet.js:148
+msgid "Empty history"
+msgstr "Изчистване на историята"
+
+#. applet.js:471
+msgid "Do you really want to empty the current history?"
+msgstr "Наистина ли искате да изчистите историята?"
+
+#. metadata.json->description
+msgid "Instantly access and manage your clipboard history."
+msgstr ""
+
+#. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste Reloaded"
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->description
-msgid ""
-"A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-msgstr "Напълно пренаписан GPaste аплет, базиран не Gnome Shell разширението"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-gpaste-
-#. ui->description
-msgid "Display 'GPaste Main Program'"
-msgstr "Покажи основната програма на GPaste"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->kb-show-
-#. history->description
-msgid "Show history"
-msgstr "Покажи историята"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->other->description
-msgid "Other"
-msgstr "Друго"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->key-
-#. bindings->description
-msgid "Key bindings"
-msgstr "Клавишни кобинации"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->shown-
-#. entries->description
+#. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Покажи записите"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-empty-
-#. history->description
-msgid "Display 'Empty history'"
-msgstr "Покажи \"Изчистване на историята\""
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-track-
-#. switch->description
+#. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
 msgstr "Покажи \"Проследяване на промените в историята\""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-new-
-#. item->description
+#. settings-schema.json->display-new-item->description
 msgid "Display 'New item'"
 msgstr "Покажи \"Нов запис\""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-
-#. searchbar->description
+#. settings-schema.json->display-searchbar->description
 msgid "Display search bar"
 msgstr "Покажи търсачка"
+
+#. settings-schema.json->display-gpaste-ui->description
+msgid "Display 'GPaste Main Program'"
+msgstr "Покажи основната програма на GPaste"
+
+#. settings-schema.json->display-empty-history->description
+msgid "Display 'Empty history'"
+msgstr "Покажи \"Изчистване на историята\""
+
+#. settings-schema.json->key-bindings->description
+msgid "Key bindings"
+msgstr "Клавишни кобинации"
+
+#. settings-schema.json->kb-show-history->description
+msgid "Show history"
+msgstr "Покажи историята"
+
+#. settings-schema.json->other->description
+msgid "Other"
+msgstr "Друго"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/ca.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/ca.po
@@ -1,14 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2024-07-19 03:06+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,74 +19,74 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
-msgstr ""
-"Si us plau, introduïu el text que vulgueu afegir l'historial actual:"
+msgstr "Si us plau, introduïu el text que vulgueu afegir l'historial actual:"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Cancel·lar"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
 msgstr ""
-"GPaste no està instal·lat. Instal·leu els paquets necessaris i "
-"reinicieu Cinnamon perquè aquesta miniaplicació comenci a funcionar."
+"GPaste no està instal·lat. Instal·leu els paquets necessaris i reinicieu "
+"Cinnamon perquè aquesta miniaplicació comenci a funcionar."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Escriviu per buscar..."
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste no està instal·lat]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "Porta-papers de Gpaste"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "Programa principal de Gpaste"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Seleccionar l'historial"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Registrar canvis al porta-papers"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(Buit)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(No hi ha resultats)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Nou element"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Netejar l'historial"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "Segur que voleu buidar l'historial actual?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
 msgstr "Accediu i gestioneu la història del vostre porta-papers"
 
 #. metadata.json->name
@@ -95,6 +96,10 @@ msgstr "GPaste Reloaded"
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Elements mostrats"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/da.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/da.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-28 09:54+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2023-12-24 13:35+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Indtast teksten, du vil tilføje til den nuværende historik:"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Annullér"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -38,53 +39,54 @@ msgstr ""
 "GPaste er ikke installeret. De nødvendige pakker skal installeres og "
 "Cinnamon genstartes, før panelprogrammet virker."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Skriv for at søge …"
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste er ikke installeret]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "GPaste-udklipsholder"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "GPaste-hovedprogram"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Vælg historik"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Spor ændringer til udklipsholderen"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(Tom)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(Ingen resultater)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Nyt element"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Tom historik"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "Vil du virkelig slette den nuværende historik?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
 msgstr "Få øjeblikkelig adgang til og styr på din udklipsholderhistorik"
 
 #. metadata.json->name
@@ -94,6 +96,10 @@ msgstr "GPaste genopfundet"
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Viste poster"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/de.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/de.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: gpaste-reloaded@feuerfuchs.eu 2.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-28 09:54+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2017-11-28 09:55+0100\n"
 "Last-Translator: Feuerfuchs <git@feuerfuchs.eu>\n"
 "Language-Team: Feuerfuchs\n"
@@ -19,65 +20,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: applet.js:55
-msgid "[GPaste is not installed]"
-msgstr "[GPaste ist nicht installiert]"
-
-#: applet.js:91
-msgid "GPaste clipboard"
-msgstr "GPaste Clipboard"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->gpaste-
-#. settings->description
-#: applet.js:97 applet.js:135
-msgid "GPaste Main Program"
-msgstr "GPaste Hauptprogramm"
-
-#: applet.js:102
-msgid "Select History"
-msgstr "History auswählen"
-
-#: applet.js:111
-msgid "Track clipboard changes"
-msgstr "Änderungen verfolgen"
-
-#: applet.js:119
-msgid "(Empty)"
-msgstr "(Leer)"
-
-#: applet.js:122
-msgid "(No results)"
-msgstr "(Keine Ergebnisse)"
-
-#: applet.js:127
-msgid "New item"
-msgstr "Neuer Eintrag"
-
-#: applet.js:130
-msgid "Empty history"
-msgstr "History leeren"
-
-#: applet.js:447
-msgid "Do you really want to empty the current history?"
-msgstr "Möchtest du wirklich die aktuelle History leeren?"
-
-#: GPasteNewItemDialog.js:48
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Gib den Text ein, den du zur aktuellen History hinzufügen möchtest:"
 
-#: GPasteNewItemDialog.js:54 GPasteNotInstalledDialog.js:27
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:58
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: GPasteSearchItem.js:29
-msgid "Type to search..."
-msgstr "Suchbegriff eingeben..."
-
-#: GPasteNotInstalledDialog.js:22
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -85,62 +40,95 @@ msgstr ""
 "GPaste ist nicht installiert. Bitte installiere die nötigen Pakete und "
 "starte danach Cinnamon neu, damit dieses Applet funktionieren kann."
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->name
+#. GPasteSearchItem.js:34
+msgid "Type to search..."
+msgstr "Suchbegriff eingeben..."
+
+#. applet.js:73
+msgid "[GPaste is not installed]"
+msgstr "[GPaste ist nicht installiert]"
+
+#. applet.js:109
+msgid "GPaste clipboard"
+msgstr "GPaste Clipboard"
+
+#. settings-schema.json->gpaste-settings->description
+#. applet.js:115 applet.js:153
+msgid "GPaste Main Program"
+msgstr "GPaste Hauptprogramm"
+
+#. applet.js:120
+msgid "Select History"
+msgstr "History auswählen"
+
+#. applet.js:129
+msgid "Track clipboard changes"
+msgstr "Änderungen verfolgen"
+
+#. applet.js:137
+msgid "(Empty)"
+msgstr "(Leer)"
+
+#. applet.js:140
+msgid "(No results)"
+msgstr "(Keine Ergebnisse)"
+
+#. applet.js:145
+msgid "New item"
+msgstr "Neuer Eintrag"
+
+#. applet.js:148
+msgid "Empty history"
+msgstr "History leeren"
+
+#. applet.js:471
+msgid "Do you really want to empty the current history?"
+msgstr "Möchtest du wirklich die aktuelle History leeren?"
+
+#. metadata.json->description
+msgid "Instantly access and manage your clipboard history."
+msgstr ""
+
+#. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste Reloaded"
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->description
-msgid ""
-"A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-msgstr ""
-"Eine komplette Überarbeitung des GPaste-Applets basierend auf der Gnome "
-"Shell-Erweiterung"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-gpaste-
-#. ui->description
-msgid "Display 'GPaste Main Program'"
-msgstr "Zeige 'GPaste Hauptprogramm'"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->kb-show-
-#. history->description
-msgid "Show history"
-msgstr "History anzeigen"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->other->description
-msgid "Other"
-msgstr "Sonstiges"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->key-
-#. bindings->description
-msgid "Key bindings"
-msgstr "Tastenkombinationen"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->shown-
-#. entries->description
+#. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Angezeigte Einträge"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-empty-
-#. history->description
-msgid "Display 'Empty history'"
-msgstr "Zeige 'History leeren'"
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-track-
-#. switch->description
+#. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
 msgstr "Zeige 'Änderungen verfolgen'"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-new-
-#. item->description
+#. settings-schema.json->display-new-item->description
 msgid "Display 'New item'"
 msgstr "Zeige 'Neuer Eintrag'"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-
-#. searchbar->description
+#. settings-schema.json->display-searchbar->description
 msgid "Display search bar"
 msgstr "Zeige Suchleiste"
 
-#~ msgid "Just enter whatever you want to add to the current history:"
-#~ msgstr ""
-#~ "Gib einfach den Text ein, der zur aktuellen History hinzugefügt werden "
-#~ "soll:"
+#. settings-schema.json->display-gpaste-ui->description
+msgid "Display 'GPaste Main Program'"
+msgstr "Zeige 'GPaste Hauptprogramm'"
+
+#. settings-schema.json->display-empty-history->description
+msgid "Display 'Empty history'"
+msgstr "Zeige 'History leeren'"
+
+#. settings-schema.json->key-bindings->description
+msgid "Key bindings"
+msgstr "Tastenkombinationen"
+
+#. settings-schema.json->kb-show-history->description
+msgid "Show history"
+msgstr "History anzeigen"
+
+#. settings-schema.json->other->description
+msgid "Other"
+msgstr "Sonstiges"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/es.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/es.po
@@ -90,6 +90,10 @@ msgstr "Accede y gestiona al instante el historial del portapapeles"
 msgid "GPaste Reloaded"
 msgstr "GPaste recargado"
 
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr "Mostrar el icono de la bandeja, incluso cuando el applet no está en uso"
+
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Entradas visualizadas"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/es.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/es.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2023-11-20 17:18-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,19 +18,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Introduzca el texto que desea añadir al historial actual:"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -37,66 +38,68 @@ msgstr ""
 "GPaste no está instalado. Por favor, instale los paquetes necesarios y "
 "reinicie Cinnamon para que este applet empiece a funcionar."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Escriba para buscar..."
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste no está instalado]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "Portapapeles GPaste"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "Programa principal de GPaste"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Seleccionar historial"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Seguir los cambios en el portapapeles"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(Vacío)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(Sin resultados)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Nuevo item"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Borrar historial"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "¿Realmente quiere vaciar el historial actual?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
 msgstr "Accede y gestiona al instante el historial del portapapeles"
 
 #. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste recargado"
 
-#. settings-schema.json->always-show-icon->description
-msgid "Show tray icon, even when the applet is not in use"
-msgstr "Mostrar el icono de la bandeja, incluso cuando el applet no está en uso"
-
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Entradas visualizadas"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
+"Mostrar el icono de la bandeja, incluso cuando el applet no está en uso"
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
@@ -129,9 +132,3 @@ msgstr "Mostrar historial"
 #. settings-schema.json->other->description
 msgid "Other"
 msgstr "Otro"
-
-#~ msgid ""
-#~ "A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-#~ msgstr ""
-#~ "Una reescritura completa del applet GPaste basado en la extensión Gnome "
-#~ "Shell"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/fi.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/fi.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2024-11-13 19:32+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,19 +19,19 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Kirjoita teksti, jonka haluat lisätä historiaan:"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Peru"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -38,53 +39,54 @@ msgstr ""
 "GPaste ei ole asennettuna. Asenna sudo apt install gpaste gir1.2-gpaste-1.0 "
 "ja käynnistä sitten Cinnamon uudelleen."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Kirjoita haku..."
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste ei ole asennettu]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "GPaste leikepöytä"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "GPaste ohjelma"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Valitse historia"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Seuraa leikepöydän muutoksia"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(tyhjä)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(ei tuloksia)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Uusi kohde"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Tyhjennä historia"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "Haluatko tyhjentää nykyisen historian?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
 msgstr "Selaa leikepöydän historiaa ja liitä niitä ohjelmiin"
 
 #. metadata.json->name
@@ -94,6 +96,10 @@ msgstr "GPaste Reloaded"
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Näytä kohteet"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
@@ -126,9 +132,3 @@ msgstr "Näytä historia"
 #. settings-schema.json->other->description
 msgid "Other"
 msgstr "Muu"
-
-#~ msgid ""
-#~ "A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-#~ msgstr ""
-#~ "GPaste on kirjoitettu kokonaan uudelleen ja perustuu Gnome Shell "
-#~ "laajennukseen"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/fr.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/fr.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2023-10-29 17:43+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -18,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr ""
 "Veuillez saisir le texte que vous souhaitez ajouter à l'historique actuel :"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Abandon"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -39,53 +40,54 @@ msgstr ""
 "GPaste n'est pas installé. Veuillez installer les paquets nécessaires, puis "
 "redémarrer Cinnamon afin que cette applet commence à fonctionner."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Saisir votre recherche..."
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste n'est pas installé]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "Presse-papiers GPaste"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "Programme principal GPaste"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Sélectionner Historique"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Suivre les modifications du presse-papiers"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(Vide)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(Aucun résultat)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Nouvel élément"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Historique vide"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "Voulez-vous vraiment vider l'historique actuel ?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
 msgstr "Accès instantané et gestion de l'historique de votre presse-papier"
 
 #. metadata.json->name
@@ -95,6 +97,10 @@ msgstr "GPaste rechargé"
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Afficher les entrées"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
@@ -127,9 +133,3 @@ msgstr "Afficher l'historique"
 #. settings-schema.json->other->description
 msgid "Other"
 msgstr "Autre"
-
-#~ msgid ""
-#~ "A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-#~ msgstr ""
-#~ "Une réécriture complète de l'applet GPaste basée sur l'extension Gnome "
-#~ "Shell"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/gpaste-reloaded@feuerfuchs.eu.pot
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/gpaste-reloaded@feuerfuchs.eu.pot
@@ -88,6 +88,10 @@ msgstr ""
 msgid "GPaste Reloaded"
 msgstr ""
 
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
+
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr ""

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/gpaste-reloaded@feuerfuchs.eu.pot
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/gpaste-reloaded@feuerfuchs.eu.pot
@@ -1,99 +1,99 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# GPASTE RELOADED
+# This file is put in the public domain.
+# feuerfuchs, 2016
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: gpaste-reloaded@feuerfuchs.eu 2.6\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr ""
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr ""
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr ""
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
 msgstr ""
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr ""
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr ""
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr ""
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr ""
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr ""
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr ""
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr ""
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr ""
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr ""
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr ""
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr ""
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+msgid "Instantly access and manage your clipboard history."
 msgstr ""
 
 #. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr ""
 
-#. settings-schema.json->always-show-icon->description
-msgid "Show tray icon, even when the applet is not in use"
-msgstr ""
-
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
+msgstr ""
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
 msgstr ""
 
 #. settings-schema.json->display-track-switch->description

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/hr.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/hr.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # gogo <trebelnik2@gmail.com>, 2017.
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: GPaste Reloaded\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-01 22:47+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2017-05-01 22:54+0200\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -16,64 +17,22 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: applet.js:55
-msgid "[GPaste is not installed]"
-msgstr "[GPaste nije instaliran]"
-
-#: applet.js:91
-msgid "GPaste clipboard"
-msgstr "Gpaste međuspremnik"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->gpaste-
-#. settings->description
-#: applet.js:97 applet.js:135
-msgid "GPaste Main Program"
-msgstr "GPaste glavni program"
-
-#: applet.js:102
-msgid "Select History"
-msgstr "Odaberi povijest"
-
-#: applet.js:111
-msgid "Track clipboard changes"
-msgstr "Prati promjene međuspremnika"
-
-#: applet.js:119
-msgid "(Empty)"
-msgstr "(Prazno)"
-
-#: applet.js:122
-msgid "(No results)"
-msgstr "(Nema rezultata)"
-
-#: applet.js:127
-msgid "New item"
-msgstr "Nova stavka"
-
-#: applet.js:130
-msgid "Empty history"
-msgstr "Isprazni povijest"
-
-#: applet.js:436
-msgid "Do you really want to empty the current history?"
-msgstr "Sigurno želite obrisati trenutnu povijest?"
-
-#: GPasteNewItemDialog.js:47
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Upišite tekst koji želite dodati u trenutnu povijest:"
 
-#: GPasteNewItemDialog.js:53 GPasteNotInstalledDialog.js:26
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "U redu"
 
-#: GPasteNewItemDialog.js:57
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Odustani"
 
-#: GPasteNotInstalledDialog.js:21
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -81,44 +40,96 @@ msgstr ""
 "GPaste nije instaliran. Instalirajte potrebne pakete i zatim ponovno "
 "pokrenite Cinnamon kako bi ovaj aplet radio."
 
-#: GPasteSearchItem.js:28
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Upišite za pretragu..."
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->name
+#. applet.js:73
+msgid "[GPaste is not installed]"
+msgstr "[GPaste nije instaliran]"
+
+#. applet.js:109
+msgid "GPaste clipboard"
+msgstr "Gpaste međuspremnik"
+
+#. settings-schema.json->gpaste-settings->description
+#. applet.js:115 applet.js:153
+msgid "GPaste Main Program"
+msgstr "GPaste glavni program"
+
+#. applet.js:120
+msgid "Select History"
+msgstr "Odaberi povijest"
+
+#. applet.js:129
+msgid "Track clipboard changes"
+msgstr "Prati promjene međuspremnika"
+
+#. applet.js:137
+msgid "(Empty)"
+msgstr "(Prazno)"
+
+#. applet.js:140
+msgid "(No results)"
+msgstr "(Nema rezultata)"
+
+#. applet.js:145
+msgid "New item"
+msgstr "Nova stavka"
+
+#. applet.js:148
+msgid "Empty history"
+msgstr "Isprazni povijest"
+
+#. applet.js:471
+msgid "Do you really want to empty the current history?"
+msgstr "Sigurno želite obrisati trenutnu povijest?"
+
+#. metadata.json->description
+msgid "Instantly access and manage your clipboard history."
+msgstr ""
+
+#. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste aplet"
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->description
-msgid ""
-"A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-msgstr "Cjelokupno napisan GPaste aplet temeljen na Gnome proširenju"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-gpaste-
-#. ui->description
-msgid "Display 'GPaste Main Program'"
-msgstr "Prikaži 'GPaste glavni program'"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->general->description
+#. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Prikazane stavke"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-empty-
-#. history->description
-msgid "Display 'Empty history'"
-msgstr "Prikaži 'Isprazni povijest'"
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-track-
-#. switch->description
+#. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
 msgstr "Prikaži 'Prati promjene međuspremnika'"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-new-
-#. item->description
+#. settings-schema.json->display-new-item->description
 msgid "Display 'New item'"
 msgstr "Prikaži 'Nova stavka'"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-
-#. searchbar->description
+#. settings-schema.json->display-searchbar->description
 msgid "Display search bar"
 msgstr "Prikaži traku pretrage"
+
+#. settings-schema.json->display-gpaste-ui->description
+msgid "Display 'GPaste Main Program'"
+msgstr "Prikaži 'GPaste glavni program'"
+
+#. settings-schema.json->display-empty-history->description
+msgid "Display 'Empty history'"
+msgstr "Prikaži 'Isprazni povijest'"
+
+#. settings-schema.json->key-bindings->description
+msgid "Key bindings"
+msgstr ""
+
+#. settings-schema.json->kb-show-history->description
+#, fuzzy
+msgid "Show history"
+msgstr "Isprazni povijest"
+
+#. settings-schema.json->other->description
+msgid "Other"
+msgstr ""

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/hu.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/hu.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2023-06-30 23:36+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -17,20 +18,20 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr ""
 "Kérem írja be a szöveget, amit a jelenlegi előzményekhez szeretne adni:"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Mégse"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -38,53 +39,54 @@ msgstr ""
 "A GPaste nincs telepítve. Kérjük, telepítse a szükséges csomagokat, majd a "
 "kisalkalmazás használatához indítsa újra a Cinnamont."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Gépeljen a kereséshez…"
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste nincs installálva]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "GPaste vágólap"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "GPaste Fő Program"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Kiválasztási előzmények"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Vágólap változásainak követése"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(Üres)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(Nincs találat)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Új elem"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Előzmények törlése"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "Tényleg törölni szeretné a jelenlegi előzményeket?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
 msgstr "Azonnal elérheti és kezelheti a vágólap előzményeit"
 
 #. metadata.json->name
@@ -94,6 +96,10 @@ msgstr "GPaste újratöltve"
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Bejegyzések megjelenítése"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
@@ -126,9 +132,3 @@ msgstr "Előzmények megjelenítése"
 #. settings-schema.json->other->description
 msgid "Other"
 msgstr "Egyéb"
-
-#~ msgid ""
-#~ "A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-#~ msgstr ""
-#~ "Egy teljesen újraírt GPaste kisalkalmazás a Gnome Shell kiterjesztés "
-#~ "alapján"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/is.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/is.po
@@ -5,8 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2024-10-08 19:21+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic\n"
@@ -17,76 +18,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Lokalize 23.08.5\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Settu inn textann sem þú vilt bæta við fyrirliggjandi feril:"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "Í lagi"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Hætta við"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
 msgstr ""
-"GPaste er ekki uppsett. Settu inn nauðsynlega pakka og endurræstu síðan"
-" Cinnamon svo að forritlingurinn geti farið að virka."
+"GPaste er ekki uppsett. Settu inn nauðsynlega pakka og endurræstu síðan "
+"Cinnamon svo að forritlingurinn geti farið að virka."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Skrifaðu til að leita..."
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste er ekki uppsett]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "GPaste-klippispjald"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "Aðalforrit GPaste"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Veldu feril"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Rekja breytingar á klippispjaldi"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(tómt)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(engar niðurstöður)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Nýtt atriði"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Tæma feril"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "Viltu í alvörunni tæma fyrirliggjandi feril?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
 msgstr ""
-"Sýslaðu með feril klippispjaldsins og hafðu fljótlegan aðgang að áður"
-" afrituðum atriðum"
+"Sýslaðu með feril klippispjaldsins og hafðu fljótlegan aðgang að áður "
+"afrituðum atriðum"
 
 #. metadata.json->name
 msgid "GPaste Reloaded"
@@ -95,6 +97,10 @@ msgstr "GPaste Reloaded"
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Birtar færslur"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/it.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/it.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2023-10-29 17:00+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Inserisci il testo che desideri aggiungere alla cronologia corrente:"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Annulla"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -38,53 +39,54 @@ msgstr ""
 "GPaste non è installato. Installa i pacchetti necessari e riavvia Cinnamon "
 "affinché questa applet inizi a funzionare."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Digita per cercare..."
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste non è installato]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "GPaste Clipboard"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "Programma Principale GPaste"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Seleziona Cronologia"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Tieni traccia delle modifiche alla clipboard"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(Vuota)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(Nessun risultato)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Nuovo elemento"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Svuota cronologia"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "Vuoi davvero svuotare la cronologia attuale?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
 msgstr "Accedi e gestisci istantaneamente la cronologia degli appunti"
 
 #. metadata.json->name
@@ -94,6 +96,10 @@ msgstr "GPaste Reloaded"
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Voci mostrate"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
@@ -126,9 +132,3 @@ msgstr "Mostra cronologia"
 #. settings-schema.json->other->description
 msgid "Other"
 msgstr "Altro"
-
-#~ msgid ""
-#~ "A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-#~ msgstr ""
-#~ "Una riscrittura completa dell'applet GPaste basata sull'estensione Gnome "
-#~ "Shell"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/nl.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/nl.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2024-04-21 11:10+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,19 +17,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Voer de tekst in die je aan de huidige geschiedenis wilt toevoegen:"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -36,53 +37,54 @@ msgstr ""
 "GPaste is niet geïnstalleerd. Installeer de benodigde pakketten en start "
 "vervolgens Cinnamon opnieuw op zodat deze applet kan beginnen werken."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Typ om te zoeken..."
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste is niet geïnstalleerd]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "GPaste klembord"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "GPaste hoofdprogramma"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Selecteer geschiedenis"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Volg klembordwijzigingen"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(Leeg)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(Geen resultaten)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Nieuw item"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Geschiedenis leegmaken"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "Wil je echt de huidige geschiedenis leegmaken?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
 msgstr "Direct toegang krijgen tot en beheren van je klembordgeschiedenis"
 
 #. metadata.json->name
@@ -92,6 +94,10 @@ msgstr "GPaste Reloaded"
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Getoonde items"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/pl.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/pl.po
@@ -1,83 +1,38 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-08 18:59+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2018-04-08 19:22+0200\n"
+"Last-Translator: xearonet\n"
 "Language-Team: \n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: xearonet\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n"
-"%100<10 || n%100>=20) ? 1 : 2);\n"
-"Language: pl\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
 
-#: applet.js:55
-msgid "[GPaste is not installed]"
-msgstr "[GPaste nie jest zainstalowane]"
-
-#: applet.js:91
-msgid "GPaste clipboard"
-msgstr "Schowek GPaste"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->gpaste-
-#. settings->description
-#: applet.js:97 applet.js:135
-msgid "GPaste Main Program"
-msgstr "Program główny GPaste"
-
-#: applet.js:102
-msgid "Select History"
-msgstr "Wybierz historię"
-
-#: applet.js:111
-msgid "Track clipboard changes"
-msgstr "Śledź zmiany w schowku"
-
-#: applet.js:119
-msgid "(Empty)"
-msgstr "(Pusto)"
-
-#: applet.js:122
-msgid "(No results)"
-msgstr "(Brak wyników)"
-
-#: applet.js:127
-msgid "New item"
-msgstr "Nowy wpis"
-
-#: applet.js:130
-msgid "Empty history"
-msgstr "Wyczyść historię"
-
-#: applet.js:447
-msgid "Do you really want to empty the current history?"
-msgstr "Czy na pewno chcesz usunąć całą historię?"
-
-#: GPasteNewItemDialog.js:48
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Wprowadź tekst, który chcesz dodać do bieżącej historii:"
 
-#: GPasteNewItemDialog.js:54 GPasteNotInstalledDialog.js:27
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:58
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: GPasteSearchItem.js:29
-msgid "Type to search..."
-msgstr "Wpisz aby wyszukać..."
-
-#: GPasteNotInstalledDialog.js:22
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -85,56 +40,95 @@ msgstr ""
 "GPaste nie jest zainstalowany. Proszę zainstalować niezbędne pakiety, a "
 "następnie ponownie uruchomić Cinnamona, aby ten aplet zaczął działać."
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->name
+#. GPasteSearchItem.js:34
+msgid "Type to search..."
+msgstr "Wpisz aby wyszukać..."
+
+#. applet.js:73
+msgid "[GPaste is not installed]"
+msgstr "[GPaste nie jest zainstalowane]"
+
+#. applet.js:109
+msgid "GPaste clipboard"
+msgstr "Schowek GPaste"
+
+#. settings-schema.json->gpaste-settings->description
+#. applet.js:115 applet.js:153
+msgid "GPaste Main Program"
+msgstr "Program główny GPaste"
+
+#. applet.js:120
+msgid "Select History"
+msgstr "Wybierz historię"
+
+#. applet.js:129
+msgid "Track clipboard changes"
+msgstr "Śledź zmiany w schowku"
+
+#. applet.js:137
+msgid "(Empty)"
+msgstr "(Pusto)"
+
+#. applet.js:140
+msgid "(No results)"
+msgstr "(Brak wyników)"
+
+#. applet.js:145
+msgid "New item"
+msgstr "Nowy wpis"
+
+#. applet.js:148
+msgid "Empty history"
+msgstr "Wyczyść historię"
+
+#. applet.js:471
+msgid "Do you really want to empty the current history?"
+msgstr "Czy na pewno chcesz usunąć całą historię?"
+
+#. metadata.json->description
+msgid "Instantly access and manage your clipboard history."
+msgstr ""
+
+#. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste Reloaded"
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->description
-msgid ""
-"A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-msgstr ""
-"Przepisany od nowa aplet GPaste bazujący na rozszerzeniu z Gnome Shell"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-gpaste-
-#. ui->description
-msgid "Display 'GPaste Main Program'"
-msgstr "Pokaż 'Program główny GPaste'"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->kb-show-
-#. history->description
-msgid "Show history"
-msgstr "Pokaż historię"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->other->description
-msgid "Other"
-msgstr "Inne"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->key-
-#. bindings->description
-msgid "Key bindings"
-msgstr "Przypisanie klawiszy"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->shown-
-#. entries->description
+#. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Pokaż wpisy"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-empty-
-#. history->description
-msgid "Display 'Empty history'"
-msgstr "Pokaż 'Wyczyść historię'"
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-track-
-#. switch->description
+#. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
 msgstr "Pokaż 'Śledź zmiany w schowku'"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-new-
-#. item->description
+#. settings-schema.json->display-new-item->description
 msgid "Display 'New item'"
 msgstr "Pokaż 'Nowy wpis'"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-
-#. searchbar->description
+#. settings-schema.json->display-searchbar->description
 msgid "Display search bar"
 msgstr "Pokaż pasek wyszukiwania"
+
+#. settings-schema.json->display-gpaste-ui->description
+msgid "Display 'GPaste Main Program'"
+msgstr "Pokaż 'Program główny GPaste'"
+
+#. settings-schema.json->display-empty-history->description
+msgid "Display 'Empty history'"
+msgstr "Pokaż 'Wyczyść historię'"
+
+#. settings-schema.json->key-bindings->description
+msgid "Key bindings"
+msgstr "Przypisanie klawiszy"
+
+#. settings-schema.json->kb-show-history->description
+msgid "Show history"
+msgstr "Pokaż historię"
+
+#. settings-schema.json->other->description
+msgid "Other"
+msgstr "Inne"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/pt.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/pt.po
@@ -91,6 +91,10 @@ msgstr ""
 msgid "GPaste Reloaded"
 msgstr "GPaste Reloaded"
 
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr "Mostrar ícone na bandeja, mesmo quando o applet não está em uso"
+
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Entradas exibidas"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/pt.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/pt.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-23 23:31+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2024-04-29 15:08-0400\n"
 "Last-Translator: Rúben Lopes <rubenmpl@sapo.pt>\n"
 "Language-Team: \n"
@@ -17,87 +18,87 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: GPasteNewItemDialog.js:53
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Por favor, insira o texto que quer acrescentar ao histórico:"
 
-#: GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:63
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: GPasteNotInstalledDialog.js:27
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
 msgstr ""
-"O GPaste não estão instalado. Por favor instale os pacotes necessários "
-"e de seguida reinicie o Cinnamon para que este applet possa funcionar."
+"O GPaste não estão instalado. Por favor instale os pacotes necessários e de "
+"seguida reinicie o Cinnamon para que este applet possa funcionar."
 
-#: GPasteSearchItem.js:34
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Escreva para procurar..."
 
-#: applet.js:73
+#. applet.js:73
 msgid "[GPaste is not installed]"
 msgstr "[GPaste não instalado]"
 
-#: applet.js:109
+#. applet.js:109
 msgid "GPaste clipboard"
 msgstr "Área de transferência do GPaste"
 
 #. settings-schema.json->gpaste-settings->description
-#: applet.js:115 applet.js:153
+#. applet.js:115 applet.js:153
 msgid "GPaste Main Program"
 msgstr "Programa principal do GPaste"
 
-#: applet.js:120
+#. applet.js:120
 msgid "Select History"
 msgstr "Selecione Histórico"
 
-#: applet.js:129
+#. applet.js:129
 msgid "Track clipboard changes"
 msgstr "Monitorizar alterações"
 
-#: applet.js:137
+#. applet.js:137
 msgid "(Empty)"
 msgstr "(Vazio)"
 
-#: applet.js:140
+#. applet.js:140
 msgid "(No results)"
 msgstr "(Sem resultados)"
 
-#: applet.js:145
+#. applet.js:145
 msgid "New item"
 msgstr "Novo item"
 
-#: applet.js:148
+#. applet.js:148
 msgid "Empty history"
 msgstr "Limpar histórico"
 
-#: applet.js:465
+#. applet.js:471
 msgid "Do you really want to empty the current history?"
 msgstr "Deseja mesmo limpar o histórico?"
 
 #. metadata.json->description
-msgid "Instantly access and manage your clipboard history"
-msgstr ""
-"Aceda instantaneamente e gira o seu histórico da área de transferência"
+#, fuzzy
+msgid "Instantly access and manage your clipboard history."
+msgstr "Aceda instantaneamente e gira o seu histórico da área de transferência"
 
 #. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste Reloaded"
 
-#. settings-schema.json->always-show-icon->description
-msgid "Show tray icon, even when the applet is not in use"
-msgstr "Mostrar ícone na bandeja, mesmo quando o applet não está em uso"
-
 #. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Entradas exibidas"
+
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr "Mostrar ícone na bandeja, mesmo quando o applet não está em uso"
 
 #. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/ru.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/ru.po
@@ -1,79 +1,38 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-02 20:14+0500\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2017-05-02 20:24+0500\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: \n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"Language: ru\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: applet.js:55
-msgid "[GPaste is not installed]"
-msgstr "[GPaste не установлен]"
-
-#: applet.js:91
-msgid "GPaste clipboard"
-msgstr "Буфер обмена GPaste"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->gpaste-
-#. settings->description
-#: applet.js:97 applet.js:135
-msgid "GPaste Main Program"
-msgstr "Главная программа GPaste"
-
-#: applet.js:102
-msgid "Select History"
-msgstr "Выбрать историю"
-
-#: applet.js:111
-msgid "Track clipboard changes"
-msgstr "Отслеживать изменения буфера обмена"
-
-#: applet.js:119
-msgid "(Empty)"
-msgstr "(Пусто)"
-
-#: applet.js:122
-msgid "(No results)"
-msgstr "(Нет результатов)"
-
-#: applet.js:127
-msgid "New item"
-msgstr "Новый элемент"
-
-#: applet.js:130
-msgid "Empty history"
-msgstr "Очистить историю"
-
-#: applet.js:436
-msgid "Do you really want to empty the current history?"
-msgstr "Вы действительно хотите очистить текущую историю?"
-
-#: GPasteNewItemDialog.js:47
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Введите текст, который вы хотите добавить в текущую историю:"
 
-#: GPasteNewItemDialog.js:53 GPasteNotInstalledDialog.js:26
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:57
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Отмена"
 
-#: GPasteNotInstalledDialog.js:21
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -81,46 +40,96 @@ msgstr ""
 "GPaste не установлен. Установите необходимые пакеты и перезапустите "
 "Cinnamon, чтобы модуль начал работать."
 
-#: GPasteSearchItem.js:28
+#. GPasteSearchItem.js:34
 msgid "Type to search..."
 msgstr "Введите для поиска..."
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->name
+#. applet.js:73
+msgid "[GPaste is not installed]"
+msgstr "[GPaste не установлен]"
+
+#. applet.js:109
+msgid "GPaste clipboard"
+msgstr "Буфер обмена GPaste"
+
+#. settings-schema.json->gpaste-settings->description
+#. applet.js:115 applet.js:153
+msgid "GPaste Main Program"
+msgstr "Главная программа GPaste"
+
+#. applet.js:120
+msgid "Select History"
+msgstr "Выбрать историю"
+
+#. applet.js:129
+msgid "Track clipboard changes"
+msgstr "Отслеживать изменения буфера обмена"
+
+#. applet.js:137
+msgid "(Empty)"
+msgstr "(Пусто)"
+
+#. applet.js:140
+msgid "(No results)"
+msgstr "(Нет результатов)"
+
+#. applet.js:145
+msgid "New item"
+msgstr "Новый элемент"
+
+#. applet.js:148
+msgid "Empty history"
+msgstr "Очистить историю"
+
+#. applet.js:471
+msgid "Do you really want to empty the current history?"
+msgstr "Вы действительно хотите очистить текущую историю?"
+
+#. metadata.json->description
+msgid "Instantly access and manage your clipboard history."
+msgstr ""
+
+#. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste Reloaded"
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->description
-msgid ""
-"A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-msgstr ""
-"Полностью переработанный модуль GPaste, основанный на расширении Gnome "
-"Shell"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-gpaste-
-#. ui->description
-msgid "Display 'GPaste Main Program'"
-msgstr "Показать «Главная программа GPaste»"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->general->description
+#. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Показанные элементы"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-empty-
-#. history->description
-msgid "Display 'Empty history'"
-msgstr "Показать «Очистить историю»"
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-track-
-#. switch->description
+#. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
 msgstr "Показать «Отслеживать изменения буфера обмена»"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-new-
-#. item->description
+#. settings-schema.json->display-new-item->description
 msgid "Display 'New item'"
 msgstr "Показать «Новый элемент»"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-
-#. searchbar->description
+#. settings-schema.json->display-searchbar->description
 msgid "Display search bar"
 msgstr "Показать строку поиска"
+
+#. settings-schema.json->display-gpaste-ui->description
+msgid "Display 'GPaste Main Program'"
+msgstr "Показать «Главная программа GPaste»"
+
+#. settings-schema.json->display-empty-history->description
+msgid "Display 'Empty history'"
+msgstr "Показать «Очистить историю»"
+
+#. settings-schema.json->key-bindings->description
+msgid "Key bindings"
+msgstr ""
+
+#. settings-schema.json->kb-show-history->description
+#, fuzzy
+msgid "Show history"
+msgstr "Очистить историю"
+
+#. settings-schema.json->other->description
+msgid "Other"
+msgstr ""

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/sv.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/sv.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gpaste-reloaded@feuerfuchs.eu\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-08 06:24+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2017-12-08 06:26+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -18,65 +19,19 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:55
-msgid "[GPaste is not installed]"
-msgstr "[GPaste är inte installerat]"
-
-#: applet.js:91
-msgid "GPaste clipboard"
-msgstr "GPaste urklipp"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->gpaste-
-#. settings->description
-#: applet.js:97 applet.js:135
-msgid "GPaste Main Program"
-msgstr "GPaste huvudprogram"
-
-#: applet.js:102
-msgid "Select History"
-msgstr "Välj historik"
-
-#: applet.js:111
-msgid "Track clipboard changes"
-msgstr "Spåra urklippsändringar"
-
-#: applet.js:119
-msgid "(Empty)"
-msgstr "(tomt)"
-
-#: applet.js:122
-msgid "(No results)"
-msgstr "(inga träffar)"
-
-#: applet.js:127
-msgid "New item"
-msgstr "Ny post"
-
-#: applet.js:130
-msgid "Empty history"
-msgstr "Töm historiken"
-
-#: applet.js:447
-msgid "Do you really want to empty the current history?"
-msgstr "Vill du verkligen tömma den aktuella historiken?"
-
-#: GPasteNewItemDialog.js:48
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Ange den text du vill lägga till i aktuell historik:"
 
-#: GPasteNewItemDialog.js:54 GPasteNotInstalledDialog.js:27
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "OK"
 
-#: GPasteNewItemDialog.js:58
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: GPasteSearchItem.js:29
-msgid "Type to search..."
-msgstr "Skriv för att söka..."
-
-#: GPasteNotInstalledDialog.js:22
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -84,56 +39,95 @@ msgstr ""
 "GPaste är inte installerat. Installera de nödvändiga paketen och starta om "
 "Cinnamon, för att det här panelprogrammet skall börja fungera."
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->name
+#. GPasteSearchItem.js:34
+msgid "Type to search..."
+msgstr "Skriv för att söka..."
+
+#. applet.js:73
+msgid "[GPaste is not installed]"
+msgstr "[GPaste är inte installerat]"
+
+#. applet.js:109
+msgid "GPaste clipboard"
+msgstr "GPaste urklipp"
+
+#. settings-schema.json->gpaste-settings->description
+#. applet.js:115 applet.js:153
+msgid "GPaste Main Program"
+msgstr "GPaste huvudprogram"
+
+#. applet.js:120
+msgid "Select History"
+msgstr "Välj historik"
+
+#. applet.js:129
+msgid "Track clipboard changes"
+msgstr "Spåra urklippsändringar"
+
+#. applet.js:137
+msgid "(Empty)"
+msgstr "(tomt)"
+
+#. applet.js:140
+msgid "(No results)"
+msgstr "(inga träffar)"
+
+#. applet.js:145
+msgid "New item"
+msgstr "Ny post"
+
+#. applet.js:148
+msgid "Empty history"
+msgstr "Töm historiken"
+
+#. applet.js:471
+msgid "Do you really want to empty the current history?"
+msgstr "Vill du verkligen tömma den aktuella historiken?"
+
+#. metadata.json->description
+msgid "Instantly access and manage your clipboard history."
+msgstr ""
+
+#. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste Reloaded"
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->description
-msgid ""
-"A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-msgstr ""
-"En fullständig omskrivning av GPaste applet, baserad på Gnome-insticket"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-gpaste-
-#. ui->description
-msgid "Display 'GPaste Main Program'"
-msgstr "Visa \"GPaste huvudprogram\""
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->kb-show-
-#. history->description
-msgid "Show history"
-msgstr "Visa historik"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->other->description
-msgid "Other"
-msgstr "Annat"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->key-
-#. bindings->description
-msgid "Key bindings"
-msgstr "Snabbtangenter"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->shown-
-#. entries->description
+#. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Visade poster"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-empty-
-#. history->description
-msgid "Display 'Empty history'"
-msgstr "Visa \"Töm historiken\""
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-track-
-#. switch->description
+#. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
 msgstr "Visa \"Spåra urklippsändringar\""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-new-
-#. item->description
+#. settings-schema.json->display-new-item->description
 msgid "Display 'New item'"
 msgstr "Visa \"Ny post\""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-
-#. searchbar->description
+#. settings-schema.json->display-searchbar->description
 msgid "Display search bar"
 msgstr "Visa sökfält"
+
+#. settings-schema.json->display-gpaste-ui->description
+msgid "Display 'GPaste Main Program'"
+msgstr "Visa \"GPaste huvudprogram\""
+
+#. settings-schema.json->display-empty-history->description
+msgid "Display 'Empty history'"
+msgstr "Visa \"Töm historiken\""
+
+#. settings-schema.json->key-bindings->description
+msgid "Key bindings"
+msgstr "Snabbtangenter"
+
+#. settings-schema.json->kb-show-history->description
+msgid "Show history"
+msgstr "Visa historik"
+
+#. settings-schema.json->other->description
+msgid "Other"
+msgstr "Annat"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/tr.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/tr.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Serkan ÖNDER <serkanonder@outlook.com>, 2021.
@@ -6,77 +6,32 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-28 09:54+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2021-07-01 11:21+0300\n"
+"Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: tr\n"
 
-#: applet.js:55
-msgid "[GPaste is not installed]"
-msgstr "[GPaste yüklü değil]"
-
-#: applet.js:91
-msgid "GPaste clipboard"
-msgstr "GPaste panosu"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->gpaste-
-#. settings->description
-#: applet.js:97 applet.js:135
-msgid "GPaste Main Program"
-msgstr "GPaste Ana Programı"
-
-#: applet.js:102
-msgid "Select History"
-msgstr "Geçmişi Seç"
-
-#: applet.js:111
-msgid "Track clipboard changes"
-msgstr "Pano değişikliklerini izle"
-
-#: applet.js:119
-msgid "(Empty)"
-msgstr "(Boş)"
-
-#: applet.js:122
-msgid "(No results)"
-msgstr "(Sonuç yok)"
-
-#: applet.js:127
-msgid "New item"
-msgstr "Yeni öğe"
-
-#: applet.js:130
-msgid "Empty history"
-msgstr "Boş geçmiş"
-
-#: applet.js:447
-msgid "Do you really want to empty the current history?"
-msgstr "Mevcut geçmişi gerçekten boşaltmak istiyor musunuz?"
-
-#: GPasteNewItemDialog.js:48
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "Lütfen mevcut geçmişe eklemek istediğiniz metni girin:"
 
-#: GPasteNewItemDialog.js:54 GPasteNotInstalledDialog.js:27
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "Tamam"
 
-#: GPasteNewItemDialog.js:58
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "Vazgeç"
 
-#: GPasteSearchItem.js:29
-msgid "Type to search..."
-msgstr "Aramak için yaz..."
-
-#: GPasteNotInstalledDialog.js:22
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
@@ -84,57 +39,95 @@ msgstr ""
 "GPaste yüklü değil. Lütfen gerekli paketleri kurun ve ardından bu "
 "uygulamanın çalışmaya başlaması için Cinnamon`u yeniden başlatın."
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->name
+#. GPasteSearchItem.js:34
+msgid "Type to search..."
+msgstr "Aramak için yaz..."
+
+#. applet.js:73
+msgid "[GPaste is not installed]"
+msgstr "[GPaste yüklü değil]"
+
+#. applet.js:109
+msgid "GPaste clipboard"
+msgstr "GPaste panosu"
+
+#. settings-schema.json->gpaste-settings->description
+#. applet.js:115 applet.js:153
+msgid "GPaste Main Program"
+msgstr "GPaste Ana Programı"
+
+#. applet.js:120
+msgid "Select History"
+msgstr "Geçmişi Seç"
+
+#. applet.js:129
+msgid "Track clipboard changes"
+msgstr "Pano değişikliklerini izle"
+
+#. applet.js:137
+msgid "(Empty)"
+msgstr "(Boş)"
+
+#. applet.js:140
+msgid "(No results)"
+msgstr "(Sonuç yok)"
+
+#. applet.js:145
+msgid "New item"
+msgstr "Yeni öğe"
+
+#. applet.js:148
+msgid "Empty history"
+msgstr "Boş geçmiş"
+
+#. applet.js:471
+msgid "Do you really want to empty the current history?"
+msgstr "Mevcut geçmişi gerçekten boşaltmak istiyor musunuz?"
+
+#. metadata.json->description
+msgid "Instantly access and manage your clipboard history."
+msgstr ""
+
+#. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste Yeniden Yüklendi"
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->description
-msgid ""
-"A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-msgstr ""
-"Gnome Shell uzantısına dayalı GPaste uygulamasının tam bir yeniden "
-"yazılması"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-gpaste-
-#. ui->description
-msgid "Display 'GPaste Main Program'"
-msgstr "'GPaste Ana Programı'nı görüntüle"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->kb-show-
-#. history->description
-msgid "Show history"
-msgstr "Geçmişi göster"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->other->description
-msgid "Other"
-msgstr "Diğer"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->key-
-#. bindings->description
-msgid "Key bindings"
-msgstr "Anahtar bağlamaları"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->shown-
-#. entries->description
+#. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "Gösterilen girişler"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-empty-
-#. history->description
-msgid "Display 'Empty history'"
-msgstr "'Boş geçmişi' göster"
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-track-
-#. switch->description
+#. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
 msgstr "'Pano değişikliklerini izle'yi göster"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-new-
-#. item->description
+#. settings-schema.json->display-new-item->description
 msgid "Display 'New item'"
 msgstr "'Yeni öğe'yi göster"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-
-#. searchbar->description
+#. settings-schema.json->display-searchbar->description
 msgid "Display search bar"
 msgstr "Arama çubuğunu görüntüle"
+
+#. settings-schema.json->display-gpaste-ui->description
+msgid "Display 'GPaste Main Program'"
+msgstr "'GPaste Ana Programı'nı görüntüle"
+
+#. settings-schema.json->display-empty-history->description
+msgid "Display 'Empty history'"
+msgstr "'Boş geçmişi' göster"
+
+#. settings-schema.json->key-bindings->description
+msgid "Key bindings"
+msgstr "Anahtar bağlamaları"
+
+#. settings-schema.json->kb-show-history->description
+msgid "Show history"
+msgstr "Geçmişi göster"
+
+#. settings-schema.json->other->description
+msgid "Other"
+msgstr "Diğer"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/zh_CN.po
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/po/zh_CN.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# GPASTE RELOADED
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# feuerfuchs, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-28 09:54+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-12-27 14:39-0500\n"
 "PO-Revision-Date: 2023-02-09 22:26+0800\n"
 "Last-Translator: Slinet6056 <slinet6056@gmail.com>\n"
 "Language-Team: \n"
@@ -18,121 +19,114 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: applet.js:55
-msgid "[GPaste is not installed]"
-msgstr "[未安装 GPaste]"
-
-#: applet.js:91
-msgid "GPaste clipboard"
-msgstr "GPaste 剪贴板"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->gpaste-
-#. settings->description
-#: applet.js:97 applet.js:135
-msgid "GPaste Main Program"
-msgstr "GPaste 主程序"
-
-#: applet.js:102
-msgid "Select History"
-msgstr "选择历史"
-
-#: applet.js:111
-msgid "Track clipboard changes"
-msgstr "跟踪剪贴板更改"
-
-#: applet.js:119
-msgid "(Empty)"
-msgstr "(空)"
-
-#: applet.js:122
-msgid "(No results)"
-msgstr "(没有结果)"
-
-#: applet.js:127
-msgid "New item"
-msgstr "新建条目"
-
-#: applet.js:130
-msgid "Empty history"
-msgstr "清空历史"
-
-#: applet.js:447
-msgid "Do you really want to empty the current history?"
-msgstr "你确实要清空当前历史吗？"
-
-#: GPasteNewItemDialog.js:48
+#. GPasteNewItemDialog.js:53
 msgid "Please enter the text you want to add to the current history:"
 msgstr "请输入您想要添加到当前历史的文本："
 
-#: GPasteNewItemDialog.js:54 GPasteNotInstalledDialog.js:27
+#. GPasteNewItemDialog.js:59 GPasteNotInstalledDialog.js:32
 msgid "OK"
 msgstr "确定"
 
-#: GPasteNewItemDialog.js:58
+#. GPasteNewItemDialog.js:63
 msgid "Cancel"
 msgstr "取消"
 
-#: GPasteSearchItem.js:29
-msgid "Type to search..."
-msgstr "键入以搜索..."
-
-#: GPasteNotInstalledDialog.js:22
+#. GPasteNotInstalledDialog.js:27
 msgid ""
 "GPaste is not installed. Please install the necessary packages and then "
 "restart Cinnamon for this applet to start working."
 msgstr ""
-"未安装 GPaste。请安装必要的软件包，然后重启 Cinnamon 以使这个小程序开始工"
-"作。"
+"未安装 GPaste。请安装必要的软件包，然后重启 Cinnamon 以使这个小程序开始工作。"
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->name
+#. GPasteSearchItem.js:34
+msgid "Type to search..."
+msgstr "键入以搜索..."
+
+#. applet.js:73
+msgid "[GPaste is not installed]"
+msgstr "[未安装 GPaste]"
+
+#. applet.js:109
+msgid "GPaste clipboard"
+msgstr "GPaste 剪贴板"
+
+#. settings-schema.json->gpaste-settings->description
+#. applet.js:115 applet.js:153
+msgid "GPaste Main Program"
+msgstr "GPaste 主程序"
+
+#. applet.js:120
+msgid "Select History"
+msgstr "选择历史"
+
+#. applet.js:129
+msgid "Track clipboard changes"
+msgstr "跟踪剪贴板更改"
+
+#. applet.js:137
+msgid "(Empty)"
+msgstr "(空)"
+
+#. applet.js:140
+msgid "(No results)"
+msgstr "(没有结果)"
+
+#. applet.js:145
+msgid "New item"
+msgstr "新建条目"
+
+#. applet.js:148
+msgid "Empty history"
+msgstr "清空历史"
+
+#. applet.js:471
+msgid "Do you really want to empty the current history?"
+msgstr "你确实要清空当前历史吗？"
+
+#. metadata.json->description
+msgid "Instantly access and manage your clipboard history."
+msgstr ""
+
+#. metadata.json->name
 msgid "GPaste Reloaded"
 msgstr "GPaste 已重新加载"
 
-#. gpaste-reloaded@feuerfuchs.eu->metadata.json->description
-msgid ""
-"A complete rewrite of the GPaste applet based on the Gnome Shell extension"
-msgstr "一个基于 Gnome Shell 扩展完全重写的 GPaste 小程序"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-gpaste-
-#. ui->description
-msgid "Display 'GPaste Main Program'"
-msgstr "显示 “GPaste 主程序”"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->kb-show-
-#. history->description
-msgid "Show history"
-msgstr "显示历史"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->other->description
-msgid "Other"
-msgstr "其他"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->key-
-#. bindings->description
-msgid "Key bindings"
-msgstr "快捷键"
-
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->shown-
-#. entries->description
+#. settings-schema.json->shown-entries->description
 msgid "Shown entries"
 msgstr "显示条目"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-empty-
-#. history->description
-msgid "Display 'Empty history'"
-msgstr "显示 “清空历史”"
+#. settings-schema.json->always-show-icon->description
+msgid "Show tray icon, even when the applet is not in use"
+msgstr ""
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-track-
-#. switch->description
+#. settings-schema.json->display-track-switch->description
 msgid "Display 'Track clipboard changes'"
 msgstr "显示 “跟踪剪贴板更改”"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-new-
-#. item->description
+#. settings-schema.json->display-new-item->description
 msgid "Display 'New item'"
 msgstr "显示 “新建条目”"
 
-#. gpaste-reloaded@feuerfuchs.eu->settings-schema.json->display-
-#. searchbar->description
+#. settings-schema.json->display-searchbar->description
 msgid "Display search bar"
 msgstr "显示搜索栏"
+
+#. settings-schema.json->display-gpaste-ui->description
+msgid "Display 'GPaste Main Program'"
+msgstr "显示 “GPaste 主程序”"
+
+#. settings-schema.json->display-empty-history->description
+msgid "Display 'Empty history'"
+msgstr "显示 “清空历史”"
+
+#. settings-schema.json->key-bindings->description
+msgid "Key bindings"
+msgstr "快捷键"
+
+#. settings-schema.json->kb-show-history->description
+msgid "Show history"
+msgstr "显示历史"
+
+#. settings-schema.json->other->description
+msgid "Other"
+msgstr "其他"

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/settings-schema.json
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/settings-schema.json
@@ -3,6 +3,11 @@
         "type":        "header",
         "description": "Shown entries"
     },
+    "always-show-icon": {
+        "default":     true,
+        "type":        "checkbox",
+        "description": "Show tray icon, even when the applet is not in use."
+    },
     "display-track-switch": {
         "default":     true,
         "type":        "checkbox",

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/settings-schema.json
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/settings-schema.json
@@ -6,7 +6,7 @@
     "always-show-icon": {
         "default":     true,
         "type":        "checkbox",
-        "description": "Show tray icon, even when the applet is not in use."
+        "description": "Show tray icon, even when the applet is not in use"
     },
     "display-track-switch": {
         "default":     true,


### PR DESCRIPTION
Add option to hide tray icon while applet is not being used.
It would be shown when panel edit mode is on, or with key bindings.
Also added the respective .pot entry and included portuguese and spanish translations.