### PR TITLE
[CassiaWindowList@klangman] V2.4.1 fixes

### DIFF
--- a/CassiaWindowList@klangman/CHANGELOG.md
+++ b/CassiaWindowList@klangman/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.1
+
+* Use the DesaturateEffect class rather than the saturate_and_pixelate() API to adjust the icon color saturation. This has as advantage in that it is able to desaturate the color for all icons where before it was limited in what type of icons it would work on. On the other hand, it has a disadvantage in that it can't oversaturate the icons. Hopefully no one was using the >100% saturation feature because it's not gone now.
+* Fixed the option to hide windows for pinned buttons on other CassiaWindowList instances. Previously this option would only take into account pinned buttons on one other window list instance. Now it creates a super set of application that are present on all other CassiaWindowList instances that are setup to be in "Launcher" mode. Also changed the option name to make it more clear what the option does.
+* Fixed the label width to take into account the user interface scaling factor so that the label width will accommodate the same number of characters even after changing the displays "User interface scale" percentage. This might mean you will have to reduce the label width setting if you had adjusted it be your desired size based on a >100% scaling factor for your display, but now the label width will adapt correctly when changing the scaling factor
+
 ## 2.4.0
 
 * Fix issues when running under Cinnamon 6.4 (port of cobinja's fix for CobiWindowList). Make sure you have this fix BEFORE upgrading to Cinnamon 6.4

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -286,8 +286,8 @@
     "type": "switch",
     "default": false,
     "dependency" : "group-windows<4",
-    "description": "Hide window buttons of pinned buttons on other CassiaWindowList instances",
-    "tooltip": "When enabled, windows for applications with pinned buttons on other instances of the CassiaWindowList applet will not show up in this window list"
+    "description": "Hide buttons for applications on 'Launcher' instances of CassiaWindowList",
+    "tooltip": "When enabled, windows for applications with pinned buttons on other 'Launcher' mode instances of the CassiaWindowList applet will not show up in this window list"
   },
   "button-spacing": {
     "type": "spinbutton",
@@ -888,11 +888,11 @@
     "type": "spinbutton",
     "default": 100,
     "min": 0,
-    "max": 200,
+    "max": 100,
     "units": "percent",
     "step": 1,
     "description": "Icon color saturation",
-    "tooltip": "Sets the color saturation for icons from 0% (grayscale) to 200%, default is 100%\nThis option is experimental, some icons are not currently effected by this setting"
+    "tooltip": "Sets the color saturation for icons from 0% (grayscale) to 100%, default is 100%"
   },
 
   "saturation-application": {

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
@@ -286,8 +286,8 @@
     "type": "switch",
     "default": false,
     "dependency" : "group-windows<4",
-    "description": "Hide window buttons of pinned buttons on other CassiaWindowList instances",
-    "tooltip": "When enabled, windows for applications with pinned buttons on other instances of the CassiaWindowList applet will not show up in this window list"
+    "description": "Hide buttons for applications on 'Launcher' instances of CassiaWindowList",
+    "tooltip": "When enabled, windows for applications with pinned buttons on other 'Launcher' mode instances of the CassiaWindowList applet will not show up in this window list"
   },
   "button-spacing": {
     "type": "spinbutton",
@@ -883,11 +883,11 @@
     "type": "spinbutton",
     "default": 100,
     "min": 0,
-    "max": 200,
+    "max": 100,
     "units": "percent",
     "step": 1,
     "description": "Icon color saturation",
-    "tooltip": "Sets the color saturation for icons from 0% (grayscale) to 200%, default is 100%\nThis option is experimental, some icons are not currently effected by this setting"
+    "tooltip": "Sets the color saturation for icons from 0% (grayscale) to 100%, default is 100%"
   },
 
   "saturation-application": {

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.4/applet.js
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.4/applet.js
@@ -1,6 +1,6 @@
 /*
  * applet.js
- * Copyright (C) 2022-2024 Kevin Langman <klangman@gmail.com>
+ * Copyright (C) 2022-2025 Kevin Langman <klangman@gmail.com>
  * Copyright (C) 2013 Lars Mueller <cobinja@yahoo.de>
  *
  * CassiaWindowList is a fork of CobiWindowList which is found here:
@@ -1471,7 +1471,6 @@ class WindowListButton {
     this.actor.add_actor(this._labelBox);
 
     this._icon = null;
-    this._modifiedIcon = null;  // This is a version of the icon that has had it saturation modified
     this._iconBin = new St.Bin({name: "appMenuIcon"});
     this._iconBin._delegate = this;
     this._iconBox.add_actor(this._iconBin);
@@ -1927,8 +1926,10 @@ class WindowListButton {
     this._tooltip.preventShow = false;
   }
 
+  // Kinda missnamed, all this does is apply/unapply the DesaturationEffect on this._icon
   updateIconSelection() {
-     if (this._workspace.iconSaturation != 100 && this._modifiedIcon) {
+     let effect = this._icon.get_effect("desat_icon_effect");
+     if (this._workspace.iconSaturation != 100) {
         let satType = this._workspace.saturationType;
         if (satType == SaturationType.All ||
            (satType == SaturationType.Minimized && this._currentWindow && this._currentWindow.minimized) ||
@@ -1937,63 +1938,49 @@ class WindowListButton {
            (satType == SaturationType.OtherMonitors && this.isOnOtherMonitor()) ||
            (satType == SaturationType.Focused && !this._hasFocus()) )
         {
-           this._iconBin.set_child(this._modifiedIcon);
+           let saturation = (100-this._workspace.iconSaturation)/100;
+           if (effect) {
+              effect.set_factor(saturation);
+           } else {
+              if (!this.desatEffect) {
+                 this.desatEffect = new Clutter.DesaturateEffect({factor: saturation});
+              } else {
+                 this.desatEffect.set_factor(saturation);
+              }
+              this._icon.add_effect_with_name("desat_icon_effect", this.desatEffect);
+           }
            return;
         }
      }
-     this._iconBin.set_child(this._icon);
+     if (effect) {
+        this._icon.remove_effect_by_name("desat_icon_effect");
+     }
   }
 
   updateIcon() {
     let panelHeight = this._applet._panelHeight;
 
     this.iconSize = this._applet.getPanelIconSize(St.IconType.FULLCOLOR);
-
     let icon = null;
 
-    if (this._icon)
+    if (this._icon) {
+       if (this._icon.get_effect("desat_icon_effect")) {
+          this._icon.remove_effect_by_name("desat_icon_effect");
+       }
        this._icon.destroy();
-    if (this._modifiedIcon) {
-       this._modifiedIcon.destroy();
-       this._modifiedIcon = null;
     }
 
     if (this._app) {
       let appInfo = this._app.get_app_info();
       if (appInfo) {
         let infoIcon = appInfo.get_icon();
-        let saturation = this._workspace.iconSaturation;
-        if (saturation != 100) {
-           let pixBuf;
-           let themeIcon = ICONTHEME.lookup_icon(infoIcon.to_string(), this.iconSize, 0);
-           if (themeIcon) {
-              pixBuf = GdkPixbuf.Pixbuf.new_from_file_at_size(themeIcon.get_filename(), this.iconSize, this.iconSize);
-           } else {
-              pixBuf = GdkPixbuf.Pixbuf.new_from_file_at_size(infoIcon.to_string(), this.iconSize, this.iconSize);
-           }
-           if (pixBuf) {
-              let image = new Clutter.Image();
-              pixBuf.saturate_and_pixelate(pixBuf, saturation/100, false);
-              try {
-                 image.set_data(pixBuf.get_pixels(), pixBuf.get_has_alpha() ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGBA_888,
-                    this.iconSize, this.iconSize, pixBuf.get_rowstride() );
-                 this._modifiedIcon = new Clutter.Actor({width: this.iconSize, height: this.iconSize, content: image});
-              } catch(e) {
-                 // Can't set the image data, so just use the default!
-              }
-           } else {
-              //log( `Can't find icon for ${infoIcon.to_string()}` );
-           }
-        }
-        icon = new St.Icon({ gicon: infoIcon, icon_size: this.iconSize });
+        this._icon = new St.Icon({ gicon: infoIcon, icon_size: this.iconSize });
       } else {
-        icon = this._app.create_icon_texture(this.iconSize);
+        this._icon = this._app.create_icon_texture(this.iconSize);
       }
     } else {
-      icon = new St.Icon({ icon_name: "application-default-icon", icon_type: St.IconType.FULLCOLOR, icon_size: this.iconSize });
+      this._icon = new St.Icon({ icon_name: "application-default-icon", icon_type: St.IconType.FULLCOLOR, icon_size: this.iconSize });
     }
-
-    this._icon = icon;
     this.updateIconSelection();
 
     if (this._applet.orientation == St.Side.LEFT || this._applet.orientation == St.Side.RIGHT) {
@@ -2004,6 +1991,7 @@ class WindowListButton {
     if ((panelHeight - this.iconSize) & 1) {
       panelHeight--;
     }
+    this._iconBin.set_child(this._icon);
     this._iconBin.natural_width = panelHeight;
     this._iconBin.natural_height = panelHeight;
     this._labelNumberBox.natural_width = panelHeight;
@@ -2243,6 +2231,7 @@ class WindowListButton {
        }
     }
 
+    width *= global.ui_scale;
     if (width != this._labelWidth) {
        let animTime = this._settings.getValue("label-animation") ? this._settings.getValue("label-animation-time") : 0;
        resizeActor(this._labelBox, animTime, width, text, this);
@@ -3949,7 +3938,7 @@ class WindowListButton {
         [rect.x, rect.y] = this._iconBin.get_transformed_position();
         [rect.width, rect.height] = this._iconBin.get_transformed_size();
         this._windows.forEach((window) => {
-           if (window.is_on_all_workspaces() || window.get_workspace().index() === curWS ) {
+           if (window.is_on_all_workspaces() || (window.get_workspace() && window.get_workspace().index() === curWS) ) {
               window.set_icon_geometry(rect);
            }
         });
@@ -5851,15 +5840,20 @@ class WindowList extends Applet.Applet {
   // based on which applications other instances have pinned.
   checkForLauncherApplications() {
      let applets = AppletManager.getRunningInstancesForUuid("CassiaWindowList@klangman");
-     //log( `Found ${applets.length} cassia window list applets!` );
+     this._hiddenApps = [];
      for (let i=0 ; i < applets.length ; i++) {
         if (applets[i] != this) {
-           // TODO: Marge the list of pinned apps in case there are more then two instances
-           this._hiddenApps = applets[i].getPinnedList();
-           //log( `Found ${this._hiddenApps[wsIdx].length} apps to hide on workspace ${wsIdx}` );
-           //this._hiddenApps.push(...appList); // Use the "Spread Syntax" to concat to existing array
+           let pinnedList = applets[i].getPinnedList();
+           if (pinnedList) {
+              if (this._hiddenApps.length !== 0)
+                 this._hiddenApps.forEach( (element, index) => element.push(...pinnedList[index]) );
+              else
+                 pinnedList.forEach( (element) => this._hiddenApps.push( [...element] ) );
+           }
         }
      }
+     if (this._hiddenApps.length === 0 )
+        this._hiddenApps = null;
   }
 
 
@@ -5902,16 +5896,10 @@ class WindowList extends Applet.Applet {
 
   // An API that returns a list of pinned applications on this window list
   getPinnedList(){
-    let result;
-    result = this._settings.getValue("pinned-apps");
-    //log( `pinned apps for ${result.length} work spaces` );
-    //for (let idx=0 ; idx < result.length ; idx++ ){
-    //   log( `pinned apps for ws ${idx}: ${result[idx].length}` );
-    //   for (let idx2=0 ; idx2 < result[idx].length ; idx2++ ){
-    //      log( `result[${idx}][${idx2}] = ${result[idx][idx2]}` );
-    //   }
-    //}
-    return(result);
+    if (this.isLauncher())
+       return(this._settings.getValue("pinned-apps"));
+    else
+       return(null);
   }
 
   // An API that returns true if this applet is configured as a Launcher (used by other app instances)

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
@@ -5,6 +5,6 @@
     "max-instances": -1,
     "multiversion": true,
     "role": "panellauncher",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "author": "klangman"
 }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,28 +21,28 @@ msgstr ""
 msgid "all buttons"
 msgstr ""
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr ""
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr ""
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr ""
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr ""
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -64,76 +64,76 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr ""
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr ""
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr ""
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr ""
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr ""
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr ""
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr ""
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr ""
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr ""
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr ""
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr ""
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 msgid "Always on top"
 msgstr ""
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr ""
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr ""
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr ""
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr ""
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr ""
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr ""
 
@@ -155,48 +155,48 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 msgid "Move window here"
 msgstr ""
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr ""
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr ""
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr ""
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr ""
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr ""
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr ""
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr ""
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr ""
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -218,39 +218,39 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr ""
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr ""
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr ""
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr ""
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 msgid "Close other windows for application"
 msgstr ""
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr ""
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 msgid "Close all windows for application"
 msgstr ""
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
 msgstr ""
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
@@ -864,7 +864,8 @@ msgstr ""
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 
 #. 4.0->settings-schema.json->button-spacing->description
@@ -2244,10 +2245,8 @@ msgstr ""
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 
 #. 4.0->settings-schema.json->saturation-application->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ca.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: 2024-11-20 02:03+0100\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -22,28 +22,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "tots els botons"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Preferències de la miniaplicació"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "Quant a..."
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Configura..."
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr "Lloc web"
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Segur que voleu eliminar aquesta instància de la Llista de Finestres Cassia?"
@@ -66,76 +66,76 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Obre una nova finestra"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Elimina del tauler"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Elimina d'aquest espai de treball"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "Fixar al tauler"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "Fixar a aquest espai de treball"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "Fixar a altres espais de treball"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "Fixar a tots els espais de treball"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "Fixar al llançador"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Afegir nova drecera per a"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Fitxers recents"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Llocs"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 msgid "Always on top"
 msgstr "Sempre en primer pla"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Només en aquest espai de treball"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Visible a tots els espais de treball"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Moure a un altre espai de treball"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr " (aquest espai de treball)"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Moure a un altre monitor"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -157,48 +157,48 @@ msgstr "Monitor"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 msgid "Move window here"
 msgstr "Moure finestra aquí"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "sense assignar"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Assignar finestra a una drecera"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Canviar el contingut de l'etiqueta de l'aplicació"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Eliminar preferència personalitzada"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Utilitzar el títol de la finestra"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "Utilitzar el nom de l'aplicació"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Sense etiqueta"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Desagrupar les finestres de l'aplicació"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Agrupar les finestres de l'aplicació"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupar/Desagrupar automàticament"
 
@@ -220,39 +220,39 @@ msgstr "Agrupar/Desagrupar automàticament"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Moure la barra del títol a la pantalla"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Restaurar"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Minimitzar"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "Desmaximitzar"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Tancar altres"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 msgid "Close other windows for application"
 msgstr "Tancar altres finestres de l'aplicació"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Tancar totes"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 msgid "Close all windows for application"
 msgstr "Tancar totes les finestres de l'aplicació"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Tancar"
 
@@ -918,18 +918,20 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
 msgstr ""
-"Amaga els botons de finestra dels botons fixats en altres instàncies de la "
-"llista de finestres de Cassia"
+"Segur que voleu eliminar aquesta instància de la Llista de Finestres Cassia?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
+#, fuzzy
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 "Si s'activa, els botons fixats de cada instància de la miniaplicació no es "
 "mostraran en altres instàncies"
@@ -2408,11 +2410,10 @@ msgstr "Saturació del color de la icona"
 #. 4.0->settings-schema.json->icon-saturation->tooltip
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
+#, fuzzy
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 "Assigna la saturació del color de les icones des de 0% (escala de grisos) "
 "fins a 200%. Per defecte: 100%\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: 2024-01-01 10:11+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "alle knapper"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Indstillinger"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "Om …"
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Konfigurér …"
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr ""
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Fjern “%s”"
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 
@@ -61,77 +61,77 @@ msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Åbn nyt vindue"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Fjern fra panel"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Fjern fra dette arbejdsområde"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "Fastgør til panel"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "Fastgør til dette arbejdsområde"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "Fastgør til andre arbejdsområder"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "Fastgør til alle arbejdsområder"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "Fastgør til programstarter"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Tilføj ny genvejstast til"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Seneste filer"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Steder"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 #, fuzzy
 msgid "Always on top"
 msgstr "Altid"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Kun på dette arbejdsområde"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Synlig på alle arbejdsområder"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Flyt til et andet arbejdsområde"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr " (dette arbejdsområde)"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Flyt til en anden skærm"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Skærm"
 
@@ -153,49 +153,49 @@ msgstr "Skærm"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 #, fuzzy
 msgid "Move window here"
 msgstr "Luk vindue"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "ikke tildelt"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Tildel en genvejstast til vindue"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Ændr indholdet af programetiket"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Fjern brugerdefineret indstilling"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Brug vinduestitel"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "Brug programnavn"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Ingen etiket"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Opsplit gruppen af programmervinduer"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Gruppér programvinduer"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisk gruppering/opsplitning af gruppe"
 
@@ -217,41 +217,41 @@ msgstr "Automatisk gruppering/opsplitning af gruppe"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Flyt titellinje til skærm"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Gendan"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Minimér"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "Gendan"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Luk andre"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 #, fuzzy
 msgid "Close other windows for application"
 msgstr "Vis miniaturer for alle vinduer i en programpulje"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Luk alle"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 #, fuzzy
 msgid "Close all windows for application"
 msgstr "Vis miniaturer for alle vinduer i en programpulje"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Luk"
 
@@ -906,18 +906,19 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
-msgstr ""
-"Skjul fastgjorte knappers vinduesknapper i andre forekomster af "
-"CassiaVinduesliste"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
+msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
+#, fuzzy
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 "Når aktiveret, vil vinduer for programmer med fastgjorte knapper i andre "
 "forekomster af CassiaVinduesliste ikke blive vist på denne vinduesliste"
@@ -2374,11 +2375,10 @@ msgstr "Ikonfarvemætning"
 #. 4.0->settings-schema.json->icon-saturation->tooltip
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
+#, fuzzy
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 "Indstiller farvemætningen for ikoner fra 0% (gråtoner) til 200%, standard er "
 "100%.\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/de.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.3.6\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Joshiy13\n"
 "Language-Team: \n"
@@ -22,28 +22,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "alle knöpfe"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Applet-Einstellungen"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "Über..."
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Einstellen..."
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr "Website"
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "'%s' entfernen"
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Möchtest du wirklich diese Instanz von CassiaWindowsList entfernen?"
 
@@ -65,76 +65,76 @@ msgstr "Möchtest du wirklich diese Instanz von CassiaWindowsList entfernen?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Neues Fenster öffnen"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Von Panel entfernen"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Von diesem Arbeitsbereich entfernen"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "An Panel anheften"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "An den jetzigen Arbeitsplatz anheften"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "An andere Arbeitsplätze anheften"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "An alle Arbeitsplätze anheften"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "An launcher anheften"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Füge neue Tastenkombination hinzu für"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Zuletzt benutzte Dateien"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Orte"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 msgid "Always on top"
 msgstr "Immer obenauf"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Nur im jetzigen Arbeitsplatz"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Sichtbar in jedem Arbeitsplatz"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Zu anderem Arbeitsplatz verschieben"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr "(dieser Arbeitsplatz)"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Zu anderen Bildschirm verschieben"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Bildschirm"
 
@@ -156,48 +156,48 @@ msgstr "Bildschirm"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 msgid "Move window here"
 msgstr "Fenster hierhin verschieben"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "unzugewiesen"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Weise Fenster einer Tastenkombination zu"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Inhalt des Anwendungsetiketts ändern"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Benutzerdefinierte Einstellung entfernen"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Fenstertitel verwenden"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "App-namen verwenden"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Kein Label"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Gruppierung der Anwendungsfenster aufheben"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Anwendungsfenster gruppieren"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatische Gruppierung/Gruppierungsaufhebung"
 
@@ -219,39 +219,39 @@ msgstr "Automatische Gruppierung/Gruppierungsaufhebung"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Titelleiste auf den Bildschirm verschieben"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Minimieren"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "Unmaximieren"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Andere schließen"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 msgid "Close other windows for application"
 msgstr "Andere Fenster der app schließen"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Alle schließen"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 msgid "Close all windows for application"
 msgstr "Alle Fenster der App schließen"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Schließen"
 
@@ -858,16 +858,18 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
-msgstr ""
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
+msgstr "Möchtest du wirklich diese Instanz von CassiaWindowsList entfernen?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 
 #. 4.0->settings-schema.json->button-spacing->description
@@ -2247,10 +2249,8 @@ msgstr ""
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 
 #. 4.0->settings-schema.json->saturation-application->options

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: 2024-11-20 18:39-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,28 +22,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "todos los botones"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Preferencias del applet"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "Acerca de..."
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Configurar..."
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr "Sitio web"
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 
@@ -65,76 +65,76 @@ msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Abrir nueva ventana"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Quitar del panel"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Eliminar de este espacio de trabajo"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "Anclar al panel"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "Anclar a este espacio de trabajo"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "Anclar a otros espacios de trabajo"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "Anclar a todos los espacios de trabajo"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "Anclar al lanzador"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Añadir nueva tecla de acceso rápido para"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Archivos recientes"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Lugares"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 msgid "Always on top"
 msgstr "Siempre arriba"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Sólo en este espacio de trabajo"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Visible en todos los espacios de trabajo"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Mover a otro espacio de trabajo"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr " (este espacio de trabajo)"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Mover a otro monitor"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -156,48 +156,48 @@ msgstr "Monitor"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 msgid "Move window here"
 msgstr "Mover la ventana aquí"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "no asignado"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Asignar ventana a una tecla de acceso rápido"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Cambiar el contenido de la etiqueta de la aplicación"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Eliminar configuración personalizada"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Utilizar título de ventana"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "Utilizar nombre de aplicación"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Sin etiqueta"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Ventanas de aplicaciones separadas"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Ventanas de aplicaciones agrupadas"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupación/desagrupación automática"
 
@@ -219,39 +219,39 @@ msgstr "Agrupación/desagrupación automática"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Mover la barra de título a la pantalla"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Restaurar"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Minimizar"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "Desmaximizar"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Cerrar otros"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 msgid "Close other windows for application"
 msgstr "Cerrar otras ventanas para la aplicación"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Cerrar todo"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 msgid "Close all windows for application"
 msgstr "Cerrar todas las ventanas para la aplicación"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Cerrar"
 
@@ -924,18 +924,19 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
-msgstr ""
-"Ocultar botones de ventana de botones anclados en otras instancias "
-"CassiaWindowList"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
+msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
+#, fuzzy
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 "Cuando se activa, las ventanas de aplicaciones con botones anclados en otras "
 "instancias del applet CassiaWindowList no se mostrarán en esta lista de "
@@ -2429,11 +2430,10 @@ msgstr "Saturación de color de icono"
 #. 4.0->settings-schema.json->icon-saturation->tooltip
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
+#, fuzzy
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 "Establece la saturación de color de los iconos de 0% (escala de grises) a "
 "200%, por defecto es 100%.\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fi.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: 2024-11-21 00:50+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -21,28 +21,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "kaikki painikkeet"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Sovelman asetukset"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "Tietoja..."
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Aseta..."
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr "Verkkosivu"
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Poista \"%s\""
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Haluatko tosiaan poistaa tämän mahdollisuuden Cassiaikkunalistasta?"
 
@@ -64,76 +64,76 @@ msgstr "Haluatko tosiaan poistaa tämän mahdollisuuden Cassiaikkunalistasta?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Avaa uusi ikkuna"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Poista paneelista"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Poista tästä työtilasta"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "Kiinnitä paneeliin"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "Kiinnitä työtilaan"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "Kiinnitä toiseen työtilaan"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "Kiinnitä kaikkiin työtiloihin"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "Kiinnitä käynnistimeen"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Lisää pikanäppäin"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Käytetyt tiedostot"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Paikat"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 msgid "Always on top"
 msgstr "Aina päällimmäisenä"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Ainoastaan tämä työtila"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Näytä kaikki työtilat"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Siirrä toiseen työtilaan"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr " (tämä työtila)"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Siirrä toiseen näyttöön"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Näyttö"
 
@@ -155,48 +155,48 @@ msgstr "Näyttö"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 msgid "Move window here"
 msgstr "Siirrä ikkuna tähän"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "ei allekirjoitettu"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Määritä ikkuna pikanäppäimelle"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Muuta sovelluksen merkin sisältöä"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Poista mukautetut aasetukset"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Käytä ikkunan otsikkoa"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "Käytä sovelluksen nimeä"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Ei merkkiä"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Pura ikkunoiden ryhmittely"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Ryhmitä sovellusikkunat"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Automaattinen ryhmittely/purku"
 
@@ -218,39 +218,39 @@ msgstr "Automaattinen ryhmittely/purku"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Siirrä otsikkorivi näytölle"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Palauta"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Pienennä"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "Suurenna"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Sulje muut"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 msgid "Close other windows for application"
 msgstr "Sulje muut ikkunat sovellusta varten"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Sulje kaikki"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 msgid "Close all windows for application"
 msgstr "Sulje kaikki ikkunat sovellusta varten"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Sulje"
 
@@ -917,18 +917,19 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
-msgstr ""
-"Piilota kiinnitettyjen painikkeiden ikkunapainikkeet muissa CassiaWindowList-"
-"esiintymissä"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
+msgstr "Haluatko tosiaan poistaa tämän mahdollisuuden Cassiaikkunalistasta?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
+#, fuzzy
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 "Kun tämä on käytössä, ikkunat sovelluksille, joiden painikkeita on "
 "kiinnitetty CassiaWindowList-sovelman muihin esiintymiin, eivät näy tässä "
@@ -2401,11 +2402,10 @@ msgstr "Kuvakkeen värin saturaatio"
 #. 4.0->settings-schema.json->icon-saturation->tooltip
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
+#, fuzzy
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 "Asettaa kuvakkeiden värikylläisyyden 0 %:sta (harmaasävy) 200 %:iin, "
 "oletusarvo on 100 %\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: 2025-03-07 16:35+0100\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -23,28 +23,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "tous les boutons"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Préférences"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "À propos..."
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Configurer..."
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr "Site web"
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Supprimer '%s'"
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 
@@ -66,76 +66,76 @@ msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Ouvrir une nouvelle fenêtre"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Retirer du panneau"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Retirer de cet espace de travail"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "Épingler au panneau"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "Épingler à cet espace de travail"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "Épingler aux autres espaces de travail"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "Épingler à tous les espaces de travail"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "Épingler au lanceur"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Ajouter un nouveau raccourci clavier pour"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Fichiers récents"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Emplacements"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 msgid "Always on top"
 msgstr "Toujours au-dessus"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Seulement sur cet espace de travail"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Visible sur tous les espaces de travail"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Déplacer vers un autre espace de travail"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr " (cet espace de travail)"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Déplacer vers un autre moniteur"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Moniteur"
 
@@ -157,48 +157,48 @@ msgstr "Moniteur"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 msgid "Move window here"
 msgstr "Déplacer la fenêtre ici"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "non attribué"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Attribuer une fenêtre à un raccourci clavier"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Modifier le libellé de l'étiquette de l'application"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Supprimer le paramètre personnalisé"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Utiliser le titre de fenêtre"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "Utiliser le nom de l'application"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Sans étiquette"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Dégrouper les fenêtres de l'application"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Grouper les fenêtres par application"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Regrouper/dégrouper automatiquement"
 
@@ -220,39 +220,39 @@ msgstr "Regrouper/dégrouper automatiquement"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Déplacer la barre de titre sur l'écran"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Restaurer"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Minimiser"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "Démaximiser"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Fermer les autres"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 msgid "Close other windows for application"
 msgstr "Fermer les autres fenêtres de l'application"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Tout fermer"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 msgid "Close all windows for application"
 msgstr "Fermer toutes les fenêtres de l'application"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Fermer"
 
@@ -930,18 +930,19 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
-msgstr ""
-"Masquer les boutons de fenêtre des boutons déjà épinglés sur d'autres "
-"instances de CassiaWindowList"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
+msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
+#, fuzzy
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 "Lorsque cette option est activée, les fenêtres des applications dont les "
 "boutons sont épinglés sur d'autres instances de l'applet CassiaWindowList "
@@ -2444,11 +2445,10 @@ msgstr "Saturation de la couleur de l'icône"
 #. 4.0->settings-schema.json->icon-saturation->tooltip
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
+#, fuzzy
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 "Définit la saturation des couleurs pour les icônes de 0 % (niveaux de gris) "
 "à 200 %, la valeur par défaut étant 100 %.\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.3.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: 2024-11-24 19:36+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,28 +22,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "minden gomb"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Kisalkalmazás beállítások"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "Névjegy…"
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Beállítások…"
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr "Weboldal"
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eltávolítás: „%s”"
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példányát?"
 
@@ -65,76 +65,76 @@ msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példány
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Új ablak megnyitása"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Eltávolítás a panelról"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Eltávolítás erről a munkaterületről"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "Panelhez rögzítés"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "Erre a munkaterületre rögzítés"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "Más munkaterületre rögzítés"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "Az összes munkaterületre rögzítés"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "Alkalmazásindítóhoz rögzítés"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Új gyorsbillentyű hozzáadása ehhez"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Nemrég használt fájlok"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Helyek"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 msgid "Always on top"
 msgstr "Mindig felül"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Csak ezen a munkaterületen"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Minden munkaterületen látható"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Áthelyezés másik munkaterületre"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr " (ez a munkaterület)"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Áthelyezés a másik kijelzőre"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Kijelző"
 
@@ -156,48 +156,48 @@ msgstr "Kijelző"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 msgid "Move window here"
 msgstr "Ablak mozdítása ide"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "nincs társítva"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Az ablak hozzárendelése egy gyorsbillentyűhöz"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Az alkalmazáscímke tartalmának módosítása"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Egyéni beállítás eltávolítása"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Ablakcím használata"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "Alkalmazásnév használata"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Nincs címke"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Ablakokat ne csoportosítsa alkalmazás szerint"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Alkalmazás ablakok csoportosítása"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 
@@ -219,39 +219,39 @@ msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Címsor mozgatása a kijelzőre"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Visszaállítás"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Minimalizálás"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "Eredeti méret"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Többi bezárása"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 msgid "Close other windows for application"
 msgstr "Zárja be a többi ablakot az alkalmazáshoz"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Minden bezárása"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 msgid "Close all windows for application"
 msgstr "Zárja be az összes ablakot az alkalmazáshoz"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Bezárás"
 
@@ -913,17 +913,19 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
-msgstr ""
-"A rögzített gombok ablakgombjainak elrejtése más CassiaWindowList példányokon"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
+msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példányát?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
+#, fuzzy
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 "Ha engedélyezve van, a CassiaWindowList kisalkalmazás más példányaihoz "
 "rögzített gombokkal rendelkező alkalmazások ablakai nem jelennek meg ebben "
@@ -2403,11 +2405,10 @@ msgstr "Ikon színtelítettsége"
 #. 4.0->settings-schema.json->icon-saturation->tooltip
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
+#, fuzzy
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 "Az ikonok színtelítettségét 0%-ról (szürkeárnyalatos) 200%-ra állítja, "
 "alapértelmezés szerint 100%\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: 2025-01-03 14:48+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -23,28 +23,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "tutti i pulsanti"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Preferenze Applet"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "Informazioni su..."
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Configura..."
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr "Sito web"
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Rimuovi '%s'"
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 
@@ -66,76 +66,76 @@ msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Apri una nuova finestra"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Rimuovi dal pannello"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Rimuovi da questa area di lavoro"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "Appunta al pannello"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "Appunta a questo spazio di lavoro"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "Appunta ad altre aree di lavoro"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "Appunta in tutte le aree di lavoro"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "Appunta al launcher"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Aggiungi un nuovo tasto di scelta rapida per"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Recenti"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Posizioni"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 msgid "Always on top"
 msgstr "Sempre in primo piano"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Solo su questo spazio di lavoro"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Visibile su tutte le aree di lavoro"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Sposta su un'altra area di lavoro"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr " (questa area di lavoro)"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Sposta su un altro schermo"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -157,48 +157,48 @@ msgstr "Monitor"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 msgid "Move window here"
 msgstr "Sposta la finestra qui"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "non assegnato"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Assegna finestra ad un tasto di scelta rapida"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Cambia il contenuto dell'etichetta dell'applicazione"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Rimuovi impostazioni personalizzate"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Usa il titolo della finestra"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "Usa il nome dell'applicazione"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Nessuna etichetta"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Separa le finestre dell'applicazione"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Raggruppa le finestre dell'applicazione"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Raggruppamento/separazione automatica"
 
@@ -220,39 +220,39 @@ msgstr "Raggruppamento/separazione automatica"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Sposta la barra del titolo sullo schermo"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Ripristina"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Minimizza"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "De-massimizza"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Chiudi altri"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 msgid "Close other windows for application"
 msgstr "Chiudi le altre finestre per l'applicazione"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Chiudi tutto"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 msgid "Close all windows for application"
 msgstr "Chiudi tutte le finestre per l'applicazione"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Chiudi"
 
@@ -930,18 +930,19 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
-msgstr ""
-"Nascondi i pulsanti della finestra dei pulsanti aggiunti su altre istanze di "
-"CassiaWindowList"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
+msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
+#, fuzzy
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 "Se abilitate, le finestre per le applicazioni con pulsanti fissati su altre "
 "istanze dell'applet CassiaWindowList non verranno visualizzate in questo "
@@ -2444,11 +2445,10 @@ msgstr "Saturazione del colore dell'icona"
 #. 4.0->settings-schema.json->icon-saturation->tooltip
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
+#, fuzzy
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 "Imposta la saturazione del colore per le icone dallo 0% (scala di grigi)\n"
 "al 200%, l'impostazione predefinita è 100%\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: 2024-11-28 16:48+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -20,28 +20,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "alle knoppen"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Applet Voorkeuren"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "Over..."
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Configureren..."
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr "Website"
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Verwijder '%s'"
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Weet u zeker dat u deze instantie van CassiaWindowList wilt verwijderen?"
@@ -64,76 +64,76 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Open een nieuw venster"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Verwijderen van paneel"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Verwijderen van deze werkruimte"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "Vastmaken aan paneel"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "Vastmaken aan deze werkruimte"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "Vastmaken aan andere werkruimtes"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "Vastmaken aan alle werkruimtes"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "Vastmaken aan launcher"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Voeg nieuwe sneltoets toe voor"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Recente bestanden"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Locaties"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 msgid "Always on top"
 msgstr "Altijd bovenop"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Alleen op deze werkruimte"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Zichtbaar op alle werkruimtes"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Verplaatsen naar een andere werkruimte"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 msgid " (this workspace)"
 msgstr " (deze werkruimte)"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Verplaatsen naar een ander beeldscherm"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Beeldscherm"
 
@@ -155,48 +155,48 @@ msgstr "Beeldscherm"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 msgid "Move window here"
 msgstr "Verplaats venster hierheen"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "niet toegewezen"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Wijs venster toe aan een sneltoets"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Wijzig inhoud van applicatielabel"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Verwijder aangepaste instelling"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Gebruik venstertitel"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "Gebruik applicatienaam"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Geen label"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Applicatie-vensters niet groeperen"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Applicatie-vensters groeperen"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisch groeperen/ongroeperen"
 
@@ -218,39 +218,39 @@ msgstr "Automatisch groeperen/ongroeperen"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Verplaats titelbalk naar het scherm"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Herstellen"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Minimaliseren"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "Ontmaximaliseren"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Sluit anderen"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 msgid "Close other windows for application"
 msgstr "Sluit andere vensters van applicatie"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Sluit alle"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 msgid "Close all windows for application"
 msgstr "Sluit alle vensters van applicatie"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Sluiten"
 
@@ -919,18 +919,20 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
 msgstr ""
-"Verberg vensterknoppen van vastgemaakte knoppen op andere instanties van "
-"CassiaWindowList"
+"Weet u zeker dat u deze instantie van CassiaWindowList wilt verwijderen?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
+#, fuzzy
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 "Indien ingeschakeld, worden vensters voor applicaties met vastgemaakte "
 "knoppen op andere instanties van de CassiaWindowList applet niet weergegeven "
@@ -2421,11 +2423,10 @@ msgstr "Pictogramkleursaturatie"
 #. 4.0->settings-schema.json->icon-saturation->tooltip
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
+#, fuzzy
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 "Stelt de kleursaturatie in voor pictogrammen van 0% (grijstinten) tot 200%, "
 "standaard is 100%\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-12-06 20:39-0500\n"
+"POT-Creation-Date: 2025-03-09 22:44-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "все кнопки"
 
-#. 4.0/applet.js:3277 6.0/applet.js:3277 6.4/applet.js:3249
+#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
 msgid "Applet Preferences"
 msgstr "Настройки Апплета"
 
-#. 4.0/applet.js:3281 6.0/applet.js:3281 6.4/applet.js:3253
+#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
 msgid "About..."
 msgstr "О Апплете..."
 
-#. 4.0/applet.js:3285 6.0/applet.js:3285 6.4/applet.js:3257
+#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
 msgid "Configure..."
 msgstr "Настроить..."
 
-#. 4.0/applet.js:3289 6.0/applet.js:3289 6.4/applet.js:3261
+#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
 msgid "Website"
 msgstr ""
 
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Удалить '%s'"
 
-#. 4.0/applet.js:3295 6.0/applet.js:3295 6.4/applet.js:3267
+#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Вы действительно хотите удалить этот экземпляр CassiaWindowList?"
 
@@ -61,78 +61,78 @@ msgstr "Вы действительно хотите удалить этот э�
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3304 6.0/applet.js:3304 6.4/applet.js:3276
+#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
 msgid "Open new window"
 msgstr "Открыть новое окно"
 
-#. 4.0/applet.js:3312 6.0/applet.js:3312 6.4/applet.js:3284
+#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
 msgid "Remove from panel"
 msgstr "Удалить с панели"
 
-#. 4.0/applet.js:3314 6.0/applet.js:3314 6.4/applet.js:3286
+#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
 msgid "Remove from this workspace"
 msgstr "Удалить из этого рабочего стола"
 
-#. 4.0/applet.js:3320 6.0/applet.js:3320 6.4/applet.js:3292
+#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
 msgid "Pin to panel"
 msgstr "Закрепить на панели"
 
-#. 4.0/applet.js:3322 6.0/applet.js:3322 6.4/applet.js:3294
+#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
 msgid "Pin to this workspace"
 msgstr "Закрепить на этом рабочем столе"
 
-#. 4.0/applet.js:3363 6.0/applet.js:3363 6.4/applet.js:3335
+#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
 msgid "Pin to other workspaces"
 msgstr "Закрепить на другом рабочем столе"
 
-#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
+#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
 msgid "Pin to all workspaces"
 msgstr "Закрепить на всех рабочих столах"
 
-#. 4.0/applet.js:3402 6.0/applet.js:3402 6.4/applet.js:3374
+#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
 msgid "Pin to launcher"
 msgstr "Закрепить в лаунчере"
 
-#. 4.0/applet.js:3420 4.0/applet.js:3625 6.0/applet.js:3420 6.0/applet.js:3625
-#. 6.4/applet.js:3392 6.4/applet.js:3594
+#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
+#. 6.4/applet.js:3381 6.4/applet.js:3583
 msgid "Add new Hotkey for"
 msgstr "Добавить новую горячую клавишу для"
 
-#. 4.0/applet.js:3434 6.0/applet.js:3434 6.4/applet.js:3406
+#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
 msgid "Recent files"
 msgstr "Недавние файлы"
 
-#. 4.0/applet.js:3458 6.0/applet.js:3458 6.4/applet.js:3430
+#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
 msgid "Places"
 msgstr "Места"
 
-#. 4.0/applet.js:3501 6.0/applet.js:3501 6.4/applet.js:3473
+#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
 #, fuzzy
 msgid "Always on top"
 msgstr "Всегда"
 
-#. 4.0/applet.js:3513 6.0/applet.js:3513 6.4/applet.js:3485
+#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
 msgid "Only on this workspace"
 msgstr "Только на этом рабочем столе"
 
-#. 4.0/applet.js:3515 6.0/applet.js:3515 6.4/applet.js:3487
+#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
 msgid "Visible on all workspaces"
 msgstr "Видно на всех рабочих столах"
 
-#. 4.0/applet.js:3516 6.0/applet.js:3516 6.4/applet.js:3488
+#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
 msgid "Move to another workspace"
 msgstr "Переместить на другой рабочий стол"
 
-#. 4.0/applet.js:3525 6.0/applet.js:3525 6.4/applet.js:3497
+#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
 #, fuzzy
 msgid " (this workspace)"
 msgstr "Закрепить на этом рабочем столе"
 
-#. 4.0/applet.js:3538 6.0/applet.js:3538 6.4/applet.js:3510
+#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
 msgid "Move to another monitor"
 msgstr "Переместить на другой монитор"
 
-#. 4.0/applet.js:3546 6.0/applet.js:3546 6.4/applet.js:3518
+#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
 msgid "Monitor"
 msgstr "Монитор"
 
@@ -154,49 +154,49 @@ msgstr "Монитор"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3563 6.0/applet.js:3563 6.4/applet.js:3532
+#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
 #, fuzzy
 msgid "Move window here"
 msgstr "Закрой окно"
 
-#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3549
+#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
 msgid "unassigned"
 msgstr "не назначено"
 
-#. 4.0/applet.js:3591 4.0/applet.js:3622 6.0/applet.js:3591 6.0/applet.js:3622
-#. 6.4/applet.js:3560 6.4/applet.js:3591
+#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
+#. 6.4/applet.js:3549 6.4/applet.js:3580
 msgid "Assign window to a hotkey"
 msgstr "Назначить окно горячей клавише"
 
-#. 4.0/applet.js:3645 6.0/applet.js:3645 6.4/applet.js:3614
+#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
 msgid "Change application label contents"
 msgstr "Изменить текст названия приложения"
 
-#. 4.0/applet.js:3648 6.0/applet.js:3648 6.4/applet.js:3617
+#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
 msgid "Remove custom setting"
 msgstr "Удалить свои настройки"
 
-#. 4.0/applet.js:3655 6.0/applet.js:3655 6.4/applet.js:3624
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "Use window title"
 msgstr "Использовать заголовок окон"
 
-#. 4.0/applet.js:3662 6.0/applet.js:3662 6.4/applet.js:3631
+#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
 msgid "Use application name"
 msgstr "Использовать названия программ"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
 msgid "No label"
 msgstr "Без названий"
 
-#. 4.0/applet.js:3680 6.0/applet.js:3680 6.4/applet.js:3649
+#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
 msgid "Ungroup application windows"
 msgstr "Не группировать окна приложений"
 
-#. 4.0/applet.js:3688 6.0/applet.js:3688 6.4/applet.js:3657
+#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
 msgid "Group application windows"
 msgstr "Группировать окна приложений"
 
-#. 4.0/applet.js:3701 6.0/applet.js:3701 6.4/applet.js:3670
+#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
 msgid "Automatic grouping/ungrouping"
 msgstr "Автоматически группировать/разгруппировать"
 
@@ -218,41 +218,41 @@ msgstr "Автоматически группировать/разгруппир
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3729 6.0/applet.js:3729 6.4/applet.js:3698
+#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
 msgid "Move titlebar on to screen"
 msgstr "Переместить на другой экран"
 
-#. 4.0/applet.js:3734 6.0/applet.js:3734 6.4/applet.js:3703
+#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
 msgid "Restore"
 msgstr "Восстановить"
 
-#. 4.0/applet.js:3738 6.0/applet.js:3738 6.4/applet.js:3707
+#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
 msgid "Minimize"
 msgstr "Свернуть"
 
-#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "Unmaximize"
 msgstr "Обычный размер"
 
-#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
+#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
 msgid "Close others"
 msgstr "Закрыть другие"
 
-#. 4.0/applet.js:3754 6.0/applet.js:3754 6.4/applet.js:3723
+#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
 #, fuzzy
 msgid "Close other windows for application"
 msgstr "Показать миниатюры для всех окон пула приложений"
 
-#. 4.0/applet.js:3775 6.0/applet.js:3775 6.4/applet.js:3744
+#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
 msgid "Close all"
 msgstr "Закрыть всё"
 
-#. 4.0/applet.js:3777 6.0/applet.js:3777 6.4/applet.js:3746
+#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
 #, fuzzy
 msgid "Close all windows for application"
 msgstr "Показать миниатюры для всех окон пула приложений"
 
-#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
+#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
 msgid "Close"
 msgstr "Закрыть"
 
@@ -904,17 +904,19 @@ msgstr ""
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
 #. 6.4->settings-schema.json->hide-panel-apps->description
+#, fuzzy
 msgid ""
-"Hide window buttons of pinned buttons on other CassiaWindowList instances"
-msgstr ""
-"Скрыть кнопки окна закрепленных кнопок в других экземплярах CassiaWindowList"
+"Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
+msgstr "Вы действительно хотите удалить этот экземпляр CassiaWindowList?"
 
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.4->settings-schema.json->hide-panel-apps->tooltip
+#, fuzzy
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
-"instances of the CassiaWindowList applet will not show up in this window list"
+"'Launcher' mode instances of the CassiaWindowList applet will not show up in "
+"this window list"
 msgstr ""
 "Если этот параметр включен, окна приложений с закрепленными кнопками в "
 "других экземплярах апплета CassiaWindowList не будут отображаться в этом "
@@ -2361,10 +2363,8 @@ msgstr ""
 #. 6.0->settings-schema.json->icon-saturation->tooltip
 #. 6.4->settings-schema.json->icon-saturation->tooltip
 msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
-"100%\n"
-"This option is experimental, some icons are not currently effected by this "
-"setting"
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
 msgstr ""
 
 #. 4.0->settings-schema.json->saturation-application->options


### PR DESCRIPTION
- Use the DesaturateEffect class rather than the saturate_and_pixelate() API to adjust the icon color saturation. This has as advantage in that it is able to desaturate the color for all icons where before it was limited in what type of icons it would work on. On the other hand, it has a disadvantage in that it can't oversaturate the icons. Hopefully no one was using the >100% saturation feature because it's not gone now.
- Fixed the option to hide windows for pinned buttons on other CassiaWindowList instances. Previously this option would only take into account pinned buttons on one other window list instance. Now it creates a super set of application that are present on all other CassiaWindowList instances that are setup to be in "Launcher" mode. Also changed the option name to make it more clear what the option does.
- Fixed the label width to take into account the user interface scaling factor so that the label width will accommodate the same number of characters even after changing the displays "User interface scale" percentage. This might mean you will have to reduce the label width setting if you had adjusted it be your desired size based on a >100% scaling factor for your display, but now the label width will adapt correctly when changing the scaling factor