### PR TITLE
[PanelTranslator@klangman] Fixes and improvements

### DIFF
--- a/PanelTranslator@klangman/CHANGELOG.md
+++ b/PanelTranslator@klangman/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.2.0
+
+* Fixed the output for right-to-left language output by using the -no-bidi translation-shell parameter when translating text
+* Removed the Hotkey1/2 options and replaced them with 8 unique hotkey options on a new Hotkeys configuration dialog page. This makes the hotkey support more versatile and allows the Cinnamon Keyboard->Shortcuts setting page to properly show Panel Translator Hotkeys in it's user interface
+* Added support for allowing the popup dialog window to be resized
+* Save and restore popup window size on window resize events and applet startup
+* Fix handling of display scaling factors
+
 ## 1.1.0
 
 * Added two hotkey options that can perform any of the 8 translation options
@@ -13,4 +21,3 @@
 ## 1.0.1
 
 * Show any text-to-speech errors by placing the stderr text at the bottom of the GUI
-

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/applet.js
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/applet.js
@@ -60,6 +60,17 @@ const TranslateAction = {
    TransClipboardCopy: 8
 }
 
+const Hotkeys = [
+   {name: "panelTranslator-trans-selection",      setting: "hotkey-trans-selection",      action: TranslateAction.PopupSelection,     enabled: false},
+   {name: "panelTranslator-trans-clipboard",      setting: "hotkey-trans-clipboard",      action: TranslateAction.PopupClipboard,     enabled: false},
+   {name: "panelTranslator-trans-play-selection", setting: "hotkey-trans-play-selection", action: TranslateAction.PopupSelectionPlay, enabled: false},
+   {name: "panelTranslator-trans-play-clipboard", setting: "hotkey-trans-play-clipboard", action: TranslateAction.PopupClipboardPlay, enabled: false},
+   {name: "panelTranslator-play-selection",       setting: "hotkey-play-selection",       action: TranslateAction.PlaySelection,      enabled: false},
+   {name: "panelTranslator-play-clipboard",       setting: "hotkey-play-clipboard",       action: TranslateAction.PlayClipboard,      enabled: false},
+   {name: "panelTranslator-trans-copy-selection", setting: "hotkey-trans-copy-selection", action: TranslateAction.TransSelectionCopy, enabled: false},
+   {name: "panelTranslator-trans-copy-clipboard", setting: "hotkey-trans-copy-clipboard", action: TranslateAction.TransClipboardCopy, enabled: false},
+]
+
 const Engine = {
    Apertium: 0,
    Aspell: 1,
@@ -108,13 +119,21 @@ class PanelTranslatorApp extends Applet.IconApplet {
       this.getEngine();
       this.languages = [];
       this.getLanguages();
-      this.hotkey1Combo = null;
-      this.hotkey2Combo = null;
+      this._resizer = new Applet.PopupResizeHandler(this.menu.actor,
+            () => this._orientation,
+            (w,h) => this.translatorPopup.onBoxResized(w,h),
+            () => this.popup_width,
+            () => this.popup_height);
+
+      this.settings.bind("popup-width", "popup_width");
+      this.settings.bind("popup-height", "popup_height");
+
    }
 
    on_applet_added_to_panel() {
-      this._signalManager.connect(this.settings, "changed::hotkey-1", this._updateHotkeys, this);
-      this._signalManager.connect(this.settings, "changed::hotkey-2", this._updateHotkeys, this);
+      for ( let i=0 ; i < Hotkeys.length ; i++ ) {
+         this._signalManager.connect(this.settings, "changed::" + Hotkeys[i].setting, this._updateHotkeys, this);
+      }
       this._updateHotkeys()
    }
 
@@ -123,22 +142,20 @@ class PanelTranslatorApp extends Applet.IconApplet {
    }
 
    _updateHotkeys(register=true) {
-      if (this.hotkey1Combo) {
-         Main.keybindingManager.removeHotKey("panelTranslator-hotkey1");
-         this.hotkey1Combo = null;
-      }
-      if (this.hotkey2Combo) {
-         Main.keybindingManager.removeHotKey("panelTranslator-hotkey2");
-         this.hotkey2Combo = null;
-      }
-      if (register) {
-         this.hotkey1Combo = this.getHotkeySequence("hotkey-1");
-         if (this.hotkey1Combo) {
-            Main.keybindingManager.addHotKey("panelTranslator-hotkey1", this.hotkey1Combo, () => this.performHotkey("hotkey1-action") );
+      let i;
+      for ( i=0 ; i < Hotkeys.length ; i++ ) {
+         if (Hotkeys[i].enabled) {
+            Main.keybindingManager.removeHotKey(Hotkeys[i].name);
+            Hotkeys.enabled = false;
          }
-         this.hotkey2Combo = this.getHotkeySequence("hotkey-2");
-         if (this.hotkey2Combo) {
-            Main.keybindingManager.addHotKey("panelTranslator-hotkey2", this.hotkey2Combo, () => this.performHotkey("hotkey2-action") );
+
+         if (register) {
+            let hotkeyCombo = this.getHotkeySequence(Hotkeys[i].setting);
+            if (hotkeyCombo) {
+               let action = Hotkeys[i].action;
+               Main.keybindingManager.addHotKey(Hotkeys[i].name, hotkeyCombo, () => this._performTranslateAction(action));
+               Hotkeys[i].enabled = true;
+            }
          }
       }
    }
@@ -149,11 +166,6 @@ class PanelTranslatorApp extends Applet.IconApplet {
          return str;
       }
       return null;
-   }
-
-   performHotkey(name) {
-      let action = this.settings.getValue(name);
-      this._performTranslateAction(action);
    }
 
    _performTranslateAction(action) {
@@ -375,10 +387,15 @@ class TranslatorPopupItem extends PopupMenu.PopupMenuSection {
             this.toTextBox.set_text(fromText);
       });
 
-      this.fromSearchEntry = new St.Entry({ name: 'menu-search-entry', width: 210, track_hover: true, can_focus: true, x_expand: true, x_align: Clutter.ActorAlign.START });
+      let monitor = this._applet.panel.monitor;
+      let width = Math.min(monitor.width, this._applet.settings.getValue("popup-width"));
+      let height = Math.min(monitor.height, this._applet.settings.getValue("popup-height"));
+      this._applet.settings.setValue("popup-width", width);
+      this._applet.settings.setValue("popup-height", height);
+      this.fromSearchEntry = new St.Entry({ name: 'menu-search-entry', width: 210*global.ui_scale, track_hover: true, can_focus: true, x_expand: true, x_align: Clutter.ActorAlign.START });
       this.fromSearchEntry.get_clutter_text().connect( 'key-press-event', Lang.bind(this, this._onKeyPressEvent) );
       this.fromSearchEntry.get_clutter_text().connect( 'key-release-event', (actor, event) => {this._onKeyReleaseEvent(actor, event, this.fromLanguage); } );
-      this.toSearchEntry = new St.Entry({ name: 'menu-search-entry', width: 210, track_hover: true, can_focus: true, x_expand: true, x_align: Clutter.ActorAlign.END });
+      this.toSearchEntry = new St.Entry({ name: 'menu-search-entry', width: 210*global.ui_scale, track_hover: true, can_focus: true, x_expand: true, x_align: Clutter.ActorAlign.END });
       this.toSearchEntry.get_clutter_text().connect( 'key-press-event', Lang.bind(this, this._onKeyPressEvent) );
       this.toSearchEntry.get_clutter_text().connect( 'key-release-event', (actor, event) => {this._onKeyReleaseEvent(actor, event, this.toLanguage); } );
       this._searchFromIcon = new St.Icon({ style_class: 'menu-search-entry-icon', icon_name: 'edit-find', icon_type: St.IconType.SYMBOLIC });
@@ -390,18 +407,18 @@ class TranslatorPopupItem extends PopupMenu.PopupMenuSection {
       this.languageBox.add_child(this.toSearchEntry);
 
       // Setup the from/to text boxes
-      this.fromTextBox = new St.Entry({name: 'menu-search-entry', hint_text: _("{Text to translate}"), width: 250, height: 180, style: 'margin-right:2px;'});
+      this.fromTextBox = new St.Entry({name: 'menu-search-entry', hint_text: _("{Text to translate}"), width: /*250*/(width/2-45)*global.ui_scale, height: /*180*/(height-90)*global.ui_scale, style: 'margin-right:2px;'});
       let text = this.fromTextBox.get_clutter_text();
       text.set_line_wrap(true);
       text.set_single_line_mode(false);
       text.set_max_length(200);
       text.connect('text-changed', () => {this.enableTranslateIfPossible();});
       text.connect('activate', (actor, event) => {
-         Util.spawnCommandLineAsyncIO( "trans -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.readTranslation) );
+         Util.spawnCommandLineAsyncIO( "trans -no-bidi -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.readTranslation) );
          });
       this.textBox.add_child(this.fromTextBox);
 
-      this.toTextBox = new St.Entry({name: 'menu-search-entry', hint_text: _("{Translated text}"), width: 250, height: 180, style: 'margin-left:2px;'});
+      this.toTextBox = new St.Entry({name: 'menu-search-entry', hint_text: _("{Translated text}"), width: /*250*/(width/2-45)*global.ui_scale, height: /*180*/(height-90)*global.ui_scale, style: 'margin-left:2px;'});
       text = this.toTextBox.get_clutter_text();
       text.set_line_wrap(true);
       text.set_single_line_mode(false);
@@ -433,7 +450,7 @@ class TranslatorPopupItem extends PopupMenu.PopupMenuSection {
          this.toTextBox.set_text("");
          });
       this.translate = new ControlButton("media-playback-start-symbolic", _("Translate"), () => {
-         Util.spawnCommandLineAsyncIO( "trans -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.readTranslation) );
+         Util.spawnCommandLineAsyncIO( "trans -no-bidi -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.readTranslation) );
          });
       this.translate.setEnabled(false);
       let toBtnBox = new St.BoxLayout({x_align: Clutter.ActorAlign.END, x_expand: true});
@@ -460,6 +477,44 @@ class TranslatorPopupItem extends PopupMenu.PopupMenuSection {
 
       this.addActor(this.vertBox, {expand: true});
       this._applet._signalManager.connect(this._applet.settings, "changed::translate-engine", this._applet.getEngine, this._applet);
+      this._applet._signalManager.connect(global, "scale-changed", this._onScaleChanged, this);
+   }
+
+   onBoxResized(w,h) {
+      w = Math.max(Math.trunc(w), 540);
+      h = Math.max(Math.trunc(h), 160);
+      this.fromTextBox.set_width((w/2-45)*global.ui_scale);
+      this.fromTextBox.set_height((h-90)*global.ui_scale);
+
+      this.toTextBox.set_width((w/2-45)*global.ui_scale);
+      this.toTextBox.set_height((h-90)*global.ui_scale);
+      this._applet.settings.setValue("popup-width", w);
+      this._applet.settings.setValue("popup-height", h);
+   }
+
+   _onScaleChanged() {
+      let monitor = this._applet.panel.monitor;
+      let width = Math.min(monitor.width, this._applet.settings.getValue("popup-width"));
+      let height = Math.min(monitor.height, this._applet.settings.getValue("popup-height"));
+      this._applet.settings.setValue("popup-width", width);
+      this._applet.settings.setValue("popup-height", height);
+
+      this.fromSearchEntry.set_width(210*global.ui_scale);
+      this.toSearchEntry.set_width(210*global.ui_scale);
+      this.fromTextBox.set_width((width/2-45)*global.ui_scale);
+      this.fromTextBox.set_height((height-90)*global.ui_scale);
+      this.toTextBox.set_width((width/2-45)*global.ui_scale);
+      this.toTextBox.set_height((height-90)*global.ui_scale);
+
+      this.switchButton.updateDisabledIcon();
+      this.config.updateDisabledIcon();
+      this.help.updateDisabledIcon();
+      this.playFrom.updateDisabledIcon();
+      this.paste.updateDisabledIcon();
+      this.clear.updateDisabledIcon();
+      this.translate.updateDisabledIcon();
+      this.copy.updateDisabledIcon();
+      this.playTo.updateDisabledIcon();
    }
 
    // Handles key press events for the from/to language search entry widgets
@@ -583,11 +638,11 @@ class TranslatorPopupItem extends PopupMenu.PopupMenuSection {
       this.fromTextBox.set_text(text.trim());
       if (translate) {
          if (play) {
-            Util.spawnCommandLineAsyncIO( "trans -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.playTranslation) );
+            Util.spawnCommandLineAsyncIO( "trans -no-bidi -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.playTranslation) );
          } else if (copy) {
-            Util.spawnCommandLineAsyncIO( "trans -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.copyTranslation) );
+            Util.spawnCommandLineAsyncIO( "trans -no-bidi -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.copyTranslation) );
          } else {
-            Util.spawnCommandLineAsyncIO( "trans -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.readTranslation) );
+            Util.spawnCommandLineAsyncIO( "trans -no-bidi -b -e " + this._applet.engine + " " + this.fromLanguage.code + ":" + this.toLanguage.code + " \"" + escapeQuotes(this.fromTextBox.get_text()) + "\"", Lang.bind(this, this.readTranslation) );
          }
       } else {
          this.toTextBox.set_text("");
@@ -615,31 +670,36 @@ class TranslatorPopupItem extends PopupMenu.PopupMenuSection {
 class ControlButton {
     constructor(icon, tooltip, callback) {
         this.actor = new St.Bin();
-
         this.button = new St.Button({style_class: 'menu-favorites-button' /*'panel-translator-button' 'menu-favorites-button' 'keyboard-key'*/});
         this.button.connect('clicked', callback);
-
+        this.icon_name = icon;
         this.icon = new St.Icon({ icon_type: St.IconType.SYMBOLIC, icon_name: icon, icon_size: ICON_SIZE });
+        this.updateDisabledIcon();
+        this.button.set_child(this.icon);
+        this.actor.add_actor(this.button);
+        this.tooltip = new Tooltips.Tooltip(this.button, tooltip);
+    }
 
-        let themeIcon = ICONTHEME.lookup_icon(icon, ICON_SIZE, 0);
+    updateDisabledIcon() {
+        let themeIcon = ICONTHEME.lookup_icon(this.icon_name, ICON_SIZE*global.ui_scale, 0);
         if (themeIcon) {
-           let pixBuf = GdkPixbuf.Pixbuf.new_from_file_at_size(themeIcon.get_filename(), ICON_SIZE, ICON_SIZE);
+           let pixBuf = GdkPixbuf.Pixbuf.new_from_file_at_size(themeIcon.get_filename(), ICON_SIZE*global.ui_scale, ICON_SIZE*global.ui_scale);
            if (pixBuf) {
               let image = new Clutter.Image();
               pixBuf.saturate_and_pixelate(pixBuf, 1, true);
               try {
                  image.set_data(pixBuf.get_pixels(), pixBuf.get_has_alpha() ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGBA_888,
-                    ICON_SIZE, ICON_SIZE, pixBuf.get_rowstride() );
-                 this.disabledIcon = new Clutter.Actor({width: ICON_SIZE, height: ICON_SIZE, content: image});
+                    ICON_SIZE*global.ui_scale, ICON_SIZE*global.ui_scale, pixBuf.get_rowstride() );
+                 this.disabledIcon = new Clutter.Actor({width: ICON_SIZE*global.ui_scale, height: ICON_SIZE*global.ui_scale, content: image});
+                 if (this.enabledStatus === false) {
+                    // Since the disabledIcon has changed, we might need to reflect that change in the actual button
+                    this.setEnabled(false);
+                 }
               } catch(e) {
                  // Can't set the image data, so just use the default!
               }
            }
         }
-        this.button.set_child(this.icon);
-        this.actor.add_actor(this.button);
-
-        this.tooltip = new Tooltips.Tooltip(this.button, tooltip);
     }
 
     getActor() {
@@ -656,6 +716,7 @@ class ControlButton {
     }
 
     setEnabled(status) {
+        this.enabledStatus = status;
         this.button.change_style_pseudo_class("insensitive", !status);
         this.button.can_focus = status;
         this.button.reactive = status;

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/metadata.json
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/metadata.json
@@ -5,5 +5,5 @@
   "max-instances": -1,
   "author": "klangman",
   "hide-configuration": false,
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/po/PanelTranslator@klangman.pot
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/po/PanelTranslator@klangman.pot
@@ -1,79 +1,79 @@
-# SOME DESCRIPTIVE TITLE.
+# PANEL TRANSLATOR
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PanelTranslator@klangman 1.1.0\n"
+"Project-Id-Version: PanelTranslator@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-31 11:39-0400\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2025-02-01 15:50-0500\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:97 applet.js:332 applet.js:334
+#. applet.js:108 applet.js:344 applet.js:346
 msgid "Translator"
 msgstr ""
 
-#: applet.js:260
+#. applet.js:272
 msgid "Unable to query available languages from translate-shell"
 msgstr ""
 
-#: applet.js:271
+#. applet.js:283
 msgid "Required \"trans\" command not found, please install translate-shell"
 msgstr ""
 
-#: applet.js:275
+#. applet.js:287
 msgid "Error, the \"trans\" command returned an exit code of "
 msgstr ""
 
-#: applet.js:355
+#. applet.js:367
 msgid "Swap Languages"
 msgstr ""
 
-#: applet.js:393
+#. applet.js:410
 msgid "{Text to translate}"
 msgstr ""
 
-#: applet.js:404
+#. applet.js:421
 msgid "{Translated text}"
 msgstr ""
 
-#: applet.js:418
+#. applet.js:435
 msgid "Configure"
 msgstr ""
 
-#: applet.js:419
+#. applet.js:436
 msgid "Help"
 msgstr ""
 
-#: applet.js:423
+#. applet.js:440
 msgid "Play"
 msgstr ""
 
-#: applet.js:427
+#. applet.js:444
 msgid "Paste"
 msgstr ""
 
-#: applet.js:431
+#. applet.js:448
 msgid "Clear"
 msgstr ""
 
-#: applet.js:435
+#. applet.js:452
 msgid "Translate"
 msgstr ""
 
-#: applet.js:440
+#. applet.js:457
 msgid "Copy"
 msgstr ""
 
-#: applet.js:446
+#. applet.js:463
 msgid "Play Translation"
 msgstr ""
 
@@ -87,8 +87,24 @@ msgid ""
 "and other translators"
 msgstr ""
 
-#. settings-schema.json->engine-header->description
+#. settings-schema.json->general-page->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->hotkey-page->title
+msgid "Hotkeys"
+msgstr ""
+
+#. settings-schema.json->engine-settings->title
 msgid "Translation Engine"
+msgstr ""
+
+#. settings-schema.json->action-settings->title
+msgid "Panel Button Actions"
+msgstr ""
+
+#. settings-schema.json->hotkey-settings->title
+msgid "Translation action hotkeys"
 msgstr ""
 
 #. settings-schema.json->translate-engine->options
@@ -134,10 +150,6 @@ msgid ""
 "shell decide what translator to use."
 msgstr ""
 
-#. settings-schema.json->auto-header->description
-msgid "Panel Button Actions"
-msgstr ""
-
 #. settings-schema.json->left-auto-paste->options
 msgid "Disabled"
 msgstr ""
@@ -151,13 +163,13 @@ msgid "Clipboard"
 msgstr ""
 
 #. settings-schema.json->left-auto-paste->description
-msgid "Automatically paste and translate on left click"
+msgid "Automatically translate on left click"
 msgstr ""
 
 #. settings-schema.json->left-auto-paste->tooltip
 msgid ""
-"Automatically paste the current selection/clipboard content and translate it "
-"when opening the popup window using a left click on the translator panel "
+"Automatically translate the selection/clipboard contents when opening the "
+"Panel Translator popup window using a left click on the Panel Translator "
 "button"
 msgstr ""
 
@@ -172,57 +184,49 @@ msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-selection->description
 msgid "Show popup dialog and translate Selection"
 msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-clipboard->description
 msgid "Show popup dialog and translate Clipboard"
 msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-selection->description
 msgid "Show popup dialog, translate Selection and play"
 msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-clipboard->description
 msgid "Show popup dialog, translate Clipboard and play"
 msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-selection->description
 msgid "Play translation of Selection"
 msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-clipboard->description
 msgid "Play translation of Clipboard"
 msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-selection->description
 msgid "Translate Selection and copy the translation"
 msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-clipboard->description
 msgid "Translate Clipboard and copy the translation"
 msgstr ""
 
@@ -244,24 +248,4 @@ msgstr ""
 msgid ""
 "Select the action to take when holding the Ctrl key and using the middle "
 "mouse button to click on the translator panel button"
-msgstr ""
-
-#. settings-schema.json->hotkeys-header->description
-msgid "Hotkeys"
-msgstr ""
-
-#. settings-schema.json->hotkey1-action->description
-msgid "Hotkey #1"
-msgstr ""
-
-#. settings-schema.json->hotkey1-action->tooltip
-msgid "Select the action to take when the #1 hotkey is pressed"
-msgstr ""
-
-#. settings-schema.json->hotkey2-action->description
-msgid "Hotkey #2"
-msgstr ""
-
-#. settings-schema.json->hotkey2-action->tooltip
-msgid "Select the action to take when the #2 hotkey is pressed"
 msgstr ""

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/po/ca.po
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/po/ca.po
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
+# PANEL TRANSLATOR
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 #, fuzzy
 msgid ""
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PanelTranslator@klangman 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-31 11:39-0400\n"
+"POT-Creation-Date: 2025-02-01 15:50-0500\n"
 "PO-Revision-Date: 2024-07-13 02:48+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,66 +18,66 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: applet.js:97 applet.js:332 applet.js:334
+#. applet.js:108 applet.js:344 applet.js:346
 msgid "Translator"
 msgstr "Traductor"
 
-#: applet.js:260
+#. applet.js:272
 msgid "Unable to query available languages from translate-shell"
 msgstr ""
 "No ha estat possible sol·licitar els idiomes disponibles de translate-shell"
 
-#: applet.js:271
+#. applet.js:283
 msgid "Required \"trans\" command not found, please install translate-shell"
 msgstr ""
 "No s'ha trobat l'ordre requerida \"trans\". Si us plau, instal·leu translate-"
 "shell"
 
-#: applet.js:275
+#. applet.js:287
 msgid "Error, the \"trans\" command returned an exit code of "
 msgstr "Error. L'ordre \"trans\" ha retornat el codi de sortida "
 
-#: applet.js:355
+#. applet.js:367
 msgid "Swap Languages"
 msgstr "Intercanviar idiomes"
 
-#: applet.js:393
+#. applet.js:410
 msgid "{Text to translate}"
 msgstr "{Text a traduir}"
 
-#: applet.js:404
+#. applet.js:421
 msgid "{Translated text}"
 msgstr "{Text traduït}"
 
-#: applet.js:418
+#. applet.js:435
 msgid "Configure"
 msgstr "Configura"
 
-#: applet.js:419
+#. applet.js:436
 msgid "Help"
 msgstr "Ajuda"
 
-#: applet.js:423
+#. applet.js:440
 msgid "Play"
 msgstr "Reproduir"
 
-#: applet.js:427
+#. applet.js:444
 msgid "Paste"
 msgstr "Enganxar"
 
-#: applet.js:431
+#. applet.js:448
 msgid "Clear"
 msgstr "Netejar"
 
-#: applet.js:435
+#. applet.js:452
 msgid "Translate"
 msgstr "Traduir"
 
-#: applet.js:440
+#. applet.js:457
 msgid "Copy"
 msgstr "Copiar"
 
-#: applet.js:446
+#. applet.js:463
 msgid "Play Translation"
 msgstr "Reproduir traducció"
 
@@ -93,8 +93,25 @@ msgstr ""
 "Tradueix el text a altres idiomes des del tauler de Cinnamon. Utilitza "
 "Google, Bing i altres serveis de traducció"
 
-#. settings-schema.json->engine-header->description
+#. settings-schema.json->general-page->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->hotkey-page->title
+msgid "Hotkeys"
+msgstr "Dreceres"
+
+#. settings-schema.json->engine-settings->title
 msgid "Translation Engine"
+msgstr "Motor de traduccions"
+
+#. settings-schema.json->action-settings->title
+msgid "Panel Button Actions"
+msgstr "Accions dels botons del tauler"
+
+#. settings-schema.json->hotkey-settings->title
+#, fuzzy
+msgid "Translation action hotkeys"
 msgstr "Motor de traduccions"
 
 #. settings-schema.json->translate-engine->options
@@ -143,10 +160,6 @@ msgstr ""
 "sols tradueixen o reporten errors HTTP. És millor utilitzar \"Auto\" i "
 "deixar que translate-shell esculli quin traductor utilitzar."
 
-#. settings-schema.json->auto-header->description
-msgid "Panel Button Actions"
-msgstr "Accions dels botons del tauler"
-
 #. settings-schema.json->left-auto-paste->options
 msgid "Disabled"
 msgstr "Desactivat"
@@ -160,13 +173,15 @@ msgid "Clipboard"
 msgstr "Porta-papers"
 
 #. settings-schema.json->left-auto-paste->description
-msgid "Automatically paste and translate on left click"
+#, fuzzy
+msgid "Automatically translate on left click"
 msgstr "Enganxar i traduir automàticament en fer clic"
 
 #. settings-schema.json->left-auto-paste->tooltip
+#, fuzzy
 msgid ""
-"Automatically paste the current selection/clipboard content and translate it "
-"when opening the popup window using a left click on the translator panel "
+"Automatically translate the selection/clipboard contents when opening the "
+"Panel Translator popup window using a left click on the Panel Translator "
 "button"
 msgstr ""
 "Enganxa la selecció / el contingut del porta-papers i el tradueix a la "
@@ -183,29 +198,25 @@ msgstr "No fer res"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-selection->description
 msgid "Show popup dialog and translate Selection"
 msgstr "Mostrar una finestra emergent i traduir la selecció"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-clipboard->description
 msgid "Show popup dialog and translate Clipboard"
 msgstr "Mostrar una finestra emergent i traduir el contingut del porta-papers"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-selection->description
 msgid "Show popup dialog, translate Selection and play"
 msgstr "Mostrar una finestra emergent, traduir la selecció i reproduir-lo"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-clipboard->description
 msgid "Show popup dialog, translate Clipboard and play"
 msgstr ""
 "Mostrar una finestra emergent, traduir el contingut del porta-papers i "
@@ -213,29 +224,25 @@ msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-selection->description
 msgid "Play translation of Selection"
 msgstr "Reproduir la traducció de la selecció"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-clipboard->description
 msgid "Play translation of Clipboard"
 msgstr "Reproduir la traducció del porta-papers"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-selection->description
 msgid "Translate Selection and copy the translation"
 msgstr "Traduir la selecció i copiar la traducció"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-clipboard->description
 msgid "Translate Clipboard and copy the translation"
 msgstr "Traduir el contingut del porta-papers i copiar la traducció"
 
@@ -258,23 +265,3 @@ msgid ""
 "Select the action to take when holding the Ctrl key and using the middle "
 "mouse button to click on the translator panel button"
 msgstr "Seleccioneu l'acció a dur a terme mitjançant Ctrl + clic del mig"
-
-#. settings-schema.json->hotkeys-header->description
-msgid "Hotkeys"
-msgstr "Dreceres"
-
-#. settings-schema.json->hotkey1-action->description
-msgid "Hotkey #1"
-msgstr "Drecera #1"
-
-#. settings-schema.json->hotkey1-action->tooltip
-msgid "Select the action to take when the #1 hotkey is pressed"
-msgstr "Seleccioneu l'acció a dur a terme en prémer la drecera #1"
-
-#. settings-schema.json->hotkey2-action->description
-msgid "Hotkey #2"
-msgstr "Drecera #2"
-
-#. settings-schema.json->hotkey2-action->tooltip
-msgid "Select the action to take when the #2 hotkey is pressed"
-msgstr "Seleccioneu l'acció a dur a terme en prémer la drecera #2"

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/po/de.po
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/po/de.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# PANEL TRANSLATOR
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PanelTranslator@klangman 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-31 11:39-0400\n"
+"POT-Creation-Date: 2025-02-01 15:50-0500\n"
 "PO-Revision-Date: 2024-11-20 18:46+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,65 +17,65 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:97 applet.js:332 applet.js:334
+#. applet.js:108 applet.js:344 applet.js:346
 msgid "Translator"
 msgstr "Übersetzer"
 
-#: applet.js:260
+#. applet.js:272
 msgid "Unable to query available languages from translate-shell"
 msgstr "Verfügbare Sprachen können nicht von translate-shell abgefragt werden"
 
-#: applet.js:271
+#. applet.js:283
 msgid "Required \"trans\" command not found, please install translate-shell"
 msgstr ""
 "Erforderlicher Befehl \"trans\" nicht gefunden, bitte installieren translate-"
 "shell"
 
-#: applet.js:275
+#. applet.js:287
 msgid "Error, the \"trans\" command returned an exit code of "
 msgstr "Fehler, der \"trans\" Befehl hat einen Fehler code zurückgegeben "
 
-#: applet.js:355
+#. applet.js:367
 msgid "Swap Languages"
 msgstr "Sprachen tauschen"
 
-#: applet.js:393
+#. applet.js:410
 msgid "{Text to translate}"
 msgstr "{Zu übersetzender text}"
 
-#: applet.js:404
+#. applet.js:421
 msgid "{Translated text}"
 msgstr "{Übersetzter Text[}"
 
-#: applet.js:418
+#. applet.js:435
 msgid "Configure"
 msgstr "Konfigurieren"
 
-#: applet.js:419
+#. applet.js:436
 msgid "Help"
 msgstr "Hilfe"
 
-#: applet.js:423
+#. applet.js:440
 msgid "Play"
 msgstr "Abspielen"
 
-#: applet.js:427
+#. applet.js:444
 msgid "Paste"
 msgstr "Einfügen"
 
-#: applet.js:431
+#. applet.js:448
 msgid "Clear"
 msgstr "Löschen"
 
-#: applet.js:435
+#. applet.js:452
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: applet.js:440
+#. applet.js:457
 msgid "Copy"
 msgstr "Kopieren"
 
-#: applet.js:446
+#. applet.js:463
 msgid "Play Translation"
 msgstr "Übersetzung Abspielen"
 
@@ -91,8 +91,25 @@ msgstr ""
 "Übersetze Text zu anderen Sprachen des Cinnamon panels mit Google, Bing und "
 "anderen Übersetzern"
 
-#. settings-schema.json->engine-header->description
+#. settings-schema.json->general-page->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->hotkey-page->title
+msgid "Hotkeys"
+msgstr "Tastenkombinationen"
+
+#. settings-schema.json->engine-settings->title
 msgid "Translation Engine"
+msgstr "Übersetzungs Engine"
+
+#. settings-schema.json->action-settings->title
+msgid "Panel Button Actions"
+msgstr "Panel Knopf Aktionen"
+
+#. settings-schema.json->hotkey-settings->title
+#, fuzzy
+msgid "Translation action hotkeys"
 msgstr "Übersetzungs Engine"
 
 #. settings-schema.json->translate-engine->options
@@ -142,10 +159,6 @@ msgstr ""
 "\"Automatisch\" zu verwenden und translate-shell entscheiden zu lassen "
 "welcher Übersetzer benutzt werden soll."
 
-#. settings-schema.json->auto-header->description
-msgid "Panel Button Actions"
-msgstr "Panel Knopf Aktionen"
-
 #. settings-schema.json->left-auto-paste->options
 msgid "Disabled"
 msgstr "Deaktiviert"
@@ -159,13 +172,15 @@ msgid "Clipboard"
 msgstr "Zwischenablage"
 
 #. settings-schema.json->left-auto-paste->description
-msgid "Automatically paste and translate on left click"
+#, fuzzy
+msgid "Automatically translate on left click"
 msgstr "Automatisch einfügen und übersetzen wenn links geklickt wird"
 
 #. settings-schema.json->left-auto-paste->tooltip
+#, fuzzy
 msgid ""
-"Automatically paste the current selection/clipboard content and translate it "
-"when opening the popup window using a left click on the translator panel "
+"Automatically translate the selection/clipboard contents when opening the "
+"Panel Translator popup window using a left click on the Panel Translator "
 "button"
 msgstr ""
 "Automatisches Einfügen des Inhalts der aktuellen Auswahl/Zwischenablage und "
@@ -183,57 +198,49 @@ msgstr "Nichts machen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-selection->description
 msgid "Show popup dialog and translate Selection"
 msgstr "Popup dialog anzeigen und Auswahl übersetzen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-clipboard->description
 msgid "Show popup dialog and translate Clipboard"
 msgstr "Popup dialog anzeigen und Zwischenablage übersetzen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-selection->description
 msgid "Show popup dialog, translate Selection and play"
 msgstr "Popup Dialog anzeigen, Auswahl übersetzen und abspielen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-clipboard->description
 msgid "Show popup dialog, translate Clipboard and play"
 msgstr "Popup Dialog anzeigen, Zwischenablage übersetzen und abspielen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-selection->description
 msgid "Play translation of Selection"
 msgstr "Übersetzung der Auswahl abspielen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-clipboard->description
 msgid "Play translation of Clipboard"
 msgstr "Übersetzung der Zwischenablage abspielen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-selection->description
 msgid "Translate Selection and copy the translation"
 msgstr "Auswahl übersetzen und Übersetzung kopieren"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-clipboard->description
 msgid "Translate Clipboard and copy the translation"
 msgstr "Zwischenablage übersetzen und Übersetzung kopieren"
 
@@ -260,27 +267,3 @@ msgid ""
 msgstr ""
 "Wähle die Aktion aus die ausgeführt wird wenn die Strg Taste gehalten wird "
 "und mit dem mittlerem Maus Knopf auf den Übersetzer Panel Knopf geklickt wird"
-
-#. settings-schema.json->hotkeys-header->description
-msgid "Hotkeys"
-msgstr "Tastenkombinationen"
-
-#. settings-schema.json->hotkey1-action->description
-msgid "Hotkey #1"
-msgstr "Tastenkombination #1"
-
-#. settings-schema.json->hotkey1-action->tooltip
-msgid "Select the action to take when the #1 hotkey is pressed"
-msgstr ""
-"Wähle die Aktion aus, die ausgeführt wird wenn die Tastenkombination #1 "
-"gedrückt wird"
-
-#. settings-schema.json->hotkey2-action->description
-msgid "Hotkey #2"
-msgstr "Tastenkombination #2"
-
-#. settings-schema.json->hotkey2-action->tooltip
-msgid "Select the action to take when the #2 hotkey is pressed"
-msgstr ""
-"Wähle die Aktion aus, die ausgeführt wird wenn die Tastenkombination #2 "
-"gedrückt wird"

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/po/es.po
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/po/es.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# PANEL TRANSLATOR
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-31 11:39-0400\n"
+"POT-Creation-Date: 2025-02-01 15:50-0500\n"
 "PO-Revision-Date: 2024-03-31 14:02-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,63 +18,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: applet.js:97 applet.js:332 applet.js:334
+#. applet.js:108 applet.js:344 applet.js:346
 msgid "Translator"
 msgstr "Traductor"
 
-#: applet.js:260
+#. applet.js:272
 msgid "Unable to query available languages from translate-shell"
 msgstr "No se pueden consultar los idiomas disponibles desde Translate-Shell"
 
-#: applet.js:271
+#. applet.js:283
 msgid "Required \"trans\" command not found, please install translate-shell"
 msgstr "No se encontró el comando \"trans\" requerido; instale Translate-Shell"
 
-#: applet.js:275
+#. applet.js:287
 msgid "Error, the \"trans\" command returned an exit code of "
 msgstr "Error, el comando \"trans\" devuelve un código de salida de "
 
-#: applet.js:355
+#. applet.js:367
 msgid "Swap Languages"
 msgstr "Intercambiar idiomas"
 
-#: applet.js:393
+#. applet.js:410
 msgid "{Text to translate}"
 msgstr "{Texto a traducir}"
 
-#: applet.js:404
+#. applet.js:421
 msgid "{Translated text}"
 msgstr "{Texto traducido}"
 
-#: applet.js:418
+#. applet.js:435
 msgid "Configure"
 msgstr "Configurar"
 
-#: applet.js:419
+#. applet.js:436
 msgid "Help"
 msgstr "Ayuda"
 
-#: applet.js:423
+#. applet.js:440
 msgid "Play"
 msgstr "Reproducir"
 
-#: applet.js:427
+#. applet.js:444
 msgid "Paste"
 msgstr "Pegar"
 
-#: applet.js:431
+#. applet.js:448
 msgid "Clear"
 msgstr "Limpiar"
 
-#: applet.js:435
+#. applet.js:452
 msgid "Translate"
 msgstr "Traducir"
 
-#: applet.js:440
+#. applet.js:457
 msgid "Copy"
 msgstr "Copiar"
 
-#: applet.js:446
+#. applet.js:463
 msgid "Play Translation"
 msgstr "Reproducir traducción"
 
@@ -90,8 +90,25 @@ msgstr ""
 "Traduce texto a otros idiomas desde el panel de Cinnamon utilizando Google, "
 "Bing y otros traductores"
 
-#. settings-schema.json->engine-header->description
+#. settings-schema.json->general-page->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->hotkey-page->title
+msgid "Hotkeys"
+msgstr "Teclas de acceso rápido"
+
+#. settings-schema.json->engine-settings->title
 msgid "Translation Engine"
+msgstr "Motor de traducción"
+
+#. settings-schema.json->action-settings->title
+msgid "Panel Button Actions"
+msgstr "Acciones de los botones del panel"
+
+#. settings-schema.json->hotkey-settings->title
+#, fuzzy
+msgid "Translation action hotkeys"
 msgstr "Motor de traducción"
 
 #. settings-schema.json->translate-engine->options
@@ -140,10 +157,6 @@ msgstr ""
 "traducen, otros sólo informan de errores HTTP. Así que es mejor usar "
 "\"Auto\" y dejar que translate-shell decida qué traductor usar."
 
-#. settings-schema.json->auto-header->description
-msgid "Panel Button Actions"
-msgstr "Acciones de los botones del panel"
-
 #. settings-schema.json->left-auto-paste->options
 msgid "Disabled"
 msgstr "Deshabilitado"
@@ -157,13 +170,15 @@ msgid "Clipboard"
 msgstr "Portapapeles"
 
 #. settings-schema.json->left-auto-paste->description
-msgid "Automatically paste and translate on left click"
+#, fuzzy
+msgid "Automatically translate on left click"
 msgstr "Pegar y traducir automáticamente al hacer clic con el botón izquierdo"
 
 #. settings-schema.json->left-auto-paste->tooltip
+#, fuzzy
 msgid ""
-"Automatically paste the current selection/clipboard content and translate it "
-"when opening the popup window using a left click on the translator panel "
+"Automatically translate the selection/clipboard contents when opening the "
+"Panel Translator popup window using a left click on the Panel Translator "
 "button"
 msgstr ""
 "Pegar automáticamente el contenido de la selección/portapapeles actual y "
@@ -182,57 +197,49 @@ msgstr "No hacer nada"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-selection->description
 msgid "Show popup dialog and translate Selection"
 msgstr "Mostrar diálogo emergente y traducir la Selección"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-clipboard->description
 msgid "Show popup dialog and translate Clipboard"
 msgstr "Mostrar diálogo emergente y traducir el Portapapeles"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-selection->description
 msgid "Show popup dialog, translate Selection and play"
 msgstr "Mostrar diálogo emergente, traducir la Selección y reproducirla"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-clipboard->description
 msgid "Show popup dialog, translate Clipboard and play"
 msgstr "Mostrar diálogo emergente, traducir el Portapapeles y reproducirlo"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-selection->description
 msgid "Play translation of Selection"
 msgstr "Reproducción de la traducción de Selección"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-clipboard->description
 msgid "Play translation of Clipboard"
 msgstr "Reproducir traducción del Portapapeles"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-selection->description
 msgid "Translate Selection and copy the translation"
 msgstr "Traducir la Selección y copiar la traducción"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-clipboard->description
 msgid "Translate Clipboard and copy the translation"
 msgstr "Traducir Portapapeles y copiar la traducción"
 
@@ -260,27 +267,3 @@ msgstr ""
 "Seleccione la acción a realizar cuando mantenga pulsada la tecla Ctrl y "
 "utilice el botón central del ratón para hacer clic en el botón del panel "
 "traductor"
-
-#. settings-schema.json->hotkeys-header->description
-msgid "Hotkeys"
-msgstr "Teclas de acceso rápido"
-
-#. settings-schema.json->hotkey1-action->description
-msgid "Hotkey #1"
-msgstr "Tecla de acceso rápido #1"
-
-#. settings-schema.json->hotkey1-action->tooltip
-msgid "Select the action to take when the #1 hotkey is pressed"
-msgstr ""
-"Seleccione la acción a realizar cuando se presione la tecla de acceso rápido "
-"#1"
-
-#. settings-schema.json->hotkey2-action->description
-msgid "Hotkey #2"
-msgstr "Tecla de acceso rápido #2"
-
-#. settings-schema.json->hotkey2-action->tooltip
-msgid "Select the action to take when the #2 hotkey is pressed"
-msgstr ""
-"Seleccione la acción a realizar cuando se presione la tecla de acceso rápido "
-"#2"

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/po/fi.po
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/po/fi.po
@@ -1,81 +1,81 @@
-# SOME DESCRIPTIVE TITLE.
+# PANEL TRANSLATOR
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PanelTranslator@klangman 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-31 11:39-0400\n"
+"POT-Creation-Date: 2025-02-01 15:50-0500\n"
 "PO-Revision-Date: 2024-11-16 19:56+0200\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
-#: applet.js:97 applet.js:332 applet.js:334
+#. applet.js:108 applet.js:344 applet.js:346
 msgid "Translator"
 msgstr "Kääntäjä"
 
-#: applet.js:260
+#. applet.js:272
 msgid "Unable to query available languages from translate-shell"
 msgstr "Translate-shell ei voi tehdä kyselyitä tästä kielestä"
 
-#: applet.js:271
+#. applet.js:283
 msgid "Required \"trans\" command not found, please install translate-shell"
 msgstr ""
 "Vaadittua \"trans\"-komentoa ei löydy, asenna ohjelma translate-shell ensin"
 
-#: applet.js:275
+#. applet.js:287
 msgid "Error, the \"trans\" command returned an exit code of "
 msgstr "Virhe, \"trans\"-komento palautti virhekoodin "
 
-#: applet.js:355
+#. applet.js:367
 msgid "Swap Languages"
 msgstr "Vaihda kieltä"
 
-#: applet.js:393
+#. applet.js:410
 msgid "{Text to translate}"
 msgstr "{käännösteksti}"
 
-#: applet.js:404
+#. applet.js:421
 msgid "{Translated text}"
 msgstr "{käännetty teksti}"
 
-#: applet.js:418
+#. applet.js:435
 msgid "Configure"
 msgstr "Määritä"
 
-#: applet.js:419
+#. applet.js:436
 msgid "Help"
 msgstr "Ohje"
 
-#: applet.js:423
+#. applet.js:440
 msgid "Play"
 msgstr "Toista"
 
-#: applet.js:427
+#. applet.js:444
 msgid "Paste"
 msgstr "Liitä"
 
-#: applet.js:431
+#. applet.js:448
 msgid "Clear"
 msgstr "Tyhjennä"
 
-#: applet.js:435
+#. applet.js:452
 msgid "Translate"
 msgstr "Käännä"
 
-#: applet.js:440
+#. applet.js:457
 msgid "Copy"
 msgstr "Kopioi"
 
-#: applet.js:446
+#. applet.js:463
 msgid "Play Translation"
 msgstr "Puhu"
 
@@ -91,8 +91,25 @@ msgstr ""
 "Käännä tekstiä muille kielille Cinnamon-paneelista Googlen, Bingin ja muiden "
 "kääntäjien avulla. Asenna myös ohjelma translate-shell"
 
-#. settings-schema.json->engine-header->description
+#. settings-schema.json->general-page->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->hotkey-page->title
+msgid "Hotkeys"
+msgstr "Pikanäppäimet"
+
+#. settings-schema.json->engine-settings->title
 msgid "Translation Engine"
+msgstr "Käännös moottori"
+
+#. settings-schema.json->action-settings->title
+msgid "Panel Button Actions"
+msgstr "Painikkeiden toiminta"
+
+#. settings-schema.json->hotkey-settings->title
+#, fuzzy
+msgid "Translation action hotkeys"
 msgstr "Käännös moottori"
 
 #. settings-schema.json->translate-engine->options
@@ -141,10 +158,6 @@ msgstr ""
 "virheen. Suositus käyttää \"Auto\" ja antaa translate-shell:in päättää "
 "kääntäjän."
 
-#. settings-schema.json->auto-header->description
-msgid "Panel Button Actions"
-msgstr "Painikkeiden toiminta"
-
 #. settings-schema.json->left-auto-paste->options
 msgid "Disabled"
 msgstr "Pois käytöstä"
@@ -158,13 +171,15 @@ msgid "Clipboard"
 msgstr "Leikepöytä"
 
 #. settings-schema.json->left-auto-paste->description
-msgid "Automatically paste and translate on left click"
+#, fuzzy
+msgid "Automatically translate on left click"
 msgstr "Liitä ja käännä autom. hiiren vasemmalla painikkeella"
 
 #. settings-schema.json->left-auto-paste->tooltip
+#, fuzzy
 msgid ""
-"Automatically paste the current selection/clipboard content and translate it "
-"when opening the popup window using a left click on the translator panel "
+"Automatically translate the selection/clipboard contents when opening the "
+"Panel Translator popup window using a left click on the Panel Translator "
 "button"
 msgstr ""
 "Liittää leikepöydän sisällön automaattisesti ja kääntää sen painamalla "
@@ -181,57 +196,49 @@ msgstr "Älä tee mitään"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-selection->description
 msgid "Show popup dialog and translate Selection"
 msgstr "Näytä ikkuna ja käännä valinta"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-clipboard->description
 msgid "Show popup dialog and translate Clipboard"
 msgstr "Näytä ikkuna ja käännä leikepöydältä"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-selection->description
 msgid "Show popup dialog, translate Selection and play"
 msgstr "Näytä ikkuna, käännä valinta ja puhu"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-clipboard->description
 msgid "Show popup dialog, translate Clipboard and play"
 msgstr "Näytä ikkuna, käännä leikepöydältä ja puhu"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-selection->description
 msgid "Play translation of Selection"
 msgstr "Puhu valinnasta käännös"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-clipboard->description
 msgid "Play translation of Clipboard"
 msgstr "Puhu leikepöydältä käännös"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-selection->description
 msgid "Translate Selection and copy the translation"
 msgstr "Käännä valinta ja kopioi käännös"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-clipboard->description
 msgid "Translate Clipboard and copy the translation"
 msgstr "Käännä leikepöydältä ja kopioi käännös"
 
@@ -256,23 +263,3 @@ msgid ""
 msgstr ""
 "Toiminta suoritetaan, kun pidät Ctrl ja hiiren keskimmäinen painettuna "
 "kääntöpaneelissa"
-
-#. settings-schema.json->hotkeys-header->description
-msgid "Hotkeys"
-msgstr "Pikanäppäimet"
-
-#. settings-schema.json->hotkey1-action->description
-msgid "Hotkey #1"
-msgstr "Pikanäppäin #1"
-
-#. settings-schema.json->hotkey1-action->tooltip
-msgid "Select the action to take when the #1 hotkey is pressed"
-msgstr "Valitse toiminto kun pikanäppäin #1 painetaan"
-
-#. settings-schema.json->hotkey2-action->description
-msgid "Hotkey #2"
-msgstr "Pikanäppäin #2"
-
-#. settings-schema.json->hotkey2-action->tooltip
-msgid "Select the action to take when the #2 hotkey is pressed"
-msgstr "Valitse toiminto kun pikanäppäin #2 painetaan"

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/po/fr.po
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/po/fr.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# PANEL TRANSLATOR
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PanelTranslator@klangman 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-31 11:39-0400\n"
+"POT-Creation-Date: 2025-02-01 15:50-0500\n"
 "PO-Revision-Date: 2024-04-03 14:49+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -18,67 +18,67 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:97 applet.js:332 applet.js:334
+#. applet.js:108 applet.js:344 applet.js:346
 msgid "Translator"
 msgstr "Traducteur"
 
-#: applet.js:260
+#. applet.js:272
 msgid "Unable to query available languages from translate-shell"
 msgstr ""
 "Impossible de demander quelles sont les langues disponibles à partir de "
 "translate-shell"
 
-#: applet.js:271
+#. applet.js:283
 msgid "Required \"trans\" command not found, please install translate-shell"
 msgstr ""
 "La commande \"trans\" requise n'a pas été trouvée, veuillez installer "
 "translate-shell"
 
-#: applet.js:275
+#. applet.js:287
 msgid "Error, the \"trans\" command returned an exit code of "
 msgstr "Erreur, la commande \"trans\" a renvoyé un code de sortie de "
 
-#: applet.js:355
+#. applet.js:367
 msgid "Swap Languages"
 msgstr "Intervertir les langues"
 
-#: applet.js:393
+#. applet.js:410
 msgid "{Text to translate}"
 msgstr "{Texte à traduire}"
 
-#: applet.js:404
+#. applet.js:421
 msgid "{Translated text}"
 msgstr "{Texte traduit}"
 
-#: applet.js:418
+#. applet.js:435
 msgid "Configure"
 msgstr "Configurer"
 
-#: applet.js:419
+#. applet.js:436
 msgid "Help"
 msgstr "Aide"
 
-#: applet.js:423
+#. applet.js:440
 msgid "Play"
 msgstr "Écouter"
 
-#: applet.js:427
+#. applet.js:444
 msgid "Paste"
 msgstr "Coller"
 
-#: applet.js:431
+#. applet.js:448
 msgid "Clear"
 msgstr "Effacer"
 
-#: applet.js:435
+#. applet.js:452
 msgid "Translate"
 msgstr "Traduire"
 
-#: applet.js:440
+#. applet.js:457
 msgid "Copy"
 msgstr "Copier"
 
-#: applet.js:446
+#. applet.js:463
 msgid "Play Translation"
 msgstr "Écouter la traduction"
 
@@ -94,8 +94,25 @@ msgstr ""
 "Traduire un texte dans d'autres langues à partir d'un panneau Cinnamon en "
 "utilisant Google, Bing et d'autres traducteurs"
 
-#. settings-schema.json->engine-header->description
+#. settings-schema.json->general-page->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->hotkey-page->title
+msgid "Hotkeys"
+msgstr "Raccourcis-clavier"
+
+#. settings-schema.json->engine-settings->title
 msgid "Translation Engine"
+msgstr "Moteur de traduction"
+
+#. settings-schema.json->action-settings->title
+msgid "Panel Button Actions"
+msgstr "Actions des boutons du panneau"
+
+#. settings-schema.json->hotkey-settings->title
+#, fuzzy
+msgid "Translation action hotkeys"
 msgstr "Moteur de traduction"
 
 #. settings-schema.json->translate-engine->options
@@ -145,10 +162,6 @@ msgstr ""
 "est donc préférable d'utiliser \"Auto\" et de laisser translate-shell "
 "décider du traducteur à utiliser."
 
-#. settings-schema.json->auto-header->description
-msgid "Panel Button Actions"
-msgstr "Actions des boutons du panneau"
-
 #. settings-schema.json->left-auto-paste->options
 msgid "Disabled"
 msgstr "Désactivé"
@@ -162,13 +175,15 @@ msgid "Clipboard"
 msgstr "Presse-papiers"
 
 #. settings-schema.json->left-auto-paste->description
-msgid "Automatically paste and translate on left click"
+#, fuzzy
+msgid "Automatically translate on left click"
 msgstr "Coller et traduire automatiquement au clic gauche"
 
 #. settings-schema.json->left-auto-paste->tooltip
+#, fuzzy
 msgid ""
-"Automatically paste the current selection/clipboard content and translate it "
-"when opening the popup window using a left click on the translator panel "
+"Automatically translate the selection/clipboard contents when opening the "
+"Panel Translator popup window using a left click on the Panel Translator "
 "button"
 msgstr ""
 "Coller automatiquement le contenu de la sélection actuelle ou du presse-"
@@ -186,30 +201,26 @@ msgstr "Ne rien faire"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-selection->description
 msgid "Show popup dialog and translate Selection"
 msgstr "Afficher la boîte de dialogue et traduire la Sélection"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-clipboard->description
 msgid "Show popup dialog and translate Clipboard"
 msgstr ""
 "Afficher une boîte de dialogue et traduire le contenu du Presse-papiers"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-selection->description
 msgid "Show popup dialog, translate Selection and play"
 msgstr "Afficher la boîte de dialogue, traduire la sélection et l'écouter"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-clipboard->description
 msgid "Show popup dialog, translate Clipboard and play"
 msgstr ""
 "Afficher une boîte de dialogue, traduire le contenu du presse-papiers et "
@@ -217,29 +228,25 @@ msgstr ""
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-selection->description
 msgid "Play translation of Selection"
 msgstr "Écouter la traduction de la Sélection"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-clipboard->description
 msgid "Play translation of Clipboard"
 msgstr "Écouter la traduction du contenu du Presse-papiers"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-selection->description
 msgid "Translate Selection and copy the translation"
 msgstr "Traduire la Sélection et copier la traduction"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-clipboard->description
 msgid "Translate Clipboard and copy the translation"
 msgstr "Traduire le contenu du presse-papiers et copier la traduction"
 
@@ -267,25 +274,3 @@ msgstr ""
 "Sélectionnez l'action à effectuer lorsque vous maintenez la touche Ctrl "
 "enfoncée et que vous cliquez sur le bouton du panneau du traducteur à l'aide "
 "du bouton du milieu de la souris"
-
-#. settings-schema.json->hotkeys-header->description
-msgid "Hotkeys"
-msgstr "Raccourcis-clavier"
-
-#. settings-schema.json->hotkey1-action->description
-msgid "Hotkey #1"
-msgstr "Raccourci-clavier n°1"
-
-#. settings-schema.json->hotkey1-action->tooltip
-msgid "Select the action to take when the #1 hotkey is pressed"
-msgstr ""
-"Sélectionner l'action à effectuer lorsque le raccourci clavier n°1 est activé"
-
-#. settings-schema.json->hotkey2-action->description
-msgid "Hotkey #2"
-msgstr "Raccourci-clavier n°2"
-
-#. settings-schema.json->hotkey2-action->tooltip
-msgid "Select the action to take when the #2 hotkey is pressed"
-msgstr ""
-"Sélectionner l'action à effectuer lorsque le raccourci clavier n°2 est activé"

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/po/hu.po
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/po/hu.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# PANEL TRANSLATOR
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PanelTranslator@klangman 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-07-10 01:49-0400\n"
+"POT-Creation-Date: 2025-02-01 15:50-0500\n"
 "PO-Revision-Date: 2024-07-10 01:54-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -20,66 +20,66 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:97 applet.js:332 applet.js:334
+#. applet.js:108 applet.js:344 applet.js:346
 msgid "Translator"
 msgstr "Fordító"
 
-#: applet.js:260
+#. applet.js:272
 msgid "Unable to query available languages from translate-shell"
 msgstr ""
 "Nem lehet lekérdezni a rendelkezésre álló nyelveket a translate-shellből"
 
-#: applet.js:271
+#. applet.js:283
 msgid "Required \"trans\" command not found, please install translate-shell"
 msgstr ""
 "A szükséges \"trans\" parancs nem található, kérjük telepítse a translate-"
 "shellt"
 
-#: applet.js:275
+#. applet.js:287
 msgid "Error, the \"trans\" command returned an exit code of "
 msgstr "Hiba, a \"trans\" parancs a következő kilépési kódot adta vissza: "
 
-#: applet.js:355
+#. applet.js:367
 msgid "Swap Languages"
 msgstr "Nyelvek cseréje"
 
-#: applet.js:393
+#. applet.js:410
 msgid "{Text to translate}"
 msgstr "{Szöveg a fordításhoz}"
 
-#: applet.js:404
+#. applet.js:421
 msgid "{Translated text}"
 msgstr "{Lefordított szöveg}"
 
-#: applet.js:418
+#. applet.js:435
 msgid "Configure"
 msgstr "Beállítás"
 
-#: applet.js:419
+#. applet.js:436
 msgid "Help"
 msgstr "Segítség"
 
-#: applet.js:423
+#. applet.js:440
 msgid "Play"
 msgstr "Lejátszás"
 
-#: applet.js:427
+#. applet.js:444
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: applet.js:431
+#. applet.js:448
 msgid "Clear"
 msgstr "Törlés"
 
-#: applet.js:435
+#. applet.js:452
 msgid "Translate"
 msgstr "Fordítás"
 
-#: applet.js:440
+#. applet.js:457
 msgid "Copy"
 msgstr "Másolás"
 
-#: applet.js:446
+#. applet.js:463
 msgid "Play Translation"
 msgstr "Fordítás lejátszása"
 
@@ -95,8 +95,25 @@ msgstr ""
 "Fordítson szöveget más nyelvekre a Cinnamon panelről a Google, Bing és más "
 "fordítók segítségével"
 
-#. settings-schema.json->engine-header->description
+#. settings-schema.json->general-page->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->hotkey-page->title
+msgid "Hotkeys"
+msgstr "Gyorsbillentyűk"
+
+#. settings-schema.json->engine-settings->title
 msgid "Translation Engine"
+msgstr "Fordítómotor"
+
+#. settings-schema.json->action-settings->title
+msgid "Panel Button Actions"
+msgstr "Panel gombok műveletek"
+
+#. settings-schema.json->hotkey-settings->title
+#, fuzzy
+msgid "Translation action hotkeys"
 msgstr "Fordítómotor"
 
 #. settings-schema.json->translate-engine->options
@@ -146,10 +163,6 @@ msgstr ""
 "használja, és hagyja, hogy a translate-shell döntse el, melyik fordítót "
 "használja."
 
-#. settings-schema.json->auto-header->description
-msgid "Panel Button Actions"
-msgstr "Panel gombok műveletek"
-
 #. settings-schema.json->left-auto-paste->options
 msgid "Disabled"
 msgstr "Kikapcsolva"
@@ -163,13 +176,15 @@ msgid "Clipboard"
 msgstr "Vágólap"
 
 #. settings-schema.json->left-auto-paste->description
-msgid "Automatically paste and translate on left click"
+#, fuzzy
+msgid "Automatically translate on left click"
 msgstr "Automatikus beillesztés és fordítás balra kattintva"
 
 #. settings-schema.json->left-auto-paste->tooltip
+#, fuzzy
 msgid ""
-"Automatically paste the current selection/clipboard content and translate it "
-"when opening the popup window using a left click on the translator panel "
+"Automatically translate the selection/clipboard contents when opening the "
+"Panel Translator popup window using a left click on the Panel Translator "
 "button"
 msgstr ""
 "Automatikusan beilleszti az aktuális kijelölés/vágólap tartalmát és "
@@ -187,58 +202,50 @@ msgstr "Ne tegyen semmit"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-selection->description
 msgid "Show popup dialog and translate Selection"
 msgstr "Felugró párbeszédpanel megjelenítése és a kiválasztás lefordítása"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-clipboard->description
 msgid "Show popup dialog and translate Clipboard"
 msgstr "Felugró párbeszédpanel megjelenítése és a vágólap lefordítása"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-selection->description
 msgid "Show popup dialog, translate Selection and play"
 msgstr ""
 "Felugró párbeszédpanel megjelenítése, kijelölés fordítása és lejátszása"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-clipboard->description
 msgid "Show popup dialog, translate Clipboard and play"
 msgstr "Felugró párbeszédpanel megjelenítése, vágólap fordítása és lejátszása"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-selection->description
 msgid "Play translation of Selection"
 msgstr "A kijelölés fordításának lejátszása"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-clipboard->description
 msgid "Play translation of Clipboard"
 msgstr "A vágólap fordításának lejátszása"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-selection->description
 msgid "Translate Selection and copy the translation"
 msgstr "Kijelölés fordítása és a fordítás másolása"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-clipboard->description
 msgid "Translate Clipboard and copy the translation"
 msgstr "Vágólap fordítása és a fordítás másolása"
 
@@ -266,23 +273,3 @@ msgstr ""
 "Válassza ki a műveletet, amelyet a Ctrl billentyű lenyomva tartása és a "
 "középső egérgombbal a fordítópanel gombjára való kattintás közben kell "
 "végrehajtani"
-
-#. settings-schema.json->hotkeys-header->description
-msgid "Hotkeys"
-msgstr "Gyorsbillentyűk"
-
-#. settings-schema.json->hotkey1-action->description
-msgid "Hotkey #1"
-msgstr "Gyorsbillentyű #1"
-
-#. settings-schema.json->hotkey1-action->tooltip
-msgid "Select the action to take when the #1 hotkey is pressed"
-msgstr "Válassza ki az #1 gyorsbillentyű megnyomásakor végrehajtandó műveletet"
-
-#. settings-schema.json->hotkey2-action->description
-msgid "Hotkey #2"
-msgstr "Gyorsbillentyű #2"
-
-#. settings-schema.json->hotkey2-action->tooltip
-msgid "Select the action to take when the #2 hotkey is pressed"
-msgstr "Válassza ki az #2 gyorsbillentyű megnyomásakor végrehajtandó műveletet"

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/po/it.po
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/po/it.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# PANEL TRANSLATOR
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PanelTranslator@klangman 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-31 11:39-0400\n"
+"POT-Creation-Date: 2025-02-01 15:50-0500\n"
 "PO-Revision-Date: 2024-06-18 14:49+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,63 +18,63 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:97 applet.js:332 applet.js:334
+#. applet.js:108 applet.js:344 applet.js:346
 msgid "Translator"
 msgstr "Traduttore"
 
-#: applet.js:260
+#. applet.js:272
 msgid "Unable to query available languages from translate-shell"
 msgstr "Impossibile interrogare le lingue disponibili da Translate-Shell"
 
-#: applet.js:271
+#. applet.js:283
 msgid "Required \"trans\" command not found, please install translate-shell"
 msgstr "Comando \"trans\" richiesto non trovato, installare Translate-Shell"
 
-#: applet.js:275
+#. applet.js:287
 msgid "Error, the \"trans\" command returned an exit code of "
 msgstr "Errore, il comando \"trans\" ha restituito un codice di uscita di"
 
-#: applet.js:355
+#. applet.js:367
 msgid "Swap Languages"
 msgstr "Cambia lingue"
 
-#: applet.js:393
+#. applet.js:410
 msgid "{Text to translate}"
 msgstr "{Testo da tradurre}"
 
-#: applet.js:404
+#. applet.js:421
 msgid "{Translated text}"
 msgstr "{Testo tradotto}"
 
-#: applet.js:418
+#. applet.js:435
 msgid "Configure"
 msgstr "Configurazione"
 
-#: applet.js:419
+#. applet.js:436
 msgid "Help"
 msgstr "Aiuto"
 
-#: applet.js:423
+#. applet.js:440
 msgid "Play"
 msgstr "Play"
 
-#: applet.js:427
+#. applet.js:444
 msgid "Paste"
 msgstr "Incola"
 
-#: applet.js:431
+#. applet.js:448
 msgid "Clear"
 msgstr "Limpido"
 
-#: applet.js:435
+#. applet.js:452
 msgid "Translate"
 msgstr "Traduzione"
 
-#: applet.js:440
+#. applet.js:457
 msgid "Copy"
 msgstr "Copia"
 
-#: applet.js:446
+#. applet.js:463
 msgid "Play Translation"
 msgstr "Riproduci traduzione"
 
@@ -90,8 +90,25 @@ msgstr ""
 "Traduci il testo in altre lingue dal pannello Cinnamon utilizzando Google, "
 "Bing e altri traduttori"
 
-#. settings-schema.json->engine-header->description
+#. settings-schema.json->general-page->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->hotkey-page->title
+msgid "Hotkeys"
+msgstr "Tasti di scelta rapida"
+
+#. settings-schema.json->engine-settings->title
 msgid "Translation Engine"
+msgstr "Motore di traduzione"
+
+#. settings-schema.json->action-settings->title
+msgid "Panel Button Actions"
+msgstr "Azioni dei pulsanti del pannello"
+
+#. settings-schema.json->hotkey-settings->title
+#, fuzzy
+msgid "Translation action hotkeys"
 msgstr "Motore di traduzione"
 
 #. settings-schema.json->translate-engine->options
@@ -140,10 +157,6 @@ msgstr ""
 "traducono nemmeno, altri segnalano solo errori HTTP. Quindi è meglio usare "
 "\"Auto\" e lasciare che Translate-Shell decida quale traduttore usare."
 
-#. settings-schema.json->auto-header->description
-msgid "Panel Button Actions"
-msgstr "Azioni dei pulsanti del pannello"
-
 #. settings-schema.json->left-auto-paste->options
 msgid "Disabled"
 msgstr "Disattivato"
@@ -157,13 +170,15 @@ msgid "Clipboard"
 msgstr "Clipboard"
 
 #. settings-schema.json->left-auto-paste->description
-msgid "Automatically paste and translate on left click"
+#, fuzzy
+msgid "Automatically translate on left click"
 msgstr "Incolla e traduci automaticamente con il clic sinistro"
 
 #. settings-schema.json->left-auto-paste->tooltip
+#, fuzzy
 msgid ""
-"Automatically paste the current selection/clipboard content and translate it "
-"when opening the popup window using a left click on the translator panel "
+"Automatically translate the selection/clipboard contents when opening the "
+"Panel Translator popup window using a left click on the Panel Translator "
 "button"
 msgstr ""
 "Incolla automaticamente la selezione corrente/il contenuto degli appunti e "
@@ -181,57 +196,49 @@ msgstr "Non fare niente"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-selection->description
 msgid "Show popup dialog and translate Selection"
 msgstr "Mostra la finestra di dialogo popup e traduci la selezione"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-clipboard->description
 msgid "Show popup dialog and translate Clipboard"
 msgstr "Mostra la finestra di dialogo popup e traduci gli Appunti"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-selection->description
 msgid "Show popup dialog, translate Selection and play"
 msgstr "Mostra la finestra di dialogo popup, traduci la selezione e riproduci"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-clipboard->description
 msgid "Show popup dialog, translate Clipboard and play"
 msgstr "Mostra la finestra di dialogo popup, traduci gli Appunti e riproduci"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-selection->description
 msgid "Play translation of Selection"
 msgstr "Riproduci la traduzione della Selezione"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-clipboard->description
 msgid "Play translation of Clipboard"
 msgstr "Riproduci la traduzione degli Appunti"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-selection->description
 msgid "Translate Selection and copy the translation"
 msgstr "Traduci la Selezione e copia la traduzione"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-clipboard->description
 msgid "Translate Clipboard and copy the translation"
 msgstr "Traduci gli Appunti e copia la traduzione"
 
@@ -258,27 +265,3 @@ msgid ""
 msgstr ""
 "Seleziona l'azione da intraprendere tenendo premuto il tasto Ctrl e il clic "
 "del pulsante centrale del mouse sul pannello del traduttore"
-
-#. settings-schema.json->hotkeys-header->description
-msgid "Hotkeys"
-msgstr "Tasti di scelta rapida"
-
-#. settings-schema.json->hotkey1-action->description
-msgid "Hotkey #1"
-msgstr "Tasto di scelta rapida n. 1"
-
-#. settings-schema.json->hotkey1-action->tooltip
-msgid "Select the action to take when the #1 hotkey is pressed"
-msgstr ""
-"Selezionare l'azione da intraprendere quando viene premuto il tasto di "
-"scelta rapida n. 1"
-
-#. settings-schema.json->hotkey2-action->description
-msgid "Hotkey #2"
-msgstr "Tasto di scelta rapida n. 2"
-
-#. settings-schema.json->hotkey2-action->tooltip
-msgid "Select the action to take when the #2 hotkey is pressed"
-msgstr ""
-"Selezionare l'azione da intraprendere quando viene premuto il tasto di "
-"scelta rapida n. 2"

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/po/nl.po
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/po/nl.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# PANEL TRANSLATOR
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PanelTranslator@klangman 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-31 11:39-0400\n"
+"POT-Creation-Date: 2025-02-01 15:50-0500\n"
 "PO-Revision-Date: 2024-04-20 14:08+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,65 +16,65 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:97 applet.js:332 applet.js:334
+#. applet.js:108 applet.js:344 applet.js:346
 msgid "Translator"
 msgstr "Vertaler"
 
-#: applet.js:260
+#. applet.js:272
 msgid "Unable to query available languages from translate-shell"
 msgstr "Niet in staat om beschikbare talen op te vragen van translate-shell"
 
-#: applet.js:271
+#. applet.js:283
 msgid "Required \"trans\" command not found, please install translate-shell"
 msgstr ""
 "Vereiste \"trans\" commando niet gevonden, installeer alstublieft translate-"
 "shell"
 
-#: applet.js:275
+#. applet.js:287
 msgid "Error, the \"trans\" command returned an exit code of "
 msgstr "Fout, het \"trans\" commando gaf een exitcode terug van "
 
-#: applet.js:355
+#. applet.js:367
 msgid "Swap Languages"
 msgstr "Wissel talen"
 
-#: applet.js:393
+#. applet.js:410
 msgid "{Text to translate}"
 msgstr "{Tekst om te vertalen}"
 
-#: applet.js:404
+#. applet.js:421
 msgid "{Translated text}"
 msgstr "{Vertaalde tekst}"
 
-#: applet.js:418
+#. applet.js:435
 msgid "Configure"
 msgstr "Configureren"
 
-#: applet.js:419
+#. applet.js:436
 msgid "Help"
 msgstr "Hulp"
 
-#: applet.js:423
+#. applet.js:440
 msgid "Play"
 msgstr "Afspelen"
 
-#: applet.js:427
+#. applet.js:444
 msgid "Paste"
 msgstr "Plakken"
 
-#: applet.js:431
+#. applet.js:448
 msgid "Clear"
 msgstr "Wissen"
 
-#: applet.js:435
+#. applet.js:452
 msgid "Translate"
 msgstr "Vertalen"
 
-#: applet.js:440
+#. applet.js:457
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: applet.js:446
+#. applet.js:463
 msgid "Play Translation"
 msgstr "Vertaling afspelen"
 
@@ -90,8 +90,25 @@ msgstr ""
 "Tekst naar andere talen vertalen vanuit het Cinnamon-paneel met behulp van "
 "Google, Bing en andere vertalers"
 
-#. settings-schema.json->engine-header->description
+#. settings-schema.json->general-page->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->hotkey-page->title
+msgid "Hotkeys"
+msgstr "Sneltoetsen"
+
+#. settings-schema.json->engine-settings->title
 msgid "Translation Engine"
+msgstr "Vertaal-engine"
+
+#. settings-schema.json->action-settings->title
+msgid "Panel Button Actions"
+msgstr "Acties Paneelknop"
+
+#. settings-schema.json->hotkey-settings->title
+#, fuzzy
+msgid "Translation action hotkeys"
 msgstr "Vertaal-engine"
 
 #. settings-schema.json->translate-engine->options
@@ -141,10 +158,6 @@ msgstr ""
 "gebruiken en om translate-shell te laten beslissen welke vertaler te "
 "gebruiken."
 
-#. settings-schema.json->auto-header->description
-msgid "Panel Button Actions"
-msgstr "Acties Paneelknop"
-
 #. settings-schema.json->left-auto-paste->options
 msgid "Disabled"
 msgstr "Uitgeschakeld"
@@ -158,13 +171,15 @@ msgid "Clipboard"
 msgstr "Klembord"
 
 #. settings-schema.json->left-auto-paste->description
-msgid "Automatically paste and translate on left click"
+#, fuzzy
+msgid "Automatically translate on left click"
 msgstr "Automatisch plakken en vertalen bij linkermuisklik"
 
 #. settings-schema.json->left-auto-paste->tooltip
+#, fuzzy
 msgid ""
-"Automatically paste the current selection/clipboard content and translate it "
-"when opening the popup window using a left click on the translator panel "
+"Automatically translate the selection/clipboard contents when opening the "
+"Panel Translator popup window using a left click on the Panel Translator "
 "button"
 msgstr ""
 "Automatisch de huidige selectie/klembordinhoud plakken en vertalen bij het "
@@ -182,57 +197,49 @@ msgstr "Niets doen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-selection->description
 msgid "Show popup dialog and translate Selection"
 msgstr "Popup-venster weergeven en selectie vertalen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-clipboard->description
 msgid "Show popup dialog and translate Clipboard"
 msgstr "Popup-venster weergeven en klembord vertalen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-selection->description
 msgid "Show popup dialog, translate Selection and play"
 msgstr "Popup-venster weergeven, selectie vertalen en afspelen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-play-clipboard->description
 msgid "Show popup dialog, translate Clipboard and play"
 msgstr "Popup-venster weergeven, klembord vertalen en afspelen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-selection->description
 msgid "Play translation of Selection"
 msgstr "Vertaling van selectie afspelen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-play-clipboard->description
 msgid "Play translation of Clipboard"
 msgstr "Vertaling van klembord afspelen"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-selection->description
 msgid "Translate Selection and copy the translation"
 msgstr "Selectie vertalen en vertaling kopiëren"
 
 #. settings-schema.json->middle-button-action->options
 #. settings-schema.json->ctrl-middle-button-action->options
-#. settings-schema.json->hotkey1-action->options
-#. settings-schema.json->hotkey2-action->options
+#. settings-schema.json->hotkey-trans-copy-clipboard->description
 msgid "Translate Clipboard and copy the translation"
 msgstr "Klembord vertalen en vertaling kopiëren"
 
@@ -260,27 +267,3 @@ msgstr ""
 "Selecteer de actie die moet worden uitgevoerd bij het gebruik van de "
 "middelste muisknop om te klikken op de knop van de paneelvertaler wanneer de "
 "Ctrl wordt ingehouden"
-
-#. settings-schema.json->hotkeys-header->description
-msgid "Hotkeys"
-msgstr "Sneltoetsen"
-
-#. settings-schema.json->hotkey1-action->description
-msgid "Hotkey #1"
-msgstr "Sneltoets #1"
-
-#. settings-schema.json->hotkey1-action->tooltip
-msgid "Select the action to take when the #1 hotkey is pressed"
-msgstr ""
-"Selecteer de actie die moet worden uitgevoerd wanneer sneltoets #1 wordt "
-"ingedrukt"
-
-#. settings-schema.json->hotkey2-action->description
-msgid "Hotkey #2"
-msgstr "Sneltoets #2"
-
-#. settings-schema.json->hotkey2-action->tooltip
-msgid "Select the action to take when the #2 hotkey is pressed"
-msgstr ""
-"Selecteer de actie die moet worden uitgevoerd wanneer sneltoets #2 wordt "
-"ingedrukt"

--- a/PanelTranslator@klangman/files/PanelTranslator@klangman/settings-schema.json
+++ b/PanelTranslator@klangman/files/PanelTranslator@klangman/settings-schema.json
@@ -1,8 +1,38 @@
 {
-    "engine-header": {
-        "type": "header",
-        "description": "Translation Engine"
+    "layout" : {
+        "type" : "layout",
+        "pages" : ["general-page", "hotkey-page"],
+
+        "general-page" : {
+            "type" : "page",
+            "title" : "General",
+            "sections" : ["engine-settings", "action-settings"]
+        },
+        "hotkey-page" : {
+            "type" : "page",
+            "title" : "Hotkeys",
+            "sections" : ["hotkey-settings"]
+        },
+
+        "engine-settings" : {
+            "type" : "section",
+            "title" : "Translation Engine",
+            "keys" : ["translate-engine"]
+        },
+        "action-settings" : {
+            "type" : "section",
+            "title" : "Panel Button Actions",
+            "keys" : ["left-auto-paste", "left-auto-play", "middle-button-action", "ctrl-middle-button-action"]
+        },
+
+        "hotkey-settings" : {
+            "type" : "section",
+            "title" : "Translation action hotkeys",
+            "keys" : ["hotkey-trans-selection", "hotkey-trans-clipboard", "hotkey-trans-play-selection", "hotkey-trans-play-clipboard", "hotkey-play-selection", "hotkey-play-clipboard", "hotkey-trans-copy-selection", "hotkey-trans-copy-clipboard"]
+        }
+
     },
+
     "translate-engine" : {
         "type" : "combobox",
         "default": 2,
@@ -20,10 +50,6 @@
         "tooltip": "Most engines don't support play back and some don't even translate, others just report HTTP errors. So it's best to use \"Auto\" and let translate-shell decide what translator to use."
     },
 
-    "auto-header": {
-        "type": "header",
-        "description": "Panel Button Actions"
-    },
     "left-auto-paste" : {
         "type": "combobox",
         "default": 0,
@@ -32,8 +58,8 @@
             "Selection": 1,
             "Clipboard": 2
         },
-        "description": "Automatically paste and translate on left click",
-        "tooltip": "Automatically paste the current selection/clipboard content and translate it when opening the popup window using a left click on the translator panel button"
+        "description": "Automatically translate on left click",
+        "tooltip": "Automatically translate the selection/clipboard contents when opening the Panel Translator popup window using a left click on the Panel Translator button"
     },
     "left-auto-play": {
         "type": "switch",
@@ -76,50 +102,44 @@
         "tooltip": "Select the action to take when holding the Ctrl key and using the middle mouse button to click on the translator panel button"
     },
 
-    "hotkeys-header": {
-        "type": "header",
-        "description": "Hotkeys"
-    },
-    "hotkey1-action" : {
-        "type" : "combobox",
-        "default": 1,
-        "options": {
-            "Show popup dialog and translate Selection": 1,
-            "Show popup dialog and translate Clipboard": 2,
-            "Show popup dialog, translate Selection and play": 3,
-            "Show popup dialog, translate Clipboard and play": 4,
-            "Play translation of Selection": 5,
-            "Play translation of Clipboard": 6,
-            "Translate Selection and copy the translation": 7,
-            "Translate Clipboard and copy the translation": 8
-        },
-        "description": "Hotkey #1",
-        "tooltip": "Select the action to take when the #1 hotkey is pressed"
-    },
-    "hotkey-1": {
+    "hotkey-trans-selection": {
         "type": "keybinding",
-         "description": "",
+         "description": "Show popup dialog and translate Selection",
          "default": ""
     },
-    "hotkey2-action" : {
-        "type" : "combobox",
-        "default": 5,
-        "options": {
-            "Show popup dialog and translate Selection": 1,
-            "Show popup dialog and translate Clipboard": 2,
-            "Show popup dialog, translate Selection and play": 3,
-            "Show popup dialog, translate Clipboard and play": 4,
-            "Play translation of Selection": 5,
-            "Play translation of Clipboard": 6,
-            "Translate Selection and copy the translation": 7,
-            "Translate Clipboard and copy the translation": 8
-        },
-        "description": "Hotkey #2",
-        "tooltip": "Select the action to take when the #2 hotkey is pressed"
-    },
-    "hotkey-2": {
+    "hotkey-trans-clipboard": {
         "type": "keybinding",
-         "description": "",
+         "description": "Show popup dialog and translate Clipboard",
+         "default": ""
+    },
+    "hotkey-trans-play-selection": {
+        "type": "keybinding",
+         "description": "Show popup dialog, translate Selection and play",
+         "default": ""
+    },
+    "hotkey-trans-play-clipboard": {
+        "type": "keybinding",
+         "description": "Show popup dialog, translate Clipboard and play",
+         "default": ""
+    },
+    "hotkey-play-selection": {
+        "type": "keybinding",
+         "description": "Play translation of Selection",
+         "default": ""
+    },
+    "hotkey-play-clipboard": {
+        "type": "keybinding",
+         "description": "Play translation of Clipboard",
+         "default": ""
+    },
+    "hotkey-trans-copy-selection": {
+        "type": "keybinding",
+         "description": "Translate Selection and copy the translation",
+         "default": ""
+    },
+    "hotkey-trans-copy-clipboard": {
+        "type": "keybinding",
+         "description": "Translate Clipboard and copy the translation",
          "default": ""
     },
 
@@ -130,5 +150,14 @@
     "default-to-language": {
         "type" : "generic",
         "default": "French"
+    },
+
+    "popup-width" : {
+       "type" : "generic",
+       "default" : 590
+    },
+    "popup-height" : {
+       "type" : "generic",
+       "default" : 270
     }
 }


### PR DESCRIPTION
- Fixed the output for right-to-left language output by using the -no-bidi translation-shell parameter when translating text
- Removed the Hotkey1/2 options and replaced them with 8 unique hotkey options on a new Hotkeys configuration dialog page. This makes the hotkey support more versatile and allows the Cinnamon Keyboard->Shortcuts setting page to properly show Panel Translator Hotkeys in it's user interface
- Added support for allowing the popup dialog window to be resized
- Save and restore popup window size on window resize events and applet startup
- Fix handling of display scaling factors