### PR TITLE
app-launcher@mchilli: separator in groups

### DIFF
--- a/app-launcher@mchilli/README.md
+++ b/app-launcher@mchilli/README.md
@@ -14,6 +14,7 @@ _A simple launcher for your panels_
 -   customize different properties of your applet:
     -   set/hide label
     -   set custom applet icon
+    -   bind menu to a specific workspace
     -   enable/disable **notification**
     -   set **hotkey** to open the menu
     -   open with hotkey at mouse position

--- a/app-launcher@mchilli/files/app-launcher@mchilli/dialogs.py
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/dialogs.py
@@ -163,7 +163,7 @@ class AppDialog(BaseDialog):
             file = dialog.get_filename()
             dialog.destroy()
             if file.endswith('.desktop'):
-                config = configparser.ConfigParser(interpolation=None)
+                config = configparser.ConfigParser(interpolation=None, strict=False)
                 try:
                     config.read(file)
                 except Exception as e:

--- a/app-launcher@mchilli/files/app-launcher@mchilli/dialogs.py
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/dialogs.py
@@ -19,22 +19,87 @@ DEFAULT_FOLDER_ICON = "folder"
 ICON_VALID = "object-select-symbolic"
 ICON_INVALID = "process-stop-symbolic"
 
-class EditDialog():
+class BaseDialog:
+    def run(self):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def set_transient_for(self, parent=None):
+        if self.dialog:
+            self.dialog.set_transient_for(parent)
+
+    def on_size_allocate(self, widget, rect):
+        widget.disconnect_by_func(self.on_size_allocate)
+        hints = Gdk.Geometry()
+        hints.max_width = widget.get_screen().get_width()
+        hints.max_height = rect.height
+        mask = Gdk.WindowHints.MAX_SIZE
+        widget.set_geometry_hints(None, hints, mask)
+
+    def on_add_group(self, *args):
+        dialog = EditDialog('group', self.groups)
+        dialog.set_transient_for(self.dialog)
+        data, _ = dialog.run()
+        if data:
+            self.group_entry.append(data["name"], data["name"])
+            self.group_entry.set_active_id(data["name"])
+            self.new_group = {
+                "type": data["type"],
+                "name": data["name"],
+                "icon": data["icon"]
+            }
+    
+    def on_input_changed(self, *args):
+        self._validate_inputs()
+    
+    def _validate_inputs(self):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def on_choose_icon(self, *args):
+        ''' Opens an icon chooser dialog to select an icon '''
+        dialog = XApp.IconChooserDialog()
+        dialog.set_transient_for(self.dialog)
+        dialog.set_modal(True)
+
+        if self.item:
+            icon_string = self.item[1]
+            if hasattr(icon_string, 'to_string'):
+                icon_string = icon_string.to_string()
+
+            response = dialog.run_with_icon(icon_string)
+        else:
+            response = dialog.run()
+
+        if response == Gtk.ResponseType.OK:
+            self._set_icon(dialog.get_icon_string())
+
+    def _set_icon(self, icon_string):
+        ''' Sets the icon for the widget based on the provided icon_string '''
+        if hasattr(icon_string, 'to_string'):
+            icon_string = icon_string.to_string()
+        self.icon_string = icon_string
+        if icon_string.startswith("/"):
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(icon_string, 48, 48)
+            surface = Gdk.cairo_surface_create_from_pixbuf(pixbuf, self.dialog.get_scale_factor(), None)
+            self.icon_entry.set_from_surface(surface)
+        else:
+            self.icon_entry.set_from_icon_name(icon_string, Gtk.IconSize.DIALOG)
+
+    def _get_icon(self):
+        ''' Returns the current icon string '''
+        return self.icon_string
+
+class AppDialog(BaseDialog):
     def __init__(self, variant, groups, item=None):
         self.groups = groups
         self.variant = variant
         self.item = item
-        if self.variant == 'edit' and item:
-            self.type = self.item[0]['type']
-        else:
-            self.type = self.variant
-        
-        self.icon_string = DEFAULT_FOLDER_ICON if self.type == "group" else DEFAULT_APP_ICON
+        self.type = 'app'
         self.name_origin = ''
         self.new_group = None
+        self.icon_string = DEFAULT_APP_ICON
 
         self.builder = Gtk.Builder()
-        self.builder.add_from_file(os.path.join(APPLET_DIR, "ui", f"{self.type}.glade"))
+        self.builder.add_from_file(os.path.join(APPLET_DIR, "ui", "app.glade"))
         self.builder.connect_signals(self)
 
         self.dialog = self.builder.get_object("dialog")
@@ -45,115 +110,51 @@ class EditDialog():
 
         self.builder.get_object("button_cancel").set_label(_("Cancel"))
         self.builder.get_object("label_name").set_text(_("Name"))
+        self.builder.get_object("label_group").set_text(_("Group"))
+        self.builder.get_object("label_command").set_text(_("Command"))
 
         self.name_entry = self.builder.get_object("name")
         self.icon_entry = self.builder.get_object("icon")
+        self.group_entry = self.builder.get_object("group")
+        self.command_entry = self.builder.get_object("command")
 
-        if self.type == 'app':
-            self.builder.get_object("label_group").set_text(_("Group"))
-            self.builder.get_object("label_command").set_text(_("Command"))
-
-            self.group_entry = self.builder.get_object("group")
-            self.command_entry = self.builder.get_object("command")
-
-            self.group_entry.append('', '') #to display an empty group entry
-            self.group_entry.set_active_id('')
-            for group in self.groups:
-                self.group_entry.append(group, group)
+        self.group_entry.append('', '')
+        self.group_entry.set_active_id('')
+        for group in self.groups:
+            self.group_entry.append(group, group)
 
         if self.variant == 'edit':
             self.name_entry.set_text(self.item[2])
             self.name_origin = self.item[2]
             self._set_icon(self.item[1])
-            if self.type == 'app':
-                self.group_entry.set_active_id(self.item[0]["group"])
-                self.command_entry.set_text(self.item[3])
-            
+            self.group_entry.set_active_id(self.item[0]["group"])
+            self.command_entry.set_text(self.item[3])
             self._validate_inputs()
 
     def run(self):
         response = self.dialog.run()
-        
+
         if response != Gtk.ResponseType.OK:
             self.dialog.destroy()
             return None, None
 
         values = {
-                "type": self.type,
-                "name": self.name_entry.get_text(),
-                "icon": self._get_icon()
-            }
-        
-        if self.type == 'app':
-            values["group"] = self.group_entry.get_active_id()
-            values["command"] = self.command_entry.get_text()
-        
+            "type": self.type,
+            "name": self.name_entry.get_text(),
+            "icon": self._get_icon(),
+            "group": self.group_entry.get_active_id(),
+            "command": self.command_entry.get_text()
+        }
+
         self.dialog.destroy()
         return values, self.new_group
-    
-    def on_size_allocate(self, widget, rect):
-        widget.disconnect_by_func(self.on_size_allocate)
-        hints = Gdk.Geometry()
-        hints.max_width = widget.get_screen().get_width()
-        hints.max_height = rect.height
-        mask = Gdk.WindowHints.MAX_SIZE
-        widget.set_geometry_hints(None, hints, mask)
-
-    def on_choose_icon(self, *args):
-        ''' Opens an icon chooser dialog, allowing the user to select an icon
-            If an item exists, its current icon is pre-selected in the dialog
-        '''
-        dialog = XApp.IconChooserDialog()
-        dialog.set_transient_for(self.dialog)
-        dialog.set_modal(True)
-
-        if self.item:
-            icon_string = self.item[1]
-            if hasattr(icon_string, 'to_string'):
-                # is an object when opened from Settingswidget else string
-                icon_string = icon_string.to_string()
-
-            response = dialog.run_with_icon(icon_string)
-        else:
-            response = dialog.run()
-
-        if response == Gtk.ResponseType.OK:
-            self._set_icon(dialog.get_icon_string())
-    
-    def _set_icon(self, icon_string):
-        ''' Sets the icon for the widget based on the provided icon_string
-            If the icon_string is a file path, it loads the image from the file
-            Otherwise, it sets the icon using the icon theme's icon name
-        '''
-        if hasattr(icon_string, 'to_string'):
-            # is an object when opened from Settingswidget else string
-            icon_string = icon_string.to_string()
-
-        self.icon_string = icon_string
-
-        if icon_string.startswith("/"):
-            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(icon_string, 48, 48)
-            surface = Gdk.cairo_surface_create_from_pixbuf(pixbuf, self.dialog.get_scale_factor(), None)
-            self.icon_entry.set_from_surface(surface)
-        else:
-            self.icon_entry.set_from_icon_name(icon_string, Gtk.IconSize.DIALOG)
-
-    def _get_icon(self):
-        ''' Returns the current icon string
-        '''
-        return self.icon_string
 
     def on_open_filechooser(self, *args):
         dialog = Gtk.FileChooserDialog(
-            title=APP_NAME, 
-            parent=self.dialog, 
+            title=APP_NAME,
+            parent=self.dialog,
             action=Gtk.FileChooserAction.OPEN,
-            buttons=(
-                Gtk.STOCK_CANCEL,
-                Gtk.ResponseType.CANCEL,
-                Gtk.STOCK_OPEN,
-                Gtk.ResponseType.OK
-            )
+            buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
         )
         dialog.set_deletable(False)
 
@@ -163,7 +164,6 @@ class EditDialog():
             dialog.destroy()
             if file.endswith('.desktop'):
                 config = configparser.ConfigParser(interpolation=None)
-
                 try:
                     config.read(file)
                 except Exception as e:
@@ -171,7 +171,6 @@ class EditDialog():
                     return
 
                 data = config['Desktop Entry']
-
                 import_data = {}
                 if 'Name' in data:
                     if self.name_entry.get_text() == '':
@@ -196,90 +195,211 @@ class EditDialog():
                         if 'Name' in data: self.name_entry.set_text(data['Name'])
                         if 'Icon' in data: self._set_icon(data['Icon'])
                         if 'Exec' in data: self.command_entry.set_text(data['Exec'])
-
-            else:    
+            else:
                 if self._is_command_valid(file):
                     self.command_entry.set_text(file)
                 else:
                     mimetype, val = Gio.content_type_guess(filename=file, data=None)
                     icon = Gio.content_type_get_generic_icon_name(mimetype)
                     self._set_icon(icon)
-                    
                     self.command_entry.set_text(f'xdg-open {file}')
         else:
             dialog.destroy()
 
-    def on_add_group(self, *args):
-        dialog = EditDialog('group', self.groups)
-        dialog.set_transient_for(self.dialog)
-
-        data, _ = dialog.run()
-        if data:
-            self.group_entry.append(data["name"], data["name"])
-            self.group_entry.set_active_id(data["name"])
-            self.new_group =  {
-                "type": data["type"],
-                "name": data["name"],
-                "icon": data["icon"]
-            }
-
-    def set_transient_for(self, parent=None):
-        self.dialog.set_transient_for(parent)
-
-    def on_input_changed(self, *args):
-        self._validate_inputs()
-
     def _validate_inputs(self):
         name = self.name_entry.get_text()
+        valid_name = name.strip() != ''
+        if valid_name:
+            self.name_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_VALID)
+            self.name_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("Valid name"))
+        else:
+            self.name_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_INVALID)
+            self.name_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("The name cannot be empty"))
 
+        valid_command = self._is_command_valid(self.command_entry.get_text())
+        if valid_command:
+            self.command_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_VALID)
+            self.command_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("Valid command"))
+        else:
+            self.command_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_INVALID)
+            self.command_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("The command is not valid"))
+
+        self.button_ok.set_sensitive(valid_name and valid_command)
+
+    def _is_command_valid(self, command):
+        try:
+            if command == "":
+                return False
+            success, parsed = GLib.shell_parse_argv(command)
+            if not success:
+                return False
+            if GLib.find_program_in_path(parsed[0]):
+                return True
+            if not os.path.isdir(parsed[0]) and os.access(parsed[0], os.X_OK):
+                return True
+        except Exception as e:
+            print(f"Unexpected error: {e}")
+        return False
+
+class GroupDialog(BaseDialog):
+    def __init__(self, variant, groups, item=None):
+        self.groups = groups
+        self.variant = variant
+        self.item = item
+        self.type = 'group'
+        self.name_origin = ''
+        self.icon_string = DEFAULT_FOLDER_ICON
+
+        self.builder = Gtk.Builder()
+        self.builder.add_from_file(os.path.join(APPLET_DIR, "ui", "group.glade"))
+        self.builder.connect_signals(self)
+
+        self.dialog = self.builder.get_object("dialog")
+        self.dialog.set_title(APP_NAME)
+
+        self.button_ok = self.builder.get_object("button_ok")
+        self.button_ok.set_label(_("OK"))
+        self.builder.get_object("button_cancel").set_label(_("Cancel"))
+        self.builder.get_object("label_name").set_text(_("Name"))
+
+        self.name_entry = self.builder.get_object("name")
+        self.icon_entry = self.builder.get_object("icon")
+
+        if self.variant == 'edit':
+            self.name_entry.set_text(self.item[2])
+            self.name_origin = self.item[2]
+            self._set_icon(self.item[1])
+            self._validate_inputs()
+
+    def run(self):
+        response = self.dialog.run()
+        if response != Gtk.ResponseType.OK:
+            self.dialog.destroy()
+            return None, None
+
+        values = {
+            "type": self.type,
+            "name": self.name_entry.get_text(),
+            "icon": self._get_icon()
+        }
+
+        self.dialog.destroy()
+        return values, None
+    
+    def _validate_inputs(self):
+        name = self.name_entry.get_text()
         valid_name = False
 
         if name.strip() == '':
             self.name_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_INVALID)
             self.name_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("The name cannot be empty"))
         else:
-            if self.type == 'group':
-                if name != self.name_origin and name in self.groups:
-                    self.name_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_INVALID)
-                    self.name_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("The name is already used"))
-                else:
-                    valid_name = True
+            if name != self.name_origin and name in self.groups:
+                self.name_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_INVALID)
+                self.name_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("The name is already used"))
             else:
                 valid_name = True
+
         if valid_name:
             self.name_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_VALID)
             self.name_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("Valid name"))
 
-        if self.type == 'app':
-            valid_command = self._is_command_valid(self.command_entry.get_text())
-            if valid_command:
-                self.command_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_VALID)
-                self.command_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("Valid command"))
-            else:
-                self.command_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, ICON_INVALID)
-                self.command_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("The command is not valid"))
+        self.button_ok.set_sensitive(valid_name)
 
-        self.button_ok.set_sensitive(valid_name and (valid_command if self.type == 'app' else True))
+class SeparatorDialog(BaseDialog):
+    def __init__(self, variant, groups, item=None):
+        self.groups = groups
+        self.variant = variant
+        self.item = item
+        self.type = 'separator'
+        self.new_group = None
 
-    def _is_command_valid(self, command):
-        try:
-            if command == "":
-                return False
-            
-            success, parsed = GLib.shell_parse_argv(command)
-            if not success:
-                return False
+        self.builder = Gtk.Builder()
+        self.builder.add_from_file(os.path.join(APPLET_DIR, "ui", "separator.glade"))
+        self.builder.connect_signals(self)
 
-            if GLib.find_program_in_path(parsed[0]):
-                return True
+        self.dialog = self.builder.get_object("dialog")
+        self.dialog.set_title(APP_NAME)
 
-            if not os.path.isdir(parsed[0]) and os.access(parsed[0], os.X_OK):
-                return True
-            
-        except Exception as e:
-            print(f"Unexpected error: {e}")
+        self.button_ok = self.builder.get_object("button_ok")
+        self.button_ok.set_label(_("OK"))
 
-        return False
+        self.builder.get_object("button_cancel").set_label(_("Cancel"))
+        self.builder.get_object("label_group").set_text(_("Group"))
+
+        self.group_entry = self.builder.get_object("group")
+        self.color_entry = self.builder.get_object("color")
+
+        self.group_entry.append('', '')
+        self.group_entry.set_active_id('')
+        for group in self.groups:
+            self.group_entry.append(group, group)
+
+        if self.variant == 'edit':
+            self.group_entry.set_active_id(self.item[0]["group"])
+            self.color_entry.set_rgba(Gdk.RGBA(
+                red=self.item[0]["color"][0] / 255.0,
+                green=self.item[0]["color"][1] / 255.0,
+                blue=self.item[0]["color"][2] / 255.0,
+                alpha=1.0
+            ))
+    
+    def run(self):
+        response = self.dialog.run()
+        if response != Gtk.ResponseType.OK:
+            self.dialog.destroy()
+            return None, None
+
+        color = self.color_entry.get_rgba()
+        values = {
+            "type": self.type,
+            "name": '',
+            "icon": '',
+            "group": self.group_entry.get_active_id(),
+            "command": '',
+            "color": [
+                int(round(color.red * 255)),
+                int(round(color.green * 255)),
+                int(round(color.blue * 255))
+            ]
+        }
+        self.dialog.destroy()
+        return values, self.new_group
+
+class EditDialog(BaseDialog):
+    dialog_classes = {}
+
+    def __init__(self, variant, groups, item=None):
+        self.register_builtin_dialogs()
+        self.groups = groups
+        self.variant = variant
+        self.item = item
+
+        if self.variant == 'edit' and item:
+            self.type = self.item[0]['type']
+        else:
+            self.type = self.variant
+
+        dialog_class = self.dialog_classes.get(self.type)
+        if dialog_class:
+            self.dialog = dialog_class(variant, groups, item)
+        else:
+            raise ValueError(f"Unknown dialog type: {self.type}")
+
+    def run(self):
+        return self.dialog.run()
+
+    @classmethod
+    def register_dialog_class(cls, dialog_type, dialog_class):
+        cls.dialog_classes[dialog_type] = dialog_class
+
+    def register_builtin_dialogs(self):
+        if 'app' not in self.dialog_classes:
+            self.register_dialog_class('app', AppDialog)
+        if 'group' not in self.dialog_classes:
+            self.register_dialog_class('group', GroupDialog)
+        if 'separator' not in self.dialog_classes:
+            self.register_dialog_class('separator', SeparatorDialog)
 
 class ImportDialog():
     def __init__(self, data):

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/app-launcher@mchilli.pot
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/app-launcher@mchilli.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: app-launcher@mchilli 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -33,63 +33,64 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr ""
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr ""
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr ""
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr ""
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr ""
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr ""
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr ""
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr ""
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr ""
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr ""
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr ""
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr ""
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr ""
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr ""
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr ""
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr ""
 
@@ -140,7 +141,7 @@ msgstr ""
 msgid "Save the current configuration"
 msgstr ""
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr ""
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/ca.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: app-launcher@mchilli 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2025-03-02 00:27+0100\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -34,63 +34,64 @@ msgstr "Eliminar"
 msgid "Edit"
 msgstr "Editar"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Cancel·lar"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "D'acord"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Nom"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Grup"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Ordre"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "El nom no pot estar buit"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "El nom ja està en ús"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Nom vàlid"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "El nom no pot estar buit"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Ordre vàlida"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "L'ordre no és vàlida"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "El nom ja està en ús"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "Quina informació s'hauria de substituir al fitxer *.desktop?"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "segur que ho voleu eliminar?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "No"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Sí"
 
@@ -141,7 +142,7 @@ msgstr "Desar?"
 msgid "Save the current configuration"
 msgstr "Desa la configuració actual"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Separador"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/da.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2024-09-05 17:08+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -35,63 +35,64 @@ msgstr "Slet"
 msgid "Edit"
 msgstr "Redigér"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Annullér"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "OK"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Navn"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Gruppe"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Kommando"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "Navnet kan ikke være tomt"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "Navnet er allerede brugt"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Gyldigt navn"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "Navnet kan ikke være tomt"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Gyldig kommando"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "Kommandoen er ugyldig"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "Navnet er allerede brugt"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "Hvilke data skal erstattes fra *.desktop-filen?"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "Er du sikker på, du vil fjerne programmet fra menuen?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "Nej"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Ja"
 
@@ -142,7 +143,7 @@ msgstr "Spare?"
 msgid "Save the current configuration"
 msgstr "Gem den aktuelle konfiguration"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Adskiller"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/de.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2025-02-25 17:53+0100\n"
 "Last-Translator: MCHilli\n"
 "Language-Team: \n"
@@ -35,63 +35,64 @@ msgstr "Löschen"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Abbruch"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "OK"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Name"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Gruppe"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Befehl"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "Der Name darf nicht leer sein"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "Der Name wird schon verwendet"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Gültiger Name"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "Der Name darf nicht leer sein"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Gültiger Befehl"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "Der Befehl ist nicht gültig"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "Der Name wird schon verwendet"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "Welche Daten sollen von der *.desktop Datei ersetzt werden?"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "wirklich löschen?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "Nein"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Ja"
 
@@ -142,7 +143,7 @@ msgstr "Speichern?"
 msgid "Save the current configuration"
 msgstr "Aktuelle Konfiguration speichern"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Trenner"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/es.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2025-02-26 11:08-0300\n"
 "Last-Translator: haggen88\n"
 "Language-Team: \n"
@@ -35,63 +35,64 @@ msgstr "Borrar"
 msgid "Edit"
 msgstr "Editar"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Cancelar"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "OK"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Nombre"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Grupo"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Comando"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "El nombre no puede estar vacío"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "El nombre ya está siendo utilizado"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Nombre válido"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "El nombre no puede estar vacío"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Comando válido"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "El comando no es válido"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "El nombre ya está siendo utilizado"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "¿Qué datos deben reemplazarse del archivo * .desktop?"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "¿realmente lo desea borrar?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "No"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Sí"
 
@@ -142,7 +143,7 @@ msgstr "¿Guardar?"
 msgid "Save the current configuration"
 msgstr "Guardar la configuración actual"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Separador"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/fi.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-02 20:47+0300\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2025-04-03 18:58+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -19,130 +19,131 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: applet.js:117
+#. applet.js:117
 msgid "All workspaces"
 msgstr "Kaikki työtilat"
 
-#: applet.js:145
+#. applet.js:145
 msgid "Edit Applications"
 msgstr "Muokkaa sovelluksia"
 
-#: applet.js:864 applet.js:1158
+#. applet.js:864 applet.js:1158
 msgid "Delete"
 msgstr "Poista"
 
-#: applet.js:865 applet.js:1159
+#. applet.js:865 applet.js:1159
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Peru"
 
-#: dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "OK"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#: dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Nimi"
 
 #. settings-schema.json->list-applications->columns->title
-#: dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Ryhmä"
 
 #. settings-schema.json->list-applications->columns->title
-#: dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Komento"
 
-#: dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "Nimi ei voi olla tyhjä"
-
-#: dialogs.py:244
-msgid "The name is already used"
-msgstr "Nimi on jo käytössä"
-
-#: dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Kelvollinen nimi"
 
-#: dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "Nimi ei voi olla tyhjä"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Kelvollinen komento"
 
-#: dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "Komento ei kelpaa"
 
-#: dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "Nimi on jo käytössä"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "Mitä tietoja tiedostosta *.desktop tulisi korvata?"
 
-#: dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "Haluatko poistaa?"
 
-#: dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "Ei"
 
-#: dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Kyllä"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
 #. settings-schema.json->launcher-icon->description
-#: widgets.py:46 ui/widget.glade:29
+#. widgets.py:46 ui/widget.glade:29
 msgid "Icon"
 msgstr "Kuvake"
 
-#: widgets.py:51
+#. widgets.py:51
 msgid "Add application"
 msgstr "Lisää sovellus"
 
-#: widgets.py:52
+#. widgets.py:52
 msgid "Add new entry"
 msgstr "Lisää uusi kohde"
 
-#: widgets.py:55
+#. widgets.py:55
 msgid "Add separator"
 msgstr "Lisää erotin"
 
-#: widgets.py:58
+#. widgets.py:58
 msgid "Edit selected entry"
 msgstr "Muokkaa valittua merkintää"
 
-#: widgets.py:61
+#. widgets.py:61
 msgid "Duplicate selected entry"
 msgstr "Monista valittu merkintä"
 
-#: widgets.py:64
+#. widgets.py:64
 msgid "Move selected entry up"
 msgstr "Siirrä merkintää ylöspäin"
 
-#: widgets.py:67
+#. widgets.py:67
 msgid "Move selected entry down"
 msgstr "Siirrä merkintää alaspäin"
 
-#: widgets.py:70
+#. widgets.py:70
 msgid "Remove selected entry"
 msgstr "Poista valittu merkintä"
 
-#: widgets.py:76
+#. widgets.py:76
 msgid "Save?"
 msgstr "Tallentaa?"
 
-#: widgets.py:77
+#. widgets.py:77
 msgid "Save the current configuration"
 msgstr "Tallenna nykyinen kokoonpano"
 
-#: widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Erotin"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/fr.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2025-03-07 16:45+0100\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -35,64 +35,65 @@ msgstr "Supprimer"
 msgid "Edit"
 msgstr "Modifier"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Abandon"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "OK"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Nom"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Groupe"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Commande"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "Le nom ne peut pas être vide"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "Le nom est déjà utilisé"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Nom valide"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "Le nom ne peut pas être vide"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Commande valide"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "La commande est invalide"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "Le nom est déjà utilisé"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr ""
 "Quelles données doivent être remplacées à partir du fichier *.desktop ?"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "supprimer vraiment ?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "Non"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Oui"
 
@@ -143,7 +144,7 @@ msgstr "Sauver?"
 msgid "Save the current configuration"
 msgstr "Sauvegarder la configuration actuelle"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Séparateur"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/hu.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2025-04-11 09:20+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -34,63 +34,64 @@ msgstr "Törlés"
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Mégse"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "OK"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Név"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Csoport"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Parancs"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "A név nem lehet üres"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "A megadott név már használatban van"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Érvényes név"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "A név nem lehet üres"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Érvényes parancs"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "Az elindítandó parancs nem érvényes"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "A megadott név már használatban van"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "Milyen adatok legyenek kicserélve a *.desktop fájlban?"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "valóban törli?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "Nem"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Igen"
 
@@ -141,7 +142,7 @@ msgstr "Mentés?"
 msgid "Save the current configuration"
 msgstr "Az aktuális konfiguráció mentése"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Elválasztó"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/it.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2025-01-03 15:05+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -35,63 +35,64 @@ msgstr "Elimina"
 msgid "Edit"
 msgstr "Modifica"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Annulla"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "OK"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Nome"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Gruppo"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Comando"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "Il nome non può essere vuoto"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "Nome già in uso"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Nome valido"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "Il nome non può essere vuoto"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Comando valido"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "Il comando non è valido"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "Nome già in uso"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "Quale dati vuoi sostituire dal file *.desktop?"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "procedere alla rimozione?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "No"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Sì"
 
@@ -142,7 +143,7 @@ msgstr "Salvare?"
 msgid "Save the current configuration"
 msgstr "Salvare la configurazione corrente"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Separatore"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/nl.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: app-launcher@mchilli 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2025-05-13 14:33+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -33,63 +33,64 @@ msgstr "Verwijderen"
 msgid "Edit"
 msgstr "Bewerken"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Annuleren"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "OK"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Naam"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Groep"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Commando"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "De naam mag niet leeg zijn"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "Deze naam wordt al gebruikt"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Geldige naam"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "De naam mag niet leeg zijn"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Geldig commando"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "Het commando is niet geldig"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "Deze naam wordt al gebruikt"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "Welke gegevens moeten worden vervangen in het *.desktop-bestand?"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "echt verwijderen?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "Nee"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Ja"
 
@@ -140,7 +141,7 @@ msgstr "Opslaan?"
 msgid "Save the current configuration"
 msgstr "De huidige configuratie opslaan"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Scheidingsteken"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/ru.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -30,63 +30,64 @@ msgstr "Удалить"
 msgid "Edit"
 msgstr "Редактировать"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "Отменить"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "OK"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Имя"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Группа"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Команда"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "Имя не может быть пустым"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "Имя уже занято"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Допустимое имя"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "Имя не может быть пустым"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Допустимая команда"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "Эта команда недопустима"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "Имя уже занято"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "Какие данные следует заменить из *.desktop файла?"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "точно удалить?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "Нет"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Да"
 
@@ -137,7 +138,7 @@ msgstr "Сохранить?"
 msgid "Save the current configuration"
 msgstr "Сохранить текущую конфигурацию"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "Разделитель"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/tr.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2024-09-05 17:37+0200\n"
 "Last-Translator: Gökhan Gökkaya <gokhanlnx@gmail.com>\n"
 "Language-Team: \n"
@@ -35,63 +35,64 @@ msgstr "Sil"
 msgid "Edit"
 msgstr "Düzenle"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "İptal"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr ""
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "Ad"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "Grup"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "Komut"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "İsim boş olamaz"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "İsim zaten kullanılıyor"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "Geçerli isim"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "İsim boş olamaz"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "Geçerli komut"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "Komut geçerli değil"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "İsim zaten kullanılıyor"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr ""
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "silmek istiyor musun?"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "Hayır"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "Evet"
 
@@ -144,7 +145,7 @@ msgstr "Kaydetmek mi?"
 msgid "Save the current configuration"
 msgstr "Geçerli yapılandırmayı kaydet"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr ""
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/zh_CN.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/zh_CN.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2024-09-05 17:38+0200\n"
 "Last-Translator: Slinet6056 <slinet6056@gmail.com>\n"
 "Language-Team: \n"
@@ -35,63 +35,64 @@ msgstr "删除"
 msgid "Edit"
 msgstr "编辑"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "取消"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr ""
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "名称"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "组"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "命令"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "名称不能为空"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "名称已被使用"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "有效名称"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "名称不能为空"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "有效命令"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "命令无效"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "名称已被使用"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "您想要替换 *.desktop 文件中的哪些信息？"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "确认删除？"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr ""
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr ""
 
@@ -142,7 +143,7 @@ msgstr ""
 msgid "Save the current configuration"
 msgstr ""
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "分隔符"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/po/zh_TW.po
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/po/zh_TW.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: app-launcher@mchilli 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-02-25 17:53+0100\n"
+"POT-Creation-Date: 2025-05-14 16:58+0200\n"
 "PO-Revision-Date: 2025-04-23 21:18+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -33,63 +33,64 @@ msgstr "刪除"
 msgid "Edit"
 msgstr "編輯"
 
-#. applet.js:866 applet.js:1160 dialogs.py:46 dialogs.py:296 widgets.py:73
+#. applet.js:866 applet.js:1160 dialogs.py:111 dialogs.py:262 dialogs.py:327
+#. dialogs.py:416 widgets.py:73
 msgid "Cancel"
 msgstr "取消"
 
-#. dialogs.py:44 dialogs.py:295
+#. dialogs.py:109 dialogs.py:261 dialogs.py:325 dialogs.py:415
 msgid "OK"
 msgstr "確定"
 
 #. settings-schema.json->list-applications->columns->title
 #. settings-schema.json->list-groups->columns->title
-#. dialogs.py:47 widgets.py:47 ui/widget.glade:40
+#. dialogs.py:112 dialogs.py:263 widgets.py:47 ui/widget.glade:40
 msgid "Name"
 msgstr "名稱"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:53
+#. dialogs.py:113 dialogs.py:328
 msgid "Group"
 msgstr "群組"
 
 #. settings-schema.json->list-applications->columns->title
-#. dialogs.py:54 widgets.py:48 ui/widget.glade:51
+#. dialogs.py:114 widgets.py:48 ui/widget.glade:51
 msgid "Command"
 msgstr "命令"
 
-#. dialogs.py:239
-msgid "The name cannot be empty"
-msgstr "名稱不能為空"
-
-#. dialogs.py:244
-msgid "The name is already used"
-msgstr "名稱已被使用"
-
-#. dialogs.py:251
+#. dialogs.py:214 dialogs.py:305
 msgid "Valid name"
 msgstr "有效名稱"
 
-#. dialogs.py:257
+#. dialogs.py:217 dialogs.py:295
+msgid "The name cannot be empty"
+msgstr "名稱不能為空"
+
+#. dialogs.py:222
 msgid "Valid command"
 msgstr "有效命令"
 
-#. dialogs.py:260
+#. dialogs.py:225
 msgid "The command is not valid"
 msgstr "命令無效"
 
-#. dialogs.py:294
+#. dialogs.py:299
+msgid "The name is already used"
+msgstr "名稱已被使用"
+
+#. dialogs.py:414
 msgid "Which data should be replaced from *.desktop file?"
 msgstr "應該從 *.desktop 檔案取代哪些資料？"
 
-#. dialogs.py:338
+#. dialogs.py:458
 msgid "really delete?"
 msgstr "確定要刪除嗎？"
 
-#. dialogs.py:339
+#. dialogs.py:459
 msgid "No"
 msgstr "否"
 
-#. dialogs.py:340
+#. dialogs.py:460
 msgid "Yes"
 msgstr "是"
 
@@ -140,7 +141,7 @@ msgstr "要儲存嗎？"
 msgid "Save the current configuration"
 msgstr "儲存目前設定"
 
-#. widgets.py:264
+#. widgets.py:230
 msgid "Separator"
 msgstr "分隔線"
 

--- a/app-launcher@mchilli/files/app-launcher@mchilli/ui/separator.glade
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/ui/separator.glade
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkDialog" id="dialog">
+    <property name="can-focus">False</property>
+    <property name="modal">True</property>
+    <property name="window-position">mouse</property>
+    <property name="default-width">500</property>
+    <property name="type-hint">dialog</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="deletable">False</property>
+    <signal name="size-allocate" handler="on_size_allocate" swapped="no"/>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="homogeneous">True</property>
+            <property name="layout-style">expand</property>
+            <child>
+              <object class="GtkButton" id="button_cancel">
+                <property name="label">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_ok">
+                <property name="label">OK</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack-type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkLabel" id="label_group">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label">Group</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBoxText" id="group">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="valign">center</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <signal name="clicked" handler="on_add_group" swapped="no"/>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="icon-name">list-add-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkColorChooserWidget" id="color">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="rgba">rgb(127,127,127)</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">button_cancel</action-widget>
+      <action-widget response="-5">button_ok</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/app-launcher@mchilli/files/app-launcher@mchilli/widgets.py
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/widgets.py
@@ -151,10 +151,10 @@ class CustomAppList(SettingsWidget):
         self.move_up_button.set_sensitive(selection_exists and self.tree_store.iter_previous(item_iter) is not None)
         self.move_down_button.set_sensitive(selection_exists and self.tree_store.iter_next(item_iter) is not None)
 
-    def on_add_item(self, *args):
-        ''' Handles the addition of a new item to the tree store
+    def _add_item_by_type(self, type):
+        ''' Handles the addition of a new item to the tree store by type
         '''
-        dialog = EditDialog('app', self.groups)
+        dialog = EditDialog(type, self.groups)
         dialog.set_transient_for(self.get_toplevel())
         data, new_group = dialog.run()
         if not data:
@@ -167,12 +167,22 @@ class CustomAppList(SettingsWidget):
         elif new_group:
             parent = self._create_group(new_group)
 
-        self.tree_store.append(parent, self._prepare_store_entry('app', data))
+        self.tree_store.append(parent, self._prepare_store_entry(type, data))
 
         if new_group and parent:
             self.tree_view.expand_row(self.tree_store.get_path(parent), True)
 
         self._configuration_changed(True)
+
+    def on_add_item(self, *args):
+        ''' Handles the addition of a new item to the tree store
+        '''
+        self._add_item_by_type('app')
+    
+    def on_add_separator(self, *args):
+        ''' Adds a new separator to the store with a user-chosen color
+        '''
+        self._add_item_by_type('separator')
 
     def _prepare_store_entry(self, entry_type, entry_data):
         ''' Creates a formatted store entry based on the entry type and provided data
@@ -205,50 +215,6 @@ class CustomAppList(SettingsWidget):
         item = self.tree_store.append(None, self._prepare_store_entry('group', data))
         self.groups[data["name"]] = item
         return item
-
-    def on_add_separator(self, *args):
-        ''' Adds a new separator to the store with a user-chosen color
-        '''
-        rgb = self._choose_separator_color()
-        if not rgb:
-            return
-
-        data = {
-            "name": '',
-            'icon': '',
-            "group": '',
-            "command": '',
-            "color": rgb
-        }
-        self.tree_store.append(None, self._prepare_store_entry('separator', data))
-
-        self._configuration_changed(True)
-
-    def _choose_separator_color(self, rgb=[127, 127, 127]):
-        ''' Opens a color chooser dialog and returns the selected color as an RGB list
-        '''
-        dialog = Gtk.ColorChooserDialog(
-            title=APP_NAME,
-            parent=self.get_toplevel(),
-            rgba=Gdk.RGBA(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255)
-        )
-        dialog.set_type_hint(Gdk.WindowTypeHint.NORMAL)
-        dialog.set_skip_taskbar_hint(True)
-        dialog.set_deletable(False)
-        dialog.set_position(Gtk.WindowPosition.MOUSE)
-        dialog.set_use_alpha(False)
-
-        rgb = None
-        if dialog.run() == Gtk.ResponseType.OK:
-            color = dialog.get_rgba()
-            rgb = [
-                int(round(color.red * 255)),
-                int(round(color.green * 255)),
-                int(round(color.blue * 255))
-            ]
-        
-        dialog.destroy()
-        return rgb
 
     def on_remove_item(self, *args):
         ''' Handles the removal of a selected item from the tree store
@@ -286,12 +252,13 @@ class CustomAppList(SettingsWidget):
         index = self.tree_store.get_path(item_iter)[0]
         for child in self.tree_store[item_iter].iterchildren():
             data = {
-                "icon": child[1].to_string(),
-                "name": child[2],
-                "command": child[3],
-                "group": ''
+                "icon": child[1].to_string() if child[1] is not None else '',
+                "name": child[2] if child[2] is not None else '',
+                "command": child[3] if child[3] is not None else '',
+                "group": '',
+                "color": child[0]["color"] if child[0]["type"] == 'separator' else ''
             }
-            self.tree_store.insert(None, index, self._prepare_store_entry('app', data))
+            self.tree_store.insert(None, index, self._prepare_store_entry(child[0]["type"], data))
             index += 1
         self.tree_store.remove(item_iter)
 
@@ -307,68 +274,82 @@ class CustomAppList(SettingsWidget):
     def on_edit_item(self, *args):
         tree_store, item_iter = self.tree_view.get_selection().get_selected()
         item_type = self.tree_store[item_iter][0]['type']
-        if item_type in ['app', 'group']:
-            dialog = EditDialog('edit', self.groups, self.tree_store[item_iter])
-            dialog.set_transient_for(self.get_toplevel())
-            data, new_group = dialog.run()
-            if not data:
-                return
-            
-            if new_group:
-                self._create_group(new_group)
 
-            # edit an application
-            if data["type"] == "app":
-                if data["group"] != self.tree_store[item_iter][0]["group"]:
-                    old_parent = self.tree_store[item_iter].get_parent()
+        dialog = EditDialog('edit', self.groups, self.tree_store[item_iter])
+        dialog.set_transient_for(self.get_toplevel())
+        data, new_group = dialog.run()
+        if not data:
+            return
+        
+        if new_group:
+            self._create_group(new_group)
 
-                    parent = None
-                    if data["group"] in self.groups:
-                        parent = self.groups[data["group"]]
-                    elif new_group:
-                        parent = self._create_group(new_group)
-                    
-                    self.tree_store.remove(item_iter)
-                    self.tree_store.append(parent, self._prepare_store_entry('app', data))
+        # edit an application
+        if data["type"] == "app":
+            if data["group"] != self.tree_store[item_iter][0]["group"]:
+                old_parent = self.tree_store[item_iter].get_parent()
 
-                    if new_group:
-                        self.tree_view.expand_row(self.tree_store.get_path(parent), True)
+                parent = None
+                if data["group"] in self.groups:
+                    parent = self.groups[data["group"]]
+                elif new_group:
+                    parent = self._create_group(new_group)
+                
+                self.tree_store.remove(item_iter)
+                self.tree_store.append(parent, self._prepare_store_entry('app', data))
 
-                    # delete old parent if there are no children left
-                    if old_parent:
-                        if not self.tree_store.iter_has_child(old_parent.iter):
-                            self.groups.pop(self.tree_store[old_parent.iter][2], None)
-                            self.tree_store.remove(old_parent.iter)
-                else:
-                    self.tree_store[item_iter][1] = Gio.Icon.new_for_string(
-                        data["icon"])
-                    self.tree_store[item_iter][2] = data["name"]
-                    self.tree_store[item_iter][3] = data["command"]
+                if new_group:
+                    self.tree_view.expand_row(self.tree_store.get_path(parent), True)
 
-            # edit a group
-            elif data["type"] == "group":
-                group_origin = self.tree_store[item_iter][2]
-
-                self.tree_store[item_iter][1] = Gio.Icon.new_for_string(data["icon"])
+                # delete old parent if there are no children left
+                if old_parent:
+                    if not self.tree_store.iter_has_child(old_parent.iter):
+                        self.groups.pop(self.tree_store[old_parent.iter][2], None)
+                        self.tree_store.remove(old_parent.iter)
+            else:
+                self.tree_store[item_iter][1] = Gio.Icon.new_for_string(
+                    data["icon"])
                 self.tree_store[item_iter][2] = data["name"]
-                for child in self.tree_store[item_iter].iterchildren():
-                    child[0]["group"] = data["name"]
-                self.groups[data["name"]] = self.groups.pop(
-                    group_origin, None)
-            
-            self._configuration_changed(True)
+                self.tree_store[item_iter][3] = data["command"]
+
+        # edit a group
+        elif data["type"] == "group":
+            group_origin = self.tree_store[item_iter][2]
+
+            self.tree_store[item_iter][1] = Gio.Icon.new_for_string(data["icon"])
+            self.tree_store[item_iter][2] = data["name"]
+            for child in self.tree_store[item_iter].iterchildren():
+                child[0]["group"] = data["name"]
+            self.groups[data["name"]] = self.groups.pop(
+                group_origin, None)
                 
         # edit a separator
-        elif item_type == 'separator':
-            current_color = self.tree_store[item_iter][0]['color']
-            rgb = self._choose_separator_color(current_color)
-            if not rgb:
-                return
-            
-            self.tree_store[item_iter][0]['color'] = rgb
-            self.tree_store[item_iter][2] = self._create_separator_markup(rgb)
+        elif data["type"] == "separator":
+            if data["group"] != self.tree_store[item_iter][0]["group"]:
+                old_parent = self.tree_store[item_iter].get_parent()
 
-            self._configuration_changed(True)
+                parent = None
+                if data["group"] in self.groups:
+                    parent = self.groups[data["group"]]
+                elif new_group:
+                    parent = self._create_group(new_group)
+                
+                self.tree_store.remove(item_iter)
+                self.tree_store.append(parent, self._prepare_store_entry('separator', data))
+
+                if new_group:
+                    self.tree_view.expand_row(self.tree_store.get_path(parent), True)
+
+                # delete old parent if there are no children left
+                if old_parent:
+                    if not self.tree_store.iter_has_child(old_parent.iter):
+                        self.groups.pop(self.tree_store[old_parent.iter][2], None)
+                        self.tree_store.remove(old_parent.iter)
+            else:
+                self.tree_store[item_iter][0]['color'] = data["color"]
+                self.tree_store[item_iter][2] = self._create_separator_markup(data["color"])
+
+        self._configuration_changed(True)
 
     def on_duplicate_item(self, *args):
         ''' Duplicates the currently selected item in the tree view

--- a/app-launcher@mchilli/files/app-launcher@mchilli/widgets.py
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/widgets.py
@@ -260,6 +260,8 @@ class CustomAppList(SettingsWidget):
             }
             self.tree_store.insert(None, index, self._prepare_store_entry(child[0]["type"], data))
             index += 1
+
+        self.groups.pop(self.tree_store[item_iter][2], None)
         self.tree_store.remove(item_iter)
 
     def _remove_item_and_cleanup_parent(self, item_iter):
@@ -269,6 +271,7 @@ class CustomAppList(SettingsWidget):
         self.tree_store.remove(item_iter)
         
         if parent and not self.tree_store.iter_has_child(parent.iter):
+            self.groups.pop(self.tree_store[parent.iter][2], None)
             self.tree_store.remove(parent.iter)
 
     def on_edit_item(self, *args):


### PR DESCRIPTION
- rewrite the dialogs to make it easier to add new dialogs
- add possibility to add separators to groups
(Feature request by @don-dolarson on https://cinnamon-spices.linuxmint.com/applets/view/344)
- fix bug, if a group is deleted it remains in the selection
- fix bug, if a *.desktop file contains duplicates
- update readme and translations files