### PR TITLE
[Sensors@claudiux] Fixes temperature highlighting when there are multiple temperatures

### DIFF
--- a/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
+++ b/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v5.3.2~20250228
+  * Fixes scenario where special characters would appear next to temperatures on the panel.
+
 ### v5.3.1~20250223
   * Removed option "Only show positive values" for fans. (Value fixed to false.)
   * Fixes #6845.

--- a/Sensors@claudiux/files/Sensors@claudiux/applet.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/applet.js
@@ -507,7 +507,7 @@ class SensorsApplet extends Applet.Applet {
       }
       //~ let l = new St.Label({text: c, style_class: 'applet-box sensors-size120'});
       //~ let l = new St.Label({text: c, style_class: 'applet-box'});
-      let l = new St.Label({text: (i===0) ? c : this.separator + c});
+      let l = new St.Label({text: (i===0 || this.separator == "NO_SEP") ? c : this.separator + c});
       if (l_style)
         l.set_style(l_style);
 
@@ -527,9 +527,9 @@ class SensorsApplet extends Applet.Applet {
         case "bar":
           return "───\n";
         case "blank":
-          return "\n\n\n";
+          return "\n";
         default:
-          return "\n\n";
+          return "NO_SEP";
       }
     } else {
       switch (this.separator_type) {
@@ -538,7 +538,7 @@ class SensorsApplet extends Applet.Applet {
         case "blank":
           return " ";
         default:
-          return "  ";
+          return "NO_SEP";
       }
     }
   }

--- a/Sensors@claudiux/files/Sensors@claudiux/applet.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/applet.js
@@ -527,7 +527,7 @@ class SensorsApplet extends Applet.Applet {
         case "bar":
           return "───\n";
         case "blank":
-          return "\n";
+          return "\r\n";
         default:
           return "NO_SEP";
       }

--- a/Sensors@claudiux/files/Sensors@claudiux/metadata.json
+++ b/Sensors@claudiux/files/Sensors@claudiux/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "Sensors@claudiux",
   "name": "Sensors Monitor",
   "description": "Displays the values of many computer sensors concerning Temperatures (CPU - GPU - Power Supply), Fan Speed, Voltages, Intrusions. Notifies you with color changes when a value reaches or exceeds its limit.",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "max-instances": 1,
   "cinnamon-version": [
     "3.8",

--- a/Sensors@claudiux/files/Sensors@claudiux/stylesheet.css
+++ b/Sensors@claudiux/files/Sensors@claudiux/stylesheet.css
@@ -5,7 +5,7 @@
 .sensors-label {
     background: transparent;
     margin: 1px;
-    padding: 0 2px;
+    padding: 2px;
     border: 2px;
     border-radius: 10px;
     border-color: rgba(127,127,127,0.5);
@@ -15,7 +15,7 @@
 .sensors-high {
     background: DarkOrange;
     margin: 1px;
-    padding: 0 2px;
+    padding: 2px;
     border: 2px;
     border-radius: 10px;
     border-color: rgba(255,141,0,0.5);
@@ -25,7 +25,7 @@
 .sensors-critical {
     background: FireBrick;
     margin: 1px;
-    padding: 0 2px;
+    padding: 2px;
     border: 2px;
     border-radius: 10px;
     border-color: rgba(194,34,34,0.5);
@@ -35,7 +35,7 @@
 .sensors-label-noborder {
     background: transparent;
     margin: 1px;
-    padding: 0 2px;
+    padding: 2px;
     border: 0;
     text-align: center;
 }
@@ -43,7 +43,7 @@
 .sensors-high-noborder {
     background: DarkOrange;
     margin: 1px;
-    padding: 0 2px;
+    padding: 2px;
     border: 0;
     text-align: center;
 }
@@ -51,7 +51,7 @@
 .sensors-critical-noborder {
     background: FireBrick;
     margin: 1px;
-    padding: 0 2px;
+    padding: 2px;
     border: 0;
     text-align: center;
 }


### PR DESCRIPTION
@claudiux 

### Steps to reproduce the bug
1. Configure the applet to display more than 1 temperature on the panel
2. Set the separator:
    1. If your panel is horizontal, set the separator to `(none)`
    2. If your panel is vertical, set the separator to `blank`
3. Set a high and/or critical temperature for any of the temperatures that are displayed on the panel

![2025-02-28_14-06](https://github.com/user-attachments/assets/6a3d4925-465b-46b4-ba40-1cc64654e1b2)

![2025-02-28_14-07](https://github.com/user-attachments/assets/6da1e40e-3308-4f1c-8e1a-c14a9f7d9f24)