### PR TITLE
mailnagapplet@ozderya.net: Add option to hide tray icon when there are no unread emails

### DIFF
--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/applet.js
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/applet.js
@@ -32,7 +32,7 @@ const UUID = "mailnagapplet@ozderya.net";
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")
 
 function _(str) {
-  return Gettext.dgettext(UUID, str);
+	return Gettext.dgettext(UUID, str);
 }
 
 const dbus_name = "mailnag.MailnagService";
@@ -40,7 +40,7 @@ const dbus_path = "/mailnag/MailnagService";
 const dbus_interface = "mailnag.MailnagService";
 
 const dbus_xml =
-"<node name=\"/mailnag/MailnagService\"> \
+	"<node name=\"/mailnag/MailnagService\"> \
   <interface name=\"mailnag.MailnagService\"> \
     <signal name=\"MailsRemoved\"> \
       <arg type=\"aa{sv}\" name=\"remaining_mails\" /> \
@@ -70,89 +70,81 @@ const MailnagProxy = Gio.DBusProxy.makeProxyWrapper(dbus_xml);
 // if have more than this many, show "Mark All Read" button
 const SHOW_MARK_ALL_COUNT = 3;
 
-function dump(x)
-{
-    if (typeof x === "object" && x !== null) {
-        global.log(JSON.stringify(x));
-    }
-    else
-    {
-        global.log(String(x));
-    }
+function dump(x) {
+	if (typeof x === "object" && x !== null) {
+		global.log(JSON.stringify(x));
+	}
+	else {
+		global.log(String(x));
+	}
 }
 
-function MailItem(id, sender, sender_address, subject, datetime, account)
-{
+function MailItem(id, sender, sender_address, subject, datetime, account) {
 	this._init(id, sender, sender_address, subject, datetime, account);
 }
 
 MailItem.prototype = {
 	__proto__: PopupMenu.PopupBaseMenuItem.prototype,
 
-	_init: function(id, sender, sender_address, subject, datetime, account)
-	{
+	_init: function (id, sender, sender_address, subject, datetime, account) {
 		PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
 
 		this.id = id;
-        this.subject = subject;
-        this.account = account;
+		this.subject = subject;
+		this.account = account;
 		this.datetime = datetime;
 
-        if (sender == "")
-        {
-            sender = sender_address;
-        }
-        this.sender = sender;
+		if (sender == "") {
+			sender = sender_address;
+		}
+		this.sender = sender;
 
-		try
-		{
+		try {
 			this._sender_label = new St.Label(
-				{text: sender, style_class: "mailnag-sender-label"});
+				{ text: sender, style_class: "mailnag-sender-label" });
 			this._subject_label = new St.Label(
-				{text: subject, style_class: "mailnag-subject-label"});
+				{ text: subject, style_class: "mailnag-subject-label" });
 			this._datetime_label = new St.Label(
-				{text: this.formatDatetime(datetime),
-				 style_class: 'popup-inactive-menu-item'});
+				{
+					text: this.formatDatetime(datetime),
+					style_class: 'popup-inactive-menu-item'
+				});
 
 			// mark read icon
 			let markReadIcon = new St.Icon({
-				icon_name:   'edit-delete',
-				icon_type:   St.IconType.SYMBOLIC,
+				icon_name: 'edit-delete',
+				icon_type: St.IconType.SYMBOLIC,
 				style_class: 'popup-menu-icon'
 			});
 			this.markReadButton = new St.Button(
-				{child: markReadIcon, style_class: "mailnag-mark-read-button"});
+				{ child: markReadIcon, style_class: "mailnag-mark-read-button" });
 
 			// setup layout
-			this._vBox = new St.BoxLayout({vertical: true});
+			this._vBox = new St.BoxLayout({ vertical: true });
 
 			this._vBox.add(this._sender_label);
 			this._vBox.add(this._subject_label);
 
-			this.addActor(this._vBox, {expand: true});
+			this.addActor(this._vBox, { expand: true });
 			this.addActor(this._datetime_label);
 			this.addActor(this.markReadButton,
-						  {expand: false, align: St.Align.END});
+				{ expand: false, align: St.Align.END });
 		}
-		catch (e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
-	activate: function(event, keepMenu)
-	{
+	activate: function (event, keepMenu) {
 		this.emit('activate', event, true); // keepMenu=True, prevents menu from closing
 	},
 
-	updateTimeDisplay: function()
-	{
+	updateTimeDisplay: function () {
 		this._datetime_label.text = this.formatDatetime(this.datetime);
 	},
 
 	// formats datetime relative to now
-	formatDatetime: function(datetime)
-	{
+	formatDatetime: function (datetime) {
 		let now = new Date();
 		const sec_1min = 60; // 60 sec
 		const sec_1h = 60 * 60; // 60 min * 60 sec
@@ -180,8 +172,7 @@ MailItem.prototype = {
 			{
 				return "1 hour ago";
 			}
-			else
-			{
+			else {
 				return Math.floor(time_diff / sec_1h) + _(" hours ago");
 			}
 		}
@@ -199,83 +190,74 @@ MailItem.prototype = {
 			{
 				return Math.ceil(days_diff / days_1w) + _(" weeks ago");
 			}
-			else
-			{
+			else {
 				return datetime.toLocaleDateString();
 			}
 		}
 	}
 }
 
-function AccountMenu(account, orientation)
-{
-    this._init(account, orientation);
+function AccountMenu(account, orientation) {
+	this._init(account, orientation);
 }
 
 AccountMenu.prototype = {
-    __proto__: PopupMenu.PopupSubMenuMenuItem.prototype,
+	__proto__: PopupMenu.PopupSubMenuMenuItem.prototype,
 
-    _init: function(account, orientation)
-    {
-        PopupMenu.PopupSubMenuMenuItem.prototype._init.call(this, account, false);
-        this._orientation = orientation; // needed for sorting
+	_init: function (account, orientation) {
+		PopupMenu.PopupSubMenuMenuItem.prototype._init.call(this, account, false);
+		this._orientation = orientation; // needed for sorting
 		this.label.style_class = "mailnag-account-label";
 		this.menuItems = {};
-    },
+	},
 
-    add: function(mailMenuItem)
-    {
-        if (this._orientation == St.Side.TOP)
-        {
-            this.menu.addMenuItem(mailMenuItem, 0); // add to top of menu
-        }
-        else
-        {
-            this.menu.addMenuItem(mailMenuItem); // add to bottom of menu
-        }
+	add: function (mailMenuItem) {
+		if (this._orientation == St.Side.TOP) {
+			this.menu.addMenuItem(mailMenuItem, 0); // add to top of menu
+		}
+		else {
+			this.menu.addMenuItem(mailMenuItem); // add to bottom of menu
+		}
 
 		this.menuItems[mailMenuItem.id] = mailMenuItem;
-    }
+	}
 }
 
-function NotificationSource()
-{
+function NotificationSource() {
 	this._init.apply(this, arguments);
 }
 
 NotificationSource.prototype = {
 	__proto__: MessageTray.Source.prototype,
 
-	_init: function()
-	{
+	_init: function () {
 		MessageTray.Source.prototype._init.call(this, "Mailnag");
 		this._setSummaryIcon(this.createNotificationIcon());
 	},
 
-	createNotificationIcon: function()
-	{
-		return new St.Icon({icon_name: 'mail-unread', icon_size: this.ICON_SIZE});
+	createNotificationIcon: function () {
+		return new St.Icon({ icon_name: 'mail-unread', icon_size: this.ICON_SIZE });
 	}
 }
 
 function MyApplet(metadata, orientation, panel_height, instance_id) {
-    this._init(metadata, orientation, panel_height, instance_id);
+	this._init(metadata, orientation, panel_height, instance_id);
 }
 
 MyApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
+	__proto__: Applet.TextIconApplet.prototype,
 
-    _init: function(metadata, orientation, panel_height, instance_id) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+	_init: function (metadata, orientation, panel_height, instance_id) {
+		Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
 
 		this._orientation = orientation;
 
-        this.set_applet_icon_symbolic_name("mail-read");
-        this.set_applet_tooltip('?');
+		this.set_applet_icon_symbolic_name("mail-read");
+		this.set_applet_tooltip('?');
 		this.set_applet_label('?');
 
-        this.menuItems = {};
-        this.accountMenus = {};
+		this.menuItems = {};
+		this.accountMenus = {};
 
 		this.menuManager = new PopupMenu.PopupMenuManager(this);
 		this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -286,8 +268,7 @@ MyApplet.prototype = {
 
 		this.mailnagWasRunning = false;
 
-		try
-		{
+		try {
 			// init notifications
 			this._notificationSource = new NotificationSource();
 			if (Main.messageTray) Main.messageTray.add(this._notificationSource);
@@ -296,43 +277,40 @@ MyApplet.prototype = {
 			this.settings = new Settings.AppletSettings(
 				this, metadata["uuid"], instance_id);
 			this.settings.bindProperty(Settings.BindingDirection.IN,
-                "notifications", "notifications_enabled", function(){});
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "launch_client_on_click", "launch_client_on_click", function(){});
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "client", "client", function(){});
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "middle_click", "middle_click_behavior", function(){});
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "max_length", "max_length", this.onSettingsChanged.bind(this));
+				"hide_on_zero", "hide_on_zero_enabled", this.onSettingsChanged.bind(this));
+			this.settings.bindProperty(Settings.BindingDirection.IN,
+				"notifications", "notifications_enabled", function () { });
+			this.settings.bindProperty(Settings.BindingDirection.IN,
+				"launch_client_on_click", "launch_client_on_click", function () { });
+			this.settings.bindProperty(Settings.BindingDirection.IN,
+				"client", "client", function () { });
+			this.settings.bindProperty(Settings.BindingDirection.IN,
+				"middle_click", "middle_click_behavior", function () { });
+			this.settings.bindProperty(Settings.BindingDirection.IN,
+				"max_length", "max_length", this.onSettingsChanged.bind(this));
 		}
-		catch (e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 
-		try
-		{
+		try {
 			// watch bus
 			this.busWatcherId = Gio.bus_watch_name(
 				Gio.BusType.SESSION, dbus_name, Gio.BusNameOwnerFlags.NONE,
 				Lang.bind(this, this.onBusAppeared), Lang.bind(this, this.onBusVanished));
 		}
-		catch(e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
-    },
+	},
 
-	onSettingsChanged: function() {
+	onSettingsChanged: function () {
 		this.onBusAppeared();
-    },
+	},
 
 	// called on applet startup (even though mailnag bus already exists)
-	onBusAppeared: function()
-	{
-		try
-		{
+	onBusAppeared: function () {
+		try {
 			let bus = Gio.bus_get_sync(Gio.BusType.SESSION, null)
 			this.mailnag = new MailnagProxy(bus, dbus_name, dbus_path);
 
@@ -346,17 +324,14 @@ MyApplet.prototype = {
 
 			this.mailnagWasRunning = true;
 		}
-		catch(e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
-	onBusVanished: function()
-	{
+	onBusVanished: function () {
 		// disconnect signals
-		if (typeof this._onMailsAddedId !== "undefined")
-		{
+		if (typeof this._onMailsAddedId !== "undefined") {
 			this.mailnag.disconnectSignal(this._onMailsAddedId);
 			this.mailnag.disconnectSignal(this._onMailsRemovedId);
 			delete this._onMailsAddedId;
@@ -365,254 +340,211 @@ MyApplet.prototype = {
 
 		// TODO: delete any notifications currently alive
 
-		if (this.mailnagWasRunning)
-		{
+		if (this.mailnagWasRunning) {
 			this.showError(_("Mailnag daemon stopped working!"));
 		}
-		else
-		{
+		else {
 			this.showError(_("Mailnag daemon isn't running! Do you have it installed?"));
 		}
 	},
 
-	loadMails: function()
-	{
+	loadMails: function () {
 		this.menu.removeAll();
 		this.menuItems = {};
 		this.accountMenus = {};
 
-		try
-		{
+		try {
 			let mails = this.getMails();
-			if (mails.length > 0)
-			{
+			if (mails.length > 0) {
 				this.removeNoUnread();
 
 				mails = this.sortMails(mails);
 
-				if (mails.length > SHOW_MARK_ALL_COUNT)
-				{
+				if (mails.length > SHOW_MARK_ALL_COUNT) {
 					this.showMarkAllRead();
 				}
 
-				for (var mail of Object.values(mails))
-                {
-                    let mi = this.makeMenuItem(mail);
+				for (var mail of Object.values(mails)) {
+					let mi = this.makeMenuItem(mail);
 					this.addMailMenuItem(mi);
-                }
+				}
 			}
-			else
-			{
+			else {
 				this.showNoUnread();
 			}
 			this.showMailCount();
 		}
-		catch (e)
-		{
+		catch (e) {
 			// TODO: show error messsage in menu
 			global.logError(e);
 		}
 	},
 
-	getMails: function()
-	{
-		try
-		{
+	getMails: function () {
+		try {
 			let mails = this.mailnag.GetMailsSync();
 			return this.fromDbusMailList(mails);
 		}
-		catch (e)
-		{
+		catch (e) {
 			// TODO: show error messsage in menu
 			global.logError(e);
 		}
 	},
 
 	// converts the mail list returned from dbus to a list of dictionaries
-	fromDbusMailList: function(dbusList)
-	{
+	fromDbusMailList: function (dbusList) {
 		let mails = dbusList[0];
 		let r = [];
 
-		for (var mail of Object.values(mails))
-		{
+		for (var mail of Object.values(mails)) {
 			let [sender, size1] = mail['sender_name'].get_string();
 			let [sender_address, size2] = mail['sender_addr'].get_string();
 			let [subject, size3] = mail['subject'].get_string();
 			let [mail_id, size4] = mail['id'].get_string();
-            let datetime = new Date(mail['datetime'].get_int32()*1000); // sec to ms
-            let account = "";
-            try
-            {
-                let [accountx, size5] = mail['account_name'].get_string();
-                account = accountx;
+			let datetime = new Date(mail['datetime'].get_int32() * 1000); // sec to ms
+			let account = "";
+			try {
+				let [accountx, size5] = mail['account_name'].get_string();
+				account = accountx;
 
 				// make mail id unique in case same mail appears in multiple accounts (in case of mail forwarding)
 				mail_id += "_" + account;
-            }
-            catch (e)
-            {
-                // ignored
-            }
+			}
+			catch (e) {
+				// ignored
+			}
 
-			r.push({id: mail_id, sender: sender, datetime: datetime,
-                    sender_address: sender_address, subject: subject,
-                    account: account});
+			r.push({
+				id: mail_id, sender: sender, datetime: datetime,
+				sender_address: sender_address, subject: subject,
+				account: account
+			});
 		}
 		return r;
 	},
 
-	sortMails: function(mails)
-	{
+	sortMails: function (mails) {
 		// ascending order
-		mails.sort(function(m1, m2) {return m1.datetime - m2.datetime;});
+		mails.sort(function (m1, m2) { return m1.datetime - m2.datetime; });
 		return mails;
 	},
 
-	onMailsAdded: function(source, t, newMails)
-	{
-		try
-		{
+	onMailsAdded: function (source, t, newMails) {
+		try {
 			this.removeNoUnread();
 
 			newMails = this.fromDbusMailList(newMails);
 			newMails = this.sortMails(newMails);
 
-			if (this.currentMailCount() + newMails.length > SHOW_MARK_ALL_COUNT)
-			{
+			if (this.currentMailCount() + newMails.length > SHOW_MARK_ALL_COUNT) {
 				this.showMarkAllRead();
 			}
 
-			for (var mail of Object.values(newMails))
-            {
-                let mi = this.makeMenuItem(mail);
+			for (var mail of Object.values(newMails)) {
+				let mi = this.makeMenuItem(mail);
 				this.addMailMenuItem(mi);
 			}
 			this.notify(newMails);
 			this.showMailCount();
 
-			if (this.currentMailCount() > SHOW_MARK_ALL_COUNT)
-			{
+			if (this.currentMailCount() > SHOW_MARK_ALL_COUNT) {
 				this.showMarkAllRead();
 			}
 		}
-		catch(e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
-	onMailsRemoved: function(source, t, remainingMails)
-	{
-		try
-		{
+	onMailsRemoved: function (source, t, remainingMails) {
+		try {
 			remainingMails = this.fromDbusMailList(remainingMails);
 
 			// make a list of remaining ids
 			let ids = [];
-			for (let mail of Object.values(remainingMails))
-			{
+			for (let mail of Object.values(remainingMails)) {
 				ids.push(mail.id);
 			}
 
 			// remove menu item if its id isn't in the list
-			for (let mi of Object.values(this.menuItems))
-			{
-				if (ids.indexOf(mi.id) < 0)
-				{
+			for (let mi of Object.values(this.menuItems)) {
+				if (ids.indexOf(mi.id) < 0) {
 					this.removeMailMenuItem(mi.id);
 				}
 			}
 		}
-		catch (e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
-	makeMenuItem: function(mail)
-	{
-		let mi = new MailItem(mail.id, 
-				      mail.sender.length > this.max_length ? mail.sender.substr(0,this.max_length) + "..." : mail.sender,
-				      mail.sender_address.length > this.max_length ? mail.sender_address.substr(0,this.max_length) + "..." : mail.sender_address,
-				      mail.subject.length > this.max_length ? mail.subject.substr(0,this.max_length) + "..." : mail.subject,
-				      mail.datetime, mail.account);
+	makeMenuItem: function (mail) {
+		let mi = new MailItem(mail.id,
+			mail.sender.length > this.max_length ? mail.sender.substr(0, this.max_length) + "..." : mail.sender,
+			mail.sender_address.length > this.max_length ? mail.sender_address.substr(0, this.max_length) + "..." : mail.sender_address,
+			mail.subject.length > this.max_length ? mail.subject.substr(0, this.max_length) + "..." : mail.subject,
+			mail.datetime, mail.account);
 		mi.markReadButton.connect(
 			'clicked',
-            Lang.bind(this, function(){this.markMailRead(mail.id)}));
-        mi.connect('activate', Lang.bind(this, this.launchClient));
+			Lang.bind(this, function () { this.markMailRead(mail.id) }));
+		mi.connect('activate', Lang.bind(this, this.launchClient));
 		this.menuItems[mail.id] = mi;
 		return mi;
-    },
+	},
 
-    makeAccountMenu: function(account)
-    {
-        let accmenu = new AccountMenu(account, this._orientation);
-        this.accountMenus[account] = accmenu;
+	makeAccountMenu: function (account) {
+		let accmenu = new AccountMenu(account, this._orientation);
+		this.accountMenus[account] = accmenu;
 
-        if (this._orientation == St.Side.TOP)
-        {
-            this.menu.addMenuItem(accmenu, 0);
-        }
-        else
-        {
-            this.menu.addMenuItem(accmenu);
-        }
+		if (this._orientation == St.Side.TOP) {
+			this.menu.addMenuItem(accmenu, 0);
+		}
+		else {
+			this.menu.addMenuItem(accmenu);
+		}
 
-        return accmenu;
-    },
+		return accmenu;
+	},
 
 	// Adds a MailItem to the menu. If `account` is defined it's added
 	// to its 'account menu'. An 'account menu' is created if it
 	// doesn't exist.
-	addMailMenuItem : function(mailItem)
-	{
-        if (mailItem.account)
-        {
-            let accmenu;
-            if (mailItem.account in this.accountMenus)
-            {
-                accmenu = this.accountMenus[mailItem.account];
-            }
-            else
-            {
-                accmenu = this.makeAccountMenu(mailItem.account);
-            }
-            accmenu.add(mailItem);
-        }
-        else
-        {
-            if (this._orientation == St.Side.TOP)
-            {
-                this.menu.addMenuItem(mailItem, 0); // add to top of menu
-            }
-            else
-            {
-                this.menu.addMenuItem(mailItem); // add to bottom of menu
-            }
-        }
+	addMailMenuItem: function (mailItem) {
+		if (mailItem.account) {
+			let accmenu;
+			if (mailItem.account in this.accountMenus) {
+				accmenu = this.accountMenus[mailItem.account];
+			}
+			else {
+				accmenu = this.makeAccountMenu(mailItem.account);
+			}
+			accmenu.add(mailItem);
+		}
+		else {
+			if (this._orientation == St.Side.TOP) {
+				this.menu.addMenuItem(mailItem, 0); // add to top of menu
+			}
+			else {
+				this.menu.addMenuItem(mailItem); // add to bottom of menu
+			}
+		}
 	},
 
-	notify: function(mails)
-	{
-		try
-		{
+	notify: function (mails) {
+		try {
 			if (!this.notifications_enabled) return;
 
 			let ntfTitle = "";
 			let ntfBody = "";
 			let markButtonLabel = "";
-			if (mails.length > 1)
-			{
+			if (mails.length > 1) {
 				ntfTitle = _("You have %d new mails!").format(mails.length);
 				markButtonLabel = _("Mark All Read");
-				for (var mail of Object.values(mails))
-				{
+				for (var mail of Object.values(mails)) {
 					ntfBody += mail.subject + "\n";
 				}
 			}
-			else
-			{
+			else {
 				ntfTitle = _("You have new mail!");
 				ntfBody = mails[0].subject;
 				markButtonLabel = _("Mark Read");
@@ -626,27 +558,22 @@ MyApplet.prototype = {
 			)
 			notification.setTransient(true);
 			notification.addButton('mark-read', markButtonLabel);
-			notification.connect('action-invoked', Lang.bind(this, function(source, action) {
-				if (action == 'mark-read')
-				{
+			notification.connect('action-invoked', Lang.bind(this, function (source, action) {
+				if (action == 'mark-read') {
 					this.markMailsRead(mails)
 					source.destroy();
 				}
 			}));
 			this._notificationSource.notify(notification);
 		}
-		catch (e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
-	showMarkAllRead: function()
-	{
-		try
-		{
-			if (typeof this._markAllRead !== "undefined")
-			{
+	showMarkAllRead: function () {
+		try {
+			if (typeof this._markAllRead !== "undefined") {
 				this.removeMarkAllRead();
 			}
 
@@ -655,118 +582,107 @@ MyApplet.prototype = {
 
 			this._markAllRead.connect('activate', Lang.bind(this, this.markAllRead));
 
-			if (this._orientation == St.Side.TOP)
-			{
+			if (this._orientation == St.Side.TOP) {
 				this.menu.addMenuItem(this._separator);
 				this.menu.addMenuItem(this._markAllRead);
 			}
-			else
-			{
+			else {
 				this.menu.addMenuItem(this._markAllRead, 0);
 				this.menu.addMenuItem(this._separator, 1);
 			}
 		}
-		catch (e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
-	removeMarkAllRead: function()
-	{
-		try
-		{
-			if (typeof this._markAllRead !== "undefined")
-			{
+	removeMarkAllRead: function () {
+		try {
+			if (typeof this._markAllRead !== "undefined") {
 				this._markAllRead.destroy();
 				this._separator.destroy();
 				delete this._markAllRead;
 				delete this._separator;
 			}
 		}
-		catch (e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
 	// removes all items from menu and adds a message
-	showNoUnread: function()
-	{
-		try
-		{
-            this.menu.removeAll();
-            this.accountMenus = {};
-            this.menuItems = {};
+	showNoUnread: function () {
+		try {
+			this.menu.removeAll();
+			this.accountMenus = {};
+			this.menuItems = {};
 			this._noUnreadItem = this.menu.addAction(_("No unread mails."));
 			this.set_applet_icon_symbolic_name("mail-read");
 		}
-		catch (e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
 	// makes sure "no unread mail" is not shown
-	removeNoUnread: function()
-	{
-		try
-		{
-			if (typeof this._noUnreadItem !== "undefined")
-			{
+	removeNoUnread: function () {
+		try {
+			if (typeof this._noUnreadItem !== "undefined") {
 				this._noUnreadItem.destroy();
 				delete this._noUnreadItem;
 			}
 			this.set_applet_icon_symbolic_name("mail-unread");
 		}
-		catch (e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
-	currentMailCount: function()
-	{
+	currentMailCount: function () {
 		return Object.keys(this.menuItems).length;
 	},
 
-	showMailCount: function()
-	{
+	// MODIFIED: This function now controls the applet's visibility based on a setting.
+	showMailCount: function () {
 		// display '?' if mailnag proxy is not present
-		if (typeof this.mailnag === 'undefined')
-		{
+		if (typeof this.mailnag === 'undefined') {
 			this.set_applet_label('?');
 			this.set_applet_tooltip(_("Mailnag daemon is not running!"));
-		}
-		else
-		{
-			let num = Object.keys(this.menuItems).length
+			this.actor.show(); // Always show if there's a startup error
+		} else {
+			let num = Object.keys(this.menuItems).length;
 			this.set_applet_label(num.toString());
-			if (num > 0)
-            {
-                if (num == 1)
-                {
-                    let s = "";
-                    for (var m of Object.values(this.menuItems)) // actually there is only 1 item
-                    {
-                        s = _("You have a mail from %s!").format(m.sender);
-                    }
-                    this.set_applet_tooltip(s);
-                }
-                else
-                {
-                    this.set_applet_tooltip(_("You have %d unread mails!").format(num));
-                }
-            }
-			else
-			{
+
+			// Conditionally show/hide based on setting
+			if (this.hide_on_zero_enabled) {
+				if (num > 0) {
+					this.actor.show();
+				} else {
+					this.actor.hide();
+				}
+			} else {
+				this.actor.show(); // Always show if setting is disabled
+			}
+
+			// Update tooltip
+			if (num > 0) {
+				if (num == 1) {
+					let s = "";
+					for (var m of Object.values(this.menuItems)) {
+						s = _("You have a mail from %s!").format(m.sender);
+					}
+					this.set_applet_tooltip(s);
+				} else {
+					this.set_applet_tooltip(_("You have %d unread mails!").format(num));
+				}
+			} else {
 				this.set_applet_tooltip(_("No unread mails."));
 			}
 		}
 	},
 
-	showError: function(message)
-	{
+	// MODIFIED: This function now ensures the applet is visible on error.
+	showError: function (message) {
 		global.logError("MailnagApplet ERROR: " + message);
 
 		this.menu.removeAll();
@@ -774,12 +690,11 @@ MyApplet.prototype = {
 		this.set_applet_tooltip(_("Click to see error!"));
 		this.menu.addAction(_("Error: " + message));
 		this.set_applet_icon_symbolic_name("mail-unread");
+		this.actor.show(); // Ensure the applet is visible to show the error
 	},
 
-	markMailRead: function(id)
-	{
-		try
-		{
+	markMailRead: function (id) {
+		try {
 			// remove account name from mail id
 			let actual_id = id.slice(0, id.indexOf("_"));
 
@@ -788,25 +703,21 @@ MyApplet.prototype = {
 
 			this.removeMailMenuItem(id);
 		}
-		catch(e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
-	removeMailMenuItem: function(id)
-	{
+	removeMailMenuItem: function (id) {
 		// switch the focus to `menu` from `menuItem` to prevent menu from closing
 		this.menu.actor.grab_key_focus();
 
 		// update account menu if there is one
 		let account = this.menuItems[id].account;
-		if (account)
-		{
+		if (account) {
 			let accountMenu = this.accountMenus[account];
 			delete accountMenu.menuItems[id];
-			if (Object.keys(accountMenu.menuItems).length == 0)
-			{
+			if (Object.keys(accountMenu.menuItems).length == 0) {
 				// remove account menu as well
 				accountMenu.destroy();
 				delete this.accountMenus[account];
@@ -818,15 +729,13 @@ MyApplet.prototype = {
 		delete this.menuItems[id];
 
 		// handle other visual updates
-		if (Object.keys(this.menuItems).length == 0)
-		{
+		if (Object.keys(this.menuItems).length == 0) {
 			this.showNoUnread();
 			this.menu.close();
 		}
 		this.showMailCount();
 
-		if (this.currentMailCount() <= SHOW_MARK_ALL_COUNT)
-		{
+		if (this.currentMailCount() <= SHOW_MARK_ALL_COUNT) {
 			this.removeMarkAllRead();
 		}
 
@@ -834,104 +743,86 @@ MyApplet.prototype = {
 	},
 
 	// marks a list of mails as read
-	markMailsRead: function(mails)
-	{
-		try
-		{
-			for (var mail of Object.values(mails))
-			{
+	markMailsRead: function (mails) {
+		try {
+			for (var mail of Object.values(mails)) {
 				this.markMailRead(mail.id)
 			}
 		}
-		catch(e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
 	// mark all currently displayed mail as read
-	markAllRead: function()
-	{
-		for (var m of Object.values(this.menuItems))
-		{
+	markAllRead: function () {
+		for (var m of Object.values(this.menuItems)) {
 			this.markMailRead(m.id);
 		}
-    },
+	},
 
-    launchClient: function()
-    {
-        if (!this.launch_client_on_click) return;
+	launchClient: function () {
+		if (!this.launch_client_on_click) return;
 
-        if (this.client.startsWith("http")) // client is a web page
-        {
-            Util.spawnCommandLine("xdg-open " + this.client);
-        }
-        else // client is a command
-        {
-            Util.spawnCommandLine(this.client);
-        }
-        this.menu.close();
-    },
+		if (this.client.startsWith("http")) // client is a web page
+		{
+			Util.spawnCommandLine("xdg-open " + this.client);
+		}
+		else // client is a command
+		{
+			Util.spawnCommandLine(this.client);
+		}
+		this.menu.close();
+	},
 
-    on_applet_clicked: function(event) {
-        if (!this.menu.isOpen)
-        {
-            for (let accmenu of Object.values(this.accountMenus))
-            {
-                accmenu.menu.open();
-            }
+	on_applet_clicked: function (event) {
+		if (!this.menu.isOpen) {
+			for (let accmenu of Object.values(this.accountMenus)) {
+				accmenu.menu.open();
+			}
 
-			for (let mi of Object.values(this.menuItems))
-			{
+			for (let mi of Object.values(this.menuItems)) {
 				mi.updateTimeDisplay();
 			}
-        }
-        this.menu.toggle();
-    },
+		}
+		this.menu.toggle();
+	},
 
-	_onButtonPressEvent: function (actor, event)
-	{
+	_onButtonPressEvent: function (actor, event) {
 		if (event.get_button() == 2) // 2: middle button
 		{
-			switch (this.middle_click_behavior)
-			{
+			switch (this.middle_click_behavior) {
 				case "mark_read":
-				    this.markAllRead();
-				    break;
+					this.markAllRead();
+					break;
 				case "launch_client":
-				    this.launchClient();
-				    break;
+					this.launchClient();
+					break;
 				default:
-				    // do nothing
-				    break;
+					// do nothing
+					break;
 			}
 		}
 		return Applet.Applet.prototype._onButtonPressEvent.call(this, actor, event);
 	},
 
-	on_orientation_changed: function(orientation)
-	{
+	on_orientation_changed: function (orientation) {
 		this._orientation = orientation
-		try
-		{
+		try {
 			this.loadMails();
 		}
-		catch (e)
-		{
+		catch (e) {
 			global.logError(e);
 		}
 	},
 
-	on_applet_removed_from_panel: function()
-	{
+	on_applet_removed_from_panel: function () {
 		// TODO: remove all notifications
-		if (typeof this._onMailsAddedId !== "undefined")
-		{
+		if (typeof this._onMailsAddedId !== "undefined") {
 			this.mailnag.disconnectSignal(this._onMailsAddedId);
 			delete this._onMailsAddedId;
 		}
-		if (typeof this._onMailsRemovedId !== "undefined")
-		{
+		if (typeof this._onMailsRemovedId !== "undefined") {
 			this.mailnag.disconnectSignal(this._onMailsRemovedId);
 			delete this._onMailsRemovedId;
 		}
@@ -941,5 +832,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    return new MyApplet(metadata, orientation, panel_height, instance_id);
+	return new MyApplet(metadata, orientation, panel_height, instance_id);
 }

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/es.po
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/es.po
@@ -62,7 +62,7 @@ msgstr "¡Tienes %d correos nuevos!"
 
 #. applet.js:608 applet.js:653
 msgid "Mark All Read"
-msgstr "Marcar todo como léido"
+msgstr "Marcar todo como leído"
 
 #. applet.js:616
 msgid "You have new mail!"
@@ -105,6 +105,18 @@ msgstr "Mailnag"
 #. metadata.json->description
 msgid "Mailnag mail notifier applet"
 msgstr "Applet de notificación Mailnag"
+
+#. settings-schema.json->hide_on_zero->description
+msgid "Hide icon when no unread emails"
+msgstr "Ocultar icono cuando no haya correos sin leer"
+
+#. settings-schema.json->hide_on_zero->tooltip
+msgid ""
+"If enabled, the applet icon will disappear from the panel when the "
+"unread email count is zero."
+msgstr ""
+"Si está activado, el icono del applet desaparecerá del panel cuando "
+"no haya correos sin leer."
 
 #. settings-schema.json->notifications->description
 msgid "Show notifications"

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/mailnagapplet@ozderya.net.pot
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/po/mailnagapplet@ozderya.net.pot
@@ -104,6 +104,16 @@ msgstr ""
 msgid "Mailnag mail notifier applet"
 msgstr ""
 
+#. settings-schema.json->hide_on_zero->description
+msgid "Hide icon when no unread emails"
+msgstr ""
+
+#. settings-schema.json->hide_on_zero->tooltip
+msgid ""
+"If enabled, the applet icon will disappear from the panel when the "
+"unread email count is zero."
+msgstr ""
+
 #. settings-schema.json->notifications->description
 msgid "Show notifications"
 msgstr ""

--- a/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/settings-schema.json
+++ b/mailnagapplet@ozderya.net/files/mailnagapplet@ozderya.net/settings-schema.json
@@ -1,46 +1,48 @@
 {
-	"notifications" : {
-		"type" : "checkbox",
-		"default" : true,
-		"description" : "Show notifications",
-		"tooltip" : "Enables display of mail arrived notifications by applet. Make sure you disable mailnag notification plugin, otherwise you will have duplicates."
+    "hide_on_zero": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Hide icon when no unread emails",
+        "tooltip": "If enabled, the applet icon will disappear from the panel when the unread email count is zero."
     },
-
-    "launch_client_on_click" : {
-        "type" : "checkbox",
-        "default" : false,
-        "description" : "Launch mail client on click",
-        "tooltip" : "Mail client is launched when clicked on a menu item."
+    "notifications": {
+        "type": "checkbox",
+        "default": true,
+        "description": "Show notifications",
+        "tooltip": "Enables display of mail arrived notifications by applet. Make sure you disable mailnag notification plugin, otherwise you will have duplicates."
     },
-
-	"middle_click" : {
-		"type" : "combobox",
-		"default" : "mark_read",
-		"description" : "On middle click:",
-		"tooltip" : "What to do when middle clicked on applet icon",
-		"options" : {
-			"Mark all read" : "mark_read",
-			"Launch mail client" : "launch_client",
-			"Do nothing" : "do_nothing"
-		}
-	},
-
-    "max_length" : {
-        "type" : "spinbutton",
-        "default" : 32,
-        "min" : 0,
-        "max" : 256,
-        "step" : 1,
-        "unit" : "characters",
-        "description" : "Max sender / subject display length",
-        "tooltip" : "Sender or subject lines longer than this will be cropped"
+    "launch_client_on_click": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Launch mail client on click",
+        "tooltip": "Mail client is launched when clicked on a menu item."
     },
-	
-    "client" : {
-        "type" : "entry",
-        "default" : "thunderbird",
-        "description" : "Mail client to launch (or webpage)",
-        "tooltip" : "Enter the command to launch your mail client here. You can also enter a web address that starts with 'http'.",
-        "indent" : true
+    "middle_click": {
+        "type": "combobox",
+        "default": "mark_read",
+        "description": "On middle click:",
+        "tooltip": "What to do when middle clicked on applet icon",
+        "options": {
+            "Mark all read": "mark_read",
+            "Launch mail client": "launch_client",
+            "Do nothing": "do_nothing"
+        }
+    },
+    "max_length": {
+        "type": "spinbutton",
+        "default": 32,
+        "min": 0,
+        "max": 256,
+        "step": 1,
+        "unit": "characters",
+        "description": "Max sender / subject display length",
+        "tooltip": "Sender or subject lines longer than this will be cropped"
+    },
+    "client": {
+        "type": "entry",
+        "default": "thunderbird",
+        "description": "Mail client to launch (or webpage)",
+        "tooltip": "Enter the command to launch your mail client here. You can also enter a web address that starts with 'http'.",
+        "indent": true
     }
 }


### PR DESCRIPTION
Mentioning @hyOzd as he's listed as the spice author [here](https://cinnamon-spices.linuxmint.com/applets/view/244), as well as @clefebvre since I can see he's responsible for much of this code.

This small PR adds the option to have the tray icon only show up when there are no unread messages, otherwise it removes itself from the panel.

I find this really handy to de-clutter the panel, as showing a persistent icon saying you have zero emails isn't very useful in my opinion. Also, having it appear only when there's a new email makes it stand out more, which I find works even better as a notification tool.

I've set its default value to `false` so that it doesn't confuse people when they update and the icon suddenly disappear.

I have also translated the strings to Spanish since that's my first language, and also corrected a small typo (`léido -> leído`).

Apologies for the polluted diff... VS Code reformatted everything on save and changed the indents, new lines, etc., so now everything shows up as modified. Hope it's not an issue 🙏
