### PR TITLE
turn-off-monitor@zablotski:  fixing bugs

### DIFF
--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/applet.js
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/applet.js
@@ -86,7 +86,7 @@ MyApplet.prototype = {
         let duration = Math.trunc(this.mouseDeactivationDuration);
         Util.spawn_async(
             ['/bin/bash', '-c',
-            'for m in $(xinput | grep -i Mouse | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
+            'for m in $(xinput | grep -iE "touchpad|mouse" | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
             xinput disable $m; done'],
             null
         );
@@ -95,8 +95,8 @@ MyApplet.prototype = {
             function () {
                 Util.spawn_async(
                     ['/bin/bash', '-c',
-                    'for m in $(xinput | grep -i Mouse | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
-                    xinput enable $m; done'],
+            'for m in $(xinput | grep -iE "touchpad|mouse" | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
+            xinput enable $m; done'],
                     null);
                 },
             duration
@@ -122,7 +122,7 @@ MyApplet.prototype = {
     on_shortcut_used: function () {
         Util.spawn_async(
             ['/bin/bash', '-c',
-            'for m in $(xinput | grep Keyboard | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
+            'for m in $(xinput | grep -i "keyboard" | grep -iv "virtual" | grep -iv "power" | grep -iv "video" | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
             xinput disable $m; done'],
             null
         );
@@ -131,7 +131,7 @@ MyApplet.prototype = {
             function () {
                 Util.spawn_async(
                     ['/bin/bash', '-c',
-                    'for m in $(xinput | grep Keyboard | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
+                    'for m in $(xinput | grep -i "slave" | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
                     xinput enable $m; done'],
                     null);
             },


### PR DESCRIPTION
* Added a touchpad to the list of disabled devices (fixes a bug where you had to click on the applet twice to turn off the monitor).

* Fixed the command to disable the keyboard when using a shortcut.