### PR TITLE
[notifications-enhanced@hilyxx] Fixed an issue with 'Show do not disturb icon' option.

### DIFF
--- a/notifications-enhanced@hilyxx/README.md
+++ b/notifications-enhanced@hilyxx/README.md
@@ -3,10 +3,8 @@ Notifications Enhanced applet
 
 This applet is similar to system notification applet but with more options to manage easily notifications.
 #### Features
-* Add a new icon to panel when "Do not disturb" mod is enabled
+* Add new icon to the panel when "Do not disturb" mod is enabled
 * New menu label when "Do not disturb" mod is enabled
-* Add a toggle switch to easily enable/disable notifications
-* Add option to show or hide notification settings in menu
-* Add an option to show "do not disturb" icon on panel when show empty tray option is disabled
+* New toggle switch in the menu to easily enable/disable notifications
+* New option to show "do not disturb" icon on panel when show empty tray option is disabled
 * Tooltip now displays notification count
-#### Known issues

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/applet.js
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/applet.js
@@ -152,6 +152,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         this._maincontainer.add(this.scrollview);
         this.scrollview.add_actor(this._notificationbin);
         this.scrollview.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
+        this.scrollview.set_clip_to_allocation(true);
 
         let vscroll = this.scrollview.get_vscroll_bar();
         vscroll.connect('scroll-start', Lang.bind(this, function() {
@@ -281,7 +282,6 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
                     
             if (!this.showNotificationCount) {  // Don't show notification count
                 this.set_applet_label('');
-                // this.clear_action.actor.hide();
             }
             this.menu_label.label.set_text(stringify(count));
             this._notificationbin.queue_relayout();
@@ -313,20 +313,17 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
 
      _show_hide_tray() { // Show or hide the notification tray.
         if(!global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
-            if (this.notifications.length || this.showEmptyTray) {
+            if (this.notifications.length || this.showEmptyTray == true) {
                 this.actor.show();
-            } else {
-                this.actor.hide();
             }
+            this.update_list();
         }
     }
 
     _show_disturb_icon() { // Show disturb icon when show empty tray option is disabled.
         if(global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
-           if (!this.showEmptyTray) {                
-                this.actor.show();
-            } else {
-                this.actor.hide();
+           if (this.showEmptyTray == true) {                
+               this.actor.show();
             }
          }
          this.update_list();

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/metadata.json
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/metadata.json
@@ -3,7 +3,7 @@
 "name": "Notifications Enhanced",
 "description": "A notification applet but with more options",
 "website": "https://github.com/linuxmint/cinnamon-spices-applets",
-"version": "1.0",
+"version": "1.1",
 "author": "hilyxx",
 "role": "notifications"
 }


### PR DESCRIPTION
- Fixed an issue when the “Show do not disturb icon” option is enabled. The icon may disappear if the “Show empty tray” option is enabled at the same time.
- Added rcalixte's fixe #12296
- Updated Readme and metadata