### PR TITLE
Add configurable keybinding for desaturate-all

### DIFF
--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/applet.js
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/applet.js
@@ -1,4 +1,7 @@
 const Applet = imports.ui.applet;
+const Lang = imports.lang;
+const Settings = imports.ui.settings;
+const UUID = "desaturate-all@hkoosha";
 const Clutter = imports.gi.Clutter;
 const Main = imports.ui.main;
 
@@ -18,6 +21,11 @@ MyApplet.prototype = {
 
         this.effect = new Clutter.DesaturateEffect();
         this.set_applet_icon_symbolic_name("applications-graphics");
+
+        this.settings = new Settings.AppletSettings(this, UUID, this.instance_id);
+        this.settings.bind("keybinding", "keybinding", this.on_keybinding_changed);
+
+        this.on_keybinding_changed();
     },
 
     _toggleEffect: function() {
@@ -30,6 +38,10 @@ MyApplet.prototype = {
 
     on_applet_clicked: function() {
         this._toggleEffect();
+    },
+
+    on_keybinding_changed() {
+        Main.keybindingManager.addHotKey(UUID, this.keybinding, Lang.bind(this, this._toggleEffect));
     }
 };
 

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/ca.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/ca.po
@@ -1,14 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
+# DESATURATE ALL
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hkoosha, 2023
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
 "PO-Revision-Date: 2024-07-05 00:42+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -25,3 +26,7 @@ msgstr "Desaturar Tot"
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
 msgstr "Converteix la teva pantalla a escala de grisos."
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
+msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/da.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/da.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# DESATURATE ALL
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hkoosha, 2023
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
 "PO-Revision-Date: 2023-12-28 15:43+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -25,3 +26,7 @@ msgstr "Fjern farver overalt"
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
 msgstr "Konvertér alle farver til gråtoner og tilbage igen med et enkelt klik."
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
+msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/de.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/de.po
@@ -1,22 +1,23 @@
-# SOME DESCRIPTIVE TITLE.
+# DESATURATE ALL
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hkoosha, 2023
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
 "PO-Revision-Date: 2024-03-22 22:14+0100\n"
+"Last-Translator: Martin Posselt <nekomajin@gmx.de>\n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Martin Posselt <nekomajin@gmx.de>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
 
 #. metadata.json->name
 msgid "Desaturate All"
@@ -25,3 +26,7 @@ msgstr "Alles entsättigen"
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
 msgstr "Die Bildschirmausgabe in Graustufen umwandeln."
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
+msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/desaturate-all@hkoosha.pot
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/desaturate-all@hkoosha.pot
@@ -1,17 +1,17 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# DESATURATE ALL
+# This file is put in the public domain.
+# hkoosha, 2023
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: desaturate-all@hkoosha 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,4 +23,8 @@ msgstr ""
 
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
+msgstr ""
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
 msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/es.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/es.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# DESATURATE ALL
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hkoosha, 2023
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
 "PO-Revision-Date: 2023-12-28 11:10-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -24,3 +25,7 @@ msgstr "Desaturar todo"
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
 msgstr "Convierta su pantalla a escala de grises."
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
+msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/fi.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/fi.po
@@ -1,22 +1,23 @@
-# SOME DESCRIPTIVE TITLE.
+# DESATURATE ALL
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hkoosha, 2023
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
 "PO-Revision-Date: 2024-11-13 14:22+0200\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
 #. metadata.json->name
 msgid "Desaturate All"
@@ -25,3 +26,7 @@ msgstr "Desaturate All"
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
 msgstr "Muunna näyttösi kokonaan harmaasävyille."
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
+msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/fr.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/fr.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# DESATURATE ALL
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hkoosha, 2023
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
 "PO-Revision-Date: 2023-12-28 11:57+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -25,3 +26,7 @@ msgstr "Tout désaturer"
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
 msgstr "Convertir votre écran en niveaux de gris."
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
+msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/hu.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/hu.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# DESATURATE ALL
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hkoosha, 2023
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
 "PO-Revision-Date: 2024-01-06 16:04+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -25,3 +26,7 @@ msgstr "Minden színtelenítése"
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
 msgstr "Alakítsa át a képernyőjét szürkeárnyalatossá."
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
+msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/it.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/it.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# DESATURATE ALL
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hkoosha, 2023
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
 "PO-Revision-Date: 2024-06-18 15:25+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -25,3 +26,7 @@ msgstr "Desatura tutto"
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
 msgstr "Converti il ​​tuo schermo in scala di grigi."
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
+msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/nl.po
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/po/nl.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# DESATURATE ALL
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hkoosha, 2023
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-28 10:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-22 12:52-0500\n"
 "PO-Revision-Date: 2024-04-20 17:35+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -23,3 +24,7 @@ msgstr "Desatureer Alles"
 #. metadata.json->description
 msgid "Convert your screen to grayscale."
 msgstr "Zet uw scherm om naar grijstinten."
+
+#. settings-schema.json->keybinding->description
+msgid "Shortcut to toggle grayscale"
+msgstr ""

--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/settings-schema.json
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/settings-schema.json
@@ -1,0 +1,7 @@
+{
+    "keybinding" : {
+        "type" : "keybinding",
+        "description" : "Shortcut to toggle grayscale",
+        "default" : ""
+    }
+}


### PR DESCRIPTION
I have this set in my local version of desaturate-all (in `~/.local/share/cinnamon/applets`). For some reason, when trying to use the `./test-spice` script, the settings menu would not open on the developer copy, and I'm not exactly sure why. However, this works for me locally so it might be an issue with me having both the developer copy and the main copy?