### PR TITLE
NightLightSwitch@claudiux: Add tooltips

### DIFF
--- a/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/6.4/applet.js
+++ b/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/6.4/applet.js
@@ -20,8 +20,7 @@ const UUID = "NightLightSwitch@claudiux";
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 
 function _(text) {
-  let loc = Gettext.dgettext(UUID, text);
-  return loc != text ? loc : window._(text);
+  return Gettext.dgettext(UUID, text);
 }
 
 

--- a/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/6.4/applet.js
+++ b/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/6.4/applet.js
@@ -5,6 +5,7 @@ const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
 const St = imports.gi.St;
 const GLib = imports.gi.GLib;
+const Gettext = imports.gettext;
 //~ const CinnamonDesktop = imports.gi.CinnamonDesktop;
 //~ const RROutput = CinnamonDesktop.RROutput;
 
@@ -15,6 +16,14 @@ const GLib = imports.gi.GLib;
 //~ const BrightnessBusName = "org.cinnamon.SettingsDaemon.Power.Screen";
 
 const UUID = "NightLightSwitch@claudiux";
+
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+
+function _(text) {
+  let loc = Gettext.dgettext(UUID, text);
+  return loc != text ? loc : window._(text);
+}
+
 
 //~ class BrightnessSlider extends PopupMenu.PopupSliderMenuItem {
     //~ constructor(applet, label, icon, busName, minimum_value) {
@@ -223,8 +232,10 @@ class NightLightSwitch extends Applet.IconApplet {
     this.nightLightEnabled = this.gsettings.get_boolean("night-light-enabled");
     if (this.nightLightEnabled) {
       this.set_applet_icon_symbolic_name("night-light-2-symbolic");
+      this.set_applet_tooltip(_("Night Light Enabled - Click to Disable"));
     } else {
       this.set_applet_icon_symbolic_name("night-light-disabled-2-symbolic");
+      this.set_applet_tooltip(_("Night Light Disabled - Click to Enable"));
     }
   }
 

--- a/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/CHANGELOG.md
+++ b/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v1.0.2~20250306
+  * Adds applet tooltips
+
 ### v1.0.1~20250124
   * Fixes #6800. No longer requires the gir1.2-gweather-4.0 package.
 

--- a/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/metadata.json
+++ b/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/metadata.json
@@ -5,5 +5,5 @@
   "uuid": "NightLightSwitch@claudiux",
   "name": "Night Light Switch",
   "author": "claudiux",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/NightLightSwitch@claudiux.pot
+++ b/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/NightLightSwitch@claudiux.pot
@@ -1,14 +1,14 @@
 # NIGHT LIGHT SWITCH
 # This file is put in the public domain.
-# claudiux, 2016
+# claudiux, 2025
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: NightLightSwitch@claudiux 1.0.0\n"
+"Project-Id-Version: NightLightSwitch@claudiux 1.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-01-23 21:14+0100\n"
+"POT-Creation-Date: 2025-03-06 19:22-0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,8 +17,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.4/applet.js:197
+#. 6.4/applet.js:207
 msgid "Configure..."
+msgstr ""
+
+#. 6.4/applet.js:235
+msgid "Night Light Enabled - Click to Disable"
+msgstr ""
+
+#. 6.4/applet.js:238
+msgid "Night Light Disabled - Click to Enable"
 msgstr ""
 
 #. metadata.json->description

--- a/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/ca.po
+++ b/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: NightLightSwitch@claudiux 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-01-23 21:14+0100\n"
+"POT-Creation-Date: 2025-03-06 19:22-0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,9 +18,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.4/applet.js:197
+#. 6.4/applet.js:207
 msgid "Configure..."
 msgstr "Configura..."
+
+#. 6.4/applet.js:235
+msgid "Night Light Enabled - Click to Disable"
+msgstr ""
+
+#. 6.4/applet.js:238
+msgid "Night Light Disabled - Click to Enable"
+msgstr ""
 
 #. metadata.json->description
 msgid "A simple Cinnamon applet to activate/deactivate Night Light mode."

--- a/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/es.po
+++ b/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: NightLightSwitch@claudiux 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-01-23 21:14+0100\n"
+"POT-Creation-Date: 2025-03-06 19:22-0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,9 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 6.4/applet.js:197
+#. 6.4/applet.js:207
 msgid "Configure..."
 msgstr "Configurar..."
+
+#. 6.4/applet.js:235
+msgid "Night Light Enabled - Click to Disable"
+msgstr ""
+
+#. 6.4/applet.js:238
+msgid "Night Light Disabled - Click to Enable"
+msgstr ""
 
 #. metadata.json->description
 msgid "A simple Cinnamon applet to activate/deactivate Night Light mode."

--- a/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/fr.po
+++ b/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: NightLightSwitch@claudiux 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-01-23 21:14+0100\n"
+"POT-Creation-Date: 2025-03-06 19:22-0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,9 +18,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.4/applet.js:197
+#. 6.4/applet.js:207
 msgid "Configure..."
 msgstr "Configurer..."
+
+#. 6.4/applet.js:235
+msgid "Night Light Enabled - Click to Disable"
+msgstr ""
+
+#. 6.4/applet.js:238
+msgid "Night Light Disabled - Click to Enable"
+msgstr ""
 
 #. metadata.json->description
 msgid "A simple Cinnamon applet to activate/deactivate Night Light mode."

--- a/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/nl.po
+++ b/NightLightSwitch@claudiux/files/NightLightSwitch@claudiux/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: NightLightSwitch@claudiux 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-01-23 21:14+0100\n"
+"POT-Creation-Date: 2025-03-06 19:22-0100\n"
 "PO-Revision-Date: 2025-02-21 18:55+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,9 +16,17 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.4/applet.js:197
+#. 6.4/applet.js:207
 msgid "Configure..."
 msgstr "Configureren..."
+
+#. 6.4/applet.js:235
+msgid "Night Light Enabled - Click to Disable"
+msgstr ""
+
+#. 6.4/applet.js:238
+msgid "Night Light Disabled - Click to Enable"
+msgstr ""
 
 #. metadata.json->description
 msgid "A simple Cinnamon applet to activate/deactivate Night Light mode."


### PR DESCRIPTION
Sometimes I become confused if the icon shows the result of my click or the current state of the night light, so it would be useful to show current state when hovering the panel icon as a tooltip.

cc @claudiux 