### PR TITLE
turn-off-monitor@zablotski: Add optional feature of locking cinnamon session

### DIFF
--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/applet.js
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/applet.js
@@ -53,6 +53,14 @@ MyApplet.prototype = {
             null
         );
 
+        this.settings.bindProperty(Settings.BindingDirection.IN,
+            'screenlock',
+            'screenlock',
+            null,
+            null
+        );
+
+
         // Keybinding:
         this.settings.bindProperty(Settings.BindingDirection.IN,
             "keybinding",
@@ -90,6 +98,9 @@ MyApplet.prototype = {
             xinput disable $m; done'],
             null
         );
+        if (this.screenlock) {
+                Util.spawnCommandLine('cinnamon-screensaver-command --lock');
+        }
         Util.spawnCommandLine('xset dpms force off');
         setTimeoutInSeconds(
             function () {

--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/settings-schema.json
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/settings-schema.json
@@ -10,7 +10,8 @@
       "sections": [
         "section-mouse",
         "section-keybinding",
-        "section-icon"
+        "section-icon",
+        "section-lock"
       ]
     },
     "section-mouse": {
@@ -33,6 +34,13 @@
       "keys": [
         "use-symbolic-icon",
         "icon-color"
+      ]
+    },
+    "section-lock": {
+      "type": "section",
+      "title": "Screen lock",
+      "keys": [
+        "screenlock"
       ]
     }
   },
@@ -62,5 +70,10 @@
     "default": "green",
     "description": "Color of the symbolic icon",
     "dependency": "use-symbolic-icon"
+  },
+  "screenlock": {
+    "type": "switch",
+    "default": false,
+    "description": "Lock also cinnamon session"
   }
 }


### PR DESCRIPTION
This PR adds feature of locking cinnamon session along with switching screens off. Configurable with default toggle state off, so nothing suddenly changes for anyone after update.
@zablotski 