### PR TITLE
cpu-monitor-text@gnemonix : Issue#7080 Improve percentage display so applet width does not change

### DIFF
--- a/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
+++ b/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
@@ -72,13 +72,13 @@ MyApplet.prototype = {
 	},
 
 	_pad: function(percent) {
-		let str = "";
+        	let str = percent.toString();
 		let str_length = this.max_percentage.toString().length;
 		
-		while(str.length < str_length) {
-			str = " " + str;
+        	while(str.length < str_length) {
+			str = "\u2007" + str;
 		}
-		return (str + percent.toString()).slice(str_length);
+        	return (str);
 	},
 
 	_update: function() {


### PR DESCRIPTION
cpu-monitor-text@gnemonix

When the CPU percentage changes number of digits the width of the applet changes and moves things around.
Improve the functionality by padding the percentage with Figure Space characters.

Issue #7080