### PR TITLE
Missing value in emit of  'value-changed' action of cinnamon-timer.

### DIFF
--- a/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/6.4/applet.js
+++ b/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/6.4/applet.js
@@ -216,7 +216,7 @@ class MyApplet extends Applet.TextIconApplet {
         this.menu.addMenuItem(this.timerMenuItem);
 
         this._timerSlider = new PopupMenu.PopupSliderMenuItem(0);
-        this._timerSlider.connect('value-changed', () => this.sliderChanged());
+        this._timerSlider.connect('value-changed', (slider, value) => this.sliderChanged(slider, value));
         this._timerSlider.connect('drag-end', () => this.sliderReleased());
 
         this._contentSection = new PopupMenu.PopupMenuSection();


### PR DESCRIPTION
In Distro: Linux Mint 22.1 Xia base: Ubuntu 24.04 noble the slider didn't work, gave 24 hours time-out regardless of the slide.

Turned out that 'value' passed with 'value-changed' into sliderChanged(slider, value) was undefined, the commit is fixing this.