### PR TITLE
multicore-sys-monitor@ccadeptic23: Fix memory graph disappearing

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/6.0/Graphs.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/6.0/Graphs.js
@@ -92,7 +92,7 @@ GraphVBars.prototype = {
 
       let use_natural_colors = this.configSettings.getUseProgressiveColors();
 
-      if (!this.configSettings.getByActivity()) {
+      if (!this.configSettings.getByActivity() || providerName == 'SWAP') {
         //use this to select cpu from our colorlist, its incase we have more cpus than colors
         //This shouldnt happen but just incase
         let cpunum = i % colorsList.length;


### PR DESCRIPTION
@claudiux

Memory, network and disk graphs were disappearing when the CPU graph was configured to use colors by activity level and the swap usage was above 20%.

Both the CPU and Swap graphs are bar charts and they share the same rendering function. That function was trying to get the colors configured by activity level for swap, but there's no such setting for swap, only for CPU. When swap usage reached 20%, the rendering function tried to get the color for the activity level >20%, but there's no color there. Swap has only 1 color configured.

The solution I applied is not very clean, but it works and has little impact. Let me know :+1:.

![image](https://github.com/user-attachments/assets/73e5e0a5-8cd1-43a6-a794-6062b7542248)

### Before this PR
![image](https://github.com/user-attachments/assets/f1a18b09-6554-4fc1-bd44-1e6efac57ba1)

### After this PR
![image](https://github.com/user-attachments/assets/880ee3f4-3a67-45a6-aaed-df3a73d6576f)

