### PR TITLE
[Sensors@claudiux] v5.3.1: Removed 'Only show positive values' option for fans

### DIFF
--- a/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
+++ b/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v5.3.1~20250223
+  * Removed option "Only show positive values" for fans. (Value fixed to false.)
+
 ### v5.3.0~20250222
   * Users can now choose the type of separator.
 

--- a/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
+++ b/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### v5.3.1~20250223
   * Removed option "Only show positive values" for fans. (Value fixed to false.)
+  * Fixes #6845.
 
 ### v5.3.0~20250222
   * Users can now choose the type of separator.

--- a/Sensors@claudiux/files/Sensors@claudiux/applet.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/applet.js
@@ -351,7 +351,8 @@ class SensorsApplet extends Applet.Applet {
     this.s.bind("show_fan_name", "show_fan_name", null, null);
     this.s.bind("chars_fan", "chars_fan", this._on_chars_fan_modified, null);
     this._on_chars_fan_modified();
-    this.s.bind("strictly_positive_fan", "strictly_positive_fan", this.populate_fan_sensors_in_settings, null);
+    //~ this.s.bind("strictly_positive_fan", "strictly_positive_fan", this.populate_fan_sensors_in_settings, null);
+    this.strictly_positive_fan = false;
     this.s.bind("show_fan_unit", "show_fan_unit", this.updateUI, null);
     this.s.bind("fan_unit", "fan_unit", this.updateUI, null);
     this.s.bind("fan_sensors", "fan_sensors", null, null);

--- a/Sensors@claudiux/files/Sensors@claudiux/metadata.json
+++ b/Sensors@claudiux/files/Sensors@claudiux/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "Sensors@claudiux",
   "name": "Sensors Monitor",
   "description": "Displays the values of many computer sensors concerning Temperatures (CPU - GPU - Power Supply), Fan Speed, Voltages, Intrusions. Notifies you with color changes when a value reaches or exceeds its limit.",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "max-instances": 1,
   "cinnamon-version": [
     "3.8",

--- a/Sensors@claudiux/files/Sensors@claudiux/settings-schema.json
+++ b/Sensors@claudiux/files/Sensors@claudiux/settings-schema.json
@@ -170,7 +170,6 @@
       "type": "section",
       "title": "Options",
       "keys": [
-        "strictly_positive_fan",
         "show_fan_unit",
         "fan_unit",
         "journalize_fan"


### PR DESCRIPTION
Fixes #6845.