### PR TITLE
[directory-menu@torchipeppo] v0.9.0: Add option to hide "Open Folder" and "Open in Terminal"

### DIFF
--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
@@ -56,6 +56,7 @@ class CassettoneApplet extends Applet.TextIconApplet {
         this.settings.bind("favorites-first", "favorites_first", null, null);
         this.settings.bind("pinned-first", "pinned_first", null, null);
         this.settings.bind("order-by", "order_by", null, null);
+        this.settings.bind("show-header", "show_header", null, null);
         this.starting_uri = this.normalize_tilde(this.starting_uri);
 
         this.set_applet_tooltip(_(this.tooltip_text));
@@ -178,6 +179,7 @@ class CassettoneApplet extends Applet.TextIconApplet {
             "favorites_first": this.favorites_first,
             "pinned_first": this.pinned_first,
             "order_by": this.order_by,
+            "show_header": this.show_header,
         }
 
         Util.spawn_async(['python3', `${this.metadata.path}/popup_menu.py`, JSON.stringify(args)]);

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/metadata.json
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "directory-menu@torchipeppo",
     "name": "Directory Menu",
     "description": "Quickly navigate through directories on your system using a dropdown menu.",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "author": "torchipeppo",
     "max-instances": "-1"
 }

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/ca.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.7.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: 2024-11-20 02:09+0100\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr "Obrir directori"
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr "Obrir al Terminal"
 
@@ -61,13 +61,38 @@ msgstr "Text de la informació d'eines"
 msgid "Panel Text"
 msgstr "Text del tauler"
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
-msgstr "Comportament"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
+msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Inclou els fitxers ocults"
+
+#. settings-schema.json->limit-characters->description
+#, fuzzy
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr "Limita el número de caràcters màxim dels submenús"
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Límit de caràcters"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"(Aproximadament) Limita el número de caràcters de cada element.\n"
+"Útil si penseu que el menú és massa ample."
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
+msgstr ""
 
 #. settings-schema.json->order-by->options
 msgid "Name"
@@ -88,22 +113,6 @@ msgstr "Mostrar els elements preferits primer"
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
 msgstr "Mostrar els elements fixats primer"
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr "Limita el número de caràcters màxim dels submenús"
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr "Límit de caràcters"
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
-"(Aproximadament) Limita el número de caràcters de cada element.\n"
-"Útil si penseu que el menú és massa ample."
 
 #. settings-schema.json->keybindings-section->description
 msgid "Keybindings"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/de.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: 2024-03-29 23:13+0100\n"
 "Last-Translator: Martin Posselt <nekomajin@gmx.de>\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr "Ordner öffnen"
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr "Im Terminal öffnen"
 
@@ -63,13 +63,37 @@ msgstr "Tooltip-Text"
 msgid "Panel Text"
 msgstr ""
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
 msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Versteckte Dateien anzeigen"
+
+#. settings-schema.json->limit-characters->description
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr ""
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Zeichenbegrenzung"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"Begrenzt die Anzahl der Zeichen für jeden Eintrag.\n"
+"Nützlich, wenn das Menü zu umfangreich ist."
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
+msgstr ""
 
 #. settings-schema.json->order-by->options
 msgid "Name"
@@ -90,22 +114,6 @@ msgstr ""
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
 msgstr ""
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr ""
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr "Zeichenbegrenzung"
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
-"Begrenzt die Anzahl der Zeichen für jeden Eintrag.\n"
-"Nützlich, wenn das Menü zu umfangreich ist."
 
 #. settings-schema.json->keybindings-section->description
 msgid "Keybindings"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/directory-menu@torchipeppo.pot
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/directory-menu@torchipeppo.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: directory-menu@torchipeppo 0.8.0\n"
+"Project-Id-Version: directory-menu@torchipeppo 0.9.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr ""
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr ""
 
@@ -58,12 +58,34 @@ msgstr ""
 msgid "Panel Text"
 msgstr ""
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
 msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
+msgstr ""
+
+#. settings-schema.json->limit-characters->description
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr ""
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr ""
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
 msgstr ""
 
 #. settings-schema.json->order-by->options
@@ -84,20 +106,6 @@ msgstr ""
 
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
-msgstr ""
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr ""
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr ""
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
 msgstr ""
 
 #. settings-schema.json->keybindings-section->description

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/es.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: 2024-11-01 11:42-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr "Abrir carpeta"
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr "Abrir en el terminal"
 
@@ -61,13 +61,38 @@ msgstr "Texto de información sobre herramientas"
 msgid "Panel Text"
 msgstr "Texto del panel"
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
-msgstr "Comportamiento"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
+msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Incluir archivos ocultos"
+
+#. settings-schema.json->limit-characters->description
+#, fuzzy
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr "Limitar el número máximo de caracteres en los submenús"
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Límite de caracteres"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"Limita (aproximadamente) el número de caracteres de cada entrada.\n"
+"Útil si crees que el menú es demasiado amplio."
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
+msgstr ""
 
 #. settings-schema.json->order-by->options
 msgid "Name"
@@ -88,22 +113,6 @@ msgstr "Mostrar primero los artículos favoritos"
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
 msgstr "Mostrar primero los elementos fijados"
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr "Limitar el número máximo de caracteres en los submenús"
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr "Límite de caracteres"
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
-"Limita (aproximadamente) el número de caracteres de cada entrada.\n"
-"Útil si crees que el menú es demasiado amplio."
 
 #. settings-schema.json->keybindings-section->description
 msgid "Keybindings"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/fi.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/fi.po
@@ -7,22 +7,22 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.8.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: \n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr "Avaa kansio"
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr "Avaa päätteessä"
 
@@ -33,8 +33,7 @@ msgstr "Directory Menu"
 #. metadata.json->description
 msgid ""
 "Quickly navigate through directories on your system using a dropdown menu."
-msgstr ""
-"Selaa nopeasti tietokoneen hakemistoja näppärän pudotusvalikon avulla."
+msgstr "Selaa nopeasti tietokoneen hakemistoja näppärän pudotusvalikon avulla."
 
 #. settings-schema.json->starting-uri->description
 msgid "Base Directory"
@@ -60,13 +59,38 @@ msgstr "Työkalun teksti"
 msgid "Panel Text"
 msgstr "Paneelin teksti"
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
-msgstr "Toiminta"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
+msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Näytä piilotiedostot"
+
+#. settings-schema.json->limit-characters->description
+#, fuzzy
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr "Rajoita kansionimien merkkien enimmäismäärää"
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Merkkirajoitus"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"(suunnilleen) Rajoita kunkin kansion merkkien määrää.\n"
+"Hyödyllinen, jos valikko on mielestäsi liian laaja."
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
+msgstr ""
 
 #. settings-schema.json->order-by->options
 msgid "Name"
@@ -87,22 +111,6 @@ msgstr "Näytä suosikit ensin"
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
 msgstr "Näytä kiinnitetyt ensin"
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr "Rajoita kansionimien merkkien enimmäismäärää"
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr "Merkkirajoitus"
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
-"(suunnilleen) Rajoita kunkin kansion merkkien määrää.\n"
-"Hyödyllinen, jos valikko on mielestäsi liian laaja."
 
 #. settings-schema.json->keybindings-section->description
 msgid "Keybindings"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/fr.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: 2025-03-07 16:57+0100\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr "Ouvrir le dossier"
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr "Ouvrir dans un terminal"
 
@@ -63,13 +63,38 @@ msgstr "Texte de l'info-bulle"
 msgid "Panel Text"
 msgstr "Texte sur le panneau"
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
-msgstr "Comportement"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
+msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Montrer également les fichiers cachés"
+
+#. settings-schema.json->limit-characters->description
+#, fuzzy
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr "Limiter le nombre maximum de caractères dans les sous-menus"
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Nombre maximal de caractères"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"Limiter (approximativement) le nombre de caractères de chaque entrée.\n"
+"Utile si vous trouvez que le menu est trop large."
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
+msgstr ""
 
 #. settings-schema.json->order-by->options
 msgid "Name"
@@ -90,22 +115,6 @@ msgstr "Afficher les favoris en premier"
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
 msgstr "Afficher les épinglés en premier"
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr "Limiter le nombre maximum de caractères dans les sous-menus"
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr "Nombre maximal de caractères"
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
-"Limiter (approximativement) le nombre de caractères de chaque entrée.\n"
-"Utile si vous trouvez que le menu est trop large."
 
 #. settings-schema.json->keybindings-section->description
 msgid "Keybindings"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/hu.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.7.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: 2024-11-25 07:14+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr "Könyvtár megnyitása"
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr "Megnyitás terminálban"
 
@@ -62,13 +62,38 @@ msgstr "Eszköztipp szövege"
 msgid "Panel Text"
 msgstr "Panel szöveg"
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
-msgstr "Viselkedés"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
+msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Tartalmazza a rejtett fájlokat is"
+
+#. settings-schema.json->limit-characters->description
+#, fuzzy
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr "Korlátozza a karakterek maximális számát az almenükben"
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Karakter Limit"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"(Körülbelül) Korlátozza a karakterek számát minden bejegyzésnél.\n"
+"Hasznos, ha úgy érzi, hogy a menü túl széles lenne."
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
+msgstr ""
 
 #. settings-schema.json->order-by->options
 msgid "Name"
@@ -89,22 +114,6 @@ msgstr "Először jelenítse meg a kedvenc elemeket"
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
 msgstr "Először jelenítse meg a kitűzött elemeket"
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr "Korlátozza a karakterek maximális számát az almenükben"
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr "Karakter Limit"
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
-"(Körülbelül) Korlátozza a karakterek számát minden bejegyzésnél.\n"
-"Hasznos, ha úgy érzi, hogy a menü túl széles lenne."
 
 #. settings-schema.json->keybindings-section->description
 msgid "Keybindings"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/it.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.8.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: 2024-11-06 18:40+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr "Apri cartella"
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr "Apri nel terminale"
 
@@ -60,13 +60,38 @@ msgstr "Didascalia"
 msgid "Panel Text"
 msgstr "Testo sul pannello"
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
-msgstr "Comportamento"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
+msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Mostra i file nascosti"
+
+#. settings-schema.json->limit-characters->description
+#, fuzzy
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr "Limita il numero di caratteri nel menù"
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Limite di caratteri"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"Limita (approssimativamente) il numero di caratteri di ciascuna riga.\n"
+"Utile se il menù risulta troppo largo."
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
+msgstr ""
 
 #. settings-schema.json->order-by->options
 msgid "Name"
@@ -87,22 +112,6 @@ msgstr "Mostra preferiti per primi"
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
 msgstr "Mostra elementi fissati per primi"
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr "Limita il numero di caratteri nel menù"
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr "Limite di caratteri"
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
-"Limita (approssimativamente) il numero di caratteri di ciascuna riga.\n"
-"Utile se il menù risulta troppo largo."
 
 #. settings-schema.json->keybindings-section->description
 msgid "Keybindings"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/nl.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: 2024-11-28 17:21+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr "Map openen"
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr "Openen in terminal"
 
@@ -59,13 +59,38 @@ msgstr "Tooltip-tekst"
 msgid "Panel Text"
 msgstr "Paneeltekst"
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
-msgstr "Gedrag"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
+msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Verborgen bestanden opnemen"
+
+#. settings-schema.json->limit-characters->description
+#, fuzzy
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr "Beperk het maximale aantal tekens op de submenu's"
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Tekenlimiet"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"(Bij benadering) Beperk het aantal tekens van elk item.\n"
+"Handig als u vindt dat het menu te breed is."
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
+msgstr ""
 
 #. settings-schema.json->order-by->options
 msgid "Name"
@@ -86,22 +111,6 @@ msgstr "Toon favoriete items eerst"
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
 msgstr "Toon vastgemaakte items eerst"
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr "Beperk het maximale aantal tekens op de submenu's"
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr "Tekenlimiet"
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
-"(Bij benadering) Beperk het aantal tekens van elk item.\n"
-"Handig als u vindt dat het menu te breed is."
 
 #. settings-schema.json->keybindings-section->description
 msgid "Keybindings"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/pt.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-10-31 18:13+0100\n"
+"POT-Creation-Date: 2025-04-22 12:08-0400\n"
 "PO-Revision-Date: 2024-12-28 07:34-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: popup_menu.py:71
+#. popup_menu.py:95
 msgid "Open Folder"
 msgstr "Abrir pasta"
 
-#: popup_menu.py:76
+#. popup_menu.py:100
 msgid "Open in Terminal"
 msgstr "Abrir no terminal"
 
@@ -61,13 +61,38 @@ msgstr "Texto da Dica"
 msgid "Panel Text"
 msgstr "Texto do Painel"
 
-#. settings-schema.json->behavior-section->description
-msgid "Behavior"
-msgstr "Comportameno"
+#. settings-schema.json->visibility-section->description
+msgid "Visibility"
+msgstr ""
+
+#. settings-schema.json->show-header->description
+msgid "Include \"Open Folder\" and \"Open in Terminal\""
+msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Incluir ficheiros ocultos"
+
+#. settings-schema.json->limit-characters->description
+#, fuzzy
+msgid "Limit the Maximum Number of Characters in the Submenus"
+msgstr "Limitar o Número Máximo de Caracteres nos Submenus"
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Limite de Caracteres"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"O número (aproximado) de caracteres para cada entrada.\n"
+"Útil caso achar que o menu está muito largo."
+
+#. settings-schema.json->ordering-section->description
+msgid "Ordering"
+msgstr ""
 
 #. settings-schema.json->order-by->options
 msgid "Name"
@@ -88,22 +113,6 @@ msgstr "Mostrar itens favoritos primeiro"
 #. settings-schema.json->pinned-first->description
 msgid "Show pinned items first"
 msgstr "Mostrar itens marcados primeiro"
-
-#. settings-schema.json->limit-characters->description
-msgid "Limit the Maximum Number of Characters on the Submenus"
-msgstr "Limitar o Número Máximo de Caracteres nos Submenus"
-
-#. settings-schema.json->character-limit->description
-msgid "Character Limit"
-msgstr "Limite de Caracteres"
-
-#. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
-"O número (aproximado) de caracteres para cada entrada.\n"
-"Útil caso achar que o menu está muito largo."
 
 #. settings-schema.json->keybindings-section->description
 msgid "Keybindings"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/popup_menu.py
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/popup_menu.py
@@ -90,17 +90,18 @@ class Cassettone:
         directory = Gio.File.new_for_uri(directory_uri)
         # // First, the two directory actions: Open Folder and Open In Terminal
 
-        open_image = Gtk.Image.new_from_icon_name("folder", Gtk.IconSize.MENU)
-        open_item = self.new_image_menu_item(_("Open Folder"), open_image)
-        open_item.connect("activate", lambda _: self.launch(directory.get_uri(), Gtk.get_current_event_time()))
-        menu.append(open_item)
+        if self.show_header:
+            open_image = Gtk.Image.new_from_icon_name("folder", Gtk.IconSize.MENU)
+            open_item = self.new_image_menu_item(_("Open Folder"), open_image)
+            open_item.connect("activate", lambda _: self.launch(directory.get_uri(), Gtk.get_current_event_time()))
+            menu.append(open_item)
 
-        term_image = Gtk.Image.new_from_icon_name("terminal", Gtk.IconSize.MENU)
-        term_item = self.new_image_menu_item(_("Open in Terminal"), term_image)
-        term_item.connect("activate", lambda _: self.open_terminal_at_path(directory.get_path()))
-        menu.append(term_item)
+            term_image = Gtk.Image.new_from_icon_name("terminal", Gtk.IconSize.MENU)
+            term_item = self.new_image_menu_item(_("Open in Terminal"), term_image)
+            term_item.connect("activate", lambda _: self.open_terminal_at_path(directory.get_path()))
+            menu.append(term_item)
 
-        menu.append(Gtk.SeparatorMenuItem.new())
+            menu.append(Gtk.SeparatorMenuItem.new())
 
         # log(directory_uri)
 
@@ -274,6 +275,7 @@ class Cassettone:
         self.favorites_first = args["favorites_first"]
         self.pinned_first = args["pinned_first"]
         self.order_by = args["order_by"]
+        self.show_header = args["show_header"]
 
         self.favorites = XApp.Favorites.get_default()
 

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
@@ -27,14 +27,39 @@
         "description": "Panel Text"
     },
 
-    "behavior-section": {
+    "visibility-section": {
         "type": "section",
-        "description": "Behavior"
+        "description": "Visibility"
+    },
+    "show-header": {
+        "type": "switch",
+        "default": true,
+        "description": "Include \"Open Folder\" and \"Open in Terminal\""
     },
     "show-hidden": {
         "type": "switch",
         "default": false,
         "description": "Include hidden files"
+    },
+    "limit-characters": {
+        "type": "switch",
+        "default": false,
+        "description": "Limit the Maximum Number of Characters in the Submenus"
+    },
+    "character-limit": {
+        "type": "spinbutton",
+        "default": 50,
+        "min": 5,
+        "max": 1000,
+        "step": 5,
+        "description": "Character Limit",
+        "tooltip": "(Approximately) Limit the number of characters of each entry.\nUseful if you think the menu is too wide.",
+        "dependency": "limit-characters"
+    },
+
+    "ordering-section": {
+        "type": "section",
+        "description": "Ordering"
     },
     "order-by": {
         "type": "combobox",
@@ -54,21 +79,6 @@
         "type": "switch",
         "default": false,
         "description": "Show pinned items first"
-    },
-    "limit-characters": {
-        "type": "switch",
-        "default": false,
-        "description": "Limit the Maximum Number of Characters on the Submenus"
-    },
-    "character-limit": {
-        "type": "spinbutton",
-        "default": 50,
-        "min": 5,
-        "max": 1000,
-        "step": 5,
-        "description": "Character Limit",
-        "tooltip": "(Approximately) Limit the number of characters of each entry.\nUseful if you think the menu is too wide.",
-        "dependency": "limit-characters"
     },
 
     "keybindings-section": {


### PR DESCRIPTION
A long overdue fulfillment of the request from @Kalo79 . The title says it all this time.
Fixes #6890 