### PR TITLE
batterymonitor@pdcurtis: battery percent calculation, fix for ageing batteries

### DIFF
--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/5.4/applet.js
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/5.4/applet.js
@@ -464,9 +464,22 @@ MyApplet.prototype = {
         try {
             // Try to get the battery capacity as an int
             let capacityPath = this.batteryPath + '/capacity';
-            let capacityValue = GLib.file_get_contents(capacityPath)[1];
-            let capacityValueString = ByteArray.toString(capacityValue);
-            this.batteryPercentage = parseInt(capacityValueString);
+
+            // Original code doesn't account for battery capacity drop due to ageing
+            // let capacityValue = GLib.file_get_contents(capacityPath)[1];
+            // let capacityValueString = ByteArray.toString(capacityValue);
+            // this.batteryPercentage = parseInt(capacityValueString);
+            // this.batteryPercentage = 50;
+
+            // New battery percentage calculated from actual attainable charge vs current charge
+            let batteryFullChargePath = this.batteryPath + '/charge_full';
+            let batteryFullChargeValue = GLib.file_get_contents(batteryFullChargePath)[1];
+            let batteryNowChargePath = this.batteryPath + '/charge_now';
+            let batteryNowChargeValue = GLib.file_get_contents(batteryNowChargePath)[1];
+            let chargeFullString = ByteArray.toString(batteryFullChargeValue);
+            let chargeNowString = ByteArray.toString(batteryNowChargeValue);
+            this.batteryPercentage = Math.round(100*parseInt(chargeNowString)/parseInt(chargeFullString));
+
 
             // Try to get the battery state as a lowercase string
             let statePath = this.batteryPath + '/status';


### PR DESCRIPTION
This applet previously relied on the 'capacity' file to obtain percent charge remaning. However, with my 2012 macbook pro whose battery is not capable of reaching the design spec for full charge, this capacity is incorrect. Instead, the real effective charge percentage should be calculated using the 'charge_now' and 'charge_full' files. Matches linux mint cinnamon default battery applet % calculation now.

@pdcurtis
Linux Mint 22.1
Cinnamon 6.4.8