### PR TITLE
Configurable char limit for mail sender and subject

### DIFF
--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/applet.js
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/applet.js
@@ -303,6 +303,8 @@ MyApplet.prototype = {
                 "client", "client", function(){});
             this.settings.bindProperty(Settings.BindingDirection.IN,
                 "middle_click", "middle_click_behavior", function(){});
+            this.settings.bindProperty(Settings.BindingDirection.IN,
+                "max_length", "max_length", this.onSettingsChanged.bind(this));
 		}
 		catch (e)
 		{
@@ -320,6 +322,10 @@ MyApplet.prototype = {
 		{
 			global.logError(e);
 		}
+    },
+
+	onSettingsChanged: function() {
+		this.onBusAppeared();
     },
 
 	// called on applet startup (even though mailnag bus already exists)
@@ -526,8 +532,10 @@ MyApplet.prototype = {
 
 	makeMenuItem: function(mail)
 	{
-		let mi = new MailItem(mail.id, mail.sender, mail.sender_address, 
-				      mail.subject.length > 64 ? mail.subject.substr(0,64) + "..." : mail.subject, 
+		let mi = new MailItem(mail.id, 
+				      mail.sender.length > this.max_length ? mail.sender.substr(0,this.max_length) + "..." : mail.sender,
+				      mail.sender_address.length > this.max_length ? mail.sender_address.substr(0,this.max_length) + "..." : mail.sender_address,
+				      mail.subject.length > this.max_length ? mail.subject.substr(0,this.max_length) + "..." : mail.subject,
 				      mail.datetime, mail.account);
 		mi.markReadButton.connect(
 			'clicked',

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/bg.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/bg.po
@@ -1,123 +1,116 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-19 20:38+0300\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2017-10-19 21:09+0300\n"
+"Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: bg\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "Току-що"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "Минута по-рано"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr "минути по-рано"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "Час по-рано"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr "часа по-рано "
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "вчера"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr "дни по-рано"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr "седмици по-рано"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Конфигуриране на Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Mailnag демона спря!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Mailnag не работи! Инсталирахте ли го?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Имате %d нови писма!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Маркирай всички като прочетени"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Имате поща!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Маркирай като прочетено"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Няма нови писма."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Mailnag демона не работи!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Имате писмо от %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Имате %d непрочетени писма!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Натиснете, за да видите грешката!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Грешка:"
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Аплет за известия на Mailnag"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Показвай известия"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -125,44 +118,50 @@ msgstr ""
 "Включва аплет за известяване при пристигане на ново писмо. Убедете се че "
 "Mailnag плъгина е изключен, в противен случай ще има дублиране."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Стартиране на пощенски клиент при натискане"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "Пощенския клиент ще стартира, когато натиснате на елемента в менюто."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "При натискане на колелцето:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Какво да се случи при клик с колелцето върху иконката на аплета"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Маркирай всички като прочетени"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Стартирай пощенския клиент"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Не прави нищо"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Пощенски клент за стартиране (или страница)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Въведете команда за стартиране на пощенски клиент. Също така може да "
 "въведете мрежов адрес, започващ с 'http'"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Стартиране на пощенски клиент при натискане"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "Пощенския клиент ще стартира, когато натиснате на елемента в менюто."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "При натискане на колелцето:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Какво да се случи при клик с колелцето върху иконката на аплета"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Маркирай всички като прочетени"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Стартирай пощенския клиент"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Не прави нищо"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/ca.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/ca.po
@@ -1,14 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2024-07-14 02:13+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,106 +19,98 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "ara mateix"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "fa 1 minute"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " minuts avans"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 hora enrere"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " hores enrere"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "ahir"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " dies enrere"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " setmanes enrere"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Configurar Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "El servei de Mailnag ha deixat de funcionar!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "El servei de Mailnag no està en marxa! El teniu instal·lat?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Teniu %d correus nous!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Marcar tot com a llegit"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Teniu correu nou!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Marcar com a llegit"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "No hi ha correus no llegits."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "El servei de Mailnag no està en marxa!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Teniu un correu de %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Teniu %d correus sense llegir!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Cliqueu per a veure l'error!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Error: "
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Miniaplicació notificadora de correus Mailnag"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Mostrar notificacions"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -126,44 +119,50 @@ msgstr ""
 "correus. En cas d'activar-ho, desactiveu el plugin de notificacions de "
 "Mailnag o rebreu notificacions duplicades."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Iniciar el client de correu en fer clic"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "S'iniciarà el client de correu en clicar un element del menú."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "En fer clic del mig:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Acció a realitzar en fer clic del mig a la icona de la miniaplicació"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Marcar tot com a llegit"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Iniciar el client de correu"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "No fer res"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Client de correu a llançar (o lloc web)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Introduïu l'ordre per a executar el vostre client de correu aquí. També "
 "podeu introduir un lloc web que comenci per 'http'."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Iniciar el client de correu en fer clic"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "S'iniciarà el client de correu en clicar un element del menú."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "En fer clic del mig:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Acció a realitzar en fer clic del mig a la icona de la miniaplicació"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Marcar tot com a llegit"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Iniciar el client de correu"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "No fer res"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/da.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/da.po
@@ -1,170 +1,169 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 20:35+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2017-08-17 19:31+0200\n"
+"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: da\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "lige nu"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 minut siden"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " minutter siden"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 time siden"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " timer siden"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "i går"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " dage siden"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " uger siden"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Konfigurér Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Mailnag-dæmonen holdt op med at virke!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Mailnag-dæmonen kører ikke! Er den installeret?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Du har %d nye mail!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Markér alle som læst"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Du har ny mail!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Markér som læst"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Ingen ulæste mail."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Mailnag-dæmonen kører ikke!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Der er mail fra %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Du har %d ulæste mail!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Klik for at se fejl!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Fejl: "
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Få meddelelser om mail via Mailnag"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Vis meddelelser"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
 msgstr ""
-"Tillader visning af meddelelser om ny mail. Deaktivér Mailnags \"notification"
-"\"-plugin for at undgå dobbeltmeddelelser."
+"Tillader visning af meddelelser om ny mail. Deaktivér Mailnags "
+"\"notification\"-plugin for at undgå dobbeltmeddelelser."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Kør mailklienten ved klik"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "Mailklienten startes, når der klikkes på et menupunkt."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Midterklik:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr ""
+"Hvad der skal ske, når der klikkes med midterste tast på panelprogrammets "
+"ikon"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Markér alle som læst"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Kør mailklient"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Gør ingenting"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Mailklient (eller webside)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Indtast kommandoen til din mailklient her. Du kan også indtaste en "
 "webadresse, som begynder med \"http\"."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Kør mailklienten ved klik"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "Mailklienten startes, når der klikkes på et menupunkt."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Midterklik:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr ""
-"Hvad der skal ske, når der klikkes med midterste tast på panelprogrammets "
-"ikon"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Markér alle som læst"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Kør mailklient"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Gør ingenting"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/de.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/de.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2021-11-06 10:20+0100\n"
 "Last-Translator: Stefan12O\n"
 "Language-Team: \n"
@@ -18,156 +19,154 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "gerade eben"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "vor einer Minute"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " Minuten her"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "vor einer Stunde"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " Stunden her"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "gestern"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " Tage her"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " Wochen her"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Mailnag konfigurieren"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Der Mailnag Daemon hat aufgehört zu arbeiten!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Der Mailnag Daemon läuft nicht. Ist er installiert?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Du hast %d neue Mails!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Alle als gelesen markieren"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Du hast neue Mails!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Als gelesen markieren"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Keine ungelesenen Mails."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Der Mailnag Daemon läuft nicht!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Du hast eine Mail von %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Du hast %d ungelesene Mails!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Anklicken um die Fehlermeldung zu sehen!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Fehler: "
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr ""
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Mailnag Benachrichtigungsapplet"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Benachrichtigungen anzeigen"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
 msgstr ""
-"Aktiviert die Anzeige neuer Mails durch das Applet. In diesem Fall sollte "
-"in Mailnag das Benachrichtigungs-Plugin (Libnotify) deaktiviert sein, sonst "
+"Aktiviert die Anzeige neuer Mails durch das Applet. In diesem Fall sollte in "
+"Mailnag das Benachrichtigungs-Plugin (Libnotify) deaktiviert sein, sonst "
 "bekommt man doppelte Meldungen."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Starte das Mailprogramm beim Anklicken einer Mail"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr ""
+"Das Mailprogramm wird gestartet, wenn eine Mail in der Anzeige angeklickt "
+"wird."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Bei Klick der mittleren Maustaste:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr ""
+"Aktion, die ausgeführt wird, wenn mit der mittleren Maustaste auf das Applet "
+"Icon geklickt wird."
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Alle als gelesen markieren"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Mailprogramm starten"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Nichts tun"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Mailprogramm oder Webseite, die gestartet wird."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Gebe hier den Befehl ein, der das Mailprogramm startet. Es kann auch eine "
 "Webseite sein, die mit 'http' startet."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Starte das Mailprogramm beim Anklicken einer Mail"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr ""
-"Das Mailprogramm wird gestartet, wenn eine Mail in der Anzeige angeklickt "
-"wird."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Bei Klick der mittleren Maustaste:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr ""
-"Aktion, die ausgeführt wird, wenn mit der mittleren Maustaste auf das "
-"Applet Icon geklickt wird."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Alle als gelesen markieren"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Mailprogramm starten"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Nichts tun"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/es.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/es.po
@@ -1,123 +1,116 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-26 20:23+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2018-07-26 20:41+0200\n"
+"Last-Translator: JM Piñol <jmpigon@gmail.com>\n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
-"Last-Translator: JM Piñol <jmpigon@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: es\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "justo ahora"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 minuto atrás"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr "minutos atrás"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 hora atrás"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr "horas atrás"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "ayer"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr "días atrás"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr "semanas atrás"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Configurar Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "¡El daemon Mailnag ha dejado de funcionar!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "¡El daemon Mailnag no se está ejecutando! ¿Está instalado?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "¡Tienes %d correos nuevos!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Marcar todo como léido"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "¡Tienes nuevo correo!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Marcar como leído"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Sin correo no leído."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "¡El daemon Mailnag no se está ejecutando!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "¡Tienes un correo de %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "¡Tienes %d correos sin leer!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "¡Hacer click para ver el error!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Error:"
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Applet de notificación Mailnag"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Mostrar notificaciones"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -126,45 +119,50 @@ msgstr ""
 "desactivar el plugin de notificación Mailnag, de otra forma tendrás "
 "duplicados."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Ejecutar cliente de correo al hacer click"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "El cliente de correo se ejecuta al hacer click en un elemento del menú"
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Al hacer click con el botón central:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Qué hacer al hacer click en el icono del applet con el botón central"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Marcar todos como leídos"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Ejecutar cliente de correo"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "No hacer nada"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Cliente de correo que ejecutar (o página web)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Introducir el comando para ejecutar tu cliente de correo aquí. También "
 "puedes introducir una dirección web que empiece por 'http'."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Ejecutar cliente de correo al hacer click"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr ""
-"El cliente de correo se ejecuta al hacer click en un elemento del menú"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Al hacer click con el botón central:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Qué hacer al hacer click en el icono del applet con el botón central"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Marcar todos como leídos"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Ejecutar cliente de correo"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "No hacer nada"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/fi.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/fi.po
@@ -1,125 +1,118 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2024-11-14 00:33+0200\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "juuri nyt"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 minuutti sitten"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " minuuttia sitten"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 tunti sitten"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " tuntia sitten"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "eilen"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " päivää sitten"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " viikkoa sitten"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Määritä Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Mailnag lakkasi toimimasta!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Gnote ei ole käynnissä! Oletko asentanut mailnag ohjelman?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Sinulla on %d uutta viestiä!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Merkitse kaikki luetuiksi"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Sinulle on sähköpostia!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Merkitse luetuksi"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Ei lukematonta sähköpostia."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Mailnag ei ole käynnissä!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Sinulle on sähköpostia %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Sinulla on %d lukematonta!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Painamalla näet virheilmoituksen!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Virhe: "
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr ""
 "Mailnag ilmoittaa saapuneista sähköposteista. Asenna myös mailnag ohjelma "
 "lisäksi"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Näytä ilmoitukset"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -127,44 +120,50 @@ msgstr ""
 "Näyttää ilmoituksen saapuneesta postista. Varmista, että poistat mailnag-"
 "ilmoitukset laajennuksen käytöstä, muuten sinulla on kaksoiskappaleita."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Avaa sähköpostiohjelma painamalla"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "Sähköpostiohjelma käynnistyy kun paneelin kuvaketta painetaan."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Hiiren keskipainike:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Mitä tapahtuu kun sovelman kuvaketta painetaan keskipainikkeella"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Merkitse kaikki luetuiksi"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Avaa sähköpostiohjelma"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Älä tee mitään"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Sähköpostiohjelma (tai verkkosivu)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Kirjoita komento tähän joka käynnistää sähköpostiohjelman. Voit myös "
 "kirjoittaa \"http\" osoitteen."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Avaa sähköpostiohjelma painamalla"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "Sähköpostiohjelma käynnistyy kun paneelin kuvaketta painetaan."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Hiiren keskipainike:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Mitä tapahtuu kun sovelman kuvaketta painetaan keskipainikkeella"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Merkitse kaikki luetuiksi"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Avaa sähköpostiohjelma"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Älä tee mitään"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/fr.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/fr.po
@@ -1,170 +1,168 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-26 20:23+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2020-01-24 19:00+0200\n"
+"Last-Translator: Anonymous <anon@ymous.me>\n"
 "Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
-"Last-Translator: Anonymous <anon@ymous.me>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fr\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "à l'instant"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "il y a 1 minute"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " minutes passées"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "il y a 1 heure"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " heures passées"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "hier"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr "jours passés"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr "semaines passées"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Configurer Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Le démon Mailnag a cessé de fonctionner !"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Le démon Mailnag n'est pas lancé ! L'avez-vous installé ?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Vous avez %d nouveaux courriers !"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Marquer tous comme lus"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Vous avez du courrier !"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Marquer comme lu"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Aucun courrier non lu."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Le démon Mailnag n'est pas lancé !"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Vous avez un courrier de %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Vous avez %d courriers non lus !"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Cliquez pour voir l'erreur !"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Erreur :"
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Applet de notification Mailnag"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Montrer les notifications"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
 msgstr ""
-"Active l'affichage des notifications de courrier reçu par l'applet. "
-"Assurez-vous de désactiver le plugin de notification de mailnag pour éviter"
-"les doublons."
+"Active l'affichage des notifications de courrier reçu par l'applet. Assurez-"
+"vous de désactiver le plugin de notification de mailnag pour éviterles "
+"doublons."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Démarrer le client mail en cliquant"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "Le client de courrier démarre lors du click sur une entrée du menu."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Action du click du milieu :"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Que faire lors d'un click du milieu sur l'icône de l'applet"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Marquer tous comme lus"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Démarrer le client de courrier"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Ne rien faire"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Client de courrier à démarrer (ou page web)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
-"Indiquez la commande de démarrage du client mail ici. Vous pouvez aussi entrer "
-"une adresse web commençant par 'http'."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Démarrer le client mail en cliquant"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr ""
-"Le client de courrier démarre lors du click sur une entrée du menu."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Action du click du milieu :"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Que faire lors d'un click du milieu sur l'icône de l'applet"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Marquer tous comme lus"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Démarrer le client de courrier"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Ne rien faire"
+"Indiquez la commande de démarrage du client mail ici. Vous pouvez aussi "
+"entrer une adresse web commençant par 'http'."

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/hu.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/hu.po
@@ -1,122 +1,115 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2021-03-30 21:37+0200\n"
+"Last-Translator: Bosák Balázs <bossbob88@gmail.com>\n"
+"Language-Team: \n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Last-Translator: Bosák Balázs <bossbob88@gmail.com>\n"
-"Language-Team: \n"
 "X-Generator: Poedit 2.4.2\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "éppen most"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 perce"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " percekkel ezelőtt"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 órája"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " órákkal ezelőtt"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "tegnap"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " napokkal ezelőtt"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " hetekkel ezelőtt"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Mailnag beállítása"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Mailnag kiszolgáló leállt!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Mailnag kiszolgáló nem fut! Telepítette már?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Önnek %d új levele van!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Az összes megjelölése olvasottként"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Új levele érkezett!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Megjelölés olvasottként"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Nincs olvasatlan levél."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Mailnag kiszolgáló nem fut!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Levele érkezett a következő személytől: %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Önnek %d olvasatlan levele van!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Kattintson a hiba megtekintéséhez!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Hiba: "
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Mailnag e-mail értesítő kisalkalmazás"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Értesítések megjelenítése"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -125,44 +118,50 @@ msgstr ""
 "beérkező e-mailekről. Győződjön meg róla, hogy letiltotta a mailnag "
 "értesítési bővítményt, különben duplán fog értesítéseket kapni."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Indítsa el a levelező klienst kattintással"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "A levelező kliens akkor indul el, amikor rákattint egy menüpontra."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Középső kattintással:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Mit tegyen, ha középső gombbal kattint a kisalkalmazás ikonra"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Az összes megjelölése olvasottként"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Levelező kliens indítása"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Ne tegyen semmit"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Indítandó levelező kliens (vagy weboldal)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Írja be a parancsot a levelező kliens indításához. Megadhat egy „http” "
 "kezdetű webcímet is."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Indítsa el a levelező klienst kattintással"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "A levelező kliens akkor indul el, amikor rákattint egy menüpontra."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Középső kattintással:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Mit tegyen, ha középső gombbal kattint a kisalkalmazás ikonra"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Az összes megjelölése olvasottként"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Levelező kliens indítása"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Ne tegyen semmit"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/it.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/it.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2022-06-03 17:13+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,106 +19,98 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "adesso"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 minuto fa"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " minuti fa"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 ora fa"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " ore fa"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "ieri"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " giorni fa"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " settimane fa"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Configura Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Il demone Mailnag ha smesso di funzionare!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Il demone Mailnag non è in esecuzione! L'hai installato?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Hai %d nuove e-mail!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Segna Tutte come Già Lette"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Hai nuove e-mail!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Segna come Letta"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Nessuna e-mail non letta."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Il demone Mailnag non è in esecuzione!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Hai una nuova e-mail da %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Hai %d e-mail non lette!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Clicca qui per vedere errori!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Errore: "
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Applet di notifica email Mailnag"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Mostra notifiche"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -126,45 +119,51 @@ msgstr ""
 "Assicurati di disabilitare il plugin di notifica mailnag, altrimenti avrai "
 "duplicati."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Avvia il client di posta al clic"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr ""
+"Il client di posta viene avviato quando si fa clic su una voce di menu."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Azione al clic centrale:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Cosa fare quando si fa clic centrale sull'icona dell'applet"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Segna tutte come già lette"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Avvia il client di posta elettronica"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Non fare niente"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Client di posta da avviare (o pagina Web)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Immettere il comando per avviare il client di posta qui. Puoi anche inserire "
 "un indirizzo web che inizia con 'http'."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Avvia il client di posta al clic"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr ""
-"Il client di posta viene avviato quando si fa clic su una voce di menu."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Azione al clic centrale:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Cosa fare quando si fa clic centrale sull'icona dell'applet"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Segna tutte come già lette"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Avvia il client di posta elettronica"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Non fare niente"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/mailnagapplet@ozderya.net.pot
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/mailnagapplet@ozderya.net.pot
@@ -1,163 +1,161 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# MAILNAG
+# This file is put in the public domain.
+# hyOzd, 2016
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: mailnagapplet@ozderya.net 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr ""
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr ""
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr ""
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr ""
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr ""
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr ""
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr ""
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr ""
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr ""
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr ""
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr ""
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr ""
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr ""
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr ""
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr ""
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr ""
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr ""
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr ""
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr ""
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr ""
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr ""
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr ""
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr ""
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr ""
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
 msgstr ""
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
-msgid "Mail client to launch (or webpage)"
-msgstr ""
-
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
-msgid ""
-"Enter the command to launch your mail client here. You can also enter a web "
-"address that starts with 'http'."
-msgstr ""
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
+#. settings-schema.json->launch_client_on_click->description
 msgid "Launch mail client on click"
 msgstr ""
 
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
+#. settings-schema.json->launch_client_on_click->tooltip
 msgid "Mail client is launched when clicked on a menu item."
 msgstr ""
 
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
+#. settings-schema.json->middle_click->description
 msgid "On middle click:"
 msgstr ""
 
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
+#. settings-schema.json->middle_click->tooltip
 msgid "What to do when middle clicked on applet icon"
 msgstr ""
 
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
+#. settings-schema.json->middle_click->options
 msgid "Mark all read"
 msgstr ""
 
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
+#. settings-schema.json->middle_click->options
 msgid "Launch mail client"
 msgstr ""
 
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
+#. settings-schema.json->middle_click->options
 msgid "Do nothing"
+msgstr ""
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
+msgid "Mail client to launch (or webpage)"
+msgstr ""
+
+#. settings-schema.json->client->tooltip
+msgid ""
+"Enter the command to launch your mail client here. You can also enter a web "
+"address that starts with 'http'."
 msgstr ""

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/nl.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/nl.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2024-04-21 12:37+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,106 +17,98 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "zojuist"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 minuut geleden"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " minuten geleden"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 uur geleden"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " uren geleden"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "gisteren"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " dagen geleden"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " weken geleden"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Configureer Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Mailnag daemon is gestopt met werken!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Mailnag daemon draait niet! Heb je het geïnstalleerd?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Je hebt %d nieuwe e-mails!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Alles markeren als gelezen"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Je hebt nieuwe e-mail!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Markeer als gelezen"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Geen ongelezen e-mails."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Mailnag daemon is niet actief!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Je hebt een e-mail van %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Je hebt %d ongelezen e-mails!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Klik om de fout te zien!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Fout: "
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Mailnag e-mailmeldingsapplet"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Toon meldingen"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -124,44 +117,50 @@ msgstr ""
 "applet. Zorg ervoor dat je de mailnag-meldingsplugin uitschakelt, anders "
 "krijg je duplicaten."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Start e-mailclient bij klikken"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "E-mailclient wordt gestart wanneer er op een menu-item wordt geklikt."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Bij middelklik:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Wat te doen bij een middelklik op het applet-pictogram"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Alles markeren als gelezen"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Start e-mailclient"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Doe niets"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "E-mailclient om te starten (of webpagina)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Voer hier het commando in om je e-mailclient te starten. Je kunt ook een "
 "webadres invoeren dat begint met 'http'."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Start e-mailclient bij klikken"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "E-mailclient wordt gestart wanneer er op een menu-item wordt geklikt."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Bij middelklik:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Wat te doen bij een middelklik op het applet-pictogram"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Alles markeren als gelezen"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Start e-mailclient"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Doe niets"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/pl.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/pl.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR: Marcin Golesz <marcingolesz@gmail.com>, 2018.
@@ -6,163 +6,164 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-07 02:58+0300\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2018-10-07 02:58+0300\n"
+"Last-Translator: Marcin Golesz <marcingolesz@gmail.com>\n"
 "Language-Team: \n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
-"Last-Translator: Marcin Golesz <marcingolesz@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: pl\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "teraz"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "minutę temu"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " minut temu"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "godzinę temu"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " godzin temu"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "wczoraj"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " dni temu"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " tygodni temu"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Konfiguruj Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Daemon Mailnag został zatrzymany!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Daemon Mailnag nie jest uruchomiony! Czy jest zainstalowany?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Masz %d nowych maili!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Oznacz wszystkie jako przeczytane"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Masz nową wiadomość!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Oznacz jako przeczytane"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Brak nowych wiadomości."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Daemon Mailnag nie jest uruchomiony!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Dostałeś maila od %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Masz %d nieprzeczytanych wiadomości!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Kliknij, aby zobaczyć błąd!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Błąd:"
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Aplet powiadomień Mailnag"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Pokaż powiadomienia"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
 msgstr ""
-"Włącza powiadomienia apletu o nadchodzących mailach. Upewnij się "
-"że wyłączyłeś plugin powiadomień Mailnag, w przeciwnym razie będą występować duplikaty."
+"Włącza powiadomienia apletu o nadchodzących mailach. Upewnij się że "
+"wyłączyłeś plugin powiadomień Mailnag, w przeciwnym razie będą występować "
+"duplikaty."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Po kliknięciu, uruchom klienta pocztowego"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr ""
+"Po kliknięciu na dowolną opcję w menu, zostanie uruchomiony klient pocztowy."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Po kliknięciu środkowym przyciskiem myszy:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Co zrobić po kliknięciu środkowym przyciskiem myszy na aplecie"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Oznacz wszystkie jako przeczytane"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Uruchom klienta pocztowego"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Nic nie rób"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Klient pocztowy do uruchomienia (lub strona internetowa)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
-"Wprowadź komendę wywołującą twojego kienta pocztowego. Możesz również wprowadzić adres "
-"strony internetowej, który musi się zaczynać od 'http'"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Po kliknięciu, uruchom klienta pocztowego"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "Po kliknięciu na dowolną opcję w menu, zostanie uruchomiony klient pocztowy."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Po kliknięciu środkowym przyciskiem myszy:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Co zrobić po kliknięciu środkowym przyciskiem myszy na aplecie"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Oznacz wszystkie jako przeczytane"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Uruchom klienta pocztowego"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Nic nie rób"
+"Wprowadź komendę wywołującą twojego kienta pocztowego. Możesz również "
+"wprowadzić adres strony internetowej, który musi się zaczynać od 'http'"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/pt_BR.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/pt_BR.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Marcelo Aof, 2021.
@@ -6,171 +6,169 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2021-11-06 13:55-0300\n"
+"Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Last-Translator: Marcelo Aof\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: pt_BR\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "agora mesmo"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 minuto atrás"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " minutos atrás"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 hora atrás"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " horas atrás"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "ontem"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " dias atrás"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " semanas atrás"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Configurar o Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "O processo do Mailnag parou de funcionar!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr ""
-"O processo do Mailnag não está em execução! Você realmente instalou o "
-"applet?"
+"O processo do Mailnag não está em execução! Você realmente instalou o applet?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Você recebeu %d novos e-mails!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Marcar tudo como lido"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Você recebeu um novo e-mail!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Marcar como lido"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Nenhum e-mail novo."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "O processo do Mailnag não está em execução!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Você recebeu um e-mail de %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Você tem %d e-mails não lidos!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Clique para ver o erro!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Erro: "
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Mailnag, applet de notificação de e-mails"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Mostrar notificações"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
 msgstr ""
 "Exibe notificações do applet quando você receber e-mails. Se você ativar "
 "essa opção, lembre-se de desativar outros plugins de notificação de e-mail, "
-"como por exemplo: outras extensões do mailnag. Caso contrário, você "
-"receberá notificações duplicadas."
+"como por exemplo: outras extensões do mailnag. Caso contrário, você receberá "
+"notificações duplicadas."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Abrir um cliente de e-mail ao clicar"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr ""
+"Um cliente de e-mail é aberto quando você clicar em um e-mail no menu do "
+"Mailnag."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Ao clicar com o botão do meio:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr ""
+"Define o que acontece quando você clicar com o botão do meio no ícone do "
+"applet"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Marcar tudo como lido"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Abrir o cliente de e-mail"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Fazer nada"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Cliente de e-mail para abrir (ou página da web)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Digite aqui o comando para abrir o seu cliente de e-mail preferido. Em vez "
 "disso, você também pode inserir um endereço da web que comece com 'http'."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Abrir um cliente de e-mail ao clicar"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr ""
-"Um cliente de e-mail é aberto quando você clicar em um e-mail no menu do "
-"Mailnag."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Ao clicar com o botão do meio:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr ""
-"Define o que acontece quando você clicar com o botão do meio no ícone do "
-"applet"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Marcar tudo como lido"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Abrir o cliente de e-mail"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Fazer nada"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/ru.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/ru.po
@@ -4,8 +4,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"Report-Msgid-Bugs-To: genaloner@gmail.com\n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2021-02-16 11:23+0100\n"
 "Last-Translator: Gena <genaloner@gmail.com>\n"
 "Language-Team: русский <>\n"
@@ -13,110 +14,102 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "только что"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 минуту назад"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " минут(ы/у) назад"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 час назад"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " час(a/ов) назад"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "вчера"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " дн(ей/я) назад"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " недел(ь/ю/и) назад"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Настроить Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Демон Mailnag перестал работать!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Демон Mailnag не запущен! Вы его устанавливали?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Новых непрочитанных писем: %d"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Отметить все как прочитанное"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Вы получили новое письмо"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Отметить как прочитанное"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Нет непрочитанных писем"
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Демон Mailnag не запущен!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Вы получили сообщение от %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Непрочитанных писем: %d"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Нажмите, чтобы посмотреть ошибку!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Ошибка:"
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Апплет оповещений для Mailnag"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Показывать оповещения"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -124,44 +117,50 @@ msgstr ""
 "Включает уведомления о письмах через апплет. Убедитесь, что вы отключили "
 "плагин уведомлений Mailnag, иначе уведомления будут дублироваться."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Запуск почтового клиента по клику"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "Запуск почтового клиента при нажатии на элемент меню."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "По клику средней кнопки мыши:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Что делать при нажатии средней кнопки мыши на значке апплета"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Отметить все как прочитанные"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Запустить почтовый клиент"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Ничего не делать"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Почтовый клиент для запуска (или веб-страницы)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Введите команду для запуска почтового клиента здесь. Вы также можете ввести "
 "веб-адрес, начинающийся с «http»."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Запуск почтового клиента по клику"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "Запуск почтового клиента при нажатии на элемент меню."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "По клику средней кнопки мыши:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Что делать при нажатии средней кнопки мыши на значке апплета"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Отметить все как прочитанные"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Запустить почтовый клиент"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Ничего не делать"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/sv.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/sv.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: mailnagapplet@ozderya.net\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-10 13:11+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2017-09-10 13:11+0200\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -18,106 +19,98 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "just nu"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 minut sedan"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " minuter sedan"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 timma sedan"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " timmar sedan"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "igår"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " dagar sedan"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " veckor sedan"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Konfigurera Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Mailnag-tjänsten slutade fungera!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Mailnag-tjänsten kär inte igång! Har du den installerad?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "Du har %d nya mejl!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Markera alla som lästa"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Du har nya mejl!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Markera som läst"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Inga olästa mejl."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Mailnag-tjänsten är inte igång!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "Du har mejl från %s!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "Du har %d olästa mejl!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Klicka för att se felet!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "FEL:"
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Mailnag e-postaviseringsprogram"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Visa aviseringar"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -125,44 +118,50 @@ msgstr ""
 "Visar avisering av inkommande e-post i panelen. Tillse att Mailnags "
 "aviseringstillägg är inaktiverat, annars får du dubbla aviseringar."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Starta e-postklienten vid klick"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "E-postklienten startas vid klick på en menypost."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Vid mushjulsklick:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Vad som skall ske vid mushjulsklick på panelikonen"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Markera alla som lästa"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Starta e-postklienten"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Gör ingenting"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "E-postklient att starta (eller webbsida)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Ange kommandot för att starta din e-postklient här. Du kan också ange en "
 "webbadress som startar med \"http(s)\"."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Starta e-postklienten vid klick"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "E-postklienten startas vid klick på en menypost."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Vid mushjulsklick:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Vad som skall ske vid mushjulsklick på panelikonen"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Markera alla som lästa"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Starta e-postklienten"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Gör ingenting"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/tr.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/tr.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Serkan ÖNDER <serkanonder@outlook.com>, 2021.
@@ -6,118 +6,111 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2021-01-04 15:24+0300\n"
+"Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: tr\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "hemen şimdi"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1 dakika önce"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr " dakikalar önce"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1 saat önce"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr " saatler önce"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "dün"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr " günler önce"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr " haftalar önce"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "Mailnag'i yapılandırın"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Mailnag arka plan programı çalışmayı durdurdu!"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Mailnag arka plan programı çalışmıyor! Yüklediniz mi?"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "%d yeni postanız var!"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "Tümünü Okundu Olarak İşaretle"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "Yeni postanız var!"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "Okundu olarak İşaretle"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "Okunmamış posta yok."
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Mailnag arka plan programı çalışmıyor!"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "%s'den bir postanız var!"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "%d okunmamış postanız var!"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "Hatayı görmek için tıklayın!"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "Hata: "
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Mailnag posta bildirim uygulaması"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "Bildirimleri göster"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
@@ -126,44 +119,50 @@ msgstr ""
 "Mailnag bildirim eklentisini devre dışı bıraktığınızdan emin olun, aksi "
 "takdirde kopyalarınız olur."
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "Tıklamayla posta istemcisini başlatın"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "Posta istemcisi, bir menü öğesine tıklandığında başlatılır."
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "Orta tıklamada:"
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "Uygulama simgesine orta tıklandığında ne yapılmalı"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "Tümünü okundu olarak işaretle"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "Posta istemcisini başlatın"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "Hiçbir şey yapma"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "Başlatılacak posta istemcisi (veya web sayfası)"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "Posta istemcinizi başlatmak için komutu buraya girin. Ayrıca 'http' ile "
 "başlayan bir web adresi de girebilirsiniz."
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "Tıklamayla posta istemcisini başlatın"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "Posta istemcisi, bir menü öğesine tıklandığında başlatılır."
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "Orta tıklamada:"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "Uygulama simgesine orta tıklandığında ne yapılmalı"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "Tümünü okundu olarak işaretle"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "Posta istemcisini başlatın"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "Hiçbir şey yapma"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/zh_CN.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/zh_CN.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# MAILNAG
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# hyOzd, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 19:27+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-01-26 12:36-0500\n"
 "PO-Revision-Date: 2017-09-04 10:45+0800\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,151 +19,149 @@ msgstr ""
 "X-Generator: Poedit 2.0.3\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: applet.js:165
+#. applet.js:169
 msgid "just now"
 msgstr "刚刚"
 
-#: applet.js:169
-msgid "1 minute ago"
-msgstr "1分钟前"
-
-#: applet.js:173
+#. applet.js:177
 msgid " minutes ago"
 msgstr "分钟前"
 
-#: applet.js:177
-msgid "1 hour ago"
-msgstr "1小时前"
-
-#: applet.js:181
+#. applet.js:185
 msgid " hours ago"
 msgstr "小时前"
 
-#: applet.js:188
+#. applet.js:192
 msgid "yesterday"
 msgstr "昨天"
 
-#: applet.js:192
+#. applet.js:196
 msgid " days ago"
 msgstr "天前"
 
-#: applet.js:196
+#. applet.js:200
 msgid " weeks ago"
 msgstr "周前"
 
-#: applet.js:281
+#. applet.js:285
 msgid "Configure Mailnag"
 msgstr "配置Mailnag"
 
-#: applet.js:360
+#. applet.js:370
 msgid "Mailnag daemon stopped working!"
 msgstr "Mailnag守护进程停止工作！"
 
-#: applet.js:364
+#. applet.js:374
 msgid "Mailnag daemon isn't running! Do you have it installed?"
 msgstr "Mailnag守护进程没有运行！您是否已经安装Mailnag？"
 
-#: applet.js:593
-#, c-format
+#. applet.js:607
+#, javascript-format
 msgid "You have %d new mails!"
 msgstr "您有%d封新邮件！"
 
-#: applet.js:594 applet.js:639
+#. applet.js:608 applet.js:653
 msgid "Mark All Read"
 msgstr "标记全部已读"
 
-#: applet.js:602
+#. applet.js:616
 msgid "You have new mail!"
 msgstr "您有新邮件！"
 
-#: applet.js:604
+#. applet.js:618
 msgid "Mark Read"
 msgstr "标记已读"
 
-#: applet.js:687 applet.js:749
+#. applet.js:701 applet.js:763
 msgid "No unread mails."
 msgstr "没有未读邮件。"
 
-#: applet.js:725
+#. applet.js:739
 msgid "Mailnag daemon is not running!"
 msgstr "Mailnag守护进程没有运行！"
 
-#: applet.js:738
-#, c-format
+#. applet.js:752
+#, javascript-format
 msgid "You have a mail from %s!"
 msgstr "您有一封来自%s的邮件！"
 
-#: applet.js:744
-#, c-format
+#. applet.js:758
+#, javascript-format
 msgid "You have %d unread mails!"
 msgstr "您有%d封未读邮件！"
 
-#: applet.js:760
+#. applet.js:774
 msgid "Click to see error!"
 msgstr "点击查看错误！"
 
-#: applet.js:761
+#. applet.js:775
 msgid "Error: "
 msgstr "错误："
 
-#. mailnagapplet@ozderya.net->metadata.json->name
+#. metadata.json->name
 msgid "Mailnag"
 msgstr "Mailnag"
 
-#. mailnagapplet@ozderya.net->metadata.json->description
+#. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Mailnag邮件通知小程序"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->description
+#. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr "显示通知"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->notifications->tooltip
+#. settings-schema.json->notifications->tooltip
 msgid ""
 "Enables display of mail arrived notifications by applet. Make sure you "
 "disable mailnag notification plugin, otherwise you will have duplicates."
 msgstr ""
-"启用显示小程序的邮件到达通知。请确保您禁用了mailnag通知插件，否则您会收到重"
-"复的通知。"
+"启用显示小程序的邮件到达通知。请确保您禁用了mailnag通知插件，否则您会收到重复"
+"的通知。"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->description
+#. settings-schema.json->launch_client_on_click->description
+msgid "Launch mail client on click"
+msgstr "点击时启动邮件客户端"
+
+#. settings-schema.json->launch_client_on_click->tooltip
+msgid "Mail client is launched when clicked on a menu item."
+msgstr "点击菜单条目时启动邮件客户端。"
+
+#. settings-schema.json->middle_click->description
+msgid "On middle click:"
+msgstr "中键点击时："
+
+#. settings-schema.json->middle_click->tooltip
+msgid "What to do when middle clicked on applet icon"
+msgstr "中键点击小程序图标的反应"
+
+#. settings-schema.json->middle_click->options
+msgid "Mark all read"
+msgstr "标记全部已读"
+
+#. settings-schema.json->middle_click->options
+msgid "Launch mail client"
+msgstr "启动邮件客户端"
+
+#. settings-schema.json->middle_click->options
+msgid "Do nothing"
+msgstr "什么也不做"
+
+#. settings-schema.json->max_length->description
+msgid "Max sender / subject display length"
+msgstr ""
+
+#. settings-schema.json->max_length->tooltip
+msgid "Sender or subject lines longer than this will be cropped"
+msgstr ""
+
+#. settings-schema.json->client->description
 msgid "Mail client to launch (or webpage)"
 msgstr "要启动的邮件客户端（或网页）"
 
-#. mailnagapplet@ozderya.net->settings-schema.json->client->tooltip
+#. settings-schema.json->client->tooltip
 msgid ""
 "Enter the command to launch your mail client here. You can also enter a web "
 "address that starts with 'http'."
 msgstr ""
 "在这里输入用来启动您的邮件客户端的命令。您也可以输入一个以“http”开头的网络地"
 "址。"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->description
-msgid "Launch mail client on click"
-msgstr "点击时启动邮件客户端"
-
-#. mailnagapplet@ozderya.net->settings-
-#. schema.json->launch_client_on_click->tooltip
-msgid "Mail client is launched when clicked on a menu item."
-msgstr "点击菜单条目时启动邮件客户端。"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->description
-msgid "On middle click:"
-msgstr "中键点击时："
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->tooltip
-msgid "What to do when middle clicked on applet icon"
-msgstr "中键点击小程序图标的反应"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Mark all read"
-msgstr "标记全部已读"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Launch mail client"
-msgstr "启动邮件客户端"
-
-#. mailnagapplet@ozderya.net->settings-schema.json->middle_click->options
-msgid "Do nothing"
-msgstr "什么也不做"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/settings-schema.json
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/settings-schema.json
@@ -25,6 +25,17 @@
 		}
 	},
 
+    "max_length" : {
+        "type" : "spinbutton",
+        "default" : 32,
+        "min" : 0,
+        "max" : 256,
+        "step" : 1,
+        "unit" : "characters",
+        "description" : "Max sender / subject display length",
+        "tooltip" : "Sender or subject lines longer than this will be cropped"
+    },
+	
     "client" : {
         "type" : "entry",
         "default" : "thunderbird",


### PR DESCRIPTION
- The limit is now configurable on the applet settings page.
- Limit now applies to sender name, sender address and subject.

See #6810 and #5230 

Comments and suggestions are greatly appreciated.