### PR TITLE
Sensors@claudiux: Update German (de) translation

### DIFF
--- a/Sensors@claudiux/files/Sensors@claudiux/po/de.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
 "POT-Creation-Date: 2025-01-30 13:21+0100\n"
-"PO-Revision-Date: 2025-01-30 16:27+0100\n"
+"PO-Revision-Date: 2025-01-30 19:41+0100\n"
 "Last-Translator: Michael Härtl <haertl.mike@gmail.com>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -211,7 +211,7 @@ msgstr "⦿ Temperatur"
 
 #. settings-schema.json->page_Fans->title
 msgid "𖣘 Fan"
-msgstr "🤂 Lüfter"
+msgstr "𖣘 Lüfter"
 
 #. settings-schema.json->page_Voltages->title
 msgid "🗲 Voltage"


### PR DESCRIPTION
Use correct Unicode character for fan symbol (𖣘, BAMUM LETTER PHASE-C MA NSIEE).
See: https://github.com/linuxmint/cinnamon-spices-applets/pull/6824#issuecomment-2625210964