### PR TITLE
[CassiaWindowList@klangman] Version 2.4.2

### DIFF
--- a/CassiaWindowList@klangman/CHANGELOG.md
+++ b/CassiaWindowList@klangman/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.4.2
+
+* Renamed the "Number label" to "Icon overlay label" since it no longer only shows numbers
+* Added 5 new icon overlay label content options
+* Changed the icon overlay "smart" option into a toggle switch rather than a drop-down list
+* Hide the "smart" icon overlay options when it does not make sense for the type of icon overlay setting
+* Move the Ellipsis group indicator option to the status indicator drop-down list
+* Added 3 new status indicator types (app group count, monitor number, workspace number)
+* Added window progress support, shown using the icon overlay label or button label prepend
+* Added an "Hide status indicators when space is limited" option to replace the "Auto" drop-down list option
+* Fixed the minimized indicator character to use the down arrow for all cases except when on a top panel
+* Moved some options that were under the "Number label" options into the "Display status indicator" drop-down list
+* Show a group count in the tooltip text if a button has more than one window associated with it
+* Use the "Negative circled" number unicode characters for the "Application group count" status indicators
+  since the bracketed numbers (which were used previously) are oddly sized and hard to read for many font sets
+* Fix a number of typos and grammar mistakes (thanks to RupinderM)
+
+Note: Due to reworking a several options under the "Label" tab in the configuration dialog, some options may need to be changed to restore the window list behave to what it was before upgrading to version 2.4.2. Sorry for the inconvenience. 
+
 ## 2.4.1
 
 * Use the DesaturateEffect class rather than the saturate_and_pixelate() API to adjust the icon color saturation. This has as advantage in that it is able to desaturate the color for all icons where before it was limited in what type of icons it would work on. On the other hand, it has a disadvantage in that it can't oversaturate the icons. Hopefully no one was using the >100% saturation feature because it's not gone now.

--- a/CassiaWindowList@klangman/README.md
+++ b/CassiaWindowList@klangman/README.md
@@ -1,7 +1,9 @@
 This is a Cinnamon window list and panel launcher applet based on CobiWindowList with a number of additional features designed to give you more control over how your window-list operates.
 
-Recent new features (Aug 2023 - Dec 2024):
+**Recent new features (Aug 2023 - Jul 2025):**
 
+* Added several new option to the Status Indicator and Icon Overlay Label drop-down lists
+* Added progress indicator support (Firefox downloading, Update manager, Nemo file copying)
 * Focus a buttons window when dragging an object to the window-list so the user can drop on the window
 * Added scroll-wheel options, cycle all window-list windows and cycle group/pool windows
 * Added context menu options to close all/other windows for the buttons application
@@ -36,7 +38,11 @@ Recent new features (Aug 2023 - Dec 2024):
 * Smart numeric hotkeys to assign a set of 1-9 hotkeys to a specific application
 * A bunch of fixes
 
-The design goals are to:
+**Upgrading notes:**
+
+* After upgrading to 2.4.2 you might need to change some options under the "Labels" tab to restore some elements of your setup. This is due to a small "Label" options redesign in order to allow for some new features and to improve ease of use.
+
+**The design goals are to:**
 
 1. Allow you to declutter your window list when running many windows without having to do without button labels
 2. Keyboard hot-keys to switch to specific windows so you don't have to reach for the mouse so often

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
@@ -65,6 +65,18 @@ const FLASH_INTERVAL = 500;
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 const PANEL_ZONE_TEXT_SIZES = "panel-zone-text-sizes";
 
+const U_PERCENT    = "\u{066A}";
+const U_MIN_UP     = "\u{2191}";
+const U_MIN_DOWN   = "\u{2193}";
+const U_PINNED     = "\u{1F4CC}";
+const U_ELLIPSIS_V = "\u{22EE}";
+const U_ELLIPSIS_H = "\u{2026}";
+
+const U_DIGIT_ONE = 10122; // Circled One 9312 -- Parenthesized One 9332 -- Negative Circled Digit One 10122
+const U_DIGIT_SPLIT = 9451; // Negative Circled Number Eleven
+const U_DIGIT_SPLIT_NUM = 11;
+const U_DIGIT_LIMIT = 20;
+const U_MANY = "\u{2026}";  // Used when the number is greater than U_DIGIT_LIMIT
 
 const STYLE_CLASS_ATTENTION_STATE = "grouped-window-list-item-demands-attention";
 
@@ -150,16 +162,21 @@ const DisplayCaption = {
 
 // The possible user Settings for how the number label should be displayed
 const DisplayNumber = {
-  No: 0,            // The number label for a  window list button is never displayed
-  All: 1,           // ... always displayed
-  Smart: 2          // ... only displayed when 2 of more windows exist
+  All: false,           // ... always displayed
+  Smart: true          // ... only displayed when 2 of more windows exist
 }
 
 const NumberType = {
-  Nothing:      0,  // Don't show any Number labels
   GroupWindows: 1,  // Application Group Window Count
   WorkspaceNum: 2,  // Workspace Number
-  MonitorNum:   3   // Monitor Number
+  MonitorNum:   3,  // Monitor Number
+  TitleChar:    4,  // First character of the window title
+  // Numbers below 100 can have a "smart" configuration, 100 and above don't have a smart option
+  Nothing:      100,  // Don't show any Number labels (was 0 in the past)
+  Minimized:    101,  // Minimized window indicator
+  Pinned:       102,  // Pinned window-list button indicator
+  MinAndPin:    103,  // Both minimized and pinned indicators
+  Ellipsis:     104   // Use a Ellipsis Unicode character to indicate the button is grouped with more than one window
 }
 
 // Possible values for the WindowListButton._grouped variable which determines how each individual windowlist button is currently grouped
@@ -252,7 +269,11 @@ const IndicatorType = {
    Minimized: 1,
    Pinned: 2,
    Both: 3,
-   Auto: 7
+   Auto: 7,
+   GroupWindows: 11,  // Application Group Window Count
+   Ellipsis:     12,
+   WorkspaceNum: 13,  // Workspace Number
+   MonitorNum:   14   // Monitor Number
 }
 
 // This is the possible values for the scroll wheel when the Thumbnail menu is open
@@ -308,6 +329,12 @@ const HideLabels = {
    OtherMonitors: 3
 }
 
+const ProgressDisplay = {
+   Disabled: 0,
+   IconOverlay: 1,
+   LabelPrepend: 2
+}
+
 var hasSetMarkup = undefined;
 var hasGetFrameRect = undefined;
 var hasGetCurrentMonitor = undefined;
@@ -351,7 +378,7 @@ function resizeActor(actor, time, toWidth, text, button) {
        if (this._shrukenLabel) {
           // Since some fonts don't seem to report the right size when calling get_pixel_size() before animation is complete
           // so we need to see what the actual size is now and set _minLabelSize accordingly.
-          let minText = (this._pinned && (this._applet.indicators&IndicatorType.Pinned)) ? "\u{1F4CC}\u{2193}" : "\u{2193}";
+          let minText = (this._pinned && (this._applet.indicators===IndicatorType.Pinned || this._applet.indicators===IndicatorType.Both)) ? U_PINNED+U_MIN_DOWN : U_MIN_DOWN;
           if (text == minText) {
              let layout = this._label.get_clutter_text().get_layout();
              let [curWidth, curHeight] = layout.get_pixel_size();
@@ -1523,15 +1550,14 @@ class WindowListButton {
     this._signalManager.connect(this.actor, "scroll-event", this._onScrollEvent, this);
     //this._signalManager.connect(this.actor, "notify::allocation", this._allocationChanged, this);
     this._signalManager.connect(this._settings, "changed::caption-type", this._updateLabel, this);
-    this._signalManager.connect(this._settings, "changed::display-caption-for-pined", this._updateLabel, this);
+    this._signalManager.connect(this._settings, "changed::display-caption-for-pined", this._updateLabel, this); // typo left for compatibility
     this._signalManager.connect(this._settings, "changed::hide-caption-for-minimized", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::display-caption-for", this._updateLabel, this);
-    this._signalManager.connect(this._settings, "changed::show-ellipsis-for-groups", this._updateLabel, this);
+    this._signalManager.connect(this._settings, "changed::progress-display-type", this._updateProgress, this);
     this._signalManager.connect(this._settings, "changed::display-number", this._updateNumber, this);
     this._signalManager.connect(this._settings, "changed::menu-show-on-hover", this._updateTooltip, this);
     this._signalManager.connect(this._settings, "changed::grouped-mouse-action-btn1", this._updateTooltip, this);
     this._signalManager.connect(this._settings, "changed::show-tooltips", this._updateTooltip, this);
-    this._signalManager.connect(this._settings, "changed::number-style", Lang.bind(this, function() { this._updateNumber(); this._updateLabel(); }), this);
     this._signalManager.connect(this._settings, "changed::number-type", Lang.bind(this, function() { this._updateNumber(); this._updateLabel(); }), this);
     this._signalManager.connect(this._settings, "changed::label-width", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::button-spacing", this._updateSpacing, this);
@@ -1541,9 +1567,7 @@ class WindowListButton {
     this._signalManager.connect(this.actor, "notify::hover", this._updateVisualState, this);
     this._signalManager.connect(this._contextMenu, "open-state-changed", this._contextState, this);
 
-    this._signalManager.connect(Main.themeManager, "theme-set", Lang.bind(this, function() {
-      this.updateView();
-    }), this);
+    this._signalManager.connect(Main.themeManager, "theme-set", Lang.bind(this, function() { this.updateView(); }), this);
     this._signalManager.connect(St.TextureCache.get_default(), "icon-theme-changed", this.updateIcon, this);
 
     this._draggable = DND.makeDraggable(this.actor);
@@ -1556,6 +1580,12 @@ class WindowListButton {
     this.isDraggableApp = true;
     this._updateNumber();
     this._updateSpacing();
+  }
+
+  _updateProgress() {
+     // Allow the icon overlay label and the button label to add/remove any progress state
+     this._updateNumber();
+     this._updateLabel();
   }
 
   //_allocationChanged() {
@@ -1764,7 +1794,7 @@ class WindowListButton {
     this._signalManager.connect(metaWindow, "notify::gtk-application-id", this._onGtkApplicationChanged, this);
     this._signalManager.connect(metaWindow, "notify::wm-class", this._onWmClassChanged, this);
     this._signalManager.connect(metaWindow, 'notify::icon', this.updateIcon, this);
-    //this._signalManager.connect(metaWindow, "notify::progress", this._onProgressChange, this);
+    this._signalManager.connect(metaWindow, "notify::progress", this._onProgressChange, this);
     this._signalManager.connect(metaWindow, "workspace-changed", this._onWindowWorkspaceChanged, this);
 
     if (this._applet._displayPinned !== DisplayPinned.Disabled)
@@ -1822,22 +1852,16 @@ class WindowListButton {
     this._updateVisibility();
   }
 
-  /*
   _onProgressChange() {
-     if (this._currentWindow && this._currentWindow.progress !== undefined && this.actor.is_visible()) {
-        if (this._currentWindow.progress !== 0 ) {
-           let width = Math.max((this.actor.width) * (this._currentWindow.progress / 100.0), 1.0);
-           let height = Math.max((this._applet._panelHeight * 0.15), 1.0);
-           let box = Clutter.ActorBox.new(0,0,width,height);
-           log( `Updating progress to ${this._currentWindow.progress}%` );
-           this.progressOverlay.allocate(box, 0);
-           this.progressOverlay.show();
-        } else if (this.progressOverlay.is_visible()){
-           log( "Disabling progress bar" );
-           this.progressOverlay.hide();
-        }
+     let progressDisplayType = this._settings.getValue("progress-display-type");
+     if (progressDisplayType === ProgressDisplay.IconOverlay ||
+        this._applet.orientation == St.Side.LEFT  || this._applet.orientation == St.Side.RIGHT)
+     {
+        this._updateNumber();
+     } else if (progressDisplayType == ProgressDisplay.LabelPrepend ) {
+        this._updateLabel();
      }
-  }*/
+  }
 
   _updateCurrentWindow() {
     // Without slice, this will reorder to windows in the this._windows array
@@ -1926,6 +1950,11 @@ class WindowListButton {
           }
        }
     }
+    // Add text to show the number of windows in this group
+    if (this._windows.length > 1) {
+       text = text + "\n" + this._windows.length + " " + _("windows in this group")
+    }
+    // Get the most appropriate windows tile for this button
     let title = null;
     let leftClickAction = this.getButton1Action();
     if (this._windows.length > 0 && (this._windows.length === 1 || leftClickAction!==LeftClickGrouped.Thumbnail)) {
@@ -1938,6 +1967,7 @@ class WindowListButton {
     if (title===null) {
        title = this._app.get_name();
     }
+    // Compose the final text and set the tooltip text
     if (text.length == 0 || !hasSetMarkup) {
        this._tooltip.set_text(title + text);
     } else {
@@ -2032,10 +2062,25 @@ class WindowListButton {
      this._labelNumberBin.height = size;
   }
 
+  // This will update the icon overlay label
   _updateNumber() {
+    // If the window has an active progress, display the percentage if needed.
+    let progressType = this._settings.getValue("progress-display-type");
+    if (this._currentWindow && this._currentWindow.progress !== undefined && this._currentWindow.progress !== 0 &&
+        this.actor.is_visible() && (progressType === ProgressDisplay.IconOverlay || (progressType === ProgressDisplay.LabelPrepend &&
+        (this._applet.orientation === St.Side.LEFT || this._applet.orientation === St.Side.RIGHT))))
+    {
+       this._labelNumber.set_text(this._currentWindow.progress + U_PERCENT);  // Arabic Percent Sign (thinner than a normal percent sign)
+       this._labelNumberBox.show();
+       let [width, height] = this._labelNumber.get_size();
+       let size = Math.max(width, height);
+       this._labelNumberBin.width = size;
+       this._labelNumberBin.height = size;
+       return;
+    }
+    // There is no active progress, so show the default icon overlay
     let numberType = this._settings.getValue("number-type");
     let setting = this._settings.getValue("display-number");
-    let style = this._settings.getValue("number-style");
     let groupType = this._settings.getValue("group-windows");
     let text = "";
     let number = this._windows.length;
@@ -2044,10 +2089,7 @@ class WindowListButton {
        this._grouped = GroupingType.NotGrouped;
     }
 
-    if (style == 1 && (groupType == GroupType.Launcher || (this._applet.orientation == St.Side.LEFT || this._applet.orientation == St.Side.RIGHT)))
-       style = 0;  // No space for a label based window group counter, so force the icon overlay option if it's not disabled!
-
-    if (style === 0 && numberType !== NumberType.Nothing) {
+    if (numberType && numberType !== NumberType.Nothing) {
        if (numberType === NumberType.GroupWindows && ( (setting == DisplayNumber.All && number >= 1) ||
           ((setting == DisplayNumber.Smart && number >= 2) &&
           (groupType == GroupType.Grouped || groupType == GroupType.Launcher || this._grouped > GroupingType.NotGrouped))))
@@ -2057,14 +2099,38 @@ class WindowListButton {
           text += this._currentWindow.get_workspace().index()+1;
        } else if (numberType === NumberType.MonitorNum && this._currentWindow && (setting === DisplayNumber.All || this.isOnOtherMonitor())) {
           text += this._currentWindow.get_monitor()+1;
+       } else if (numberType === NumberType.TitleChar && this._currentWindow) {
+          let btns = (setting === DisplayNumber.All) ? null : this._workspace._lookupAllAppButtonsForApp(this._app);
+          if ((setting === DisplayNumber.Smart && btns.length > 1) || setting === DisplayNumber.All) {
+             let title = this._currentWindow.get_title();
+             if (title && title.length > 0) {
+                if (this._app && title.startsWith(this._app.get_name())) {
+                   title = title.substring(this._app.get_name().length).trim();
+                   if (title.startsWith("-")) {
+                      title = title.substring(1).trim();
+                   }
+                }
+                text += title.substring(0,2).trim();
+             }
+          }
+       } else if (numberType === NumberType.Minimized && this._currentWindow && this._currentWindow.minimized) {
+          text = ((this._applet.orientation !== St.Side.TOP)?U_MIN_DOWN:U_MIN_UP);  // The Unicode character up or down arrow
+       } else if (numberType === NumberType.Pinned && this._pinned) {
+          text = U_PINNED; // Unicode for the "push pin" character
+       } else if (numberType === NumberType.MinAndPin) {
+          text = "";
+          if (this._currentWindow && this._currentWindow.minimized == true)
+             text += ((this._applet.orientation !== St.Side.TOP)?U_MIN_DOWN:U_MIN_UP);  // The Unicode character up or down arrow
+          if (this._pinned)
+             text += U_PINNED; // Unicode for the "round push pin" character
+       } else if (numberType === NumberType.Ellipsis && number >= 2) {
+          text += U_ELLIPSIS_H; // Unicode for the "..." character
        }
     }
 
-    if (text == "" || style == 1) {
+    if (text == "") {
       this._labelNumberBox.hide();
-      if (style == 1)
-         this._updateLabel();
-    } else if (style == 0) {
+    } else {
       this._labelNumber.set_text(text);
       this._labelNumberBox.show();
       let [width, height] = this._labelNumber.get_size();
@@ -2097,12 +2163,10 @@ class WindowListButton {
 
     let capSetting = this._settings.getValue("display-caption-for");
     let numSetting = this._settings.getValue("display-number");
-    let pinnedSetting = this._settings.getValue("display-caption-for-pined");
+    let pinnedSetting = this._settings.getValue("display-caption-for-pined"); // typo left for compatibility
     let hideSetting = this._settings.getValue("hide-caption-for-minimized"); // For compatibility, the option name "hide-caption-for-minimized" was maintained, but now it has more then one possible value not only for minimized windows
-    let style = this._settings.getValue("number-style");
     let numberType = this._settings.getValue("number-type");
     let preferredWidth = this._settings.getValue("label-width");
-    let ellipsis = this._settings.getValue("show-ellipsis-for-groups");
     let number = this._windows.length;
     let text = "";
     let width = preferredWidth;
@@ -2194,38 +2258,49 @@ class WindowListButton {
        this._shrukenLabel = true;
     }
 
-    // Do we need a number label char
-    if (numberType !== NumberType.Nothing && style === 1) {
+    if (this._currentWindow && this._currentWindow.progress !== undefined && this._currentWindow.progress !== 0 &&
+        this.actor.is_visible() && this._settings.getValue("progress-display-type") == ProgressDisplay.LabelPrepend)
+    {
+       text = this._currentWindow.progress + U_PERCENT + text;  // Arabic Percent Sign (thinner than a normal percent sign)
+    } else if (this._applet.indicators!==IndicatorType.None) {
+       // We have some sort of label prepend option enabled
        let labelNum = 0;
-       if (numberType === NumberType.GroupWindows && ((numSetting === DisplayNumber.All && number >= 1) || ((numSetting === DisplayNumber.Smart && number >= 2) &&
-          (groupSetting === 0 || this._grouped > GroupingType.NotGrouped))))
-       {
+       if (this._applet.indicators===IndicatorType.GroupWindows && number >= 2) {
           labelNum = number;
-       } else if (numberType === NumberType.WorkspaceNum && this._currentWindow && (numSetting === DisplayNumber.All || this.isOnOtherWorkspace())) {
+       } else if (this._applet.indicators===IndicatorType.WorkspaceNum && this._currentWindow && this.isOnOtherWorkspace()) {
          labelNum =  this._currentWindow.get_workspace().index()+1;
-       } else if (numberType === NumberType.MonitorNum && this._currentWindow && (numSetting === DisplayNumber.All || this.isOnOtherMonitor())) {
+       } else if (this._applet.indicators===IndicatorType.MonitorNum && this._currentWindow && this.isOnOtherMonitor()) {
          labelNum = this._currentWindow.get_monitor()+1;
        }
        if (labelNum > 0) {
-         if (labelNum > 20) {
-           text = "\u{24A8} " + text; // The Unicode character "(m)"
+         if (labelNum > U_DIGIT_LIMIT) {
+           text = U_MANY + text; // Unicode character to represent "many"
          } else {
-           text = String.fromCharCode(9331+labelNum) + " " + text; // Bracketed number
+           if (labelNum < U_DIGIT_SPLIT_NUM) {
+             text = String.fromCharCode(U_DIGIT_ONE+(labelNum-1)) + " " + text; // Unicode number symbol
+           } else {
+             text = String.fromCharCode(U_DIGIT_SPLIT+(labelNum-U_DIGIT_SPLIT_NUM)) + " " + text; // Unicode number symbol
+           }
          }
        }
+       // Do we need a minimized char
+       if (this._currentWindow && this._currentWindow.minimized && (this._applet.indicators===IndicatorType.Minimized || this._applet.indicators===IndicatorType.Both) && this._workspace.autoIndicatorsOff==false) {
+         text = ((this._applet.orientation !== St.Side.TOP)?U_MIN_DOWN:U_MIN_UP) + text;  // The Unicode character up or down arrow
+       }
+       // Do we need a pinned char
+       if (this._pinned && (this._applet.indicators===IndicatorType.Pinned || this._applet.indicators===IndicatorType.Both) && this._workspace.autoIndicatorsOff==false) {
+           text = U_PINNED + text; // Unicode for the "push pin" character
+       }
+       // Do we need a group ellipsis char
+       if (this._applet.indicators===IndicatorType.Ellipsis === true && number >= 2)
+       {
+          text = U_ELLIPSIS_V + text;  // The Unicode character "Vertical Ellipsis"
+       }
     }
-    // Do we need a minimized char
-    if (this._currentWindow && this._currentWindow.minimized && (this._applet.indicators&IndicatorType.Minimized) && this._workspace.autoIndicatorsOff==false) {
-      text = ((this._applet.orientation === St.Side.BOTTOM)?"\u{2193}":"\u{2191}") + text;  // The Unicode character up or down arrow
-    } 
-    // Do we need a pinned char
-    if (this._pinned && (this._applet.indicators&IndicatorType.Pinned) && this._workspace.autoIndicatorsOff==false) {
-        text = "\u{1F4CC}" + text; // Unicode for the "push pin" character
-    }
-    // Do we need a group ellipsis char
-    if (ellipsis === true && number >= 2)
-    {
-       text = "\u{22EE}" + text;  // The Unicode character "Vertical Ellipsis"
+
+    // The window title might have changed, so we might need to update the icon overlay label
+    if (numberType === NumberType.TitleChar) {
+       this._updateNumber();
     }
 
     // If we don't have a minimum label size, calculate it now!
@@ -2233,7 +2308,7 @@ class WindowListButton {
        if (this._workspace.autoIndicatorsOff==true || this._applet.indicators==IndicatorType.None || (this._pinned && this._windows.length==0)) {
           this._minLabelSize = 0;
        } else {
-          let minText = (this._pinned && (this._applet.indicators&IndicatorType.Pinned)) ? "\u{1F4CC}\u{2193}" : "\u{2193}";
+          let minText = (this._pinned && (this._applet.indicators===IndicatorType.Pinned || this._applet.indicators===IndicatorType.Both)) ? U_PINNED+U_MIN_DOWN : U_MIN_DOWN;
           this._label.set_text(minText);
           let layout = this._label.get_clutter_text().get_layout();
           let [minWidth, minHeight] = layout.get_pixel_size();
@@ -4487,6 +4562,10 @@ class Workspace {
 
     appButton._pinned = true;
     appButton._updateVisibility()
+    let numberType = this._settings.getValue("number-type");
+    if (numberType === NumberType.Pinned || numberType === NumberType.MinAndPin) {
+       appButton._updateNumber();
+    }
     this._updatePinSettings();
   }
 
@@ -4600,7 +4679,7 @@ class Workspace {
              if (this.iconSaturation!=100 && this.saturationType == SaturationType.Focused) {
                 this._currentFocus.updateIconSelection();
              }
-             let pinnedSetting = this._settings.getValue("display-caption-for-pined");
+             let pinnedSetting = this._settings.getValue("display-caption-for-pined"); // typo left for compatibility
              let capSetting = this._settings.getValue("display-caption-for");
              if (pinnedSetting == PinnedLabel.Focused && capSetting === DisplayCaption.One) {
                 // Do we need to clear the label from the pooled window group
@@ -4896,7 +4975,7 @@ class Workspace {
         return;
      }
      if (this._areButtonsShrunk()==true) {
-        if (this._applet.indicators == IndicatorType.Auto) {
+        if (this._settings.getValue("auto-hide-indicators")) {
            this.autoIndicatorsOff = true;   // Remove the indicator characters
            for (let i=0 ; i<this._appButtons.length ; i++) {
               if (this._appButtons[i]._pinned || (this._appButtons[i]._currentWindow && this._appButtons[i]._currentWindow.minimized)) {
@@ -5046,7 +5125,7 @@ class WindowList extends Applet.Applet {
     this._hiddenApps = null;    // List of applications that should not be visible buttons
     this._pinnedApps = null;    // cached version of "pinned_apps"
     this._displayPinned = null; // cached "display-pinned" setting
-    this.indicators = 3;
+    this.indicators = IndicatorType.Both;
     this.instanceId = instanceId;
     this.on_orientation_changed(orientation);
   }
@@ -5390,17 +5469,15 @@ class WindowList extends Applet.Applet {
 
   _updateIndicators() {
      if (this._settings.getValue("group-windows")===GroupType.Launcher)
-        this.indicators = 0;
+        this.indicators = IndicatorType.None;
      else
         this.indicators = this._settings.getValue("display-indicators");
      for (let wsIdx=0 ; wsIdx<this._workspaces.length ; wsIdx++) {
         let ws = this._workspaces[wsIdx];
         for (let btnIdx=0 ; btnIdx < ws._appButtons.length ; btnIdx++) {
            let btn = ws._appButtons[btnIdx];
-           if (btn._pinned || btn._shrukenLabel || (btn._windows.length > 0 && btn._windows[0].minimized)) {
-              btn._minLabelSize = -1;
-              btn._updateLabel();
-           }
+           btn._minLabelSize = -1;
+           btn._updateLabel();
         }
      }
   }
@@ -5455,7 +5532,7 @@ class WindowList extends Applet.Applet {
     this._updateMonitor();
     let nWorkspaces = global.screen.get_n_workspaces();
     if (this._settings.getValue("group-windows")===GroupType.Launcher)
-       this.indicators = 0;
+       this.indicators = IndicatorType.None;
     else
       this.indicators = this._settings.getValue("display-indicators");
     // upgrade pinned-apps

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -6,7 +6,7 @@
     "caption-page" : {
       "type" : "page",
       "title" : "Labels",
-      "sections" : ["caption-settings", "caption-number-settings"] 
+      "sections" : ["caption-settings", "caption-number-settings", "caption-progress-settings"]
     },
 
     "general-page" : {
@@ -37,12 +37,17 @@
       "type" : "section",
       "title" : "Window list button label settings",
       "dependency" : "group-windows<4",
-      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "show-ellipsis-for-groups", "label-width", "label-animation", "label-animation-time"]
+      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "auto-hide-indicators", "label-width", "label-animation", "label-animation-time"]
     },
     "caption-number-settings" : {
       "type" : "section",
-      "title" : "Number label settings",
-      "keys" : ["number-type", "display-number", "number-style"]
+      "title" : "Icon overlay label settings",
+      "keys" : ["number-type", "display-number"]
+    },
+    "caption-progress-settings" : {
+      "type" : "section",
+      "title" : "Progress settings",
+      "keys" : ["progress-display-type"]
     },
     "general-settings" : {
       "type" : "section",
@@ -112,7 +117,7 @@
       "Focused": 3
     },
     "description": "Display labels for pinned buttons",
-    "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned window that are running will have a label\nFocused: Only the pinned window with focus will have a label"
+    "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned windows that are running will have a label\nFocused: Only the pinned window with focus will have a label"
   },
   "hide-caption-for-minimized": {
     "type": "combobox",
@@ -134,17 +139,20 @@
       "Minimized windows": 1,
       "Pinned applications": 2,
       "Minimized and pinned": 3,
-      "Automatic": 7
+      "Application group window count": 11,
+      "Application group indicator (⋮)": 12,
+      "Workspace number (smart)": 13,
+      "Monitor number (smart)": 14
     },
     "description": "Display status indicators",
-    "tooltip": "Choose if the minimized and the pinned indicator characters will be prepended to button label text. Buttons without a text label will not reserve as much space.\nAutomatic: The minimized and pinned indicators will only show when space is not constrained."
+    "tooltip": "Controls what information is prepended to the button label text. On horizontal panels this data is shown even when the primary label contents are removed. Setting this to None will allow for the smallest button size. When on vertical panels this setting is ignored."
   },
-  "show-ellipsis-for-groups": {
+  "auto-hide-indicators": {
     "type": "switch",
     "default": 0,
-    "dependency" : "group-windows<4",
-    "description": "Show a vertical ellipsis (...) for grouped buttons",
-    "tooltip": "Prepend a vertical ellipsis unicode charter to the labels for grouped window-list buttons with more then one window. When on a vertical panel this option is not possible and the setting will be ignored."
+    "dependency" : "display-indicators>0",
+    "description": "Hide status indicators when space is limited",
+    "tooltip": "Hide status indicators when window list space is limited causing button labels to shrink"
   },
   "trailing-pinned-behaviour": {
     "type": "switch",
@@ -171,7 +179,7 @@
     "units": "milliseconds",
     "step": 20,
     "description": "Hover time before showing a full size window preview",
-    "tooltip": "This defines the mouse hover time before a full size window preview will appear. It applies when hovering over either window-list buttons or thumbnail menu items (of course one of the full size window preview options must be enabled for this option to have any effect)"
+    "tooltip": "This defines the mouse hover time before a full size window preview will appear. It applies when hovering over either window list buttons or thumbnail menu items (of course one of the full size window preview options must be enabled for this option to have any effect)"
   },
   "label-width": {
     "type": "spinbutton",
@@ -202,36 +210,37 @@
     "type": "combobox",
     "default": 1,
     "options": {
-      "Nothing": 0,
+      "Nothing": 100,
       "Application group window count": 1,
+      "Application group indicator (…)": 104,
       "Workspace number": 2,
-      "Monitor number": 3
+      "Monitor number": 3,
+      "Two characters from the window title": 4,
+      "Minimized indicator": 101,
+      "Pinned indicator": 102,
+      "Minimized and pinned indicators": 103
     },
-    "description": "Number label contents"
+    "description": "Icon overlay label contents"
   },
   "display-number": {
-    "type": "combobox",
-    "default": 2,
-    "options": {
-      "Always": 1,
-      "Smart": 2
-    },
-    "dependency" : "number-type>0",
-    "description": "Display number",
-    "tooltip": "Controls when the number label is used. Smart means the the label will only appear when it is appropriate depending on the number label contents setting above. i.e. When there is two or more windows in a group, or when the windows workspace or monitor does not match the current one."
+    "type": "switch",
+    "default": true,
+    "dependency" : "number-type<100",
+    "description": "Only display label when needed",
+    "tooltip": "With this option enabled, the icon overlay label will only appear when it is appropriate depending on the label content (i.e. When there are two or more windows in a group, or when the windows workspace or monitor does not match the current one). When this option is disabled the label is always shown"
   },
-  "number-style": {
+
+  "progress-display-type": {
     "type": "combobox",
     "default": 1,
     "options": {
-      "Icon overlay": 0,
-      "Label prepend": 1
+      "Disabled": 0,
+      "Using icon overlay label": 1,
+      "Prepended to button label": 2
     },
-    "dependency" : "number-type>0",
-    "description": "Number style",
-    "tooltip": "Controls how the number label is presented. When on a vertical panel or when in launcher mode, the \"label prepend\" option is not possible so \"icon overlay\" will be used instead"
+    "description": "Display window progress information (%)",
+    "tooltip": "Controls how a windows progress information is presented on the window list (i.e copying in File Manager, downloading in Firefox, updating in Update Manager, etc.). When on vertical panels the \"Prepended to button label\" option will be ignored and icon overlay will be used in its place."
   },
-
 
   "group-windows": {
     "type": "combobox",
@@ -244,7 +253,7 @@
       "Launcher": 4
     },
     "description": "Window list behavior style",
-    "tooltip": "Grouped: All windows for an application are managed by one button,\nPooled: All window list buttons for an application are pooled side by side,\nAutomatic: Windows are pooled, and then grouped when space is limited,\nOne to one: Each window gets their own button with no forced ordering,\nLauncher: Only pinned button are shown, behaves like a panel launcher."
+    "tooltip": "Grouped: All windows for an application are managed by one button,\nPooled: All window list buttons for an application are pooled side by side,\nAutomatic: Windows are pooled, and then grouped when space is limited,\nOne to one: Each window gets their own button with no forced ordering,\nLauncher: Only pinned buttons are shown, behaves like a panel launcher."
   },
   "display-pinned": {
     "type": "combobox",
@@ -263,7 +272,7 @@
     "default": false,
     "dependency" : "group-windows=4",
     "description": "Synchronize launcher buttons across all workspaces",
-    "tooltip": "If enabled, the number and order of launcher buttons on the panel will be synchronize across all workspaces."
+    "tooltip": "If enabled, the number and order of launcher buttons on the panel will be synchronized across all workspaces."
   },
   "show-windows-for-current-monitor": {
     "type": "switch",
@@ -304,14 +313,14 @@
     "default": 0,
     "dependency" : "group-windows<4",
     "description": "Show a full size window preview when hovering over a button",
-    "tooltip": "If enabled, a full size preview window will appear when the mouse pointer is hovering over a window-list button. The delay before the preview appears is controlled by an option under the Advanced tab"
+    "tooltip": "If enabled, a full size preview window will appear when the mouse pointer is hovering over a window list button. The delay before the preview appears is controlled by an option under the Advanced tab"
   },
   "no-click-activate": {
     "type": "switch",
     "default": 0,
     "dependency" : "group-windows<4",
     "description": "Automatic focus change when leaving the panel",
-    "tooltip": "If enabled, the current window for a window-list button will get the focus when the mouse pointer leaves the panel. Leaving the window-list with Ctrl or Shift held or while remaining on the panel will leave the focus unchanged. This option is typically used in conjunction with the preview hovering option above."
+    "tooltip": "If enabled, the current window for a window list button will get the focus when the mouse pointer leaves the panel. Leaving the window list with Ctrl or Shift held or while remaining on the panel will leave the focus unchanged. This option is typically used in conjunction with the preview hovering option above."
   },
 
   "menu-show-on-hover": {
@@ -344,21 +353,21 @@
     "default": false,
     "dependency" : "group-windows!=3",
     "description": "Sort grouped button thumbnail menu items",
-    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and the by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window-list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
+    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and then by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
   },
   "menu-all-windows-of-pool": {
     "type": "switch",
     "default": true,
     "dependency" : "group-windows=1",
     "description": "Show thumbnails for all windows of an application pool",
-    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather than just the selected window within the application pool"
   },
   "menu-all-windows-of-auto": {
     "type": "switch",
     "default": true,
     "dependency" : "group-windows=2",
     "description": "Show thumbnails for all windows of an application pool",
-    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather than just the selected window within the application pool"
   },
   "preview-timeout-show": {
     "type": "spinbutton",
@@ -709,7 +718,7 @@
       "Change windows workspace": 2,
       "Change windows monitor": 3,
       "Change window tiling": 4,
-      "Cycle all window-list button windows": 5,
+      "Cycle all window list button windows": 5,
       "Cycle grouped/pooled button windows": 6,
       "Do nothing": 0
     },
@@ -772,13 +781,13 @@
     "type": "switch",
     "default": true,
     "description": "Smart numeric hotkeys (using \"1\" automatically extends to 1-9)",
-    "tooltip": "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The first 9 windows of the assigned application, as ordered on the window-list, will be activated by the 9 hotkeys."
+    "tooltip": "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The first 9 windows of the assigned application, as ordered on the window list, will be activated by the 9 hotkeys."
   },
   "hotkey-grave-help": {
     "type": "switch",
     "default": true,
     "description": "Use modifier(s) + ` hotkey to show hotkey hint bubbles",
-    "tooltip": "If enabled, The hotkey modifier(s) + ` will be registered for each unique modifier set defined in the hotkey list. Using these hotkeys will temporally show a hotkey hint bubble over the button icons."
+    "tooltip": "If enabled, The hotkey modifier(s) + ` will be registered for each unique modifier set defined in the hotkey list. Using these hotkeys will temporarily show a hotkey hint bubble over the button icons."
   },
 
   "hotkey-help" : {
@@ -904,7 +913,7 @@
        "Idle pinned buttons": 2,
        "Buttons for windows on other workspaces": 3,
        "Buttons for windows on other monitors": 4,
-       "All buttons excepted focused window": 5
+       "All buttons except the focused window": 5
     },
     "dependency": "icon-saturation!=100",
     "description": "Where to apply the icon color saturation",
@@ -948,5 +957,10 @@
   "runWizard": {
      "type": "generic",
      "default": 1
+  },
+
+  "upgradeIndicator": {
+     "type": "generic",
+     "default": 0
   }
 }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
@@ -6,7 +6,7 @@
     "caption-page" : {
       "type" : "page",
       "title" : "Labels",
-      "sections" : ["caption-settings", "caption-number-settings"] 
+      "sections" : ["caption-settings", "caption-number-settings", "caption-progress-settings"]
     },
 
     "general-page" : {
@@ -37,12 +37,17 @@
       "type" : "section",
       "title" : "Window list button label settings",
       "dependency" : "group-windows<4",
-      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "show-ellipsis-for-groups", "label-width", "label-animation", "label-animation-time"]
+      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "auto-hide-indicators", "label-width", "label-animation", "label-animation-time"]
     },
     "caption-number-settings" : {
       "type" : "section",
-      "title" : "Number label settings",
-      "keys" : ["number-type", "display-number", "number-style"]
+      "title" : "Icon overlay label settings",
+      "keys" : ["number-type", "display-number"]
+    },
+    "caption-progress-settings" : {
+      "type" : "section",
+      "title" : "Progress settings",
+      "keys" : ["progress-display-type"]
     },
     "general-settings" : {
       "type" : "section",
@@ -112,7 +117,7 @@
       "Focused": 3
     },
     "description": "Display labels for pinned buttons",
-    "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned window that are running will have a label\nFocused: Only the pinned window with focus will have a label"
+    "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned windows that are running will have a label\nFocused: Only the pinned window with focus will have a label"
   },
   "hide-caption-for-minimized": {
     "type": "combobox",
@@ -134,17 +139,20 @@
       "Minimized windows": 1,
       "Pinned applications": 2,
       "Minimized and pinned": 3,
-      "Automatic": 7
+      "Application group window count": 11,
+      "Application group indicator (⋮)": 12,
+      "Workspace number (smart)": 13,
+      "Monitor number (smart)": 14
     },
     "description": "Display status indicators",
-    "tooltip": "Choose if the minimized and the pinned indicator characters will be prepended to button label text. Buttons without a text label will not reserve as much space.\nAutomatic: The minimized and pinned indicators will only show when space is not constrained."
+    "tooltip": "Controls what information is prepended to the button label text. On horizontal panels this data is shown even when the primary label contents are removed. Setting this to None will allow for the smallest button size. When on vertical panels this setting is ignored."
   },
-  "show-ellipsis-for-groups": {
+  "auto-hide-indicators": {
     "type": "switch",
     "default": 0,
-    "dependency" : "group-windows<4",
-    "description": "Show a vertical ellipsis (...) for grouped buttons",
-    "tooltip": "Prepend a vertical ellipsis unicode charter to the labels for grouped window-list buttons with more then one window. When on a vertical panel this option is not possible and the setting will be ignored."
+    "dependency" : "display-indicators>0",
+    "description": "Hide status indicators when space is limited",
+    "tooltip": "Hide status indicators when window list space is limited causing button labels to shrink"
   },
   "trailing-pinned-behaviour": {
     "type": "switch",
@@ -171,7 +179,7 @@
     "units": "milliseconds",
     "step": 20,
     "description": "Hover time before showing a full size window preview",
-    "tooltip": "This defines the mouse hover time before a full size window preview will appear. It applies when hovering over either window-list buttons or thumbnail menu items (of course one of the full size window preview options must be enabled for this option to have any effect)"
+    "tooltip": "This defines the mouse hover time before a full size window preview will appear. It applies when hovering over either window list buttons or thumbnail menu items (of course one of the full size window preview options must be enabled for this option to have any effect)"
   },
   "label-width": {
     "type": "spinbutton",
@@ -202,36 +210,37 @@
     "type": "combobox",
     "default": 1,
     "options": {
-      "Nothing": 0,
+      "Nothing": 100,
       "Application group window count": 1,
+      "Application group indicator (…)": 104,
       "Workspace number": 2,
-      "Monitor number": 3
+      "Monitor number": 3,
+      "Two characters from the window title": 4,
+      "Minimized indicator": 101,
+      "Pinned indicator": 102,
+      "Minimized and pinned indicators": 103
     },
-    "description": "Number label contents"
+    "description": "Icon overlay label contents"
   },
   "display-number": {
-    "type": "combobox",
-    "default": 2,
-    "options": {
-      "Always": 1,
-      "Smart": 2
-    },
-    "dependency" : "number-type>0",
-    "description": "Display number",
-    "tooltip": "Controls when the number label is used. Smart means the the label will only appear when it is appropriate depending on the number label contents setting above. i.e. When there is two or more windows in a group, or when the windows workspace or monitor does not match the current one."
+    "type": "switch",
+    "default": true,
+    "dependency" : "number-type<100",
+    "description": "Only display label when needed",
+    "tooltip": "With this option enabled, the icon overlay label will only appear when it is appropriate depending on the label content (i.e. When there are two or more windows in a group, or when the windows workspace or monitor does not match the current one). When this option is disabled the label is always shown"
   },
-  "number-style": {
+
+  "progress-display-type": {
     "type": "combobox",
     "default": 1,
     "options": {
-      "Icon overlay": 0,
-      "Label prepend": 1
+      "Disabled": 0,
+      "Using icon overlay label": 1,
+      "Prepended to button label": 2
     },
-    "dependency" : "number-type>0",
-    "description": "Number style",
-    "tooltip": "Controls how the number label is presented. When on a vertical panel or when in launcher mode, the \"label prepend\" option is not possible so \"icon overlay\" will be used instead"
+    "description": "Display window progress information (%)",
+    "tooltip": "Controls how a windows progress information is presented on the window list (i.e copying in File Manager, downloading in Firefox, updating in Update Manager, etc.). When on vertical panels the \"Prepended to button label\" option will be ignored and icon overlay will be used in its place."
   },
-
 
   "group-windows": {
     "type": "combobox",
@@ -244,7 +253,7 @@
       "Launcher": 4
     },
     "description": "Window list behavior style",
-    "tooltip": "Grouped: All windows for an application are managed by one button,\nPooled: All window list buttons for an application are pooled side by side,\nAutomatic: Windows are pooled, and then grouped when space is limited,\nOne to one: Each window gets their own button with no forced ordering,\nLauncher: Only pinned button are shown, behaves like a panel launcher."
+    "tooltip": "Grouped: All windows for an application are managed by one button,\nPooled: All window list buttons for an application are pooled side by side,\nAutomatic: Windows are pooled, and then grouped when space is limited,\nOne to one: Each window gets their own button with no forced ordering,\nLauncher: Only pinned buttons are shown, behaves like a panel launcher."
   },
   "display-pinned": {
     "type": "combobox",
@@ -263,7 +272,7 @@
     "default": false,
     "dependency" : "group-windows=4",
     "description": "Synchronize launcher buttons across all workspaces",
-    "tooltip": "If enabled, the number and order of launcher buttons on the panel will be synchronize across all workspaces."
+    "tooltip": "If enabled, the number and order of launcher buttons on the panel will be synchronized across all workspaces."
   },
   "show-windows-for-current-monitor": {
     "type": "switch",
@@ -304,14 +313,14 @@
     "default": 0,
     "dependency" : "group-windows<4",
     "description": "Show a full size window preview when hovering over a button",
-    "tooltip": "If enabled, a full size preview window will appear when the mouse pointer is hovering over a window-list button. The delay before the preview appears is controlled by an option under the Advanced tab"
+    "tooltip": "If enabled, a full size preview window will appear when the mouse pointer is hovering over a window list button. The delay before the preview appears is controlled by an option under the Advanced tab"
   },
   "no-click-activate": {
     "type": "switch",
     "default": 0,
     "dependency" : "group-windows<4",
     "description": "Automatic focus change when leaving the panel",
-    "tooltip": "If enabled, the current window for a window-list button will get the focus when the mouse pointer leaves the panel. Leaving the window-list with Ctrl or Shift held or while remaining on the panel will leave the focus unchanged. This option is typically used in conjunction with the preview hovering option above."
+    "tooltip": "If enabled, the current window for a window list button will get the focus when the mouse pointer leaves the panel. Leaving the window list with Ctrl or Shift held or while remaining on the panel will leave the focus unchanged. This option is typically used in conjunction with the preview hovering option above."
   },
 
   "menu-show-on-hover": {
@@ -344,21 +353,21 @@
     "default": false,
     "dependency" : "group-windows!=3",
     "description": "Sort grouped button thumbnail menu items",
-    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and the by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window-list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
+    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and then by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
   },
   "menu-all-windows-of-pool": {
     "type": "switch",
     "default": true,
     "dependency" : "group-windows=1",
     "description": "Show thumbnails for all windows of an application pool",
-    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather than just the selected window within the application pool"
   },
   "menu-all-windows-of-auto": {
     "type": "switch",
     "default": true,
     "dependency" : "group-windows=2",
     "description": "Show thumbnails for all windows of an application pool",
-    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather than just the selected window within the application pool"
   },
   "preview-timeout-show": {
     "type": "spinbutton",
@@ -709,7 +718,7 @@
       "Change windows workspace": 2,
       "Change windows monitor": 3,
       "Change window tiling": 4,
-      "Cycle all window-list button windows": 5,
+      "Cycle all window list button windows": 5,
       "Cycle grouped/pooled button windows": 6,
       "Do nothing": 0
     },
@@ -772,13 +781,13 @@
     "type": "switch",
     "default": true,
     "description": "Smart numeric hotkeys (using \"1\" automatically extends to 1-9)",
-    "tooltip": "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The first 9 windows of the assigned application, as ordered on the window-list, will be activated by the 9 hotkeys."
+    "tooltip": "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The first 9 windows of the assigned application, as ordered on the window list, will be activated by the 9 hotkeys."
   },
   "hotkey-grave-help": {
     "type": "switch",
     "default": true,
     "description": "Use modifier(s) + ` hotkey to show hotkey hint bubbles",
-    "tooltip": "If enabled, The hotkey modifier(s) + ` will be registered for each unique modifier set defined in the hotkey list. Using these hotkeys will temporally show a hotkey hint bubble over the button icons."
+    "tooltip": "If enabled, The hotkey modifier(s) + ` will be registered for each unique modifier set defined in the hotkey list. Using these hotkeys will temporarily show a hotkey hint bubble over the button icons."
   },
 
   "hotkey-help" : {
@@ -899,7 +908,7 @@
        "Idle pinned buttons": 2,
        "Buttons for windows on other workspaces": 3,
        "Buttons for windows on other monitors": 4,
-       "All buttons excepted focused window": 5
+       "All buttons except the focused window": 5
     },
     "dependency": "icon-saturation!=100",
     "description": "Where to apply the icon color saturation",
@@ -943,5 +952,10 @@
   "runWizard": {
      "type": "generic",
      "default": 1
+  },
+
+  "upgradeIndicator": {
+     "type": "generic",
+     "default": 0
   }
 }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.4/applet.js
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.4/applet.js
@@ -65,6 +65,18 @@ const FLASH_INTERVAL = 500;
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 const PANEL_ZONE_TEXT_SIZES = "panel-zone-text-sizes";
 
+const U_PERCENT    = "\u{066A}";
+const U_MIN_UP     = "\u{2191}";
+const U_MIN_DOWN   = "\u{2193}";
+const U_PINNED     = "\u{1F4CC}";
+const U_ELLIPSIS_V = "\u{22EE}";
+const U_ELLIPSIS_H = "\u{2026}";
+
+const U_DIGIT_ONE = 10122; // Circled One 9312 -- Parenthesized One 9332 -- Negative Circled Digit One 10122
+const U_DIGIT_SPLIT = 9451; // Negative Circled Number Eleven
+const U_DIGIT_SPLIT_NUM = 11;
+const U_DIGIT_LIMIT = 20;
+const U_MANY = "\u{2026}";  // Used when the number is greater than U_DIGIT_LIMIT
 
 const STYLE_CLASS_ATTENTION_STATE = "grouped-window-list-item-demands-attention";
 
@@ -150,16 +162,21 @@ const DisplayCaption = {
 
 // The possible user Settings for how the number label should be displayed
 const DisplayNumber = {
-  No: 0,            // The number label for a  window list button is never displayed
-  All: 1,           // ... always displayed
-  Smart: 2          // ... only displayed when 2 of more windows exist
+  All: false,           // ... always displayed
+  Smart: true          // ... only displayed when 2 of more windows exist
 }
 
 const NumberType = {
-  Nothing:      0,  // Don't show any Number labels
   GroupWindows: 1,  // Application Group Window Count
   WorkspaceNum: 2,  // Workspace Number
-  MonitorNum:   3   // Monitor Number
+  MonitorNum:   3,  // Monitor Number
+  TitleChar:    4,  // First character of the window title
+  // Numbers below 100 can have a "smart" configuration, 100 and above don't have a smart option
+  Nothing:      100,  // Don't show any Number labels (was 0 in the past)
+  Minimized:    101,  // Minimized window indicator
+  Pinned:       102,  // Pinned window-list button indicator
+  MinAndPin:    103,  // Both minimized and pinned indicators
+  Ellipsis:     104   // Use a Ellipsis Unicode character to indicate the button is grouped with more than one window
 }
 
 // Possible values for the WindowListButton._grouped variable which determines how each individual windowlist button is currently grouped
@@ -252,7 +269,11 @@ const IndicatorType = {
    Minimized: 1,
    Pinned: 2,
    Both: 3,
-   Auto: 7
+   Auto: 7,
+   GroupWindows: 11,  // Application Group Window Count
+   Ellipsis:     12,
+   WorkspaceNum: 13,  // Workspace Number
+   MonitorNum:   14   // Monitor Number
 }
 
 // This is the possible values for the scroll wheel when the Thumbnail menu is open
@@ -308,6 +329,12 @@ const HideLabels = {
    OtherMonitors: 3
 }
 
+const ProgressDisplay = {
+   Disabled: 0,
+   IconOverlay: 1,
+   LabelPrepend: 2
+}
+
 var hasSetMarkup = undefined;
 var hasGetFrameRect = undefined;
 var hasGetCurrentMonitor = undefined;
@@ -351,7 +378,7 @@ function resizeActor(actor, time, toWidth, text, button) {
        if (this._shrukenLabel) {
           // Since some fonts don't seem to report the right size when calling get_pixel_size() before animation is complete
           // so we need to see what the actual size is now and set _minLabelSize accordingly.
-          let minText = (this._pinned && (this._applet.indicators&IndicatorType.Pinned)) ? "\u{1F4CC}\u{2193}" : "\u{2193}";
+          let minText = (this._pinned && (this._applet.indicators===IndicatorType.Pinned || this._applet.indicators===IndicatorType.Both)) ? U_PINNED+U_MIN_DOWN : U_MIN_DOWN;
           if (text == minText) {
              let layout = this._label.get_clutter_text().get_layout();
              let [curWidth, curHeight] = layout.get_pixel_size();
@@ -1501,15 +1528,14 @@ class WindowListButton {
     this._signalManager.connect(this.actor, "scroll-event", this._onScrollEvent, this);
     //this._signalManager.connect(this.actor, "notify::allocation", this._allocationChanged, this);
     this._signalManager.connect(this._settings, "changed::caption-type", this._updateLabel, this);
-    this._signalManager.connect(this._settings, "changed::display-caption-for-pined", this._updateLabel, this);
+    this._signalManager.connect(this._settings, "changed::display-caption-for-pined", this._updateLabel, this); // typo left for compatibility
     this._signalManager.connect(this._settings, "changed::hide-caption-for-minimized", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::display-caption-for", this._updateLabel, this);
-    this._signalManager.connect(this._settings, "changed::show-ellipsis-for-groups", this._updateLabel, this);
+    this._signalManager.connect(this._settings, "changed::progress-display-type", this._updateProgress, this);
     this._signalManager.connect(this._settings, "changed::display-number", this._updateNumber, this);
     this._signalManager.connect(this._settings, "changed::menu-show-on-hover", this._updateTooltip, this);
     this._signalManager.connect(this._settings, "changed::grouped-mouse-action-btn1", this._updateTooltip, this);
     this._signalManager.connect(this._settings, "changed::show-tooltips", this._updateTooltip, this);
-    this._signalManager.connect(this._settings, "changed::number-style", Lang.bind(this, function() { this._updateNumber(); this._updateLabel(); }), this);
     this._signalManager.connect(this._settings, "changed::number-type", Lang.bind(this, function() { this._updateNumber(); this._updateLabel(); }), this);
     this._signalManager.connect(this._settings, "changed::label-width", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::button-spacing", this._updateSpacing, this);
@@ -1519,9 +1545,7 @@ class WindowListButton {
     this._signalManager.connect(this.actor, "notify::hover", this._updateVisualState, this);
     this._signalManager.connect(this._contextMenu, "open-state-changed", this._contextState, this);
 
-    this._signalManager.connect(Main.themeManager, "theme-set", Lang.bind(this, function() {
-      this.updateView();
-    }), this);
+    this._signalManager.connect(Main.themeManager, "theme-set", Lang.bind(this, function() { this.updateView(); }), this);
     this._signalManager.connect(St.TextureCache.get_default(), "icon-theme-changed", this.updateIcon, this);
 
     this._draggable = DND.makeDraggable(this.actor);
@@ -1534,6 +1558,12 @@ class WindowListButton {
     this.isDraggableApp = true;
     this._updateNumber();
     this._updateSpacing();
+  }
+
+  _updateProgress() {
+     // Allow the icon overlay label and the button label to add/remove any progress state
+     this._updateNumber();
+     this._updateLabel();
   }
 
   //_allocationChanged() {
@@ -1742,7 +1772,7 @@ class WindowListButton {
     this._signalManager.connect(metaWindow, "notify::gtk-application-id", this._onGtkApplicationChanged, this);
     this._signalManager.connect(metaWindow, "notify::wm-class", this._onWmClassChanged, this);
     this._signalManager.connect(metaWindow, 'notify::icon', this.updateIcon, this);
-    //this._signalManager.connect(metaWindow, "notify::progress", this._onProgressChange, this);
+    this._signalManager.connect(metaWindow, "notify::progress", this._onProgressChange, this);
     this._signalManager.connect(metaWindow, "workspace-changed", this._onWindowWorkspaceChanged, this);
 
     if (this._applet._displayPinned !== DisplayPinned.Disabled)
@@ -1800,22 +1830,16 @@ class WindowListButton {
     this._updateVisibility();
   }
 
-  /*
   _onProgressChange() {
-     if (this._currentWindow && this._currentWindow.progress !== undefined && this.actor.is_visible()) {
-        if (this._currentWindow.progress !== 0 ) {
-           let width = Math.max((this.actor.width) * (this._currentWindow.progress / 100.0), 1.0);
-           let height = Math.max((this._applet._panelHeight * 0.15), 1.0);
-           let box = Clutter.ActorBox.new(0,0,width,height);
-           log( `Updating progress to ${this._currentWindow.progress}%` );
-           this.progressOverlay.allocate(box, 0);
-           this.progressOverlay.show();
-        } else if (this.progressOverlay.is_visible()){
-           log( "Disabling progress bar" );
-           this.progressOverlay.hide();
-        }
+     let progressDisplayType = this._settings.getValue("progress-display-type");
+     if (progressDisplayType === ProgressDisplay.IconOverlay ||
+        this._applet.orientation == St.Side.LEFT  || this._applet.orientation == St.Side.RIGHT)
+     {
+        this._updateNumber();
+     } else if (progressDisplayType == ProgressDisplay.LabelPrepend ) {
+        this._updateLabel();
      }
-  }*/
+  }
 
   _updateCurrentWindow() {
     // Without slice, this will reorder to windows in the this._windows array
@@ -1904,6 +1928,11 @@ class WindowListButton {
           }
        }
     }
+    // Add text to show the number of windows in this group
+    if (this._windows.length > 1) {
+       text = text + "\n" + this._windows.length + " " + _("windows in this group")
+    }
+    // Get the most appropriate windows tile for this button
     let title = null;
     let leftClickAction = this.getButton1Action();
     if (this._windows.length > 0 && (this._windows.length === 1 || leftClickAction!==LeftClickGrouped.Thumbnail)) {
@@ -1916,6 +1945,7 @@ class WindowListButton {
     if (title===null) {
        title = this._app.get_name();
     }
+    // Compose the final text and set the tooltip text
     if (text.length == 0 || !hasSetMarkup) {
        this._tooltip.set_text(title + text);
     } else {
@@ -2010,10 +2040,25 @@ class WindowListButton {
      this._labelNumberBin.height = size;
   }
 
+  // This will update the icon overlay label
   _updateNumber() {
+    // If the window has an active progress, display the percentage if needed.
+    let progressType = this._settings.getValue("progress-display-type");
+    if (this._currentWindow && this._currentWindow.progress !== undefined && this._currentWindow.progress !== 0 &&
+        this.actor.is_visible() && (progressType === ProgressDisplay.IconOverlay || (progressType === ProgressDisplay.LabelPrepend &&
+        (this._applet.orientation === St.Side.LEFT || this._applet.orientation === St.Side.RIGHT))))
+    {
+       this._labelNumber.set_text(this._currentWindow.progress + U_PERCENT);  // Arabic Percent Sign (thinner than a normal percent sign)
+       this._labelNumberBox.show();
+       let [width, height] = this._labelNumber.get_size();
+       let size = Math.max(width, height);
+       this._labelNumberBin.width = size;
+       this._labelNumberBin.height = size;
+       return;
+    }
+    // There is no active progress, so show the default icon overlay
     let numberType = this._settings.getValue("number-type");
     let setting = this._settings.getValue("display-number");
-    let style = this._settings.getValue("number-style");
     let groupType = this._settings.getValue("group-windows");
     let text = "";
     let number = this._windows.length;
@@ -2022,10 +2067,7 @@ class WindowListButton {
        this._grouped = GroupingType.NotGrouped;
     }
 
-    if (style == 1 && (groupType == GroupType.Launcher || (this._applet.orientation == St.Side.LEFT || this._applet.orientation == St.Side.RIGHT)))
-       style = 0;  // No space for a label based window group counter, so force the icon overlay option if it's not disabled!
-
-    if (style === 0 && numberType !== NumberType.Nothing) {
+    if (numberType && numberType !== NumberType.Nothing) {
        if (numberType === NumberType.GroupWindows && ( (setting == DisplayNumber.All && number >= 1) ||
           ((setting == DisplayNumber.Smart && number >= 2) &&
           (groupType == GroupType.Grouped || groupType == GroupType.Launcher || this._grouped > GroupingType.NotGrouped))))
@@ -2035,14 +2077,38 @@ class WindowListButton {
           text += this._currentWindow.get_workspace().index()+1;
        } else if (numberType === NumberType.MonitorNum && this._currentWindow && (setting === DisplayNumber.All || this.isOnOtherMonitor())) {
           text += this._currentWindow.get_monitor()+1;
+       } else if (numberType === NumberType.TitleChar && this._currentWindow) {
+          let btns = (setting === DisplayNumber.All) ? null : this._workspace._lookupAllAppButtonsForApp(this._app);
+          if ((setting === DisplayNumber.Smart && btns.length > 1) || setting === DisplayNumber.All) {
+             let title = this._currentWindow.get_title();
+             if (title && title.length > 0) {
+                if (this._app && title.startsWith(this._app.get_name())) {
+                   title = title.substring(this._app.get_name().length).trim();
+                   if (title.startsWith("-")) {
+                      title = title.substring(1).trim();
+                   }
+                }
+                text += title.substring(0,2).trim();
+             }
+          }
+       } else if (numberType === NumberType.Minimized && this._currentWindow && this._currentWindow.minimized) {
+          text = ((this._applet.orientation !== St.Side.TOP)?U_MIN_DOWN:U_MIN_UP);  // The Unicode character up or down arrow
+       } else if (numberType === NumberType.Pinned && this._pinned) {
+          text = U_PINNED; // Unicode for the "push pin" character
+       } else if (numberType === NumberType.MinAndPin) {
+          text = "";
+          if (this._currentWindow && this._currentWindow.minimized == true)
+             text += ((this._applet.orientation !== St.Side.TOP)?U_MIN_DOWN:U_MIN_UP);  // The Unicode character up or down arrow
+          if (this._pinned)
+             text += U_PINNED; // Unicode for the "round push pin" character
+       } else if (numberType === NumberType.Ellipsis && number >= 2) {
+          text += U_ELLIPSIS_H; // Unicode for the "..." character
        }
     }
 
-    if (text == "" || style == 1) {
+    if (text == "") {
       this._labelNumberBox.hide();
-      if (style == 1)
-         this._updateLabel();
-    } else if (style == 0) {
+    } else {
       this._labelNumber.set_text(text);
       this._labelNumberBox.show();
       let [width, height] = this._labelNumber.get_size();
@@ -2075,12 +2141,10 @@ class WindowListButton {
 
     let capSetting = this._settings.getValue("display-caption-for");
     let numSetting = this._settings.getValue("display-number");
-    let pinnedSetting = this._settings.getValue("display-caption-for-pined");
+    let pinnedSetting = this._settings.getValue("display-caption-for-pined"); // typo left for compatibility
     let hideSetting = this._settings.getValue("hide-caption-for-minimized"); // For compatibility, the option name "hide-caption-for-minimized" was maintained, but now it has more then one possible value not only for minimized windows
-    let style = this._settings.getValue("number-style");
     let numberType = this._settings.getValue("number-type");
     let preferredWidth = this._settings.getValue("label-width");
-    let ellipsis = this._settings.getValue("show-ellipsis-for-groups");
     let number = this._windows.length;
     let text = "";
     let width = preferredWidth;
@@ -2172,38 +2236,49 @@ class WindowListButton {
        this._shrukenLabel = true;
     }
 
-    // Do we need a number label char
-    if (numberType !== NumberType.Nothing && style === 1) {
+    if (this._currentWindow && this._currentWindow.progress !== undefined && this._currentWindow.progress !== 0 &&
+        this.actor.is_visible() && this._settings.getValue("progress-display-type") == ProgressDisplay.LabelPrepend)
+    {
+       text = this._currentWindow.progress + U_PERCENT + text;  // Arabic Percent Sign (thinner than a normal percent sign)
+    } else if (this._applet.indicators!==IndicatorType.None) {
+       // We have some sort of label prepend option enabled
        let labelNum = 0;
-       if (numberType === NumberType.GroupWindows && ((numSetting === DisplayNumber.All && number >= 1) || ((numSetting === DisplayNumber.Smart && number >= 2) &&
-          (groupSetting === 0 || this._grouped > GroupingType.NotGrouped))))
-       {
+       if (this._applet.indicators===IndicatorType.GroupWindows && number >= 2) {
           labelNum = number;
-       } else if (numberType === NumberType.WorkspaceNum && this._currentWindow && (numSetting === DisplayNumber.All || this.isOnOtherWorkspace())) {
+       } else if (this._applet.indicators===IndicatorType.WorkspaceNum && this._currentWindow && this.isOnOtherWorkspace()) {
          labelNum =  this._currentWindow.get_workspace().index()+1;
-       } else if (numberType === NumberType.MonitorNum && this._currentWindow && (numSetting === DisplayNumber.All || this.isOnOtherMonitor())) {
+       } else if (this._applet.indicators===IndicatorType.MonitorNum && this._currentWindow && this.isOnOtherMonitor()) {
          labelNum = this._currentWindow.get_monitor()+1;
        }
        if (labelNum > 0) {
-         if (labelNum > 20) {
-           text = "\u{24A8} " + text; // The Unicode character "(m)"
+         if (labelNum > U_DIGIT_LIMIT) {
+           text = U_MANY + text; // Unicode character to represent "many"
          } else {
-           text = String.fromCharCode(9331+labelNum) + " " + text; // Bracketed number
+           if (labelNum < U_DIGIT_SPLIT_NUM) {
+             text = String.fromCharCode(U_DIGIT_ONE+(labelNum-1)) + " " + text; // Unicode number symbol
+           } else {
+             text = String.fromCharCode(U_DIGIT_SPLIT+(labelNum-U_DIGIT_SPLIT_NUM)) + " " + text; // Unicode number symbol
+           }
          }
        }
+       // Do we need a minimized char
+       if (this._currentWindow && this._currentWindow.minimized && (this._applet.indicators===IndicatorType.Minimized || this._applet.indicators===IndicatorType.Both) && this._workspace.autoIndicatorsOff==false) {
+         text = ((this._applet.orientation !== St.Side.TOP)?U_MIN_DOWN:U_MIN_UP) + text;  // The Unicode character up or down arrow
+       }
+       // Do we need a pinned char
+       if (this._pinned && (this._applet.indicators===IndicatorType.Pinned || this._applet.indicators===IndicatorType.Both) && this._workspace.autoIndicatorsOff==false) {
+           text = U_PINNED + text; // Unicode for the "push pin" character
+       }
+       // Do we need a group ellipsis char
+       if (this._applet.indicators===IndicatorType.Ellipsis === true && number >= 2)
+       {
+          text = U_ELLIPSIS_V + text;  // The Unicode character "Vertical Ellipsis"
+       }
     }
-    // Do we need a minimized char
-    if (this._currentWindow && this._currentWindow.minimized && (this._applet.indicators&IndicatorType.Minimized) && this._workspace.autoIndicatorsOff==false) {
-      text = ((this._applet.orientation === St.Side.BOTTOM)?"\u{2193}":"\u{2191}") + text;  // The Unicode character up or down arrow
-    } 
-    // Do we need a pinned char
-    if (this._pinned && (this._applet.indicators&IndicatorType.Pinned) && this._workspace.autoIndicatorsOff==false) {
-        text = "\u{1F4CC}" + text; // Unicode for the "push pin" character
-    }
-    // Do we need a group ellipsis char
-    if (ellipsis === true && number >= 2)
-    {
-       text = "\u{22EE}" + text;  // The Unicode character "Vertical Ellipsis"
+
+    // The window title might have changed, so we might need to update the icon overlay label
+    if (numberType === NumberType.TitleChar) {
+       this._updateNumber();
     }
 
     // If we don't have a minimum label size, calculate it now!
@@ -2211,7 +2286,7 @@ class WindowListButton {
        if (this._workspace.autoIndicatorsOff==true || this._applet.indicators==IndicatorType.None || (this._pinned && this._windows.length==0)) {
           this._minLabelSize = 0;
        } else {
-          let minText = (this._pinned && (this._applet.indicators&IndicatorType.Pinned)) ? "\u{1F4CC}\u{2193}" : "\u{2193}";
+          let minText = (this._pinned && (this._applet.indicators===IndicatorType.Pinned || this._applet.indicators===IndicatorType.Both)) ? U_PINNED+U_MIN_DOWN : U_MIN_DOWN;
           this._label.set_text(minText);
           let layout = this._label.get_clutter_text().get_layout();
           let [minWidth, minHeight] = layout.get_pixel_size();
@@ -4456,6 +4531,10 @@ class Workspace {
 
     appButton._pinned = true;
     appButton._updateVisibility()
+    let numberType = this._settings.getValue("number-type");
+    if (numberType === NumberType.Pinned || numberType === NumberType.MinAndPin) {
+       appButton._updateNumber();
+    }
     this._updatePinSettings();
   }
 
@@ -4569,7 +4648,7 @@ class Workspace {
              if (this.iconSaturation!=100 && this.saturationType == SaturationType.Focused) {
                 this._currentFocus.updateIconSelection();
              }
-             let pinnedSetting = this._settings.getValue("display-caption-for-pined");
+             let pinnedSetting = this._settings.getValue("display-caption-for-pined"); // typo left for compatibility
              let capSetting = this._settings.getValue("display-caption-for");
              if (pinnedSetting == PinnedLabel.Focused && capSetting === DisplayCaption.One) {
                 // Do we need to clear the label from the pooled window group
@@ -4865,7 +4944,7 @@ class Workspace {
         return;
      }
      if (this._areButtonsShrunk()==true) {
-        if (this._applet.indicators == IndicatorType.Auto) {
+        if (this._settings.getValue("auto-hide-indicators")) {
            this.autoIndicatorsOff = true;   // Remove the indicator characters
            for (let i=0 ; i<this._appButtons.length ; i++) {
               if (this._appButtons[i]._pinned || (this._appButtons[i]._currentWindow && this._appButtons[i]._currentWindow.minimized)) {
@@ -5015,7 +5094,7 @@ class WindowList extends Applet.Applet {
     this._hiddenApps = null;    // List of applications that should not be visible buttons
     this._pinnedApps = null;    // cached version of "pinned_apps"
     this._displayPinned = null; // cached "display-pinned" setting
-    this.indicators = 3;
+    this.indicators = IndicatorType.Both;
     this.instanceId = instanceId;
     this.on_orientation_changed(orientation);
   }
@@ -5359,17 +5438,15 @@ class WindowList extends Applet.Applet {
 
   _updateIndicators() {
      if (this._settings.getValue("group-windows")===GroupType.Launcher)
-        this.indicators = 0;
+        this.indicators = IndicatorType.None;
      else
         this.indicators = this._settings.getValue("display-indicators");
      for (let wsIdx=0 ; wsIdx<this._workspaces.length ; wsIdx++) {
         let ws = this._workspaces[wsIdx];
         for (let btnIdx=0 ; btnIdx < ws._appButtons.length ; btnIdx++) {
            let btn = ws._appButtons[btnIdx];
-           if (btn._pinned || btn._shrukenLabel || (btn._windows.length > 0 && btn._windows[0].minimized)) {
-              btn._minLabelSize = -1;
-              btn._updateLabel();
-           }
+           btn._minLabelSize = -1;
+           btn._updateLabel();
         }
      }
   }
@@ -5424,7 +5501,7 @@ class WindowList extends Applet.Applet {
     this._updateMonitor();
     let nWorkspaces = global.screen.get_n_workspaces();
     if (this._settings.getValue("group-windows")===GroupType.Launcher)
-       this.indicators = 0;
+       this.indicators = IndicatorType.None;
     else
       this.indicators = this._settings.getValue("display-indicators");
     // upgrade pinned-apps

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/SetupWizard.ui
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/SetupWizard.ui
@@ -123,7 +123,7 @@ Panel buttons for all running windows.</property>
                 <child>
                   <object class="GtkRadioButton" id="launcher_radio">
                     <property name="label" translatable="yes">Panel Launcher (Quick launcher)
-Panel button only appear when you add items
+Panel buttons only appear when you pin items
 to the panel, no labels are shown, only icons.</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
@@ -190,7 +190,7 @@ backup</property>
                 <child>
                   <object class="GtkRadioButton" id="one_to_one_radio">
                     <property name="label" translatable="yes">Basic  -  Quick window access
-Every window gets it's own window list button.
+Every window gets its own window list button.
 Button labels are window titles.</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
@@ -234,8 +234,8 @@ Button labels are window titles.</property>
                 <child>
                   <object class="GtkRadioButton" id="pooled_radio">
                     <property name="label" translatable="yes">Pooling  -  Quick access &amp; compact
-Every window gets it's own window list button.
-Application buttons are pooled togeather.
+Every window gets its own window list button.
+Application buttons are pooled together.
 One button label per application pool.
 Button labels are application names.</property>
                     <property name="visible">True</property>
@@ -367,7 +367,7 @@ Button labels are application names.</property>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Unlike most Panel Launcher applets, this launcher keeps tack of 
+                    <property name="label" translatable="yes">Unlike most Panel Launcher applets, this launcher keeps track of 
 running windows and uses window Thumbnail menus.
 
 You can launch additional windows by clicking the 'Back' mouse 
@@ -505,7 +505,7 @@ windows already exist for a launcher button?</property>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">There are many more options and features to explorer in the
+                    <property name="label" translatable="yes">There are many more options and features to explore in the
 applet configurator and the window list button context menu,
 for example:
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
@@ -5,6 +5,6 @@
     "max-instances": -1,
     "multiversion": true,
     "role": "panellauncher",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "author": "klangman"
 }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CassiaWindowList@klangman 2.4.0\n"
+"Project-Id-Version: CassiaWindowList@klangman 2.4.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,32 +17,36 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr ""
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr ""
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr ""
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr ""
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr ""
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -64,76 +68,76 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr ""
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr ""
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr ""
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr ""
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr ""
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr ""
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr ""
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr ""
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr ""
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr ""
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr ""
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 msgid "Always on top"
 msgstr ""
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr ""
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr ""
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr ""
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr ""
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr ""
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr ""
 
@@ -155,48 +159,48 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 msgid "Move window here"
 msgstr ""
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr ""
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr ""
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr ""
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr ""
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr ""
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr ""
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr ""
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr ""
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -218,39 +222,39 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr ""
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr ""
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr ""
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr ""
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 msgid "Close other windows for application"
 msgstr ""
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr ""
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 msgid "Close all windows for application"
 msgstr ""
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr ""
 
@@ -315,7 +319,13 @@ msgstr ""
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
-msgid "Number label settings"
+msgid "Icon overlay label settings"
+msgstr ""
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+msgid "Progress settings"
 msgstr ""
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -392,13 +402,10 @@ msgstr ""
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr ""
 
@@ -452,7 +459,7 @@ msgstr ""
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 
@@ -514,12 +521,30 @@ msgid "Minimized and pinned"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
+#. 6.4->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+msgid "Application group indicator (⋮)"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+msgid "Workspace number (smart)"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+msgid "Monitor number (smart)"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-indicators->description
@@ -532,26 +557,24 @@ msgstr ""
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
 msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -612,7 +635,7 @@ msgstr ""
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -659,7 +682,7 @@ msgstr ""
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
-msgid "Application group window count"
+msgid "Application group indicator (…)"
 msgstr ""
 
 #. 4.0->settings-schema.json->number-type->options
@@ -674,59 +697,87 @@ msgstr ""
 msgid "Monitor number"
 msgstr ""
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Minimized indicator"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Pinned indicator"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Minimized and pinned indicators"
+msgstr ""
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
-msgid "Number label contents"
-msgstr ""
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
+msgid "Icon overlay label contents"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
+msgid "Only display label when needed"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Using icon overlay label"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
 msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
 msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
@@ -739,6 +790,12 @@ msgstr ""
 #. 6.0->settings-schema.json->group-windows->options
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
+msgstr ""
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
 msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
@@ -767,13 +824,7 @@ msgid ""
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
-msgstr ""
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 
 #. 4.0->settings-schema.json->display-pinned->options
@@ -815,7 +866,7 @@ msgstr ""
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 
 #. 4.0->settings-schema.json->show-windows-for-current-monitor->description
@@ -894,7 +945,7 @@ msgstr ""
 #. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 
@@ -908,8 +959,8 @@ msgstr ""
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -990,9 +1041,9 @@ msgstr ""
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1014,7 +1065,7 @@ msgstr ""
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 
@@ -1989,7 +2040,7 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
-msgid "Cycle all window-list button windows"
+msgid "Cycle all window list button windows"
 msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2133,7 +2184,7 @@ msgstr ""
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 
@@ -2148,8 +2199,8 @@ msgstr ""
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 
 #. 4.0->settings-schema.json->hotkey-help->description
@@ -2282,7 +2333,7 @@ msgstr ""
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+msgid "All buttons except the focused window"
 msgstr ""
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2320,7 +2371,7 @@ msgstr ""
 #. SetupWizard.ui:125
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 
@@ -2337,7 +2388,7 @@ msgstr ""
 #. SetupWizard.ui:192
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 
@@ -2352,8 +2403,8 @@ msgstr ""
 #. SetupWizard.ui:236
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2380,7 +2431,7 @@ msgstr ""
 
 #. SetupWizard.ui:370
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2412,7 +2463,7 @@ msgstr ""
 
 #. SetupWizard.ui:508
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ca.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: 2024-11-20 02:03+0100\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,32 +18,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "tots els botons"
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Preferències de la miniaplicació"
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "Quant a..."
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Configura..."
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr "Lloc web"
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Segur que voleu eliminar aquesta instància de la Llista de Finestres Cassia?"
@@ -66,76 +70,76 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Obre una nova finestra"
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Elimina del tauler"
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Elimina d'aquest espai de treball"
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "Fixar al tauler"
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "Fixar a aquest espai de treball"
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "Fixar a altres espais de treball"
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "Fixar a tots els espais de treball"
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "Fixar al llançador"
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Afegir nova drecera per a"
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Fitxers recents"
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Llocs"
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 msgid "Always on top"
 msgstr "Sempre en primer pla"
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Només en aquest espai de treball"
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Visible a tots els espais de treball"
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Moure a un altre espai de treball"
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr " (aquest espai de treball)"
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Moure a un altre monitor"
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -157,48 +161,48 @@ msgstr "Monitor"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 msgid "Move window here"
 msgstr "Moure finestra aquí"
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "sense assignar"
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Assignar finestra a una drecera"
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Canviar el contingut de l'etiqueta de l'aplicació"
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Eliminar preferència personalitzada"
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Utilitzar el títol de la finestra"
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "Utilitzar el nom de l'aplicació"
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Sense etiqueta"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Desagrupar les finestres de l'aplicació"
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Agrupar les finestres de l'aplicació"
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupar/Desagrupar automàticament"
 
@@ -220,39 +224,39 @@ msgstr "Agrupar/Desagrupar automàticament"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Moure la barra del títol a la pantalla"
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Restaurar"
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Minimitzar"
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "Desmaximitzar"
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Tancar altres"
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 msgid "Close other windows for application"
 msgstr "Tancar altres finestres de l'aplicació"
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Tancar totes"
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 msgid "Close all windows for application"
 msgstr "Tancar totes les finestres de l'aplicació"
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Tancar"
 
@@ -319,8 +323,16 @@ msgstr "Configuració de l'etiqueta del botó de la llista de finestres"
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
-msgid "Number label settings"
+#, fuzzy
+msgid "Icon overlay label settings"
 msgstr "Configuració de l'etiqueta numèrica"
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+#, fuzzy
+msgid "Progress settings"
+msgstr "Configuració de dreceres del teclat"
 
 #. 4.0->settings-schema.json->general-settings->title
 #. 6.0->settings-schema.json->general-settings->title
@@ -396,13 +408,10 @@ msgstr "Mai"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr "Sempre"
 
@@ -458,10 +467,11 @@ msgstr "Mostra etiquetes per a botons fixats"
 #. 4.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.4->settings-schema.json->display-caption-for-pined->tooltip
+#, fuzzy
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 "Mai: Les finestres fixades no tindran etiqueta\n"
@@ -531,13 +541,34 @@ msgid "Minimized and pinned"
 msgstr "Minimitzat i fixat"
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
-msgstr "Automàtic"
+#. 6.4->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr "Recompte de finestres de grups d'aplicacions"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Application group indicator (⋮)"
+msgstr "Recompte de finestres de grups d'aplicacions"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Workspace number (smart)"
+msgstr "Número de l'espai de treball"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Monitor number (smart)"
+msgstr "Número del monitor"
 
 #. 4.0->settings-schema.json->display-indicators->description
 #. 6.0->settings-schema.json->display-indicators->description
@@ -549,35 +580,25 @@ msgstr "Mostra els indicadors d'estat"
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
-"Tria si els indicadors de minimitzat i fixat es mostraran abans del text de "
-"l'etiqueta del botó. Els botons sense etiqueta de text no reservaran tant "
-"d'espai.\n"
-"Automàtic: els indicadors de minimitzat i fixat es mostraran només si hi ha "
-"prou espai per a ells."
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
-msgstr "Mostrà una el·lipsi vertical (...) per a botons agrupats"
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
+msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
-"Afegeix una el·lipsi vertical a les etiquetes agrupades per botons de llista "
-"de finestra amb més d'una finestra. Aquesta opció no té cap efecte sobre els "
-"taulers verticals (serà ignorada)."
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -642,9 +663,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -695,7 +717,8 @@ msgstr "Res"
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
-msgid "Application group window count"
+#, fuzzy
+msgid "Application group indicator (…)"
 msgstr "Recompte de finestres de grups d'aplicacions"
 
 #. 4.0->settings-schema.json->number-type->options
@@ -710,67 +733,98 @@ msgstr "Número de l'espai de treball"
 msgid "Monitor number"
 msgstr "Número del monitor"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized indicator"
+msgstr "Finestres minimitzades"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Pinned indicator"
+msgstr "Aplicacions fixades"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized and pinned indicators"
+msgstr "Minimitzat i fixat"
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
-msgid "Number label contents"
+#, fuzzy
+msgid "Icon overlay label contents"
 msgstr "Contingut de l'etiqueta numèrica"
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr "Intel·ligent"
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
-msgstr "Mostrar número"
+msgid "Only display label when needed"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
+#, fuzzy
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 "Controla quan s'utilitzarà l'etiqueta numèrica. 'Intel·ligent' significa que "
 "apareixerà només quan sigui necessari, tenint en compte les opcions de dalt. "
 "Per exemple, quan hi hagi dues o més finestres en un grup, o quan l'espai de "
 "treball o el monitor de les finestres no sigui l'actual."
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr "Desactivat"
+
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#, fuzzy
+msgid "Using icon overlay label"
 msgstr "Sobreposar l'icona"
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
-msgstr "Afegir etiqueta"
-
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
-msgstr "Estil de numeració"
-
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
-msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
-"Controla la presentació de l'etiqueta numèrica. En cas d'usar taulers "
-"verticals, la opció d'etiqueta no es pot utilitzar i, per tant, s'utilitzarà "
-"la sobreposició de la icona en lloc seu"
+
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
+msgid ""
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
+msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -783,6 +837,12 @@ msgstr "Agrupades"
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
 msgstr "En conjunt"
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
+msgstr "Automàtic"
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -805,12 +865,13 @@ msgstr "Comportament de l'estil de la llista de finestres"
 #. 4.0->settings-schema.json->group-windows->tooltip
 #. 6.0->settings-schema.json->group-windows->tooltip
 #. 6.4->settings-schema.json->group-windows->tooltip
+#, fuzzy
 msgid ""
 "Grouped: All windows for an application are managed by one button,\n"
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 "Agrupades: Totes les finestres d'una aplicació son gestionades per un botó,\n"
 "En conjunt: Tots els botons de la llista de finestres per a una aplicació "
@@ -821,12 +882,6 @@ msgstr ""
 "entre elles,\n"
 "Llançador: Només es mostra el botó fixat, que es comporta com un llançador "
 "al tauler."
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
-msgstr "Desactivat"
 
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
@@ -869,9 +924,10 @@ msgstr "Sincronitzar botons llançadors a tots els espais de treball"
 #. 4.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
+#, fuzzy
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 "Si s'activa, el número i l'ordre dels botons llançadors al tauler serà "
 "sincronitzat per tots els espais de treball."
@@ -965,9 +1021,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 "Si s'activa, una previsualització de la pantalla completa apareixerà quan el "
@@ -983,9 +1040,10 @@ msgstr "Canvia el focus automàticament en sortir del tauler"
 #. 4.0->settings-schema.json->no-click-activate->tooltip
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -1075,10 +1133,11 @@ msgstr "Ordenar els elements del menú de miniatures dels botons agrupats"
 #. 4.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1104,9 +1163,10 @@ msgstr "Mostra miniatures per totes les finestres agrupades d'una aplicació"
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 "Si s'activa, el menú emergent contindrà totes les finestres agrupades de "
@@ -2107,7 +2167,8 @@ msgstr "Canviar el mosaic de les finestres"
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
-msgid "Cycle all window-list button windows"
+#, fuzzy
+msgid "Cycle all window list button windows"
 msgstr "Desplaçar-se pels botons de les finestres de la llista"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2265,10 +2326,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.4->settings-schema.json->hotkey-sequence->tooltip
+#, fuzzy
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 "Si s'activa, les dreceres del teclat acabant en número (ex: Alt+1) crearan "
@@ -2287,10 +2349,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
+#, fuzzy
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 "Si s'activa, els modificadors + ` de dreceres d'accés ràpid es registraran "
 "per cada conjunt de modificadors únic definit a la llista de dreceres "
@@ -2452,7 +2515,8 @@ msgstr "Botons per finestres en altres monitors"
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+#, fuzzy
+msgid "All buttons except the focused window"
 msgstr "Tots els botons menys el de la finestra en primer pla"
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2494,9 +2558,10 @@ msgstr ""
 "Tauler de botons per a totes les finestres en execució."
 
 #. SetupWizard.ui:125
+#, fuzzy
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 "Tauler llançadora (Llançador ràpid)\n"
@@ -2516,9 +2581,10 @@ msgid "How do you want your Window List to operate?"
 msgstr "Quin funcionament voleu que tingui la vostra llista de finestres?"
 
 #. SetupWizard.ui:192
+#, fuzzy
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 "Bàsic  -  Accés ràpid a les finestres\n"
@@ -2538,10 +2604,11 @@ msgstr ""
 "Les etiquetes dels botons són els títols de les finestres."
 
 #. SetupWizard.ui:236
+#, fuzzy
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2574,8 +2641,9 @@ msgid "Panel Launcher Setup"
 msgstr "Posada en marxa del tauler llançador"
 
 #. SetupWizard.ui:370
+#, fuzzy
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2615,8 +2683,9 @@ msgid "All done!"
 msgstr "Tot fet!"
 
 #. SetupWizard.ui:508
+#, fuzzy
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: 2024-01-01 10:11+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -14,32 +14,36 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "alle knapper"
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Indstillinger"
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "Om …"
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Konfigurér …"
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr ""
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Fjern “%s”"
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 
@@ -61,77 +65,77 @@ msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Åbn nyt vindue"
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Fjern fra panel"
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Fjern fra dette arbejdsområde"
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "Fastgør til panel"
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "Fastgør til dette arbejdsområde"
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "Fastgør til andre arbejdsområder"
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "Fastgør til alle arbejdsområder"
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "Fastgør til programstarter"
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Tilføj ny genvejstast til"
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Seneste filer"
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Steder"
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 #, fuzzy
 msgid "Always on top"
 msgstr "Altid"
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Kun på dette arbejdsområde"
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Synlig på alle arbejdsområder"
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Flyt til et andet arbejdsområde"
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr " (dette arbejdsområde)"
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Flyt til en anden skærm"
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Skærm"
 
@@ -153,49 +157,49 @@ msgstr "Skærm"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 #, fuzzy
 msgid "Move window here"
 msgstr "Luk vindue"
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "ikke tildelt"
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Tildel en genvejstast til vindue"
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Ændr indholdet af programetiket"
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Fjern brugerdefineret indstilling"
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Brug vinduestitel"
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "Brug programnavn"
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Ingen etiket"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Opsplit gruppen af programmervinduer"
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Gruppér programvinduer"
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisk gruppering/opsplitning af gruppe"
 
@@ -217,41 +221,41 @@ msgstr "Automatisk gruppering/opsplitning af gruppe"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Flyt titellinje til skærm"
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Gendan"
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Minimér"
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "Gendan"
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Luk andre"
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 #, fuzzy
 msgid "Close other windows for application"
 msgstr "Vis miniaturer for alle vinduer i en programpulje"
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Luk alle"
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 #, fuzzy
 msgid "Close all windows for application"
 msgstr "Vis miniaturer for alle vinduer i en programpulje"
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Luk"
 
@@ -319,8 +323,15 @@ msgstr "Indstillinger for vindueslisteknappernes etiketter"
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
 #, fuzzy
-msgid "Number label settings"
+msgid "Icon overlay label settings"
 msgstr "Indstillinger for programgruppernes nummeretiketter"
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+#, fuzzy
+msgid "Progress settings"
+msgstr "Genvejstastindstillinger"
 
 #. 4.0->settings-schema.json->general-settings->title
 #. 6.0->settings-schema.json->general-settings->title
@@ -396,13 +407,10 @@ msgstr "Aldrig"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr "Altid"
 
@@ -457,10 +465,11 @@ msgstr "Vis etiketter for fastgjorte knapper"
 #. 4.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.4->settings-schema.json->display-caption-for-pined->tooltip
+#, fuzzy
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 "Aldrig: Ingen fastgjorte vinduer vil have en etiket\n"
@@ -529,13 +538,35 @@ msgid "Minimized and pinned"
 msgstr "Minimerede og fastgjorte"
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
-msgstr "Automatisk"
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group window count"
+msgstr "Gruppér programvinduer"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Application group indicator (⋮)"
+msgstr "Gruppér programvinduer"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Workspace number (smart)"
+msgstr "Vis antal"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Monitor number (smart)"
+msgstr "Skærm"
 
 #. 4.0->settings-schema.json->display-indicators->description
 #. 6.0->settings-schema.json->display-indicators->description
@@ -547,31 +578,24 @@ msgstr "Vis statusindikatorer"
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
-msgstr ""
-"Vælg, om indikatortegnene for minimeret og fastgjort skal tilføjes "
-"knapetikettens tekst. Knapper uden en tekstetiket vil ikke reservere så "
-"meget plads.\n"
-"Automatisk: De minimerede og fastgjorte indikatorer vises kun, når der ikke "
-"er begrænset plads."
-
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
+msgstr ""
+
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -637,7 +661,7 @@ msgstr "Tidsforsinkelse før menuen vises"
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -687,7 +711,7 @@ msgstr "Gør intet"
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
 #, fuzzy
-msgid "Application group window count"
+msgid "Application group indicator (…)"
 msgstr "Gruppér programvinduer"
 
 #. 4.0->settings-schema.json->number-type->options
@@ -704,65 +728,93 @@ msgstr "Vis antal"
 msgid "Monitor number"
 msgstr "Skærm"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized indicator"
+msgstr "Minimerede vinduer"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Pinned indicator"
+msgstr "Fastgjorte programmer"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized and pinned indicators"
+msgstr "Minimerede og fastgjorte"
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
 #, fuzzy
-msgid "Number label contents"
+msgid "Icon overlay label contents"
 msgstr "Etiketindhold"
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
-msgstr "Vis antal"
+msgid "Only display label when needed"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr "Deaktiveret"
+
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#, fuzzy
+msgid "Using icon overlay label"
 msgstr "Overlejret ikonet"
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
-msgstr "Foranstillet etiketten"
-
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
-msgstr "Antalsstil"
-
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
-#, fuzzy
-msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
-"Styrer, hvordan antallet af vinduer i en grupperet knap præsenteres. På et "
-"lodret panel er indstillingen “Foranstillet etiketten” ikke mulig, så "
-"“Overlejret ikonet” vil blive brugt i stedet"
+
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
+msgid ""
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
+msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -775,6 +827,12 @@ msgstr "Grupperet"
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
 msgstr "Samlet"
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
+msgstr "Automatisk"
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -797,12 +855,13 @@ msgstr "Opførsel af vinduesliste"
 #. 4.0->settings-schema.json->group-windows->tooltip
 #. 6.0->settings-schema.json->group-windows->tooltip
 #. 6.4->settings-schema.json->group-windows->tooltip
+#, fuzzy
 msgid ""
 "Grouped: All windows for an application are managed by one button,\n"
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 "Grupperet: Alle vinduer i et program styres af én knap,\n"
 "Samlet: Alle vindueslisteknapper for et program er samlet side om side,\n"
@@ -810,12 +869,6 @@ msgstr ""
 "En til en: Hvert vindue får sin egen knap uden tvungen rækkefølge,\n"
 "Programstarter: Kun fastgjorte knapper vises, opfører sig som en "
 "panelprogramstarter."
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
-msgstr "Deaktiveret"
 
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
@@ -858,9 +911,10 @@ msgstr "Synkronisérr programstarterknapper på tværs af alle arbejdsområder"
 #. 4.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
+#, fuzzy
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 "Hvis aktiveret, synkroniseres antallet og rækkefølgen af "
 "programstarterknapper på panelet på tværs af alle arbejdsområder."
@@ -950,7 +1004,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 "Aktivér for at vise værktøjstips med vinduestitel eller programnavn, når man "
@@ -966,8 +1020,8 @@ msgstr ""
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -1054,9 +1108,9 @@ msgstr "Gendan eller hold nede for miniaturemenu"
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1076,9 +1130,10 @@ msgstr "Vis miniaturer for alle vinduer i en programpulje"
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 "Hvis aktiveret, vil en pop up-menu indeholde alle programvinduer i "
@@ -2078,7 +2133,7 @@ msgstr "Brug vinduestitel"
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
 #, fuzzy
-msgid "Cycle all window-list button windows"
+msgid "Cycle all window list button windows"
 msgstr "Bladr gennem programvinduer"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2232,10 +2287,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.4->settings-schema.json->hotkey-sequence->tooltip
+#, fuzzy
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 "Hvis aktiveret, vil genvejstaster, der slutter med tasten “1” (f.eks. "
@@ -2252,10 +2308,11 @@ msgstr "Brug ændringstaster + ` genvejstast for at vise genvejstastebobler"
 #. 4.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
+#, fuzzy
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 "Hvis aktiveret, vil genvejstastens ændringstaster + ` blive registreret for "
 "hvert unikt ændringstastsæt, der er defineret i genvejstastelisten. Brug af "
@@ -2418,7 +2475,8 @@ msgstr "Knapper for vinduer på andre skærme"
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+#, fuzzy
+msgid "All buttons except the focused window"
 msgstr "Alle knapper undtagen det fokuserede vindue"
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2458,9 +2516,10 @@ msgstr ""
 "Panelknapper til alle kørende vinduer."
 
 #. SetupWizard.ui:125
+#, fuzzy
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 "Panelprogramstarter (hurtig start)\n"
@@ -2480,9 +2539,10 @@ msgid "How do you want your Window List to operate?"
 msgstr "Hvordan skal din vinduesliste fungere?"
 
 #. SetupWizard.ui:192
+#, fuzzy
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 "Grundlæggende — Hurtig adgang til vinduer\n"
@@ -2502,10 +2562,11 @@ msgstr ""
 "Knapetiketterne er vinduestitler."
 
 #. SetupWizard.ui:236
+#, fuzzy
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2536,8 +2597,9 @@ msgid "Panel Launcher Setup"
 msgstr "Opsætning af panelprogramstarter"
 
 #. SetupWizard.ui:370
+#, fuzzy
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2576,8 +2638,9 @@ msgid "All done!"
 msgstr "Færdig!"
 
 #. SetupWizard.ui:508
+#, fuzzy
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/de.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.3.6\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Joshiy13\n"
 "Language-Team: \n"
@@ -18,32 +18,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "alle knöpfe"
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Applet-Einstellungen"
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "Über..."
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Einstellen..."
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr "Website"
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "'%s' entfernen"
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Möchtest du wirklich diese Instanz von CassiaWindowsList entfernen?"
 
@@ -65,76 +69,76 @@ msgstr "Möchtest du wirklich diese Instanz von CassiaWindowsList entfernen?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Neues Fenster öffnen"
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Von Panel entfernen"
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Von diesem Arbeitsbereich entfernen"
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "An Panel anheften"
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "An den jetzigen Arbeitsplatz anheften"
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "An andere Arbeitsplätze anheften"
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "An alle Arbeitsplätze anheften"
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "An launcher anheften"
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Füge neue Tastenkombination hinzu für"
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Zuletzt benutzte Dateien"
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Orte"
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 msgid "Always on top"
 msgstr "Immer obenauf"
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Nur im jetzigen Arbeitsplatz"
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Sichtbar in jedem Arbeitsplatz"
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Zu anderem Arbeitsplatz verschieben"
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr "(dieser Arbeitsplatz)"
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Zu anderen Bildschirm verschieben"
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Bildschirm"
 
@@ -156,48 +160,48 @@ msgstr "Bildschirm"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 msgid "Move window here"
 msgstr "Fenster hierhin verschieben"
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "unzugewiesen"
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Weise Fenster einer Tastenkombination zu"
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Inhalt des Anwendungsetiketts ändern"
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Benutzerdefinierte Einstellung entfernen"
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Fenstertitel verwenden"
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "App-namen verwenden"
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Kein Label"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Gruppierung der Anwendungsfenster aufheben"
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Anwendungsfenster gruppieren"
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatische Gruppierung/Gruppierungsaufhebung"
 
@@ -219,39 +223,39 @@ msgstr "Automatische Gruppierung/Gruppierungsaufhebung"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Titelleiste auf den Bildschirm verschieben"
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Minimieren"
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "Unmaximieren"
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Andere schließen"
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 msgid "Close other windows for application"
 msgstr "Andere Fenster der app schließen"
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Alle schließen"
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 msgid "Close all windows for application"
 msgstr "Alle Fenster der App schließen"
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Schließen"
 
@@ -318,7 +322,13 @@ msgstr ""
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
-msgid "Number label settings"
+msgid "Icon overlay label settings"
+msgstr ""
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+msgid "Progress settings"
 msgstr ""
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -395,13 +405,10 @@ msgstr ""
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr ""
 
@@ -455,7 +462,7 @@ msgstr ""
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 
@@ -517,12 +524,30 @@ msgid "Minimized and pinned"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
+#. 6.4->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+msgid "Application group indicator (⋮)"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+msgid "Workspace number (smart)"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+msgid "Monitor number (smart)"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-indicators->description
@@ -535,26 +560,24 @@ msgstr ""
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
 msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -615,7 +638,7 @@ msgstr ""
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -662,7 +685,7 @@ msgstr ""
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
-msgid "Application group window count"
+msgid "Application group indicator (…)"
 msgstr ""
 
 #. 4.0->settings-schema.json->number-type->options
@@ -677,59 +700,88 @@ msgstr ""
 msgid "Monitor number"
 msgstr ""
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Minimized indicator"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Pinned indicator"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Minimized and pinned indicators"
+msgstr ""
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
-msgid "Number label contents"
-msgstr ""
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr ""
+#, fuzzy
+msgid "Icon overlay label contents"
+msgstr "Inhalt des Anwendungsetiketts ändern"
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
+msgid "Only display label when needed"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Using icon overlay label"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
 msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
 msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
@@ -742,6 +794,12 @@ msgstr ""
 #. 6.0->settings-schema.json->group-windows->options
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
+msgstr ""
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
 msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
@@ -770,13 +828,7 @@ msgid ""
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
-msgstr ""
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 
 #. 4.0->settings-schema.json->display-pinned->options
@@ -818,7 +870,7 @@ msgstr ""
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 
 #. 4.0->settings-schema.json->show-windows-for-current-monitor->description
@@ -898,7 +950,7 @@ msgstr ""
 #. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 
@@ -912,8 +964,8 @@ msgstr ""
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -994,9 +1046,9 @@ msgstr ""
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1018,7 +1070,7 @@ msgstr ""
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 
@@ -1993,7 +2045,7 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
-msgid "Cycle all window-list button windows"
+msgid "Cycle all window list button windows"
 msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2137,7 +2189,7 @@ msgstr ""
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 
@@ -2152,8 +2204,8 @@ msgstr ""
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 
 #. 4.0->settings-schema.json->hotkey-help->description
@@ -2286,7 +2338,7 @@ msgstr ""
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+msgid "All buttons except the focused window"
 msgstr ""
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2324,7 +2376,7 @@ msgstr ""
 #. SetupWizard.ui:125
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 
@@ -2341,7 +2393,7 @@ msgstr ""
 #. SetupWizard.ui:192
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 
@@ -2356,8 +2408,8 @@ msgstr ""
 #. SetupWizard.ui:236
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2384,7 +2436,7 @@ msgstr ""
 
 #. SetupWizard.ui:370
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2416,7 +2468,7 @@ msgstr ""
 
 #. SetupWizard.ui:508
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: 2025-03-10 09:26-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,32 +18,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "todos los botones"
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Preferencias del applet"
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "Acerca de..."
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Configurar..."
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr "Sitio web"
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 
@@ -65,76 +69,76 @@ msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Abrir nueva ventana"
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Quitar del panel"
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Eliminar de este espacio de trabajo"
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "Anclar al panel"
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "Anclar a este espacio de trabajo"
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "Anclar a otros espacios de trabajo"
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "Anclar a todos los espacios de trabajo"
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "Anclar al lanzador"
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Añadir nueva tecla de acceso rápido para"
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Archivos recientes"
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Lugares"
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 msgid "Always on top"
 msgstr "Siempre arriba"
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Sólo en este espacio de trabajo"
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Visible en todos los espacios de trabajo"
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Mover a otro espacio de trabajo"
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr " (este espacio de trabajo)"
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Mover a otro monitor"
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -156,48 +160,48 @@ msgstr "Monitor"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 msgid "Move window here"
 msgstr "Mover la ventana aquí"
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "no asignado"
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Asignar ventana a una tecla de acceso rápido"
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Cambiar el contenido de la etiqueta de la aplicación"
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Eliminar configuración personalizada"
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Utilizar título de ventana"
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "Utilizar nombre de aplicación"
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Sin etiqueta"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Ventanas de aplicaciones separadas"
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Ventanas de aplicaciones agrupadas"
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupación/desagrupación automática"
 
@@ -219,39 +223,39 @@ msgstr "Agrupación/desagrupación automática"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Mover la barra de título a la pantalla"
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Restaurar"
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Minimizar"
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "Desmaximizar"
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Cerrar otros"
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 msgid "Close other windows for application"
 msgstr "Cerrar otras ventanas para la aplicación"
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Cerrar todo"
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 msgid "Close all windows for application"
 msgstr "Cerrar todas las ventanas para la aplicación"
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Cerrar"
 
@@ -318,8 +322,16 @@ msgstr "Configuración de la etiqueta del botón de la lista de ventanas"
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
-msgid "Number label settings"
+#, fuzzy
+msgid "Icon overlay label settings"
 msgstr "Configuración de la etiqueta numérica"
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+#, fuzzy
+msgid "Progress settings"
+msgstr "Configuración de teclas de acceso rápido"
 
 #. 4.0->settings-schema.json->general-settings->title
 #. 6.0->settings-schema.json->general-settings->title
@@ -395,13 +407,10 @@ msgstr "Nunca"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr "Siempre"
 
@@ -457,10 +466,11 @@ msgstr "Mostrar etiquetas para los botones anclados"
 #. 4.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.4->settings-schema.json->display-caption-for-pined->tooltip
+#, fuzzy
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 "Nunca: Ninguna ventana anclada tendrá etiqueta\n"
@@ -531,13 +541,34 @@ msgid "Minimized and pinned"
 msgstr "Minimizado y anclado"
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
-msgstr "Automático"
+#. 6.4->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr "Recuento de ventanas de grupos de aplicaciones"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Application group indicator (⋮)"
+msgstr "Recuento de ventanas de grupos de aplicaciones"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Workspace number (smart)"
+msgstr "Número de espacio de trabajo"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Monitor number (smart)"
+msgstr "Número de monitor"
 
 #. 4.0->settings-schema.json->display-indicators->description
 #. 6.0->settings-schema.json->display-indicators->description
@@ -549,35 +580,25 @@ msgstr "Mostrar indicadores de estado"
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
-"Elija si los caracteres indicadores de minimizado y anclado se antepondrán "
-"al texto de la etiqueta del botón. Los botones sin etiqueta de texto no "
-"reservarán tanto espacio.\n"
-"Automático: Los indicadores de minimizado y anclado sólo se mostrarán cuando "
-"no haya restricciones de espacio."
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
-msgstr "Mostrar una elipsis vertical (...) para los botones agrupados"
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
+msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
-"Anteponer una carta unicode de elipsis vertical a las etiquetas de los "
-"botones de lista de ventanas agrupadas con más de una ventana. En un panel "
-"vertical, esta opción no es posible y la configuración se ignorará."
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -644,9 +665,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -700,7 +722,8 @@ msgstr "Nada"
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
-msgid "Application group window count"
+#, fuzzy
+msgid "Application group indicator (…)"
 msgstr "Recuento de ventanas de grupos de aplicaciones"
 
 #. 4.0->settings-schema.json->number-type->options
@@ -715,32 +738,55 @@ msgstr "Número de espacio de trabajo"
 msgid "Monitor number"
 msgstr "Número de monitor"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized indicator"
+msgstr "Ventanas minimizadas"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Pinned indicator"
+msgstr "Aplicaciones ancladas"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized and pinned indicators"
+msgstr "Minimizado y anclado"
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
-msgid "Number label contents"
+#, fuzzy
+msgid "Icon overlay label contents"
 msgstr "Contenido de la etiqueta numérica"
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr "Inteligente"
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
-msgstr "Mostrar número"
+msgid "Only display label when needed"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
+#, fuzzy
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 "Controla cuándo se utiliza la etiqueta numérica. Inteligente significa que "
 "la etiqueta sólo aparecerá cuando sea apropiado en función de la "
@@ -748,35 +794,43 @@ msgstr ""
 "cuando haya dos o más ventanas en un grupo, o cuando el espacio de trabajo o "
 "monitor de la ventana no coincida con el actual."
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr "Desactivado"
+
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#, fuzzy
+msgid "Using icon overlay label"
 msgstr "Superponer icono"
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
-msgstr "Añadir etiqueta"
-
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
-msgstr "Estilo de número"
-
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
-msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
-"Controla cómo se presenta la etiqueta numérica. En un panel vertical o en "
-"modo lanzador, no es posible utilizar la opción \"etiqueta previa\", por lo "
-"que se utilizará \"icono superpuesto\""
+
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
+msgid ""
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
+msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -789,6 +843,12 @@ msgstr "Agrupadas"
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
 msgstr "Agrupado"
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
+msgstr "Automático"
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -811,12 +871,13 @@ msgstr "Estilo de comportamiento de la lista de ventanas"
 #. 4.0->settings-schema.json->group-windows->tooltip
 #. 6.0->settings-schema.json->group-windows->tooltip
 #. 6.4->settings-schema.json->group-windows->tooltip
+#, fuzzy
 msgid ""
 "Grouped: All windows for an application are managed by one button,\n"
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 "Agrupadas: Todas las ventanas de una aplicación se gestionan mediante un "
 "botón,\n"
@@ -826,12 +887,6 @@ msgstr ""
 "Uno a uno: Cada ventana tiene su propio botón sin orden forzado,\n"
 "Lanzador: Sólo se muestra el botón anclado, se comporta como un lanzador de "
 "paneles."
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
-msgstr "Desactivado"
 
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
@@ -875,9 +930,10 @@ msgstr "Sincronizar los botones de inicio en todas las áreas de trabajo"
 #. 4.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
+#, fuzzy
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 "Si se activa, el número y el orden de los botones de inicio del panel se "
 "sincronizarán en todos los espacios de trabajo."
@@ -972,9 +1028,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 "Si se activa, aparecerá una ventana de previsualización a tamaño completo "
@@ -991,9 +1048,10 @@ msgstr "Cambio automático de enfoque al salir del panel"
 #. 4.0->settings-schema.json->no-click-activate->tooltip
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -1085,10 +1143,11 @@ msgstr "Ordenar los elementos del menú de miniaturas de botones agrupados"
 #. 4.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1114,9 +1173,10 @@ msgstr "Mostrar miniaturas de todas las ventanas de un grupo de aplicaciones"
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 "Si se activa, un menú emergente contendrá todas las ventanas de la "
@@ -2121,7 +2181,8 @@ msgstr "Cambiar mosaico de ventana"
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
-msgid "Cycle all window-list button windows"
+#, fuzzy
+msgid "Cycle all window list button windows"
 msgstr "Desplazarse por los botones de las ventanas de la lista"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2282,10 +2343,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.4->settings-schema.json->hotkey-sequence->tooltip
+#, fuzzy
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 "Si está activada, las teclas de acceso rápido que terminan con la tecla "
@@ -2305,10 +2367,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
+#, fuzzy
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 "Si se activa, el/los modificador(es) de teclas de acceso rápido + ` se "
 "registrará para cada conjunto de modificadores único definido en la lista de "
@@ -2470,7 +2533,8 @@ msgstr "Botones para ventanas en otros monitores"
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+#, fuzzy
+msgid "All buttons except the focused window"
 msgstr "Todos los botones excepto la ventana enfocada"
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2512,9 +2576,10 @@ msgstr ""
 "Panel de botones para todas las ventanas en ejecución."
 
 #. SetupWizard.ui:125
+#, fuzzy
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 "Panel Launcher (Lanzador rápido)\n"
@@ -2534,9 +2599,10 @@ msgid "How do you want your Window List to operate?"
 msgstr "¿Cómo quiere que funcione su lista de ventanas?"
 
 #. SetupWizard.ui:192
+#, fuzzy
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 "Básico - Acceso rápido a las ventanas\n"
@@ -2556,10 +2622,11 @@ msgstr ""
 "Las etiquetas de los botones son los títulos de las ventanas."
 
 #. SetupWizard.ui:236
+#, fuzzy
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2591,8 +2658,9 @@ msgid "Panel Launcher Setup"
 msgstr "Configuración del Lanzador rápido"
 
 #. SetupWizard.ui:370
+#, fuzzy
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2633,8 +2701,9 @@ msgid "All done!"
 msgstr "¡Ya está!"
 
 #. SetupWizard.ui:508
+#, fuzzy
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fi.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-02 23:03+0300\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: 2025-04-02 23:10+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -17,41 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: 6.4/applet.js:562 4.0/applet.js:584 6.0/applet.js:584
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "kaikki painikkeet"
 
-#: 6.4/applet.js:3238 4.0/applet.js:3266 6.0/applet.js:3266
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Sovelman asetukset"
 
-#: 6.4/applet.js:3242 4.0/applet.js:3270 6.0/applet.js:3270
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "Tietoja..."
 
-#: 6.4/applet.js:3246 4.0/applet.js:3274 6.0/applet.js:3274
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Aseta..."
 
-#: 6.4/applet.js:3250 4.0/applet.js:3278 6.0/applet.js:3278
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr "Verkkosivu"
 
-#: 6.4/applet.js:3254 4.0/applet.js:3282 6.0/applet.js:3282
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Poista \"%s\""
 
-#: 6.4/applet.js:3256 4.0/applet.js:3284 6.0/applet.js:3284
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Haluatko tosiaan poistaa tämän mahdollisuuden Cassiaikkunalistasta?"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -64,85 +62,85 @@ msgstr "Haluatko tosiaan poistaa tämän mahdollisuuden Cassiaikkunalistasta?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 6.4/applet.js:3265 4.0/applet.js:3293 6.0/applet.js:3293
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Avaa uusi ikkuna"
 
-#: 6.4/applet.js:3273 4.0/applet.js:3301 6.0/applet.js:3301
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Poista paneelista"
 
-#: 6.4/applet.js:3275 4.0/applet.js:3303 6.0/applet.js:3303
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Poista tästä työtilasta"
 
-#: 6.4/applet.js:3281 4.0/applet.js:3309 6.0/applet.js:3309
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "Kiinnitä paneeliin"
 
-#: 6.4/applet.js:3283 4.0/applet.js:3311 6.0/applet.js:3311
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "Kiinnitä työtilaan"
 
-#: 6.4/applet.js:3324 4.0/applet.js:3352 6.0/applet.js:3352
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "Kiinnitä toiseen työtilaan"
 
-#: 6.4/applet.js:3345 4.0/applet.js:3373 6.0/applet.js:3373
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "Kiinnitä kaikkiin työtiloihin"
 
-#: 6.4/applet.js:3363 4.0/applet.js:3391 6.0/applet.js:3391
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "Kiinnitä käynnistimeen"
 
-#: 6.4/applet.js:3381 6.4/applet.js:3583 4.0/applet.js:3409 4.0/applet.js:3614
-#: 6.0/applet.js:3409 6.0/applet.js:3614
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Lisää pikanäppäin"
 
-#: 6.4/applet.js:3395 4.0/applet.js:3423 6.0/applet.js:3423
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Käytetyt tiedostot"
 
-#: 6.4/applet.js:3419 4.0/applet.js:3447 6.0/applet.js:3447
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Paikat"
 
-#: 6.4/applet.js:3462 4.0/applet.js:3490 6.0/applet.js:3490
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 msgid "Always on top"
 msgstr "Aina päällimmäisenä"
 
-#: 6.4/applet.js:3474 4.0/applet.js:3502 6.0/applet.js:3502
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Ainoastaan tämä työtila"
 
-#: 6.4/applet.js:3476 4.0/applet.js:3504 6.0/applet.js:3504
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Näytä kaikki työtilat"
 
-#: 6.4/applet.js:3477 4.0/applet.js:3505 6.0/applet.js:3505
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Siirrä toiseen työtilaan"
 
-#: 6.4/applet.js:3486 4.0/applet.js:3514 6.0/applet.js:3514
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr " (tämä työtila)"
 
-#: 6.4/applet.js:3499 4.0/applet.js:3527 6.0/applet.js:3527
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Siirrä toiseen näyttöön"
 
-#: 6.4/applet.js:3507 4.0/applet.js:3535 6.0/applet.js:3535
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Näyttö"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -155,57 +153,57 @@ msgstr "Näyttö"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 6.4/applet.js:3521 4.0/applet.js:3552 6.0/applet.js:3552
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 msgid "Move window here"
 msgstr "Siirrä ikkuna tähän"
 
-#: 6.4/applet.js:3538 4.0/applet.js:3569 6.0/applet.js:3569
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "ei allekirjoitettu"
 
-#: 6.4/applet.js:3549 6.4/applet.js:3580 4.0/applet.js:3580 4.0/applet.js:3611
-#: 6.0/applet.js:3580 6.0/applet.js:3611
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Määritä ikkuna pikanäppäimelle"
 
-#: 6.4/applet.js:3603 4.0/applet.js:3634 6.0/applet.js:3634
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Muuta sovelluksen merkin sisältöä"
 
-#: 6.4/applet.js:3606 4.0/applet.js:3637 6.0/applet.js:3637
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Poista mukautetut aasetukset"
 
-#: 6.4/applet.js:3613 4.0/applet.js:3644 6.0/applet.js:3644
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Käytä ikkunan otsikkoa"
 
-#: 6.4/applet.js:3620 4.0/applet.js:3651 6.0/applet.js:3651
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "Käytä sovelluksen nimeä"
 
-#: 6.4/applet.js:3627 4.0/applet.js:3658 6.0/applet.js:3658
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Ei merkkiä"
 
-#: 6.4/applet.js:3638 4.0/applet.js:3669 6.0/applet.js:3669
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Pura ikkunoiden ryhmittely"
 
-#: 6.4/applet.js:3646 4.0/applet.js:3677 6.0/applet.js:3677
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Ryhmitä sovellusikkunat"
 
-#: 6.4/applet.js:3659 4.0/applet.js:3690 6.0/applet.js:3690
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Automaattinen ryhmittely/purku"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -218,51 +216,57 @@ msgstr "Automaattinen ryhmittely/purku"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 6.4/applet.js:3687 4.0/applet.js:3718 6.0/applet.js:3718
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Siirrä otsikkorivi näytölle"
 
-#: 6.4/applet.js:3692 4.0/applet.js:3723 6.0/applet.js:3723
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Palauta"
 
-#: 6.4/applet.js:3696 4.0/applet.js:3727 6.0/applet.js:3727
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Pienennä"
 
-#: 6.4/applet.js:3702 4.0/applet.js:3733 6.0/applet.js:3733
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "Suurenna"
 
-#: 6.4/applet.js:3710 4.0/applet.js:3741 6.0/applet.js:3741
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Sulje muut"
 
-#: 6.4/applet.js:3712 4.0/applet.js:3743 6.0/applet.js:3743
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 msgid "Close other windows for application"
 msgstr "Sulje muut ikkunat sovellusta varten"
 
-#: 6.4/applet.js:3733 4.0/applet.js:3764 6.0/applet.js:3764
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Sulje kaikki"
 
-#: 6.4/applet.js:3735 4.0/applet.js:3766 6.0/applet.js:3766
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 msgid "Close all windows for application"
 msgstr "Sulje kaikki ikkunat sovellusta varten"
 
-#: 6.4/applet.js:3751 4.0/applet.js:3782 6.0/applet.js:3782
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Sulje"
 
-#: SetupWizard.py:188
+#. SetupWizard.py:188
 msgid "Exit"
 msgstr "Lopeta"
 
-#: SetupWizard.py:210
+#. SetupWizard.py:210
 msgid "Next"
 msgstr "Seuraava"
 
-#: SetupWizard.py:283
+#. SetupWizard.py:283
 msgid "Backup file already exist. Do you want to overwrite it?"
 msgstr "Varmuuskoipo on jo tehty. Haluatko varmasti korvata sen?"
 
@@ -278,156 +282,161 @@ msgstr ""
 "CobiWindowListiin perustuva ikkunaluettelo/paneelikäynnistimet, jossa on "
 "joitain lisäominaisuuksia"
 
-#. 6.4->settings-schema.json->caption-page->title
 #. 4.0->settings-schema.json->caption-page->title
 #. 6.0->settings-schema.json->caption-page->title
+#. 6.4->settings-schema.json->caption-page->title
 msgid "Labels"
 msgstr "Merkit"
 
-#. 6.4->settings-schema.json->general-page->title
 #. 4.0->settings-schema.json->general-page->title
 #. 6.0->settings-schema.json->general-page->title
+#. 6.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Yleistä"
 
-#. 6.4->settings-schema.json->preview-page->title
 #. 4.0->settings-schema.json->preview-page->title
 #. 6.0->settings-schema.json->preview-page->title
+#. 6.4->settings-schema.json->preview-page->title
 msgid "Thumbnails"
 msgstr "Pikkukuvakkeet"
 
-#. 6.4->settings-schema.json->hotkey-page->title
 #. 4.0->settings-schema.json->hotkey-page->title
 #. 6.0->settings-schema.json->hotkey-page->title
+#. 6.4->settings-schema.json->hotkey-page->title
 msgid "Hotkeys"
 msgstr "Pikanäppäimet"
 
-#. 6.4->settings-schema.json->advanced-page->title
 #. 4.0->settings-schema.json->advanced-page->title
 #. 6.0->settings-schema.json->advanced-page->title
+#. 6.4->settings-schema.json->advanced-page->title
 msgid "Advanced"
 msgstr "Kehittynyt"
 
-#. 6.4->settings-schema.json->caption-settings->title
 #. 4.0->settings-schema.json->caption-settings->title
 #. 6.0->settings-schema.json->caption-settings->title
+#. 6.4->settings-schema.json->caption-settings->title
 msgid "Window list button label settings"
 msgstr "Ikkunalistna painikkeen asetukset"
 
-#. 6.4->settings-schema.json->caption-number-settings->title
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
-msgid "Number label settings"
+#. 6.4->settings-schema.json->caption-number-settings->title
+#, fuzzy
+msgid "Icon overlay label settings"
 msgstr "Numero merkin asetukset"
 
-#. 6.4->settings-schema.json->general-settings->title
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+#, fuzzy
+msgid "Progress settings"
+msgstr "Pikanäppäimien asetukset"
+
 #. 4.0->settings-schema.json->general-settings->title
 #. 6.0->settings-schema.json->general-settings->title
+#. 6.4->settings-schema.json->general-settings->title
 msgid "General window list settings"
 msgstr "Ylleisen ikkunan listan asetukset"
 
-#. 6.4->settings-schema.json->general-mouse->title
 #. 4.0->settings-schema.json->general-mouse->title
 #. 6.0->settings-schema.json->general-mouse->title
+#. 6.4->settings-schema.json->general-mouse->title
 msgid "Window list mouse settings"
 msgstr "Ikkunalistan hiiren asetukset"
 
-#. 6.4->settings-schema.json->preview-settings->title
 #. 4.0->settings-schema.json->preview-settings->title
 #. 6.0->settings-schema.json->preview-settings->title
+#. 6.4->settings-schema.json->preview-settings->title
 msgid "Thumbnails menu settings"
 msgstr "Pikkukuvakkeiden valikon asetukset"
 
-#. 6.4->settings-schema.json->preview-mouse-section->title
 #. 4.0->settings-schema.json->preview-mouse-section->title
 #. 6.0->settings-schema.json->preview-mouse-section->title
+#. 6.4->settings-schema.json->preview-mouse-section->title
 msgid "Thumbnails menu mouse settings"
 msgstr "Pikkukuvavalikon hiiren asetukset"
 
-#. 6.4->settings-schema.json->hotkey-settings->title
 #. 4.0->settings-schema.json->hotkey-settings->title
 #. 6.0->settings-schema.json->hotkey-settings->title
+#. 6.4->settings-schema.json->hotkey-settings->title
 msgid "Hotkey settings"
 msgstr "Pikanäppäimien asetukset"
 
-#. 6.4->settings-schema.json->adv-mouse-settings->title
-#. 6.4->settings-schema.json->adv-mouse-list->description
 #. 4.0->settings-schema.json->adv-mouse-settings->title
 #. 4.0->settings-schema.json->adv-mouse-list->description
 #. 6.0->settings-schema.json->adv-mouse-settings->title
 #. 6.0->settings-schema.json->adv-mouse-list->description
+#. 6.4->settings-schema.json->adv-mouse-settings->title
+#. 6.4->settings-schema.json->adv-mouse-list->description
 msgid "Ctrl/Shift + mouse button actions"
 msgstr "Ctrl/Shift + hiirenpainikkeiden toiminnot"
 
-#. 6.4->settings-schema.json->caption-type->options
 #. 4.0->settings-schema.json->caption-type->options
 #. 6.0->settings-schema.json->caption-type->options
+#. 6.4->settings-schema.json->caption-type->options
 msgid "Application name"
 msgstr "Sovelluksen nimi"
 
-#. 6.4->settings-schema.json->caption-type->options
 #. 4.0->settings-schema.json->caption-type->options
 #. 6.0->settings-schema.json->caption-type->options
+#. 6.4->settings-schema.json->caption-type->options
 msgid "Window title"
 msgstr "Ikkunan otsikko"
 
-#. 6.4->settings-schema.json->caption-type->description
 #. 4.0->settings-schema.json->caption-type->description
 #. 6.0->settings-schema.json->caption-type->description
+#. 6.4->settings-schema.json->caption-type->description
 msgid "Label contents"
 msgstr "Tarran sisältö"
 
-#. 6.4->settings-schema.json->caption-type->tooltip
 #. 4.0->settings-schema.json->caption-type->tooltip
 #. 6.0->settings-schema.json->caption-type->tooltip
+#. 6.4->settings-schema.json->caption-type->tooltip
 msgid "What the content of the label will be"
 msgstr "Mikä etiketin sisältö tulee olemaan"
 
-#. 6.4->settings-schema.json->display-caption-for->options
-#. 6.4->settings-schema.json->display-caption-for-pined->options
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
+#. 6.4->settings-schema.json->display-caption-for->options
+#. 6.4->settings-schema.json->display-caption-for-pined->options
 msgid "Never"
 msgstr "Koskaan"
 
-#. 6.4->settings-schema.json->display-caption-for->options
-#. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
+#. 6.4->settings-schema.json->display-caption-for->options
+#. 6.4->settings-schema.json->display-caption-for-pined->options
 msgid "Always"
 msgstr "Aina"
 
-#. 6.4->settings-schema.json->display-caption-for->options
-#. 6.4->settings-schema.json->display-caption-for-pined->options
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
+#. 6.4->settings-schema.json->display-caption-for->options
+#. 6.4->settings-schema.json->display-caption-for-pined->options
 msgid "Focused"
 msgstr "Khdistettu"
 
-#. 6.4->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for->options
+#. 6.4->settings-schema.json->display-caption-for->options
 msgid "One per application pool"
 msgstr "Yksi sovellusta kohden"
 
-#. 6.4->settings-schema.json->display-caption-for->description
 #. 4.0->settings-schema.json->display-caption-for->description
 #. 6.0->settings-schema.json->display-caption-for->description
+#. 6.4->settings-schema.json->display-caption-for->description
 msgid "Display labels for generic window list buttons"
 msgstr "Näytä yleisten ikkunaluettelopainikkeiden tarrat"
 
-#. 6.4->settings-schema.json->display-caption-for->tooltip
 #. 4.0->settings-schema.json->display-caption-for->tooltip
 #. 6.0->settings-schema.json->display-caption-for->tooltip
+#. 6.4->settings-schema.json->display-caption-for->tooltip
 msgid ""
 "Never: No windows get labels\n"
 "Always: All windows get labels\n"
@@ -441,25 +450,26 @@ msgstr ""
 "Yksi per sovelluspooli: Vain yksi tarra vierekkäisten sovellusikkunoiden "
 "joukolle"
 
-#. 6.4->settings-schema.json->display-caption-for-pined->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
+#. 6.4->settings-schema.json->display-caption-for-pined->options
 msgid "Running"
 msgstr "Ajaa"
 
-#. 6.4->settings-schema.json->display-caption-for-pined->description
 #. 4.0->settings-schema.json->display-caption-for-pined->description
 #. 6.0->settings-schema.json->display-caption-for-pined->description
+#. 6.4->settings-schema.json->display-caption-for-pined->description
 msgid "Display labels for pinned buttons"
 msgstr "Näytä tarrat kiinnitetyissä painikkeissa"
 
-#. 6.4->settings-schema.json->display-caption-for-pined->tooltip
 #. 4.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.0->settings-schema.json->display-caption-for-pined->tooltip
+#. 6.4->settings-schema.json->display-caption-for-pined->tooltip
+#, fuzzy
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 "Ei koskaan: kiinnitetyissä ikkunoissa ei ole tunnistetta\n"
@@ -467,45 +477,45 @@ msgstr ""
 "Käynnissä: Vain kiinnitetyissä käynnissä olevissa ikkunoissa on tunniste\n"
 "Kohdistettu: Vain kiinnitetyllä tarkennetulla ikkunalla on tunniste"
 
-#. 6.4->settings-schema.json->hide-caption-for-minimized->options
-#. 6.4->settings-schema.json->display-indicators->options
 #. 4.0->settings-schema.json->hide-caption-for-minimized->options
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->hide-caption-for-minimized->options
 #. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->hide-caption-for-minimized->options
+#. 6.4->settings-schema.json->display-indicators->options
 msgid "None"
 msgstr "Ollenkaan"
 
-#. 6.4->settings-schema.json->hide-caption-for-minimized->options
-#. 6.4->settings-schema.json->display-indicators->options
 #. 4.0->settings-schema.json->hide-caption-for-minimized->options
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->hide-caption-for-minimized->options
 #. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->hide-caption-for-minimized->options
+#. 6.4->settings-schema.json->display-indicators->options
 msgid "Minimized windows"
 msgstr "Pienennetyt ikkunat"
 
-#. 6.4->settings-schema.json->hide-caption-for-minimized->options
 #. 4.0->settings-schema.json->hide-caption-for-minimized->options
 #. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.4->settings-schema.json->hide-caption-for-minimized->options
 msgid "Windows on other workspaces"
 msgstr "Ikkunat muissa työtiloissa"
 
-#. 6.4->settings-schema.json->hide-caption-for-minimized->options
 #. 4.0->settings-schema.json->hide-caption-for-minimized->options
 #. 6.0->settings-schema.json->hide-caption-for-minimized->options
+#. 6.4->settings-schema.json->hide-caption-for-minimized->options
 msgid "Windows on other monitors"
 msgstr "Ikkunat muissa näytöissä"
 
-#. 6.4->settings-schema.json->hide-caption-for-minimized->description
 #. 4.0->settings-schema.json->hide-caption-for-minimized->description
 #. 6.0->settings-schema.json->hide-caption-for-minimized->description
+#. 6.4->settings-schema.json->hide-caption-for-minimized->description
 msgid "Hide labels for"
 msgstr "Piilota tarrat kohteelle"
 
-#. 6.4->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 4.0->settings-schema.json->hide-caption-for-minimized->tooltip
 #. 6.0->settings-schema.json->hide-caption-for-minimized->tooltip
+#. 6.4->settings-schema.json->hide-caption-for-minimized->tooltip
 msgid ""
 "Select the type of window state for which window list button labels should "
 "be hidden. For application pools, the label will still show unless all "
@@ -515,79 +525,89 @@ msgstr ""
 "Ryhmien nimi näkyy edelleen, ellei kaikissa ikkunoissa ole valittua "
 "ominaisuutta"
 
-#. 6.4->settings-schema.json->display-indicators->options
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
 msgid "Pinned applications"
 msgstr "Kiinnitetyt sovellukset"
 
-#. 6.4->settings-schema.json->display-indicators->options
 #. 4.0->settings-schema.json->display-indicators->options
 #. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
 msgid "Minimized and pinned"
 msgstr "Pienennetyt ja kiinnitetyt"
 
-#. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
-msgid "Automatic"
-msgstr "Automaattinen"
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr "Sovellusryhmän ikkunoiden määrä"
 
-#. 6.4->settings-schema.json->display-indicators->description
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Application group indicator (⋮)"
+msgstr "Sovellusryhmän ikkunoiden määrä"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Workspace number (smart)"
+msgstr "Työtilan numero"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Monitor number (smart)"
+msgstr "Näytön numero"
+
 #. 4.0->settings-schema.json->display-indicators->description
 #. 6.0->settings-schema.json->display-indicators->description
+#. 6.4->settings-schema.json->display-indicators->description
 msgid "Display status indicators"
 msgstr "Näytä tilailmaisimet"
 
-#. 6.4->settings-schema.json->display-indicators->tooltip
 #. 4.0->settings-schema.json->display-indicators->tooltip
 #. 6.0->settings-schema.json->display-indicators->tooltip
+#. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
-"Valitse, lisätäänkö pienennetyt ja kiinnitetyt ilmaisinmerkit painikkeen "
-"otsikon tekstiin. Painikkeet ilman tekstitunnistetta eivät varaa yhtä paljon "
-"tilaa.\n"
-"Automaattinen: Pienennetyt ja kiinnitetyt ilmaisimet näkyvät vain, kun tilaa "
-"ei ole rajoitettu."
 
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
-msgstr "Näytä pystysuora ellipsi (...) ryhmitetyille painikkeille"
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
+msgstr ""
 
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
-"Liitä pystysuora ellipsinen unicode-kirjaus ryhmiteltyjen "
-"ikkunaluettelopainikkeiden, joissa on useampi kuin yksi ikkuna, tarrojen "
-"eteen. Pystypaneelissa tämä vaihtoehto ei ole mahdollinen ja asetus jätetään "
-"huomioimatta."
 
-#. 6.4->settings-schema.json->trailing-pinned-behaviour->description
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
+#. 6.4->settings-schema.json->trailing-pinned-behaviour->description
 msgid "Add new window buttons ahead of trailing pinned buttons"
 msgstr ""
 "Lisää uusia ikkunapainikkeita perässä olevien kiinnitettyjen painikkeiden "
 "edelle"
 
-#. 6.4->settings-schema.json->trailing-pinned-behaviour->tooltip
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->tooltip
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->tooltip
+#. 6.4->settings-schema.json->trailing-pinned-behaviour->tooltip
 msgid ""
 "When enabled, new windows will be added to the left of any pinned buttons "
 "currently placed on the right of the window list, effectively this allows "
@@ -598,11 +618,6 @@ msgstr ""
 "vasemmalle puolelle, mikä käytännössä mahdollistaa kiinnitetyn painikkeen "
 "pitämisen ikkunaluettelon lopussa"
 
-#. 6.4->settings-schema.json->fade-animation-time->units
-#. 6.4->settings-schema.json->hover-peek-delay->units
-#. 6.4->settings-schema.json->label-animation-time->units
-#. 6.4->settings-schema.json->preview-timeout-show->units
-#. 6.4->settings-schema.json->preview-timeout-hide->units
 #. 4.0->settings-schema.json->fade-animation-time->units
 #. 4.0->settings-schema.json->hover-peek-delay->units
 #. 4.0->settings-schema.json->label-animation-time->units
@@ -613,18 +628,23 @@ msgstr ""
 #. 6.0->settings-schema.json->label-animation-time->units
 #. 6.0->settings-schema.json->preview-timeout-show->units
 #. 6.0->settings-schema.json->preview-timeout-hide->units
+#. 6.4->settings-schema.json->fade-animation-time->units
+#. 6.4->settings-schema.json->hover-peek-delay->units
+#. 6.4->settings-schema.json->label-animation-time->units
+#. 6.4->settings-schema.json->preview-timeout-show->units
+#. 6.4->settings-schema.json->preview-timeout-hide->units
 msgid "milliseconds"
 msgstr "millisekuntti"
 
-#. 6.4->settings-schema.json->fade-animation-time->description
 #. 4.0->settings-schema.json->fade-animation-time->description
 #. 6.0->settings-schema.json->fade-animation-time->description
+#. 6.4->settings-schema.json->fade-animation-time->description
 msgid "Fade animation effect duration"
 msgstr "Häivytysanimaatiotehosteen kesto"
 
-#. 6.4->settings-schema.json->fade-animation-time->tooltip
 #. 4.0->settings-schema.json->fade-animation-time->tooltip
 #. 6.0->settings-schema.json->fade-animation-time->tooltip
+#. 6.4->settings-schema.json->fade-animation-time->tooltip
 msgid ""
 "This defines the duration of the fade-in/out animation effect. It applies to "
 "the Thumbnail menus and the full size window previews"
@@ -632,18 +652,19 @@ msgstr ""
 "Tämä määrittää häivytysanimaatiotehosteen keston. Se koskee "
 "pikkukuvavalikoita ja täysikokoisia ikkunoiden esikatseluja"
 
-#. 6.4->settings-schema.json->hover-peek-delay->description
 #. 4.0->settings-schema.json->hover-peek-delay->description
 #. 6.0->settings-schema.json->hover-peek-delay->description
+#. 6.4->settings-schema.json->hover-peek-delay->description
 msgid "Hover time before showing a full size window preview"
 msgstr "Osoitinaika ennen täysikokoisen ikkunan esikatselun näyttämistä"
 
-#. 6.4->settings-schema.json->hover-peek-delay->tooltip
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
+#. 6.4->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -653,164 +674,203 @@ msgstr ""
 "(tietenkin yksi täysikokoisista ikkunan esikatseluvaihtoehdoista on otettava "
 "käyttöön, jotta tällä valinnalla olisi vaikutusta)"
 
-#. 6.4->settings-schema.json->label-width->units
-#. 6.4->settings-schema.json->button-spacing->units
 #. 4.0->settings-schema.json->label-width->units
 #. 4.0->settings-schema.json->button-spacing->units
 #. 6.0->settings-schema.json->label-width->units
 #. 6.0->settings-schema.json->button-spacing->units
+#. 6.4->settings-schema.json->label-width->units
+#. 6.4->settings-schema.json->button-spacing->units
 msgid "pixels"
 msgstr "pixelit"
 
-#. 6.4->settings-schema.json->label-width->description
 #. 4.0->settings-schema.json->label-width->description
 #. 6.0->settings-schema.json->label-width->description
+#. 6.4->settings-schema.json->label-width->description
 msgid "Label width"
 msgstr "Tarran pituus"
 
-#. 6.4->settings-schema.json->label-width->tooltip
 #. 4.0->settings-schema.json->label-width->tooltip
 #. 6.0->settings-schema.json->label-width->tooltip
+#. 6.4->settings-schema.json->label-width->tooltip
 msgid "This defines the width of the label section of a window list button"
 msgstr "Tämä määrittää ikkunaluettelopainikkeen tunnisteosan leveyden"
 
-#. 6.4->settings-schema.json->label-animation->description
 #. 4.0->settings-schema.json->label-animation->description
 #. 6.0->settings-schema.json->label-animation->description
+#. 6.4->settings-schema.json->label-animation->description
 msgid "Animate label"
 msgstr "Animoitu tunniste"
 
-#. 6.4->settings-schema.json->label-animation-time->description
 #. 4.0->settings-schema.json->label-animation-time->description
 #. 6.0->settings-schema.json->label-animation-time->description
+#. 6.4->settings-schema.json->label-animation-time->description
 msgid "Label animation duration"
 msgstr "Tunnisteen animaation kesto"
 
-#. 6.4->settings-schema.json->number-type->options
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
 msgid "Nothing"
 msgstr "Tyhjää"
 
-#. 6.4->settings-schema.json->number-type->options
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
-msgid "Application group window count"
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group indicator (…)"
 msgstr "Sovellusryhmän ikkunoiden määrä"
 
-#. 6.4->settings-schema.json->number-type->options
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
 msgid "Workspace number"
 msgstr "Työtilan numero"
 
-#. 6.4->settings-schema.json->number-type->options
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
 msgid "Monitor number"
 msgstr "Näytön numero"
 
-#. 6.4->settings-schema.json->number-type->description
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized indicator"
+msgstr "Pienennetyt ikkunat"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Pinned indicator"
+msgstr "Kiinnitetyt sovellukset"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized and pinned indicators"
+msgstr "Pienennetyt ja kiinnitetyt"
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
-msgid "Number label contents"
+#. 6.4->settings-schema.json->number-type->description
+#, fuzzy
+msgid "Icon overlay label contents"
 msgstr "Numerotunnisteen sisältö"
 
-#. 6.4->settings-schema.json->display-number->options
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr "Fiksu"
-
-#. 6.4->settings-schema.json->display-number->description
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
-msgid "Display number"
-msgstr "Näytettävä numero"
+#. 6.4->settings-schema.json->display-number->description
+msgid "Only display label when needed"
+msgstr ""
 
-#. 6.4->settings-schema.json->display-number->tooltip
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
+#. 6.4->settings-schema.json->display-number->tooltip
+#, fuzzy
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 "Ohjaa, milloin numerotarraa käytetään. Älykäs tarkoittaa, että tarra tulee "
 "näkyviin vain silloin, kun se on tarkoituksenmukaista yllä olevan "
 "numerotarran sisältöasetuksen mukaan. eli kun ryhmässä on kaksi tai useampia "
 "ikkunoita tai kun Windowsin työtila tai näyttö ei vastaa nykyistä."
 
-#. 6.4->settings-schema.json->number-style->options
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr "Poissa käytöstä"
+
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#, fuzzy
+msgid "Using icon overlay label"
 msgstr "Kuvakkeen peittokuva"
 
-#. 6.4->settings-schema.json->number-style->options
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-msgid "Label prepend"
-msgstr "Tunnisteen edelle"
-
-#. 6.4->settings-schema.json->number-style->description
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-msgid "Number style"
-msgstr "Numeron tyyli"
-
-#. 6.4->settings-schema.json->number-style->tooltip
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
-"Ohjaa numerotunnisteen esittämistä. Pystypaneelissa tai käynnistystilassa "
-"\"tarran alkuun\" -vaihtoehto ei ole mahdollista, joten sen sijaan käytetään "
-"\"kuvakepeittokuvaa\""
 
-#. 6.4->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
+msgid ""
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
+msgstr ""
+
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
 msgid "Grouped"
 msgstr "Ryhmitelty"
 
-#. 6.4->settings-schema.json->group-windows->options
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
 msgstr "Yhdistetty"
 
-#. 6.4->settings-schema.json->group-windows->options
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
+msgstr "Automaattinen"
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
 msgid "One to one"
 msgstr "Yhdestä yhteen"
 
-#. 6.4->settings-schema.json->group-windows->options
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
 msgid "Launcher"
 msgstr "Käynnistin"
 
-#. 6.4->settings-schema.json->group-windows->description
 #. 4.0->settings-schema.json->group-windows->description
 #. 6.0->settings-schema.json->group-windows->description
+#. 6.4->settings-schema.json->group-windows->description
 msgid "Window list behavior style"
 msgstr "Ikkunaluettelon käyttäytymistyyli"
 
-#. 6.4->settings-schema.json->group-windows->tooltip
 #. 4.0->settings-schema.json->group-windows->tooltip
 #. 6.0->settings-schema.json->group-windows->tooltip
+#. 6.4->settings-schema.json->group-windows->tooltip
+#, fuzzy
 msgid ""
 "Grouped: All windows for an application are managed by one button,\n"
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 "Ryhmitetty: Kaikkia sovelluksen ikkunoita hallitaan yhdellä painikkeella,\n"
 "Pooled: Kaikki sovelluksen ikkunaluettelopainikkeet on yhdistetty "
@@ -822,33 +882,27 @@ msgstr ""
 "Käynnistysohjelma: Vain kiinnitetty painike näytetään, se toimii kuin "
 "paneelikäynnistin."
 
-#. 6.4->settings-schema.json->display-pinned->options
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
-msgid "Disabled"
-msgstr "Poissa käytöstä"
-
 #. 6.4->settings-schema.json->display-pinned->options
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
 msgid "Unique for each workspace"
 msgstr "Ainutlaatuinen jokaiseen työtilaan"
 
-#. 6.4->settings-schema.json->display-pinned->options
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->display-pinned->options
 msgid "Common across workspaces"
 msgstr "Yleinen kaikissa työtiloissa"
 
-#. 6.4->settings-schema.json->display-pinned->description
 #. 4.0->settings-schema.json->display-pinned->description
 #. 6.0->settings-schema.json->display-pinned->description
+#. 6.4->settings-schema.json->display-pinned->description
 msgid "Pinning of window list buttons"
 msgstr "Ikkunaluettelopainikkeiden kiinnitys"
 
-#. 6.4->settings-schema.json->display-pinned->tooltip
 #. 4.0->settings-schema.json->display-pinned->tooltip
 #. 6.0->settings-schema.json->display-pinned->tooltip
+#. 6.4->settings-schema.json->display-pinned->tooltip
 msgid ""
 "Controls whether window list buttons can be pinned, and whether each "
 "workspace has a unique set of pinned buttons or one common set shared across "
@@ -857,34 +911,36 @@ msgid ""
 msgstr ""
 "Määrittää, voidaanko ikkunaluettelon painikkeita kiinnittää ja onko "
 "jokaisessa työtilassa yksilöllinen joukko kiinnitettyjä painikkeita vai yksi "
-"yhteinen ryhmä, joka jaetaan kaikille työtileille. \"Yleinen työtiloissa\" -"
-"tilassa kiinnitettyjen painikkeiden järjestys säilyy myös työtilojen välillä."
+"yhteinen ryhmä, joka jaetaan kaikille työtileille. \"Yleinen työtiloissa\" "
+"-tilassa kiinnitettyjen painikkeiden järjestys säilyy myös työtilojen "
+"välillä."
 
-#. 6.4->settings-schema.json->synchronize-pinned->description
 #. 4.0->settings-schema.json->synchronize-pinned->description
 #. 6.0->settings-schema.json->synchronize-pinned->description
+#. 6.4->settings-schema.json->synchronize-pinned->description
 msgid "Synchronize launcher buttons across all workspaces"
 msgstr "Synkronoi käynnistyspainikkeet kaikissa työtiloissa"
 
-#. 6.4->settings-schema.json->synchronize-pinned->tooltip
 #. 4.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.0->settings-schema.json->synchronize-pinned->tooltip
+#. 6.4->settings-schema.json->synchronize-pinned->tooltip
+#, fuzzy
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 "Jos tämä on käytössä, paneelin käynnistyspainikkeiden lukumäärä ja järjestys "
 "synkronoidaan kaikissa työtiloissa."
 
-#. 6.4->settings-schema.json->show-windows-for-current-monitor->description
 #. 4.0->settings-schema.json->show-windows-for-current-monitor->description
 #. 6.0->settings-schema.json->show-windows-for-current-monitor->description
+#. 6.4->settings-schema.json->show-windows-for-current-monitor->description
 msgid "Only show windows on the same monitor"
 msgstr "Näytä vain ikkunat samassa näytössä"
 
-#. 6.4->settings-schema.json->show-windows-for-current-monitor->tooltip
 #. 4.0->settings-schema.json->show-windows-for-current-monitor->tooltip
 #. 6.0->settings-schema.json->show-windows-for-current-monitor->tooltip
+#. 6.4->settings-schema.json->show-windows-for-current-monitor->tooltip
 msgid ""
 "If enabled, this applet instance only manages windows\n"
 "that are displayed on the same monitor"
@@ -892,21 +948,21 @@ msgstr ""
 "Jos tämä on käytössä, tämä sovelman esiintymä hallitsee vain ikkunoita\n"
 "jotka näkyvät samassa näytössä"
 
-#. 6.4->settings-schema.json->show-windows-for-all-workspaces->description
 #. 4.0->settings-schema.json->show-windows-for-all-workspaces->description
 #. 6.0->settings-schema.json->show-windows-for-all-workspaces->description
+#. 6.4->settings-schema.json->show-windows-for-all-workspaces->description
 msgid "Include windows from all workspaces"
 msgstr "Sisällytä ikkunat kaikista työtiloista"
 
-#. 6.4->settings-schema.json->show-tooltips->description
 #. 4.0->settings-schema.json->show-tooltips->description
 #. 6.0->settings-schema.json->show-tooltips->description
+#. 6.4->settings-schema.json->show-tooltips->description
 msgid "Show tooltips for window list buttons"
 msgstr "Näytä vihjeet ikkunalista painikkeista"
 
-#. 6.4->settings-schema.json->show-tooltips->tooltip
 #. 4.0->settings-schema.json->show-tooltips->tooltip
 #. 6.0->settings-schema.json->show-tooltips->tooltip
+#. 6.4->settings-schema.json->show-tooltips->tooltip
 msgid ""
 "Enable to show tooltips using window title or application name when hovering "
 "over window list buttons"
@@ -914,16 +970,16 @@ msgstr ""
 "Ota käyttöön työkaluvihjeiden näyttäminen ikkunan otsikon tai sovelluksen "
 "nimen avulla, kun viet hiiren osoitinta ikkunaluettelopainikkeiden päällä"
 
-#. 6.4->settings-schema.json->hide-panel-apps->description
 #. 4.0->settings-schema.json->hide-panel-apps->description
 #. 6.0->settings-schema.json->hide-panel-apps->description
+#. 6.4->settings-schema.json->hide-panel-apps->description
 msgid ""
 "Hide buttons for applications on 'Launcher' instances of CassiaWindowList"
 msgstr "Piilota sovellusten painikkeet CassiaWindowList \"Käynnistimestä\""
 
-#. 6.4->settings-schema.json->hide-panel-apps->tooltip
 #. 4.0->settings-schema.json->hide-panel-apps->tooltip
 #. 6.0->settings-schema.json->hide-panel-apps->tooltip
+#. 6.4->settings-schema.json->hide-panel-apps->tooltip
 msgid ""
 "When enabled, windows for applications with pinned buttons on other "
 "'Launcher' mode instances of the CassiaWindowList applet will not show up in "
@@ -933,15 +989,15 @@ msgstr ""
 "kiinnitetty CassiaWindowList-sovelman muihin esiintymiin, eivät näy tässä "
 "ikkunaluettelossa"
 
-#. 6.4->settings-schema.json->button-spacing->description
 #. 4.0->settings-schema.json->button-spacing->description
 #. 6.0->settings-schema.json->button-spacing->description
+#. 6.4->settings-schema.json->button-spacing->description
 msgid "Spacing between buttons"
 msgstr "Painikkeiden väli"
 
-#. 6.4->settings-schema.json->button-spacing->tooltip
 #. 4.0->settings-schema.json->button-spacing->tooltip
 #. 6.0->settings-schema.json->button-spacing->tooltip
+#. 6.4->settings-schema.json->button-spacing->tooltip
 msgid ""
 "This defines the spacing between the buttons, the value will be divided in "
 "half and added to the left of the icon and to the right of the label on "
@@ -951,37 +1007,39 @@ msgstr ""
 "lisätään kuvakkeen vasemmalle puolelle ja vaakapaneelien tarran oikealle "
 "puolelle tai pystypaneeleissa kuvakkeen yläosaan ja painikkeeseen"
 
-#. 6.4->settings-schema.json->hover-peek-windowlist->description
 #. 4.0->settings-schema.json->hover-peek-windowlist->description
 #. 6.0->settings-schema.json->hover-peek-windowlist->description
+#. 6.4->settings-schema.json->hover-peek-windowlist->description
 msgid "Show a full size window preview when hovering over a button"
 msgstr ""
 "Näytä täysikokoinen ikkunan esikatselu, kun viet hiiren painikkeen päälle"
 
-#. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
 #. 4.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.0->settings-schema.json->hover-peek-windowlist->tooltip
+#. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 "Jos tämä on käytössä, täysikokoinen esikatseluikkuna tulee näkyviin, kun "
 "hiiren osoitin on ikkunaluettelopainikkeen päällä. Esikatselun ilmestymisen "
 "viivettä ohjataan Lisäasetukset-välilehden valinnalla"
 
-#. 6.4->settings-schema.json->no-click-activate->description
 #. 4.0->settings-schema.json->no-click-activate->description
 #. 6.0->settings-schema.json->no-click-activate->description
+#. 6.4->settings-schema.json->no-click-activate->description
 msgid "Automatic focus change when leaving the panel"
 msgstr "Automaattinen tarkennuksen vaihto poistuttaessa paneelista"
 
-#. 6.4->settings-schema.json->no-click-activate->tooltip
 #. 4.0->settings-schema.json->no-click-activate->tooltip
 #. 6.0->settings-schema.json->no-click-activate->tooltip
+#. 6.4->settings-schema.json->no-click-activate->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -992,15 +1050,15 @@ msgstr ""
 "kohdistus ei muutu. Tätä vaihtoehtoa käytetään yleensä yhdessä yllä olevan "
 "esikatselun leijuvan vaihtoehdon kanssa."
 
-#. 6.4->settings-schema.json->menu-show-on-hover->description
 #. 4.0->settings-schema.json->menu-show-on-hover->description
 #. 6.0->settings-schema.json->menu-show-on-hover->description
+#. 6.4->settings-schema.json->menu-show-on-hover->description
 msgid "Show on hover"
 msgstr "Näytä hiirellä"
 
-#. 6.4->settings-schema.json->menu-show-on-hover->tooltip
 #. 4.0->settings-schema.json->menu-show-on-hover->tooltip
 #. 6.0->settings-schema.json->menu-show-on-hover->tooltip
+#. 6.4->settings-schema.json->menu-show-on-hover->tooltip
 msgid ""
 "If enabled, a popup menu with a list of current windows will show when "
 "hovering"
@@ -1008,15 +1066,15 @@ msgstr ""
 "Jos tämä on käytössä, ponnahdusvalikko, jossa on luettelo nykyisistä "
 "ikkunoista, tulee näkyviin, kun osoitinta pidetään"
 
-#. 6.4->settings-schema.json->show-previews->description
 #. 4.0->settings-schema.json->show-previews->description
 #. 6.0->settings-schema.json->show-previews->description
+#. 6.4->settings-schema.json->show-previews->description
 msgid "Show window thumbnails in the popup window list menu"
 msgstr "Näytä ikkunoiden pikkukuvat ponnahdusikkunaluettelovalikossa"
 
-#. 6.4->settings-schema.json->show-previews->tooltip
 #. 4.0->settings-schema.json->show-previews->tooltip
 #. 6.0->settings-schema.json->show-previews->tooltip
+#. 6.4->settings-schema.json->show-previews->tooltip
 msgid ""
 "If enabled, the popup menu will show window thumbnails,\n"
 "otherwise the menu will only show window titles\n"
@@ -1026,55 +1084,56 @@ msgstr ""
 "Muutoin valikko näyttää vain ikkunoiden otsikot\n"
 "(Aina poissa käytöstä, kun Cinnamon käytetään ohjelmiston renderöintitilassa)"
 
-#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 #. 4.0->settings-schema.json->number-of-unshrunk-previews->options
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->options
+#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 msgid "Extra large"
 msgstr "Suurempi"
 
-#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 #. 4.0->settings-schema.json->number-of-unshrunk-previews->options
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->options
+#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 msgid "Large"
 msgstr "Suuri"
 
-#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 #. 4.0->settings-schema.json->number-of-unshrunk-previews->options
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->options
+#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 msgid "Medium"
 msgstr "Keskikokoinen"
 
-#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 #. 4.0->settings-schema.json->number-of-unshrunk-previews->options
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->options
+#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 msgid "Small"
 msgstr "Pieni"
 
-#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 #. 4.0->settings-schema.json->number-of-unshrunk-previews->options
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->options
+#. 6.4->settings-schema.json->number-of-unshrunk-previews->options
 msgid "Extra small"
 msgstr "Pienempi"
 
-#. 6.4->settings-schema.json->number-of-unshrunk-previews->description
 #. 4.0->settings-schema.json->number-of-unshrunk-previews->description
 #. 6.0->settings-schema.json->number-of-unshrunk-previews->description
+#. 6.4->settings-schema.json->number-of-unshrunk-previews->description
 msgid "Default thumbnail window size"
 msgstr "Pikkukuvaikkunan oletuskoko"
 
-#. 6.4->settings-schema.json->menu-sort-groups->description
 #. 4.0->settings-schema.json->menu-sort-groups->description
 #. 6.0->settings-schema.json->menu-sort-groups->description
+#. 6.4->settings-schema.json->menu-sort-groups->description
 msgid "Sort grouped button thumbnail menu items"
 msgstr "Lajittele ryhmitetyt painikkeet valikon pikkukuvissa"
 
-#. 6.4->settings-schema.json->menu-sort-groups->tooltip
 #. 4.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
+#. 6.4->settings-schema.json->menu-sort-groups->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1084,38 +1143,39 @@ msgstr ""
 "vedä ja pudota järjestystoiminto poistetaan käytöstä ryhmitellyissä "
 "pikkukuvien valikoissa."
 
-#. 6.4->settings-schema.json->menu-all-windows-of-pool->description
-#. 6.4->settings-schema.json->menu-all-windows-of-auto->description
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->description
 #. 6.0->settings-schema.json->menu-all-windows-of-pool->description
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->description
+#. 6.4->settings-schema.json->menu-all-windows-of-pool->description
+#. 6.4->settings-schema.json->menu-all-windows-of-auto->description
 msgid "Show thumbnails for all windows of an application pool"
 msgstr "Näytä pikkukuvat kaikille sovellusjoukon ikkunoille"
 
-#. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
-#. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 4.0->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 6.0->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->tooltip
+#. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
+#. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 "Jos tämä on käytössä, ponnahdusvalikko sisältää kaikki sovellusjoukon "
 "sovellusikkunat eikä vain valitun ikkunan sovelluspoolissa"
 
-#. 6.4->settings-schema.json->preview-timeout-show->description
 #. 4.0->settings-schema.json->preview-timeout-show->description
 #. 6.0->settings-schema.json->preview-timeout-show->description
+#. 6.4->settings-schema.json->preview-timeout-show->description
 msgid "Hover time before showing menu"
 msgstr "Osoitinaika ennen valikon näyttämistä"
 
-#. 6.4->settings-schema.json->preview-timeout-show->tooltip
 #. 4.0->settings-schema.json->preview-timeout-show->tooltip
 #. 6.0->settings-schema.json->preview-timeout-show->tooltip
+#. 6.4->settings-schema.json->preview-timeout-show->tooltip
 msgid ""
 "The waiting time before the thumbnail menu appears when hovering over a "
 "button\n"
@@ -1125,15 +1185,15 @@ msgstr ""
 "painikkeen päälle\n"
 "(Ei käytetä siirryttäessä suoraan toiseen painikkeeseen luettelossa)"
 
-#. 6.4->settings-schema.json->preview-timeout-hide->description
 #. 4.0->settings-schema.json->preview-timeout-hide->description
 #. 6.0->settings-schema.json->preview-timeout-hide->description
+#. 6.4->settings-schema.json->preview-timeout-hide->description
 msgid "Time before closing after pointer leaves the menu"
 msgstr "Aika ennen sulkemista sen jälkeen, kun osoitin poistuu valikosta"
 
-#. 6.4->settings-schema.json->preview-timeout-hide->tooltip
 #. 4.0->settings-schema.json->preview-timeout-hide->tooltip
 #. 6.0->settings-schema.json->preview-timeout-hide->tooltip
+#. 6.4->settings-schema.json->preview-timeout-hide->tooltip
 msgid ""
 "The waiting time for the thumbnail menu to close when leaving a button\n"
 "(Not used when moving directly to a different button in the list)"
@@ -1141,24 +1201,18 @@ msgstr ""
 "Odotusaika pikkukuvavalikon sulkeutumiseen poistuttaessa painikkeesta\n"
 "(Ei käytetä siirryttäessä suoraan toiseen painikkeeseen luettelossa)"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
 #. 6.0->settings-schema.json->preview-middle-click->options
 #. 6.0->settings-schema.json->preview-back-click->options
 #. 6.0->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
 msgid "Close thumbnail menu"
 msgstr "Suljaa pikkukuvakkeiden valikko"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1171,15 +1225,15 @@ msgstr "Suljaa pikkukuvakkeiden valikko"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Close window"
 msgstr "Sulje ikkuna"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1192,15 +1246,15 @@ msgstr "Sulje ikkuna"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Minimize/Restore"
 msgstr "Pienennä/Palauta"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1213,15 +1267,15 @@ msgstr "Pienennä/Palauta"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Maximize/Restore"
 msgstr "Suurenna/Palauta"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1234,15 +1288,15 @@ msgstr "Suurenna/Palauta"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Group/Ungroup windows"
 msgstr "Ryhmittele/Pura ryhmitys"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1255,15 +1309,15 @@ msgstr "Ryhmittele/Pura ryhmitys"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to workspace 1"
 msgstr "Siirrä työtilaan 1"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1276,15 +1330,15 @@ msgstr "Siirrä työtilaan 1"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to workspace 2"
 msgstr "Siirrä työtilaan 2"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1297,15 +1351,15 @@ msgstr "Siirrä työtilaan 2"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to workspace 3"
 msgstr "Siirrä työtilaan 3"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1318,15 +1372,15 @@ msgstr "Siirrä työtilaan 3"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to workspace 4"
 msgstr "Siirrä työtilaan 4"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1339,15 +1393,15 @@ msgstr "Siirrä työtilaan 4"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to previous workspace"
 msgstr "Siirrä edelliseen työtilaan"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1360,15 +1414,15 @@ msgstr "Siirrä edelliseen työtilaan"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to next workspace"
 msgstr "Siirrä seuraavaan työtilaan"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1381,15 +1435,15 @@ msgstr "Siirrä seuraavaan työtilaan"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to this workspace"
 msgstr "Siirrä tähän työtilaan"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1402,15 +1456,15 @@ msgstr "Siirrä tähän työtilaan"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Visible on this/all workspaces"
 msgstr "Näkyy tässä/kaikissa työtiloissa"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1423,15 +1477,15 @@ msgstr "Näkyy tässä/kaikissa työtiloissa"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Toggle always on top"
 msgstr "Vaihda aina päällimmäiseksi"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1444,15 +1498,15 @@ msgstr "Vaihda aina päällimmäiseksi"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to monitor 1"
 msgstr "Siirry näyttöön 1"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1465,15 +1519,15 @@ msgstr "Siirry näyttöön 1"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to monitor 2"
 msgstr "Siirry näyttöön 2"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1486,15 +1540,15 @@ msgstr "Siirry näyttöön 2"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to monitor 3"
 msgstr "Siirry näyttöön 3"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1507,15 +1561,15 @@ msgstr "Siirry näyttöön 3"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to monitor 4"
 msgstr "Siirry näyttöön 4"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1528,15 +1582,15 @@ msgstr "Siirry näyttöön 4"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to previous monitor"
 msgstr "Siirry edelliseen näyttöön"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1549,15 +1603,15 @@ msgstr "Siirry edelliseen näyttöön"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to next monitor"
 msgstr "Siirry seuraavaan näyttöön"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1570,15 +1624,15 @@ msgstr "Siirry seuraavaan näyttöön"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Move to current/next monitor"
 msgstr "Siirry nykyiseen/seuraavaan näyttöön"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1591,15 +1645,15 @@ msgstr "Siirry nykyiseen/seuraavaan näyttöön"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Pin to panel toggle"
 msgstr "Kiinnitä paneeliin"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1612,15 +1666,15 @@ msgstr "Kiinnitä paneeliin"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Tile left"
 msgstr "Laatoita vasemmalle"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1633,15 +1687,15 @@ msgstr "Laatoita vasemmalle"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Tile top left"
 msgstr "Laatoita ylös vasemmalle"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1654,15 +1708,15 @@ msgstr "Laatoita ylös vasemmalle"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Tile top"
 msgstr "Laatoita ylös"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1675,15 +1729,15 @@ msgstr "Laatoita ylös"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Tile top right"
 msgstr "Laatoita ylös oikealle"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1696,15 +1750,15 @@ msgstr "Laatoita ylös oikealle"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Tile right"
 msgstr "Laatoita laatoita oikealle"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1717,15 +1771,15 @@ msgstr "Laatoita laatoita oikealle"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Tile bottom right"
 msgstr "Laatoita alas oikealle"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1738,15 +1792,15 @@ msgstr "Laatoita alas oikealle"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Tile bottom"
 msgstr "Laatoita alas"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1759,15 +1813,15 @@ msgstr "Laatoita alas"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Tile bottom left"
 msgstr "Laatoita alas vasemmalle"
 
-#. 6.4->settings-schema.json->preview-middle-click->options
-#. 6.4->settings-schema.json->preview-back-click->options
-#. 6.4->settings-schema.json->preview-forward-click->options
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1780,16 +1834,15 @@ msgstr "Laatoita alas vasemmalle"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-msgid "Untile window"
-msgstr "Pura laatoitus"
-
 #. 6.4->settings-schema.json->preview-middle-click->options
 #. 6.4->settings-schema.json->preview-back-click->options
 #. 6.4->settings-schema.json->preview-forward-click->options
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 6.4->settings-schema.json->mouse-action-scroll->options
+msgid "Untile window"
+msgstr "Pura laatoitus"
+
 #. 4.0->settings-schema.json->preview-middle-click->options
 #. 4.0->settings-schema.json->preview-back-click->options
 #. 4.0->settings-schema.json->preview-forward-click->options
@@ -1804,37 +1857,44 @@ msgstr "Pura laatoitus"
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
+#. 6.4->settings-schema.json->preview-middle-click->options
+#. 6.4->settings-schema.json->preview-back-click->options
+#. 6.4->settings-schema.json->preview-forward-click->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->mouse-action-scroll->options
 msgid "Do nothing"
 msgstr "Älä tee mitään"
 
-#. 6.4->settings-schema.json->preview-middle-click->description
 #. 4.0->settings-schema.json->preview-middle-click->description
 #. 6.0->settings-schema.json->preview-middle-click->description
+#. 6.4->settings-schema.json->preview-middle-click->description
 msgid "Thumbnail window middle button action"
 msgstr "Pikkukuvaikkunan keskipainikkeen toiminta"
 
-#. 6.4->settings-schema.json->preview-back-click->description
 #. 4.0->settings-schema.json->preview-back-click->description
 #. 6.0->settings-schema.json->preview-back-click->description
+#. 6.4->settings-schema.json->preview-back-click->description
 msgid "Thumbnail window back button action"
 msgstr "Pikkukuvaikkunan takaisin -painikkeen toiminta"
 
-#. 6.4->settings-schema.json->preview-forward-click->description
 #. 4.0->settings-schema.json->preview-forward-click->description
 #. 6.0->settings-schema.json->preview-forward-click->description
+#. 6.4->settings-schema.json->preview-forward-click->description
 msgid "Thumbnail window forward button action"
 msgstr "Pikkukuvaikkuna eteenpäin -painikkeen toiminta"
 
-#. 6.4->settings-schema.json->hover-peek-thumbnail->description
 #. 4.0->settings-schema.json->hover-peek-thumbnail->description
 #. 6.0->settings-schema.json->hover-peek-thumbnail->description
+#. 6.4->settings-schema.json->hover-peek-thumbnail->description
 msgid "Show a full size window preview when hovering over a Thumbnail"
 msgstr ""
 "Näytä täysikokoinen ikkunan esikatselu, kun vie hiiri pikkukuvan päälle"
 
-#. 6.4->settings-schema.json->hover-peek-thumbnail->tooltip
 #. 4.0->settings-schema.json->hover-peek-thumbnail->tooltip
 #. 6.0->settings-schema.json->hover-peek-thumbnail->tooltip
+#. 6.4->settings-schema.json->hover-peek-thumbnail->tooltip
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
 "hovering over a Thumbnail menu item. The delay before the preview appears is "
@@ -1844,15 +1904,15 @@ msgstr ""
 "hiiren osoitin on Pikkukuva-valikon kohdan päällä. Esikatselun ilmestymisen "
 "viivettä ohjataan Lisäasetukset-välilehden valinnalla"
 
-#. 6.4->settings-schema.json->no-click-activate-thumbnail->description
 #. 4.0->settings-schema.json->no-click-activate-thumbnail->description
 #. 6.0->settings-schema.json->no-click-activate-thumbnail->description
+#. 6.4->settings-schema.json->no-click-activate-thumbnail->description
 msgid "Automatic focus change when leaving the Thumbnail menu"
 msgstr "Automaattinen tarkennuksen vaihto poistuttaessa Thumbnail-valikosta"
 
-#. 6.4->settings-schema.json->no-click-activate-thumbnail->tooltip
 #. 4.0->settings-schema.json->no-click-activate-thumbnail->tooltip
 #. 6.0->settings-schema.json->no-click-activate-thumbnail->tooltip
+#. 6.4->settings-schema.json->no-click-activate-thumbnail->tooltip
 msgid ""
 "If enabled, the window associated with the Thumbnail menu item will get the "
 "focus when the mouse pointer leaves the menu. Leaving the menu with Ctrl or "
@@ -1866,60 +1926,60 @@ msgstr ""
 "jommastakummasta päästä, kohdistus ei muutu. Tätä vaihtoehtoa käytetään "
 "yleensä yhdessä yllä olevan esikatselun leijuvan vaihtoehdon kanssa."
 
-#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
-#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize most recent window"
 msgstr "Palauta/pienennä viimeisin ikkuna"
 
-#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
-#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore/Minimize 1st window in group"
 msgstr "Palauta/pienennä ensimmäinen ikkuna ryhmässä"
 
-#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
-#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore then cycle windows"
 msgstr "Palauta ja kierrä ikkunat"
 
-#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
-#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Show thumbnail menu"
 msgstr "Näytä pikkukuvavalikko"
 
-#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
-#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.4->settings-schema.json->grouped-mouse-action-btn1->options
+#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "Restore or hold for thumbnail menu"
 msgstr "Palauta pikkukuvavalikko tai pidä sitä painettuna"
 
-#. 6.4->settings-schema.json->grouped-mouse-action-btn1->description
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->description
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->description
+#. 6.4->settings-schema.json->grouped-mouse-action-btn1->description
 msgid "Left button action for grouped buttons"
 msgstr "Vasemman painikkeen toiminto ryhmitellyille painikkeille"
 
-#. 6.4->settings-schema.json->grouped-mouse-action-btn1->tooltip
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->tooltip
 #. 6.0->settings-schema.json->grouped-mouse-action-btn1->tooltip
+#. 6.4->settings-schema.json->grouped-mouse-action-btn1->tooltip
 msgid ""
 "Action taken when using the left mouse button on a window list entry for a "
 "group of windows"
@@ -1927,21 +1987,21 @@ msgstr ""
 "Toimenpide, joka suoritetaan käytettäessä hiiren vasenta painiketta "
 "ikkunaryhmän ikkunaluettelomerkinnässä"
 
-#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 #. 4.0->settings-schema.json->launcher-mouse-action-btn1->options
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->options
+#. 6.4->settings-schema.json->launcher-mouse-action-btn1->options
 msgid "New window or hold for thumbnail menu"
 msgstr "Uusi ikkuna tai pidä painettuna pikkukuvavalikkoa varten"
 
-#. 6.4->settings-schema.json->launcher-mouse-action-btn1->description
 #. 4.0->settings-schema.json->launcher-mouse-action-btn1->description
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->description
+#. 6.4->settings-schema.json->launcher-mouse-action-btn1->description
 msgid "Left button action (with running windows)"
 msgstr "Vasemman painikkeen toiminta (ikkunoiden ollessa käynnissä)"
 
-#. 6.4->settings-schema.json->launcher-mouse-action-btn1->tooltip
 #. 4.0->settings-schema.json->launcher-mouse-action-btn1->tooltip
 #. 6.0->settings-schema.json->launcher-mouse-action-btn1->tooltip
+#. 6.4->settings-schema.json->launcher-mouse-action-btn1->tooltip
 msgid ""
 "Action taken when using the left mouse button on a launcher button with one "
 "or more running windows"
@@ -1949,176 +2009,177 @@ msgstr ""
 "Toiminto käytettäessä hiiren vasenta painiketta käynnistyspainikkeessa, "
 "jossa on yksi tai useampi ikkuna"
 
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Thumbnail menu toggle"
 msgstr "Pikkukuvavalikon vaihto"
 
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Thumbnail menu hold"
 msgstr "Pikkukuvavalikon pito"
 
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Restore most recent application window"
 msgstr "Palauta viimeisin sovellusikkuna"
 
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Restore/minimize 1st window in group"
 msgstr "Palauta/pienennä ensimmäinen ikkuna ryhmässä"
 
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Restore/minimize 2nd window in group"
 msgstr "Palauta/pienennä toinen ikkuna ryhmässä"
 
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Restore/minimize 3rd window in group"
 msgstr "Palauta/pienennä kolmas ikkuna ryhmässä"
 
-#. 6.4->settings-schema.json->mouse-action-btn2->options
-#. 6.4->settings-schema.json->mouse-action-btn8->options
-#. 6.4->settings-schema.json->mouse-action-btn9->options
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
+#. 6.4->settings-schema.json->mouse-action-btn2->options
+#. 6.4->settings-schema.json->mouse-action-btn8->options
+#. 6.4->settings-schema.json->mouse-action-btn9->options
 msgid "Restore/minimize 4th window in group"
 msgstr "Palauta/pienennä neljäs ikkuna ryhmässä"
 
-#. 6.4->settings-schema.json->mouse-action-btn2->description
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description
+#. 6.4->settings-schema.json->mouse-action-btn2->description
 msgid "Middle button action"
 msgstr "Keskimmäisen painikkeen toiminto"
 
-#. 6.4->settings-schema.json->mouse-action-btn2->tooltip
 #. 4.0->settings-schema.json->mouse-action-btn2->tooltip
 #. 6.0->settings-schema.json->mouse-action-btn2->tooltip
+#. 6.4->settings-schema.json->mouse-action-btn2->tooltip
 msgid "Action taken when using the middle mouse button on window list entries"
 msgstr ""
 "Toimenpide käytettäessä hiiren keskipainiketta ikkunaluettelomerkinnöissä"
 
-#. 6.4->settings-schema.json->mouse-action-btn8->description
 #. 4.0->settings-schema.json->mouse-action-btn8->description
 #. 6.0->settings-schema.json->mouse-action-btn8->description
+#. 6.4->settings-schema.json->mouse-action-btn8->description
 msgid "Back button action"
 msgstr "Takaisinpainikkeen toiminto"
 
-#. 6.4->settings-schema.json->mouse-action-btn8->tooltip
 #. 4.0->settings-schema.json->mouse-action-btn8->tooltip
 #. 6.0->settings-schema.json->mouse-action-btn8->tooltip
+#. 6.4->settings-schema.json->mouse-action-btn8->tooltip
 msgid "Action taken when using the back mouse button on window list entries"
 msgstr ""
 "Toimenpide käytettäessä hiiren taaksepäin painiketta "
 "ikkunaluettelomerkinnöissä"
 
-#. 6.4->settings-schema.json->mouse-action-btn9->description
 #. 4.0->settings-schema.json->mouse-action-btn9->description
 #. 6.0->settings-schema.json->mouse-action-btn9->description
+#. 6.4->settings-schema.json->mouse-action-btn9->description
 msgid "Forward button action"
 msgstr "Eteenpäin painikkeen toiminto"
 
-#. 6.4->settings-schema.json->mouse-action-btn9->tooltip
 #. 4.0->settings-schema.json->mouse-action-btn9->tooltip
 #. 6.0->settings-schema.json->mouse-action-btn9->tooltip
+#. 6.4->settings-schema.json->mouse-action-btn9->tooltip
 msgid "Action taken when using the forward mouse button on window list entries"
 msgstr ""
 "Toimenpide käytettäessä hiiren eteenpäin-painiketta "
 "ikkunaluettelomerkinnöissä"
 
-#. 6.4->settings-schema.json->mouse-action-scroll->options
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
+#. 6.4->settings-schema.json->mouse-action-scroll->options
 msgid "Minimize/Restore/Maximize window"
 msgstr "Pienennä/Palauta/Suurenna ikkuna"
 
-#. 6.4->settings-schema.json->mouse-action-scroll->options
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
+#. 6.4->settings-schema.json->mouse-action-scroll->options
 msgid "Change windows workspace"
 msgstr "Vaihda ikkunan työtilaa"
 
-#. 6.4->settings-schema.json->mouse-action-scroll->options
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
+#. 6.4->settings-schema.json->mouse-action-scroll->options
 msgid "Change windows monitor"
 msgstr "Vaihda ikkunan näyttöä"
 
-#. 6.4->settings-schema.json->mouse-action-scroll->options
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
+#. 6.4->settings-schema.json->mouse-action-scroll->options
 msgid "Change window tiling"
 msgstr "Vaihda ikkunoiden asettelua"
 
-#. 6.4->settings-schema.json->mouse-action-scroll->options
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
-msgid "Cycle all window-list button windows"
+#. 6.4->settings-schema.json->mouse-action-scroll->options
+#, fuzzy
+msgid "Cycle all window list button windows"
 msgstr "Kierrä ikkunoiden painikkeet"
 
-#. 6.4->settings-schema.json->mouse-action-scroll->options
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
+#. 6.4->settings-schema.json->mouse-action-scroll->options
 msgid "Cycle grouped/pooled button windows"
 msgstr "Kierrä ryhmitetyt painikeikkunat"
 
-#. 6.4->settings-schema.json->mouse-action-scroll->description
 #. 4.0->settings-schema.json->mouse-action-scroll->description
 #. 6.0->settings-schema.json->mouse-action-scroll->description
+#. 6.4->settings-schema.json->mouse-action-scroll->description
 msgid "Scroll wheel action"
 msgstr "Hiiren rullan toiminta"
 
-#. 6.4->settings-schema.json->mouse-action-scroll->tooltip
 #. 4.0->settings-schema.json->mouse-action-scroll->tooltip
 #. 6.0->settings-schema.json->mouse-action-scroll->tooltip
+#. 6.4->settings-schema.json->mouse-action-scroll->tooltip
 msgid ""
 "Action taken when using the mouse scroll wheel on a window list button. This "
 "scroll wheel action will be disabled if the Thumbnail menu is currently open"
@@ -2126,39 +2187,39 @@ msgstr ""
 "Toiminta käytettäessä hiiren rullaa ikkunoiden painikkeessa. Jos pikkukuva "
 "on tällä hetkellä auki, tämä vieritystoiminta poistetaan käytöstä"
 
-#. 6.4->settings-schema.json->wheel-adjusts-preview-size->options
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options
+#. 6.4->settings-schema.json->wheel-adjusts-preview-size->options
 msgid "Off"
 msgstr "Pois"
 
-#. 6.4->settings-schema.json->wheel-adjusts-preview-size->options
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options
+#. 6.4->settings-schema.json->wheel-adjusts-preview-size->options
 msgid "On (temporary)"
 msgstr "Päällä (väliaikainen)"
 
-#. 6.4->settings-schema.json->wheel-adjusts-preview-size->options
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options
+#. 6.4->settings-schema.json->wheel-adjusts-preview-size->options
 msgid "On (global default)"
 msgstr "Päällä ( kaikille oletusarvo)"
 
-#. 6.4->settings-schema.json->wheel-adjusts-preview-size->options
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->options
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->options
+#. 6.4->settings-schema.json->wheel-adjusts-preview-size->options
 msgid "On (application default)"
 msgstr "Päällä (sovelluksen oletus)"
 
-#. 6.4->settings-schema.json->wheel-adjusts-preview-size->description
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->description
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->description
+#. 6.4->settings-schema.json->wheel-adjusts-preview-size->description
 msgid "Adjust the thumbnail window sizes using the scroll-wheel"
 msgstr "Säädä pikkukuvaikkunoiden kokoa vierityspyörällä"
 
-#. 6.4->settings-schema.json->wheel-adjusts-preview-size->tooltip
 #. 4.0->settings-schema.json->wheel-adjusts-preview-size->tooltip
 #. 6.0->settings-schema.json->wheel-adjusts-preview-size->tooltip
+#. 6.4->settings-schema.json->wheel-adjusts-preview-size->tooltip
 msgid ""
 "If enabled, the size of thumbnail windows will respond to the mouse scroll-"
 "wheel. The new size can have a temporary effect or persist on a global or "
@@ -2168,57 +2229,57 @@ msgstr ""
 "Uudella koolla voi olla väliaikainen vaikutus tai se voi jatkua "
 "maailmanlaajuisesti tai sovelluskohtaisesti"
 
-#. 6.4->settings-schema.json->hotkey-bindings->description
 #. 4.0->settings-schema.json->hotkey-bindings->description
 #. 6.0->settings-schema.json->hotkey-bindings->description
+#. 6.4->settings-schema.json->hotkey-bindings->description
 msgid "Hotkey binding available for assignment to a window"
 msgstr "Pikanäppäinsidonta käytettävissä määritettäväksi ikkunaan"
 
-#. 6.4->settings-schema.json->hotkey-bindings->columns->title
-#. 6.4->settings-schema.json->adv-mouse-list->columns->title
 #. 4.0->settings-schema.json->hotkey-bindings->columns->title
 #. 4.0->settings-schema.json->adv-mouse-list->columns->title
 #. 6.0->settings-schema.json->hotkey-bindings->columns->title
 #. 6.0->settings-schema.json->adv-mouse-list->columns->title
+#. 6.4->settings-schema.json->hotkey-bindings->columns->title
+#. 6.4->settings-schema.json->adv-mouse-list->columns->title
 msgid "Enabled"
 msgstr "Käytössä"
 
-#. 6.4->settings-schema.json->hotkey-bindings->columns->title
 #. 4.0->settings-schema.json->hotkey-bindings->columns->title
 #. 6.0->settings-schema.json->hotkey-bindings->columns->title
+#. 6.4->settings-schema.json->hotkey-bindings->columns->title
 msgid "Cycle application windows"
 msgstr "Kierrä sovellusten ikkunat"
 
-#. 6.4->settings-schema.json->hotkey-bindings->columns->title
 #. 4.0->settings-schema.json->hotkey-bindings->columns->title
 #. 6.0->settings-schema.json->hotkey-bindings->columns->title
+#. 6.4->settings-schema.json->hotkey-bindings->columns->title
 msgid "Key sequence"
 msgstr "Näppäinjärjestys"
 
-#. 6.4->settings-schema.json->hotkey-bindings->columns->title
 #. 4.0->settings-schema.json->hotkey-bindings->columns->title
 #. 6.0->settings-schema.json->hotkey-bindings->columns->title
+#. 6.4->settings-schema.json->hotkey-bindings->columns->title
 msgid "Description"
 msgstr "Kuvaus"
 
-#. 6.4->settings-schema.json->hotkey-bindings->tooltip
 #. 4.0->settings-schema.json->hotkey-bindings->tooltip
 #. 6.0->settings-schema.json->hotkey-bindings->tooltip
+#. 6.4->settings-schema.json->hotkey-bindings->tooltip
 msgid ""
 "Define a list of hotkeys used to bring to the foreground specific windows."
 msgstr ""
 "Määritä luettelo pikanäppäimistä, joita käytetään tuomaan etualalle tietyt "
 "ikkunat."
 
-#. 6.4->settings-schema.json->hotkey-minimize->description
 #. 4.0->settings-schema.json->hotkey-minimize->description
 #. 6.0->settings-schema.json->hotkey-minimize->description
+#. 6.4->settings-schema.json->hotkey-minimize->description
 msgid "Minimize window when hotkey target is already in focus"
 msgstr "Pienennä ikkuna, kun pikanäppäinkohde on jo tarkennettu"
 
-#. 6.4->settings-schema.json->hotkey-minimize->tooltip
 #. 4.0->settings-schema.json->hotkey-minimize->tooltip
 #. 6.0->settings-schema.json->hotkey-minimize->tooltip
+#. 6.4->settings-schema.json->hotkey-minimize->tooltip
 msgid ""
 "If enabled and application cycling is not enabled or there is only one "
 "window for the application, windows will be minimized if the window is "
@@ -2227,15 +2288,15 @@ msgstr ""
 "Jos käytössä ja sovellusten kierto ei ole käytössä tai sovelluksella on vain "
 "yksi ikkuna, ikkunat pienennetään, jos ikkuna on jo kohdistettu"
 
-#. 6.4->settings-schema.json->hotkey-new->description
 #. 4.0->settings-schema.json->hotkey-new->description
 #. 6.0->settings-schema.json->hotkey-new->description
+#. 6.4->settings-schema.json->hotkey-new->description
 msgid "Open a new window when the application is not running"
 msgstr "Avaa uusi ikkuna, kun sovellus ei ole käynnissä"
 
-#. 6.4->settings-schema.json->hotkey-new->tooltip
 #. 4.0->settings-schema.json->hotkey-new->tooltip
 #. 6.0->settings-schema.json->hotkey-new->tooltip
+#. 6.4->settings-schema.json->hotkey-new->tooltip
 msgid ""
 "Start a new window if no window is attached to a hotkey and the hotkey "
 "description is an exact match for the application name of a pinned button or "
@@ -2245,21 +2306,22 @@ msgstr ""
 "pikanäppäimen kuvaus vastaa tarkasti kiinnitetyn painikkeen tai työpöydän "
 "tiedoston nimeä"
 
-#. 6.4->settings-schema.json->hotkey-sequence->description
 #. 4.0->settings-schema.json->hotkey-sequence->description
 #. 6.0->settings-schema.json->hotkey-sequence->description
+#. 6.4->settings-schema.json->hotkey-sequence->description
 msgid "Smart numeric hotkeys (using \"1\" automatically extends to 1-9)"
 msgstr ""
 "Älykkäät numeeriset pikanäppäimet (\"1\" laajenee automaattisesti arvoihin "
 "1-9)"
 
-#. 6.4->settings-schema.json->hotkey-sequence->tooltip
 #. 4.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.0->settings-schema.json->hotkey-sequence->tooltip
+#. 6.4->settings-schema.json->hotkey-sequence->tooltip
+#, fuzzy
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 "Jos tämä on käytössä, pikanäppäimet, jotka päättyvät \"1\"-näppäimeen (eli "
@@ -2267,29 +2329,30 @@ msgstr ""
 "Määritetyn sovelluksen ensimmäiset 9 ikkunaa, kuten ikkunaluettelossa on "
 "järjestyksessä, aktivoidaan 9 pikanäppäimellä."
 
-#. 6.4->settings-schema.json->hotkey-grave-help->description
 #. 4.0->settings-schema.json->hotkey-grave-help->description
 #. 6.0->settings-schema.json->hotkey-grave-help->description
+#. 6.4->settings-schema.json->hotkey-grave-help->description
 msgid "Use modifier(s) + ` hotkey to show hotkey hint bubbles"
 msgstr ""
 "Näytä pikanäppäinvihjekuplat käyttämällä muokkareita + `-kutsunäppäintä"
 
-#. 6.4->settings-schema.json->hotkey-grave-help->tooltip
 #. 4.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.0->settings-schema.json->hotkey-grave-help->tooltip
+#. 6.4->settings-schema.json->hotkey-grave-help->tooltip
+#, fuzzy
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 "Jos käytössä, pikanäppäinten muokkaaja(t) + ` rekisteröidään jokaiselle "
 "pikanäppäinluettelossa määritetylle yksilölliselle muokkausjoukolle. Näiden "
 "pikanäppäinten käyttäminen näyttää väliaikaisesti pikanäppäinvihjekuplan "
 "painikekuvakkeiden päällä."
 
-#. 6.4->settings-schema.json->hotkey-help->description
 #. 4.0->settings-schema.json->hotkey-help->description
 #. 6.0->settings-schema.json->hotkey-help->description
+#. 6.4->settings-schema.json->hotkey-help->description
 msgid ""
 "Hotkeys can be assigned to a window in two ways:\n"
 "1) Manual: Use \"Assign window to a hotkey\" in the button context menu.\n"
@@ -2311,141 +2374,32 @@ msgstr ""
 "uudelleen. 3) Työpöytätiedostoihin liittyviä pikanäppäimiä ei voi määrittää "
 "manuaalisesti."
 
-#. 6.4->settings-schema.json->adv-mouse-list->columns->title
 #. 4.0->settings-schema.json->adv-mouse-list->columns->title
 #. 6.0->settings-schema.json->adv-mouse-list->columns->title
+#. 6.4->settings-schema.json->adv-mouse-list->columns->title
 msgid "Key and mouse button"
 msgstr "Näppäin ja hiiren painike"
 
-#. 6.4->settings-schema.json->adv-mouse-list->columns->title
 #. 4.0->settings-schema.json->adv-mouse-list->columns->title
 #. 6.0->settings-schema.json->adv-mouse-list->columns->title
+#. 6.4->settings-schema.json->adv-mouse-list->columns->title
 msgid "Mouse click context"
 msgstr "Hiiren klikkauskonteksti"
 
-#. 6.4->settings-schema.json->adv-mouse-list->columns->title
 #. 4.0->settings-schema.json->adv-mouse-list->columns->title
 #. 6.0->settings-schema.json->adv-mouse-list->columns->title
+#. 6.4->settings-schema.json->adv-mouse-list->columns->title
 msgid "Action to perform"
 msgstr "Suoritettava toimenpide"
 
-#. 6.4->settings-schema.json->adv-mouse-list->tooltip
 #. 4.0->settings-schema.json->adv-mouse-list->tooltip
 #. 6.0->settings-schema.json->adv-mouse-list->tooltip
+#. 6.4->settings-schema.json->adv-mouse-list->tooltip
 msgid ""
 "Define a set of mouse button actions when the Ctrl or Shift keys are pressed."
 msgstr ""
 "Määritä joukko hiiren painiketoimintoja, kun Ctrl- tai Shift-näppäintä "
 "painetaan."
-
-#. 6.4->settings-schema.json->animate-icon->description
-#. 4.0->settings-schema.json->animate-icon->description
-#. 6.0->settings-schema.json->animate-icon->description
-msgid "Icon animation when launching new windows"
-msgstr "Kuvakeanimaatio uusia ikkunoita käynnistettäessä"
-
-#. 6.4->settings-schema.json->animate-icon->tooltip
-#. 4.0->settings-schema.json->animate-icon->tooltip
-#. 6.0->settings-schema.json->animate-icon->tooltip
-msgid ""
-"When enabled, the icon will animate when launching new windows for an "
-"application"
-msgstr ""
-"Kun se on käytössä, kuvake animoituu, kun sovellukselle käynnistetään uusia "
-"ikkunoita"
-
-#. 6.4->settings-schema.json->backup-file-name->description
-#. 4.0->settings-schema.json->backup-file-name->description
-#. 6.0->settings-schema.json->backup-file-name->description
-msgid "Settings backup name"
-msgstr "Asetusten varmuuskopion nimi"
-
-#. 6.4->settings-schema.json->backup-file-name->tooltip
-#. 4.0->settings-schema.json->backup-file-name->tooltip
-#. 6.0->settings-schema.json->backup-file-name->tooltip
-msgid ""
-"If a name is entered here, the configuration of this applet instance will be "
-"backed up under that name. Backups will be listed in the Setup Wizard "
-"restore page when adding a new instance of CassiaWindowList to a panel."
-msgstr ""
-"Jos tähän syötetään nimi, tämän sovelman kokoonpano varmuuskopioidaan tällä "
-"nimellä. Varmuuskopiot luetellaan ohjatun asennustoiminnon palautussivulla, "
-"kun paneeliin lisätään uusi CassiaWindowList-esiintymä."
-
-#. 6.4->settings-schema.json->icon-saturation->units
-#. 4.0->settings-schema.json->icon-saturation->units
-#. 6.0->settings-schema.json->icon-saturation->units
-msgid "percent"
-msgstr "prosentti"
-
-#. 6.4->settings-schema.json->icon-saturation->description
-#. 4.0->settings-schema.json->icon-saturation->description
-#. 6.0->settings-schema.json->icon-saturation->description
-msgid "Icon color saturation"
-msgstr "Kuvakkeen värin saturaatio"
-
-#. 6.4->settings-schema.json->icon-saturation->tooltip
-#. 4.0->settings-schema.json->icon-saturation->tooltip
-#. 6.0->settings-schema.json->icon-saturation->tooltip
-msgid ""
-"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
-"100%"
-msgstr ""
-"Asettaa kuvakkeiden värikylläisyyden 0%:sta (harmaasävy) 100%:iin, oletus on "
-"100%"
-
-#. 6.4->settings-schema.json->saturation-application->options
-#. 4.0->settings-schema.json->saturation-application->options
-#. 6.0->settings-schema.json->saturation-application->options
-msgid "All Buttons"
-msgstr "Kaikki painikkeet"
-
-#. 6.4->settings-schema.json->saturation-application->options
-#. 4.0->settings-schema.json->saturation-application->options
-#. 6.0->settings-schema.json->saturation-application->options
-msgid "Minimized buttons"
-msgstr "Piilota tarrat piennetyista painikkeista"
-
-#. 6.4->settings-schema.json->saturation-application->options
-#. 4.0->settings-schema.json->saturation-application->options
-#. 6.0->settings-schema.json->saturation-application->options
-msgid "Idle pinned buttons"
-msgstr "Tyhjennä kiinnitetyt painikkeet"
-
-#. 6.4->settings-schema.json->saturation-application->options
-#. 4.0->settings-schema.json->saturation-application->options
-#. 6.0->settings-schema.json->saturation-application->options
-msgid "Buttons for windows on other workspaces"
-msgstr "Muiden työtilojen ikkunoiden painikkeet"
-
-#. 6.4->settings-schema.json->saturation-application->options
-#. 4.0->settings-schema.json->saturation-application->options
-#. 6.0->settings-schema.json->saturation-application->options
-msgid "Buttons for windows on other monitors"
-msgstr "Muiden näyttöjen ikkunoiden painikkeet"
-
-#. 6.4->settings-schema.json->saturation-application->options
-#. 4.0->settings-schema.json->saturation-application->options
-#. 6.0->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
-msgstr "Kaikki painikkeet paitsi tarkennettu ikkuna"
-
-#. 6.4->settings-schema.json->saturation-application->description
-#. 4.0->settings-schema.json->saturation-application->description
-#. 6.0->settings-schema.json->saturation-application->description
-msgid "Where to apply the icon color saturation"
-msgstr "Missä käytetään kuvakkeen värikylläisyyttä"
-
-#. 6.4->settings-schema.json->saturation-application->tooltip
-#. 4.0->settings-schema.json->saturation-application->tooltip
-#. 6.0->settings-schema.json->saturation-application->tooltip
-msgid ""
-"Which buttons will have the custom icon color saturation applied\n"
-"This option is only available when the saturation is not set to 100%"
-msgstr ""
-"Mihin painikkeisiin käytetään mukautettua kuvakkeen värikylläisyyttä\n"
-"Tämä vaihtoehto on käytettävissä vain, kun kylläisyyttä ei ole asetettu 100 "
-"%:iin"
 
 #. 4.0->settings-schema.json->adv-mouse-help->description
 msgid ""
@@ -2460,19 +2414,129 @@ msgstr ""
 "https://github.com/linuxmint/cinnamon/pull/11908\n"
 "Muokkausvalintaikkunan arvot ovat oikeat arvot ja ne, jotka tulevat voimaan."
 
-#: SetupWizard.ui:7
+#. 4.0->settings-schema.json->animate-icon->description
+#. 6.0->settings-schema.json->animate-icon->description
+#. 6.4->settings-schema.json->animate-icon->description
+msgid "Icon animation when launching new windows"
+msgstr "Kuvakeanimaatio uusia ikkunoita käynnistettäessä"
+
+#. 4.0->settings-schema.json->animate-icon->tooltip
+#. 6.0->settings-schema.json->animate-icon->tooltip
+#. 6.4->settings-schema.json->animate-icon->tooltip
+msgid ""
+"When enabled, the icon will animate when launching new windows for an "
+"application"
+msgstr ""
+"Kun se on käytössä, kuvake animoituu, kun sovellukselle käynnistetään uusia "
+"ikkunoita"
+
+#. 4.0->settings-schema.json->backup-file-name->description
+#. 6.0->settings-schema.json->backup-file-name->description
+#. 6.4->settings-schema.json->backup-file-name->description
+msgid "Settings backup name"
+msgstr "Asetusten varmuuskopion nimi"
+
+#. 4.0->settings-schema.json->backup-file-name->tooltip
+#. 6.0->settings-schema.json->backup-file-name->tooltip
+#. 6.4->settings-schema.json->backup-file-name->tooltip
+msgid ""
+"If a name is entered here, the configuration of this applet instance will be "
+"backed up under that name. Backups will be listed in the Setup Wizard "
+"restore page when adding a new instance of CassiaWindowList to a panel."
+msgstr ""
+"Jos tähän syötetään nimi, tämän sovelman kokoonpano varmuuskopioidaan tällä "
+"nimellä. Varmuuskopiot luetellaan ohjatun asennustoiminnon palautussivulla, "
+"kun paneeliin lisätään uusi CassiaWindowList-esiintymä."
+
+#. 4.0->settings-schema.json->icon-saturation->units
+#. 6.0->settings-schema.json->icon-saturation->units
+#. 6.4->settings-schema.json->icon-saturation->units
+msgid "percent"
+msgstr "prosentti"
+
+#. 4.0->settings-schema.json->icon-saturation->description
+#. 6.0->settings-schema.json->icon-saturation->description
+#. 6.4->settings-schema.json->icon-saturation->description
+msgid "Icon color saturation"
+msgstr "Kuvakkeen värin saturaatio"
+
+#. 4.0->settings-schema.json->icon-saturation->tooltip
+#. 6.0->settings-schema.json->icon-saturation->tooltip
+#. 6.4->settings-schema.json->icon-saturation->tooltip
+msgid ""
+"Sets the color saturation for icons from 0% (grayscale) to 100%, default is "
+"100%"
+msgstr ""
+"Asettaa kuvakkeiden värikylläisyyden 0%:sta (harmaasävy) 100%:iin, oletus on "
+"100%"
+
+#. 4.0->settings-schema.json->saturation-application->options
+#. 6.0->settings-schema.json->saturation-application->options
+#. 6.4->settings-schema.json->saturation-application->options
+msgid "All Buttons"
+msgstr "Kaikki painikkeet"
+
+#. 4.0->settings-schema.json->saturation-application->options
+#. 6.0->settings-schema.json->saturation-application->options
+#. 6.4->settings-schema.json->saturation-application->options
+msgid "Minimized buttons"
+msgstr "Piilota tarrat piennetyista painikkeista"
+
+#. 4.0->settings-schema.json->saturation-application->options
+#. 6.0->settings-schema.json->saturation-application->options
+#. 6.4->settings-schema.json->saturation-application->options
+msgid "Idle pinned buttons"
+msgstr "Tyhjennä kiinnitetyt painikkeet"
+
+#. 4.0->settings-schema.json->saturation-application->options
+#. 6.0->settings-schema.json->saturation-application->options
+#. 6.4->settings-schema.json->saturation-application->options
+msgid "Buttons for windows on other workspaces"
+msgstr "Muiden työtilojen ikkunoiden painikkeet"
+
+#. 4.0->settings-schema.json->saturation-application->options
+#. 6.0->settings-schema.json->saturation-application->options
+#. 6.4->settings-schema.json->saturation-application->options
+msgid "Buttons for windows on other monitors"
+msgstr "Muiden näyttöjen ikkunoiden painikkeet"
+
+#. 4.0->settings-schema.json->saturation-application->options
+#. 6.0->settings-schema.json->saturation-application->options
+#. 6.4->settings-schema.json->saturation-application->options
+#, fuzzy
+msgid "All buttons except the focused window"
+msgstr "Kaikki painikkeet paitsi tarkennettu ikkuna"
+
+#. 4.0->settings-schema.json->saturation-application->description
+#. 6.0->settings-schema.json->saturation-application->description
+#. 6.4->settings-schema.json->saturation-application->description
+msgid "Where to apply the icon color saturation"
+msgstr "Missä käytetään kuvakkeen värikylläisyyttä"
+
+#. 4.0->settings-schema.json->saturation-application->tooltip
+#. 6.0->settings-schema.json->saturation-application->tooltip
+#. 6.4->settings-schema.json->saturation-application->tooltip
+msgid ""
+"Which buttons will have the custom icon color saturation applied\n"
+"This option is only available when the saturation is not set to 100%"
+msgstr ""
+"Mihin painikkeisiin käytetään mukautettua kuvakkeen värikylläisyyttä\n"
+"Tämä vaihtoehto on käytettävissä vain, kun kylläisyyttä ei ole asetettu 100 "
+"%:iin"
+
+#. SetupWizard.ui:7
 msgid "CassiaWindowList Basic Setup Wizard"
 msgstr "CassiaWindowList Basic Setup Wizard"
 
-#: SetupWizard.ui:78
+#. SetupWizard.ui:78
 msgid "Welcome to CassiaWindowList"
 msgstr "Tervetuloa CassiaWindowListiin"
 
-#: SetupWizard.ui:95
+#. SetupWizard.ui:95
 msgid "How would you like this applet instance to behave?"
 msgstr "Miten haluaisit tämän sovelman käyttäytyvän?"
 
-#: SetupWizard.ui:105
+#. SetupWizard.ui:105
 msgid ""
 "Window List (Task bar)\n"
 "Panel buttons for all running windows."
@@ -2480,17 +2544,18 @@ msgstr ""
 "Ikkunaluettelo (tehtäväpalkki)\n"
 "Paneelin painikkeet kaikille käynnissä oleville ikkunoille."
 
-#: SetupWizard.ui:125
+#. SetupWizard.ui:125
+#, fuzzy
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 "Paneelin käynnistysohjelma (pikakäynnistin)\n"
 "Paneelipainike näkyy vain, kun lisäät kohteita\n"
 "paneeliin ei näytetä tarroja, vain kuvakkeita."
 
-#: SetupWizard.ui:146
+#. SetupWizard.ui:146
 msgid ""
 "Restore configuration from an automatic\n"
 "backup"
@@ -2498,21 +2563,22 @@ msgstr ""
 "Palauta konfiguraatio automaattisesta\n"
 "varmuuskopioida"
 
-#: SetupWizard.ui:178
+#. SetupWizard.ui:178
 msgid "How do you want your Window List to operate?"
 msgstr "Miten haluat ikkunaluettelosi toimivan?"
 
-#: SetupWizard.ui:192
+#. SetupWizard.ui:192
+#, fuzzy
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 "Perus - Nopea pääsy ikkunaan\n"
 "Jokainen ikkuna saa oman ikkunaluettelopainikkeensa.\n"
 "Painikkeiden otsikot ovat ikkunoiden otsikoita."
 
-#: SetupWizard.ui:213
+#. SetupWizard.ui:213
 msgid ""
 "Grouping  -  Very compact\n"
 "One window list button per application.\n"
@@ -2524,11 +2590,12 @@ msgstr ""
 "Pikkukuvavalikot tietyn ikkunan valitsemiseksi.\n"
 "Painikkeiden otsikot ovat ikkunoiden otsikoita."
 
-#: SetupWizard.ui:236
+#. SetupWizard.ui:236
+#, fuzzy
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2538,29 +2605,30 @@ msgstr ""
 "Yksi painiketarra sovellusryhmää kohden.\n"
 "Painikkeiden nimet ovat sovellusten nimiä."
 
-#: SetupWizard.ui:273
+#. SetupWizard.ui:273
 msgid "Just a few more options to consider"
 msgstr "Vain muutama vaihtoehto harkittavaksi"
 
-#: SetupWizard.ui:287
+#. SetupWizard.ui:287
 msgid "No Labels (icons only)"
 msgstr "Ei etikettejä (vain kuvakkeet)"
 
-#: SetupWizard.ui:305
+#. SetupWizard.ui:305
 msgid "No minimized window indicator character"
 msgstr "Ei minimoitua ikkunan merkkiä"
 
-#: SetupWizard.ui:323
+#. SetupWizard.ui:323
 msgid "No Thumbnail window menu on mouse hover"
 msgstr "Ei pikkukuva-ikkunavalikkoa hiiren osoitin"
 
-#: SetupWizard.ui:354
+#. SetupWizard.ui:354
 msgid "Panel Launcher Setup"
 msgstr "Paneelin käynnistysohjelman asetukset"
 
-#: SetupWizard.ui:370
+#. SetupWizard.ui:370
+#, fuzzy
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2580,29 +2648,30 @@ msgstr ""
 "Miten haluat hiiren vasemman painikkeen toimivan milloin\n"
 "onko ikkunat jo olemassa käynnistyspainikkeelle?"
 
-#: SetupWizard.ui:388
+#. SetupWizard.ui:388
 msgid "Open new window / Hold for Thumbnail menu"
 msgstr "Avaa uusi ikkuna / Pidä pikkukuvavalikkoa painettuna"
 
-#: SetupWizard.ui:407
+#. SetupWizard.ui:407
 msgid "Restore most recent window / Cycle windows"
 msgstr "Palauta viimeisin ikkuna / kierrä ikkunoita"
 
-#: SetupWizard.ui:427
+#. SetupWizard.ui:427
 msgid "Open the Thumbnail menu"
 msgstr "Avaa pikkukuvakkeiden valikko"
 
-#: SetupWizard.ui:461
+#. SetupWizard.ui:461
 msgid "Thumbnail window menu on mouse hover"
 msgstr "Pikkukuvaikkunan valikko hiiren osoitin"
 
-#: SetupWizard.ui:492
+#. SetupWizard.ui:492
 msgid "All done!"
 msgstr "Valmis!"
 
-#: SetupWizard.ui:508
+#. SetupWizard.ui:508
+#, fuzzy
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"
@@ -2628,19 +2697,19 @@ msgstr ""
 " • Automaattinen sovellusten ryhmittely, kun tilaa on rajoitetusti.\n"
 " • Ja paljon enemmän."
 
-#: SetupWizard.ui:530
+#. SetupWizard.ui:530
 msgid "Exit and launch the applet configurator now"
 msgstr "Poistu ja käynnistä sovelmien määritysohjelma nyt"
 
-#: SetupWizard.ui:559
+#. SetupWizard.ui:559
 msgid "Select a backup configuration to restore?"
 msgstr "Valitseko palautettava varmuuskopiokokoonpano?"
 
-#: SetupWizard.ui:602
+#. SetupWizard.ui:602
 msgid "Configuration Backup?"
 msgstr "Asetusten varmuuskopiointi?"
 
-#: SetupWizard.ui:618
+#. SetupWizard.ui:618
 msgid ""
 "If you would like to maintain an automatic backup\n"
 "of this applet configuration then select or enter a\n"
@@ -2652,26 +2721,26 @@ msgstr ""
 "varmuuskopiotiedoston kuvaus alla. Kaikki nykyiset ja tulevat\n"
 "asetusmuutokset tallennetaan tähän varmuuskopioon:"
 
-#: SetupWizard.ui:638
+#. SetupWizard.ui:638
 msgid "MainWindowList"
 msgstr "OletusIkkunaLista"
 
-#: SetupWizard.ui:639
+#. SetupWizard.ui:639
 msgid "MainPanelLauncher"
 msgstr "Oletus Paneelin käynnistäjä"
 
-#: SetupWizard.ui:640
+#. SetupWizard.ui:640
 msgid "Monitor1WindowList"
 msgstr "Näyttö1 Ikkunalista"
 
-#: SetupWizard.ui:641
+#. SetupWizard.ui:641
 msgid "Monitor2WindowList"
 msgstr "Näyttö2 Ikkunalista"
 
-#: SetupWizard.ui:642
+#. SetupWizard.ui:642
 msgid "Monitor1PanelLauncher"
 msgstr "Näyttö 1 paneelikäynnistäjä"
 
-#: SetupWizard.ui:643
+#. SetupWizard.ui:643
 msgid "Monitor2PanelLauncher"
 msgstr "Näyttö 2 paneelikäynnistäjä"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: 2025-05-03 19:40+0200\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -19,32 +19,36 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "tous les boutons"
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Préférences"
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "À propos..."
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Configurer..."
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr "Site web"
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Supprimer '%s'"
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 
@@ -66,76 +70,76 @@ msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Ouvrir une nouvelle fenêtre"
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Retirer du panneau"
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Retirer de cet espace de travail"
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "Épingler au panneau"
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "Épingler à cet espace de travail"
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "Épingler aux autres espaces de travail"
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "Épingler à tous les espaces de travail"
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "Épingler au lanceur"
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Ajouter un nouveau raccourci clavier pour"
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Fichiers récents"
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Emplacements"
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 msgid "Always on top"
 msgstr "Toujours au-dessus"
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Seulement sur cet espace de travail"
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Visible sur tous les espaces de travail"
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Déplacer vers un autre espace de travail"
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr " (cet espace de travail)"
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Déplacer vers un autre moniteur"
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Moniteur"
 
@@ -157,48 +161,48 @@ msgstr "Moniteur"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 msgid "Move window here"
 msgstr "Déplacer la fenêtre ici"
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "non attribué"
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Attribuer une fenêtre à un raccourci clavier"
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Modifier le libellé de l'étiquette de l'application"
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Supprimer le paramètre personnalisé"
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Utiliser le titre de fenêtre"
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "Utiliser le nom de l'application"
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Sans étiquette"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Dégrouper les fenêtres de l'application"
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Grouper les fenêtres par application"
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Regrouper/dégrouper automatiquement"
 
@@ -220,39 +224,39 @@ msgstr "Regrouper/dégrouper automatiquement"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Déplacer la barre de titre sur l'écran"
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Restaurer"
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Minimiser"
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "Démaximiser"
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Fermer les autres"
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 msgid "Close other windows for application"
 msgstr "Fermer les autres fenêtres de l'application"
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Tout fermer"
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 msgid "Close all windows for application"
 msgstr "Fermer toutes les fenêtres de l'application"
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Fermer"
 
@@ -319,8 +323,16 @@ msgstr "Paramètres des étiquettes de bouton de la liste des fenêtres"
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
-msgid "Number label settings"
+#, fuzzy
+msgid "Icon overlay label settings"
 msgstr "Paramètres des étiquettes de nombres"
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+#, fuzzy
+msgid "Progress settings"
+msgstr "Paramètres des raccourcis-clavier"
 
 #. 4.0->settings-schema.json->general-settings->title
 #. 6.0->settings-schema.json->general-settings->title
@@ -396,13 +408,10 @@ msgstr "Jamais"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr "Toujours"
 
@@ -459,10 +468,11 @@ msgstr "Afficher les étiquettes des boutons épinglés"
 #. 4.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.4->settings-schema.json->display-caption-for-pined->tooltip
+#, fuzzy
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 "Jamais : Aucune fenêtre épinglée n'aura d'étiquette.\n"
@@ -533,13 +543,34 @@ msgid "Minimized and pinned"
 msgstr "Minimisé et épinglé"
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
-msgstr "Automatique"
+#. 6.4->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr "Nombre de fenêtres du groupe d'application"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Application group indicator (⋮)"
+msgstr "Nombre de fenêtres du groupe d'application"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Workspace number (smart)"
+msgstr "Numéro de l'espace de travail"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Monitor number (smart)"
+msgstr "Numéro du moniteur"
 
 #. 4.0->settings-schema.json->display-indicators->description
 #. 6.0->settings-schema.json->display-indicators->description
@@ -551,36 +582,25 @@ msgstr "Afficher les indicateurs d'état"
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
-"Choisissez si les caractères indicateurs de minimisation et d'épinglage "
-"devront être ajoutés au texte de l'étiquette du bouton. Les boutons sans "
-"étiquette prendront moins de place.\n"
-"Automatique : Les indicateurs de minimisation et d'épinglage ne s'affichent "
-"que lorsque l'espace n'est pas limité."
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
-msgstr "Afficher une ellipse verticale (...) pour les boutons de groupes"
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
+msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
-"Ajouter une charte Unicode de type ellipse verticale aux étiquettes des "
-"boutons de liste de fenêtres groupées comportant plus d'une fenêtre. Dans le "
-"cas d'un panneau vertical, cette option n'est pas possible et le paramètre "
-"est ignoré."
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -648,9 +668,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -703,7 +724,8 @@ msgstr "Rien"
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
-msgid "Application group window count"
+#, fuzzy
+msgid "Application group indicator (…)"
 msgstr "Nombre de fenêtres du groupe d'application"
 
 #. 4.0->settings-schema.json->number-type->options
@@ -718,32 +740,55 @@ msgstr "Numéro de l'espace de travail"
 msgid "Monitor number"
 msgstr "Numéro du moniteur"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized indicator"
+msgstr "Fenêtres minimisées"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Pinned indicator"
+msgstr "Applications épinglées"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized and pinned indicators"
+msgstr "Minimisé et épinglé"
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
-msgid "Number label contents"
+#, fuzzy
+msgid "Icon overlay label contents"
 msgstr "Contenu de l'étiquette de nombre"
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr "Intelligent"
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
-msgstr "Afficher le nombre"
+msgid "Only display label when needed"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
+#, fuzzy
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 "Contrôle le moment où l'étiquette de numéro est utilisée. Intelligent "
 "signifie que l'étiquette n'apparaîtra que lorsqu'elle sera appropriée en "
@@ -751,35 +796,43 @@ msgstr ""
 "dire lorsqu'il y a deux fenêtres ou plus dans un groupe, ou lorsque l'espace "
 "de travail ou le moniteur de la fenêtre ne correspond pas à l'espace actuel."
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr "Désactivé"
+
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#, fuzzy
+msgid "Using icon overlay label"
 msgstr "Superposition d'icônes"
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
-msgstr "Préfixe d'étiquette"
-
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
-msgstr "Style de numérotation"
-
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
-msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
-"Contrôle la manière dont l'étiquette du numéro est présentée. Sur un panneau "
-"vertical ou en mode lanceur, l'option \" étiquette prépondérante \" n'est "
-"pas possible et l'option \" icône superposée \" sera utilisée à la place"
+
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
+msgid ""
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
+msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -792,6 +845,12 @@ msgstr "Groupé"
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
 msgstr "Regroupé"
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
+msgstr "Automatique"
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -814,12 +873,13 @@ msgstr "Style de comportement de la liste de fenêtres"
 #. 4.0->settings-schema.json->group-windows->tooltip
 #. 6.0->settings-schema.json->group-windows->tooltip
 #. 6.4->settings-schema.json->group-windows->tooltip
+#, fuzzy
 msgid ""
 "Grouped: All windows for an application are managed by one button,\n"
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 "Groupé : Toutes les fenêtres d'une application sont gérées par un seul "
 "bouton,\n"
@@ -831,12 +891,6 @@ msgstr ""
 "liste des fenêtres d'une application est regroupée côte à côte.\n"
 "Lanceur : Seuls les boutons épinglés sont affichés, ils se comportent comme "
 "des lanceurs sur le panneau."
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
-msgstr "Désactivé"
 
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
@@ -880,9 +934,10 @@ msgstr "Synchroniser les boutons du lanceur dans tous les espaces de travail"
 #. 4.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
+#, fuzzy
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 "Si cette option est activée, le nombre et l'ordre des boutons de lancement "
 "sur le panneau seront synchronisés dans tous les espaces de travail."
@@ -976,9 +1031,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 "Si cette option est activée, une fenêtre de prévisualisation pleine taille "
@@ -996,9 +1052,10 @@ msgstr ""
 #. 4.0->settings-schema.json->no-click-activate->tooltip
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -1092,10 +1149,11 @@ msgstr "Trier les éléments de menu des vignettes des boutons de groupe"
 #. 4.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1123,9 +1181,10 @@ msgstr ""
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 "Si cette option est activée, un menu contextuel contiendra toutes les "
@@ -2133,7 +2192,8 @@ msgstr "Modifier la juxtaposition des fenêtres"
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
-msgid "Cycle all window-list button windows"
+#, fuzzy
+msgid "Cycle all window list button windows"
 msgstr "Cyclage de toutes les listes de boutons de fenêtres"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2296,10 +2356,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.4->settings-schema.json->hotkey-sequence->tooltip
+#, fuzzy
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 "Si cette option est activée, les touches de raccourci se terminant par la "
@@ -2319,10 +2380,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
+#, fuzzy
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 "Si cette option est activée, le(s) modificateur(s) de raccourci + ` "
 "sera(ont) enregistré(s) pour chaque ensemble de modificateurs unique défini "
@@ -2485,7 +2547,8 @@ msgstr "Boutons pour les fenêtres sur d'autres écrans"
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+#, fuzzy
+msgid "All buttons except the focused window"
 msgstr "Tous les boutons excepté la fenêtre focalisée"
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2526,9 +2589,10 @@ msgstr ""
 "Boutons de panneau pour toutes les fenêtres en cours d'exécution."
 
 #. SetupWizard.ui:125
+#, fuzzy
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 "Lanceur de panneau (lanceur rapide)\n"
@@ -2546,9 +2610,10 @@ msgid "How do you want your Window List to operate?"
 msgstr "Comment voulez-vous que votre liste de fenêtres fonctionne ?"
 
 #. SetupWizard.ui:192
+#, fuzzy
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 "Basique - Accès rapide aux fenêtres\n"
@@ -2568,10 +2633,11 @@ msgstr ""
 "Les étiquettes des boutons sont les titres de fenêtres."
 
 #. SetupWizard.ui:236
+#, fuzzy
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2602,8 +2668,9 @@ msgid "Panel Launcher Setup"
 msgstr "Configuration du lanceur de panneau"
 
 #. SetupWizard.ui:370
+#, fuzzy
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2645,8 +2712,9 @@ msgid "All done!"
 msgstr "C'est fait !"
 
 #. SetupWizard.ui:508
+#, fuzzy
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.3.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: 2025-04-10 11:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,32 +18,36 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "minden gomb"
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Kisalkalmazás beállítások"
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "Névjegy…"
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Beállítások…"
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr "Weboldal"
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eltávolítás: „%s”"
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példányát?"
 
@@ -65,76 +69,76 @@ msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példány
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Új ablak megnyitása"
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Eltávolítás a panelról"
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Eltávolítás erről a munkaterületről"
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "Panelhez rögzítés"
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "Erre a munkaterületre rögzítés"
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "Más munkaterületre rögzítés"
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "Az összes munkaterületre rögzítés"
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "Alkalmazásindítóhoz rögzítés"
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Új gyorsbillentyű hozzáadása ehhez"
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Nemrég használt fájlok"
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Helyek"
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 msgid "Always on top"
 msgstr "Mindig felül"
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Csak ezen a munkaterületen"
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Minden munkaterületen látható"
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Áthelyezés másik munkaterületre"
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr " (ez a munkaterület)"
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Áthelyezés a másik kijelzőre"
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Kijelző"
 
@@ -156,48 +160,48 @@ msgstr "Kijelző"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 msgid "Move window here"
 msgstr "Ablak mozdítása ide"
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "nincs társítva"
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Az ablak hozzárendelése egy gyorsbillentyűhöz"
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Az alkalmazáscímke tartalmának módosítása"
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Egyéni beállítás eltávolítása"
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Ablakcím használata"
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "Alkalmazásnév használata"
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Nincs címke"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Ablakokat ne csoportosítsa alkalmazás szerint"
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Alkalmazás ablakok csoportosítása"
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 
@@ -219,39 +223,39 @@ msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Címsor mozgatása a kijelzőre"
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Visszaállítás"
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Minimalizálás"
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "Eredeti méret"
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Többi bezárása"
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 msgid "Close other windows for application"
 msgstr "Zárja be a többi ablakot az alkalmazáshoz"
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Minden bezárása"
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 msgid "Close all windows for application"
 msgstr "Zárja be az összes ablakot az alkalmazáshoz"
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Bezárás"
 
@@ -317,8 +321,16 @@ msgstr "Ablaklista gomb címke beállításai"
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
-msgid "Number label settings"
+#, fuzzy
+msgid "Icon overlay label settings"
 msgstr "Számcímke beállítások"
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+#, fuzzy
+msgid "Progress settings"
+msgstr "Gyorsbillentyűk beállításai"
 
 #. 4.0->settings-schema.json->general-settings->title
 #. 6.0->settings-schema.json->general-settings->title
@@ -394,13 +406,10 @@ msgstr "Soha"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr "Mindig"
 
@@ -455,10 +464,11 @@ msgstr "Címkék megjelenítése a rögzített gombokhoz"
 #. 4.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.4->settings-schema.json->display-caption-for-pined->tooltip
+#, fuzzy
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 "Soha: Egy rögzített ablaknak sem lesz címkéje\n"
@@ -528,13 +538,34 @@ msgid "Minimized and pinned"
 msgstr "Minimalizált és rögzített"
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
-msgstr "Automatikus"
+#. 6.4->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr "Alkalmazáscsoport ablakok száma"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Application group indicator (⋮)"
+msgstr "Alkalmazáscsoport ablakok száma"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Workspace number (smart)"
+msgstr "Munkaterület száma"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Monitor number (smart)"
+msgstr "Kijelzők száma"
 
 #. 4.0->settings-schema.json->display-indicators->description
 #. 6.0->settings-schema.json->display-indicators->description
@@ -546,35 +577,25 @@ msgstr "Állapotjelzők megjelenítése"
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
-"Válassza ki, hogy a kicsinyített és a rögzített jelzőkarakterek hozzá "
-"legyenek-e fűzve a gombcímke szövegéhez. A szöveges címke nélküli gombok nem "
-"foglalnak le annyi helyet.\n"
-"Automatikus: A kicsinyített és rögzített jelzők csak akkor jelennek meg, ha "
-"nincs szűk hely."
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
-msgstr "Függőleges ellipszis megjelenítése (...) csoportosított gombok esetén"
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
+msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
-"A több ablakot tartalmazó, csoportosított ablaklistás gombok címkéi elé egy "
-"függőleges ellipszis unicode chartert illeszt. Függőleges panelen ez az "
-"opció nem lehetséges, és a beállítás figyelmen kívül marad."
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -637,9 +658,10 @@ msgstr "Lebegtetési idő a teljes méretű ablak előnézetének megjelenítés
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -691,7 +713,8 @@ msgstr "Semmi"
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
-msgid "Application group window count"
+#, fuzzy
+msgid "Application group indicator (…)"
 msgstr "Alkalmazáscsoport ablakok száma"
 
 #. 4.0->settings-schema.json->number-type->options
@@ -706,32 +729,55 @@ msgstr "Munkaterület száma"
 msgid "Monitor number"
 msgstr "Kijelzők száma"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized indicator"
+msgstr "Minimalizált ablakok"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Pinned indicator"
+msgstr "Rögzített alkalmazások"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized and pinned indicators"
+msgstr "Minimalizált és rögzített"
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
-msgid "Number label contents"
+#, fuzzy
+msgid "Icon overlay label contents"
 msgstr "Számcímke tartalma"
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr "Inteligens"
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
-msgstr "Kijelző sorszáma"
+msgid "Only display label when needed"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
+#, fuzzy
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 "Szabályozza a számcímke használatának időpontját. Az intelligens azt "
 "jelenti, hogy a címke csak akkor jelenik meg, ha a fenti számcímke tartalma "
@@ -739,35 +785,43 @@ msgstr ""
 "csoportban, vagy ha az ablakok munkaterülete vagy monitora nem egyezik meg "
 "az aktuális ablakéval."
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr "Letiltva"
+
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#, fuzzy
+msgid "Using icon overlay label"
 msgstr "Ikon átfedés"
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
-msgstr "Címke elé"
-
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
-msgstr "Számstílus"
-
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
-msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
-"A számcímke megjelenítésének módját szabályozza. Függőleges panelen vagy "
-"indító módban a \"Címke elé\" opció nem lehetséges, így helyette az \"Ikon "
-"átfedés\" opciót használja"
+
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
+msgid ""
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
+msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -780,6 +834,12 @@ msgstr "Csoportosított"
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
 msgstr "Összevonva"
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
+msgstr "Automatikus"
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -802,12 +862,13 @@ msgstr "Az ablaklista viselkedési stílusa"
 #. 4.0->settings-schema.json->group-windows->tooltip
 #. 6.0->settings-schema.json->group-windows->tooltip
 #. 6.4->settings-schema.json->group-windows->tooltip
+#, fuzzy
 msgid ""
 "Grouped: All windows for an application are managed by one button,\n"
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 "Csoportosítva: Egy alkalmazás összes ablaka egyetlen gombbal kezelhető,\n"
 "Összevonva: Egy alkalmazás összes ablaklista gombja egymás mellé van "
@@ -816,12 +877,6 @@ msgstr ""
 "korlátozott,\n"
 "Egy az egyhez: Minden ablak saját gombot kap, kényszerrendelés nélkül,\n"
 "Indító: Csak a rögzített gombok jelennek meg, panelindítóként viselkedik."
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
-msgstr "Letiltva"
 
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
@@ -865,9 +920,10 @@ msgstr "Szinkronizálja az indítógombokat az összes munkaterületen"
 #. 4.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
+#, fuzzy
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 "Ha engedélyezve van, a panelen lévő indítógombok száma és sorrendje "
 "szinkronizálva lesz az összes munkaterületen."
@@ -959,9 +1015,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 "Ha engedélyezve van, egy teljes méretű előnézeti ablak jelenik meg, amikor "
@@ -977,9 +1034,10 @@ msgstr "Automatikus fókuszváltás a panel elhagyásakor"
 #. 4.0->settings-schema.json->no-click-activate->tooltip
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -1068,10 +1126,11 @@ msgstr "Csoportosított gombok miniatűr menüelemek rendezése"
 #. 4.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1097,9 +1156,10 @@ msgstr "Bélyegképek megjelenítése egy alkalmazáskészlet összes ablakához
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 "Ha engedélyezve van, egy felugró menü az alkalmazáskészlet összes "
@@ -2100,7 +2160,8 @@ msgstr "Ablak csempézés módosítása"
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
-msgid "Cycle all window-list button windows"
+#, fuzzy
+msgid "Cycle all window list button windows"
 msgstr "Az összes ablaklista gomb ablakának forgatása"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2258,10 +2319,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.4->settings-schema.json->hotkey-sequence->tooltip
+#, fuzzy
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 "Ha engedélyezve van, az „1” billentyűvel végződő gyorsbillentyűk (azaz "
@@ -2280,10 +2342,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
+#, fuzzy
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 "Ha engedélyezve van, a gyorsbillentyű-módosító(k) + ` minden egyes, a "
 "gyorsbillentyű-listában meghatározott egyedi módosítókészlethez regisztrálva "
@@ -2444,7 +2507,8 @@ msgstr "Gombok más monitorokon lévő ablakokhoz"
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+#, fuzzy
+msgid "All buttons except the focused window"
 msgstr "Minden gomb, kivéve a fókuszált ablakot"
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2484,9 +2548,10 @@ msgstr ""
 "Panelgombok minden futó ablakhoz."
 
 #. SetupWizard.ui:125
+#, fuzzy
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 "Panelindító (gyorsindító)\n"
@@ -2506,9 +2571,10 @@ msgid "How do you want your Window List to operate?"
 msgstr "Hogyan szeretné, hogy az ablaklistája működjön?"
 
 #. SetupWizard.ui:192
+#, fuzzy
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 "Alap – Gyors hozzáférés az ablakokhoz\n"
@@ -2528,10 +2594,11 @@ msgstr ""
 "A gombcímkék ablakcímek."
 
 #. SetupWizard.ui:236
+#, fuzzy
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2562,8 +2629,9 @@ msgid "Panel Launcher Setup"
 msgstr "Panelindító beállítása"
 
 #. SetupWizard.ui:370
+#, fuzzy
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2603,8 +2671,9 @@ msgid "All done!"
 msgstr "Minden készen van!"
 
 #. SetupWizard.ui:508
+#, fuzzy
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: 2025-01-03 14:48+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,32 +19,36 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "tutti i pulsanti"
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Preferenze Applet"
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "Informazioni su..."
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Configura..."
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr "Sito web"
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Rimuovi '%s'"
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 
@@ -66,76 +70,76 @@ msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Apri una nuova finestra"
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Rimuovi dal pannello"
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Rimuovi da questa area di lavoro"
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "Appunta al pannello"
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "Appunta a questo spazio di lavoro"
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "Appunta ad altre aree di lavoro"
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "Appunta in tutte le aree di lavoro"
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "Appunta al launcher"
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Aggiungi un nuovo tasto di scelta rapida per"
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Recenti"
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Posizioni"
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 msgid "Always on top"
 msgstr "Sempre in primo piano"
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Solo su questo spazio di lavoro"
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Visibile su tutte le aree di lavoro"
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Sposta su un'altra area di lavoro"
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr " (questa area di lavoro)"
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Sposta su un altro schermo"
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Monitor"
 
@@ -157,48 +161,48 @@ msgstr "Monitor"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 msgid "Move window here"
 msgstr "Sposta la finestra qui"
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "non assegnato"
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Assegna finestra ad un tasto di scelta rapida"
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Cambia il contenuto dell'etichetta dell'applicazione"
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Rimuovi impostazioni personalizzate"
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Usa il titolo della finestra"
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "Usa il nome dell'applicazione"
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Nessuna etichetta"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Separa le finestre dell'applicazione"
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Raggruppa le finestre dell'applicazione"
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Raggruppamento/separazione automatica"
 
@@ -220,39 +224,39 @@ msgstr "Raggruppamento/separazione automatica"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Sposta la barra del titolo sullo schermo"
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Ripristina"
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Minimizza"
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "De-massimizza"
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Chiudi altri"
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 msgid "Close other windows for application"
 msgstr "Chiudi le altre finestre per l'applicazione"
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Chiudi tutto"
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 msgid "Close all windows for application"
 msgstr "Chiudi tutte le finestre per l'applicazione"
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Chiudi"
 
@@ -319,8 +323,16 @@ msgstr "Impostazioni dell'etichetta del pulsante dell'elenco delle finestre"
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
-msgid "Number label settings"
+#, fuzzy
+msgid "Icon overlay label settings"
 msgstr "Impostazioni dell'etichetta numerica"
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+#, fuzzy
+msgid "Progress settings"
+msgstr "Impostazioni dei tasti di scelta rapida"
 
 #. 4.0->settings-schema.json->general-settings->title
 #. 6.0->settings-schema.json->general-settings->title
@@ -396,13 +408,10 @@ msgstr "Mai"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr "Sempre"
 
@@ -459,10 +468,11 @@ msgstr "Visualizza le etichette per i pulsanti aggiunti"
 #. 4.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.4->settings-schema.json->display-caption-for-pined->tooltip
+#, fuzzy
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 "Mai: nessuna finestra aggiunta avrà un'etichetta\n"
@@ -532,13 +542,34 @@ msgid "Minimized and pinned"
 msgstr "Minimizzate e appuntate"
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
-msgstr "Automatico"
+#. 6.4->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr "Conteggio finestre del gruppo di applicazioni"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Application group indicator (⋮)"
+msgstr "Conteggio finestre del gruppo di applicazioni"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Workspace number (smart)"
+msgstr "Numero dell'area di lavoro"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Monitor number (smart)"
+msgstr "Numero del monitor"
 
 #. 4.0->settings-schema.json->display-indicators->description
 #. 6.0->settings-schema.json->display-indicators->description
@@ -550,37 +581,25 @@ msgstr "Visualizza gli indicatori di stato"
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
-"Scegli se i caratteri dell'indicatore minimizzato e bloccato verranno "
-"anteposti al testo dell'etichetta del pulsante. I pulsanti senza etichetta "
-"di testo non riserveranno tanto spazio.\n"
-"Automatico: gli indicatori ridotti a icona e bloccati verranno visualizzati "
-"solo quando lo spazio non è limitato."
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
 msgstr ""
-"Mostra i puntini di sospensione verticali (...) per i pulsanti raggruppati"
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
-"Antepone un carattere unicode con puntini di sospensione verticali alle "
-"etichette per i pulsanti dell'elenco di finestre raggruppati con più di una "
-"finestra. Su un pannello verticale questa opzione non è disponibile e "
-"l'impostazione verrà ignorata."
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -647,9 +666,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -704,7 +724,8 @@ msgstr "Nulla"
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
-msgid "Application group window count"
+#, fuzzy
+msgid "Application group indicator (…)"
 msgstr "Conteggio finestre del gruppo di applicazioni"
 
 #. 4.0->settings-schema.json->number-type->options
@@ -719,32 +740,55 @@ msgstr "Numero dell'area di lavoro"
 msgid "Monitor number"
 msgstr "Numero del monitor"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized indicator"
+msgstr "Finestre ridotte a icona"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Pinned indicator"
+msgstr "Applicazioni appuntate"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized and pinned indicators"
+msgstr "Minimizzate e appuntate"
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
-msgid "Number label contents"
+#, fuzzy
+msgid "Icon overlay label contents"
 msgstr "Contenuto dell'etichetta numerica"
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr "Intelligente"
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
-msgstr "Mostra numero"
+msgid "Only display label when needed"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
+#, fuzzy
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 "Controlla quando viene utilizzata l'etichetta numerica. Intelligente "
 "significa che l'etichetta verrà visualizzata solo quando appropriato a "
@@ -752,36 +796,43 @@ msgstr ""
 "esempio quando sono presenti due o più finestre in un gruppo o quando l'area "
 "di lavoro o il monitor non corrisponde a quello corrente."
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr "Disattivato"
+
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#, fuzzy
+msgid "Using icon overlay label"
 msgstr "Sovrapposizione icona"
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
-msgstr "Etichetta anteposta"
-
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
-msgstr "Stile numero"
-
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
-msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
-"Controlla il modo in cui viene presentata l'etichetta del numero. Quando ci "
-"si trova su un pannello verticale o in modalità di avvio, l'opzione "
-"\"etichetta anteposta\" non è possibile, quindi verrà utilizzata "
-"\"sovrapposizione icona\""
+
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
+msgid ""
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
+msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -794,6 +845,12 @@ msgstr "Raggruppate"
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
 msgstr "In pool"
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
+msgstr "Automatico"
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -816,12 +873,13 @@ msgstr "Stile di comportamento dell'elenco delle finestre"
 #. 4.0->settings-schema.json->group-windows->tooltip
 #. 6.0->settings-schema.json->group-windows->tooltip
 #. 6.4->settings-schema.json->group-windows->tooltip
+#, fuzzy
 msgid ""
 "Grouped: All windows for an application are managed by one button,\n"
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 "Raggruppate: tutte le finestre di un'applicazione sono gestite da un "
 "pulsante,\n"
@@ -832,12 +890,6 @@ msgstr ""
 "Una ad una: ogni finestra ha il proprio pulsante senza ordinamento forzato,\n"
 "Avviatore: vengono visualizzati solo i pulsanti aggiunti e si comporta come "
 "un avviatore del pannello."
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
-msgstr "Disattivato"
 
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
@@ -881,9 +933,10 @@ msgstr "Sincronizza i pulsanti di avvio in tutte le aree di lavoro"
 #. 4.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
+#, fuzzy
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 "Se abilitato, il numero e l'ordine dei pulsanti di avvio sul pannello "
 "verranno sincronizzati in tutte le aree di lavoro."
@@ -977,9 +1030,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 "Se abilitato, verrà visualizzata una finestra di anteprima a dimensione "
@@ -996,9 +1050,10 @@ msgstr "Cambio automatico della messa a fuoco quando si lascia il pannello"
 #. 4.0->settings-schema.json->no-click-activate->tooltip
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -1090,10 +1145,11 @@ msgstr "Ordina le voci del menù di anteprima raggruppate"
 #. 4.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1120,9 +1176,10 @@ msgstr "Mostra le miniature per tutte le finestre di un pool di applicazioni"
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 "Se abilitato, un menù a comparsa conterrà tutte le finestre "
@@ -2130,7 +2187,8 @@ msgstr "Cambia la piastrellatura delle finestre"
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
-msgid "Cycle all window-list button windows"
+#, fuzzy
+msgid "Cycle all window list button windows"
 msgstr "Scorri tutti i pulsanti dell'elenco delle finestre"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2294,10 +2352,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.4->settings-schema.json->hotkey-sequence->tooltip
+#, fuzzy
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 "Se abilitati, i tasti di scelta rapida che terminano con il tasto \"1\" (ad "
@@ -2317,10 +2376,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
+#, fuzzy
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 "Se abilitato, i modificatori di tasti di scelta rapida + ` verranno "
 "registrati per ciascun set di modificatori univoci definito nell'elenco dei "
@@ -2488,7 +2548,8 @@ msgstr "Pulsanti per finestre su altri monitor"
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+#, fuzzy
+msgid "All buttons except the focused window"
 msgstr "Tutti i pulsanti tranne la finestra focalizzata"
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2530,9 +2591,10 @@ msgstr ""
 "Pulsanti del pannello per tutte le finestre in esecuzione."
 
 #. SetupWizard.ui:125
+#, fuzzy
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 "Pannello di avvio (avvio rapido)\n"
@@ -2552,9 +2614,10 @@ msgid "How do you want your Window List to operate?"
 msgstr "Come vuoi che funzioni il tuo Elenco finestre?"
 
 #. SetupWizard.ui:192
+#, fuzzy
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 "Base: accesso rapido alla finestra\n"
@@ -2574,10 +2637,11 @@ msgstr ""
 "Le etichette dei pulsanti sono titoli di finestre."
 
 #. SetupWizard.ui:236
+#, fuzzy
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2608,8 +2672,9 @@ msgid "Panel Launcher Setup"
 msgstr "Configurazione del Panel Launcher"
 
 #. SetupWizard.ui:370
+#, fuzzy
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2649,8 +2714,9 @@ msgid "All done!"
 msgstr "Tutto fatto!"
 
 #. SetupWizard.ui:508
+#, fuzzy
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: 2025-05-13 14:06+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,32 +16,36 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "alle knoppen"
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Applet Voorkeuren"
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "Over..."
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Configureren..."
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr "Website"
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Verwijder '%s'"
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Weet u zeker dat u deze instantie van CassiaWindowList wilt verwijderen?"
@@ -64,76 +68,76 @@ msgstr ""
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Open een nieuw venster"
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Verwijderen van paneel"
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Verwijderen van deze werkruimte"
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "Vastmaken aan paneel"
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "Vastmaken aan deze werkruimte"
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "Vastmaken aan andere werkruimtes"
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "Vastmaken aan alle werkruimtes"
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "Vastmaken aan launcher"
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Voeg nieuwe sneltoets toe voor"
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Recente bestanden"
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Locaties"
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 msgid "Always on top"
 msgstr "Altijd bovenop"
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Alleen op deze werkruimte"
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Zichtbaar op alle werkruimtes"
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Verplaatsen naar een andere werkruimte"
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 msgid " (this workspace)"
 msgstr " (deze werkruimte)"
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Verplaatsen naar een ander beeldscherm"
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Beeldscherm"
 
@@ -155,48 +159,48 @@ msgstr "Beeldscherm"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 msgid "Move window here"
 msgstr "Verplaats venster hierheen"
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "niet toegewezen"
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Wijs venster toe aan een sneltoets"
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Wijzig inhoud van applicatielabel"
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Verwijder aangepaste instelling"
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Gebruik venstertitel"
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "Gebruik applicatienaam"
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Geen label"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Applicatie-vensters niet groeperen"
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Applicatie-vensters groeperen"
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisch groeperen/ongroeperen"
 
@@ -218,39 +222,39 @@ msgstr "Automatisch groeperen/ongroeperen"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Verplaats titelbalk naar het scherm"
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Herstellen"
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Minimaliseren"
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "Ontmaximaliseren"
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Sluit anderen"
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 msgid "Close other windows for application"
 msgstr "Sluit andere vensters van applicatie"
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Sluit alle"
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 msgid "Close all windows for application"
 msgstr "Sluit alle vensters van applicatie"
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Sluiten"
 
@@ -317,8 +321,16 @@ msgstr "Instellingen voor labels van knoppen van vensterlijsten"
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
-msgid "Number label settings"
+#, fuzzy
+msgid "Icon overlay label settings"
 msgstr "Instellingen voor nummerlabels"
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+#, fuzzy
+msgid "Progress settings"
+msgstr "Instellingen sneltoetsen"
 
 #. 4.0->settings-schema.json->general-settings->title
 #. 6.0->settings-schema.json->general-settings->title
@@ -394,13 +406,10 @@ msgstr "Nooit"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr "Altijd"
 
@@ -455,10 +464,11 @@ msgstr "Labels weergeven voor vastgemaakte knoppen"
 #. 4.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.4->settings-schema.json->display-caption-for-pined->tooltip
+#, fuzzy
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 "Nooit: Geen vastgemaakte vensters krijgt labels\n"
@@ -528,13 +538,34 @@ msgid "Minimized and pinned"
 msgstr "Geminimaliseerd en vastgemaakt"
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
-msgstr "Automatisch"
+#. 6.4->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr "Aantal vensters in applicatiegroep"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Application group indicator (⋮)"
+msgstr "Aantal vensters in applicatiegroep"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Workspace number (smart)"
+msgstr "Werkruimte nummer"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Monitor number (smart)"
+msgstr "Monitor nummer"
 
 #. 4.0->settings-schema.json->display-indicators->description
 #. 6.0->settings-schema.json->display-indicators->description
@@ -546,35 +577,25 @@ msgstr "Statusindicatoren weergeven"
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
-"Kies of de indicatiekarakters voor geminimaliseerd en vastgemaakt de tekst "
-"van het knoplabel voorafgaan. Knoppen zonder tekstlabel zullen niet zoveel "
-"ruimte reserveren.\n"
-"Automatisch: De indicatoren voor geminimaliseerd en vastgemaakt worden "
-"alleen weergegeven wanneer er geen beperkte ruimte is."
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
-msgstr "Toon een verticale ellipsis (...) voor gegroepeerde knoppen"
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
+msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
-"Voeg een verticaal ellipsis Unicode-teken toe aan de labels voor "
-"gegroepeerde vensterlijstknoppen met meer dan één venster. Bij een verticaal "
-"paneel is deze optie niet mogelijk en wordt de instelling genegeerd."
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -640,9 +661,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -695,7 +717,8 @@ msgstr "Niets"
 #. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
-msgid "Application group window count"
+#, fuzzy
+msgid "Application group indicator (…)"
 msgstr "Aantal vensters in applicatiegroep"
 
 #. 4.0->settings-schema.json->number-type->options
@@ -710,32 +733,55 @@ msgstr "Werkruimte nummer"
 msgid "Monitor number"
 msgstr "Monitor nummer"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized indicator"
+msgstr "Geminimaliseerde vensters"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Pinned indicator"
+msgstr "Vastgemaakte applicaties"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized and pinned indicators"
+msgstr "Geminimaliseerd en vastgemaakt"
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
-msgid "Number label contents"
+#, fuzzy
+msgid "Icon overlay label contents"
 msgstr "Nummeren van labelinhoud"
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr "Slim"
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
-msgstr "Toon nummber"
+msgid "Only display label when needed"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
+#, fuzzy
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 "Bepaalt wanneer het nummerlabel wordt gebruikt. Slim betekent dat het label "
 "alleen verschijnt wanneer het gepast is, afhankelijk van de instelling voor "
@@ -743,35 +789,43 @@ msgstr ""
 "in een groep zijn, of wanneer de werkruimte of monitor van de vensters niet "
 "overeenkomt met de huidige."
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#, fuzzy
+msgid "Using icon overlay label"
 msgstr "Pictogramoverlay"
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
-msgstr "Label laten voorgaan"
-
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
-msgstr "Nummerstijl"
-
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
-msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
 msgstr ""
-"Bepaalt hoe het nummer label wordt gepresenteerd. Bij een verticaal paneel "
-"of in launcher modus is de 'label laten voorafgaan' optie niet mogelijk, dus "
-"'pictogramoverlay' zal in plaats daarvan worden gebruikt"
+
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
+
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
+msgid ""
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
+msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -784,6 +838,12 @@ msgstr "Gegroepeerd"
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
 msgstr "Gepoold"
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
+msgstr "Automatisch"
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -806,12 +866,13 @@ msgstr "Stijl voor vensterlijstgedrag"
 #. 4.0->settings-schema.json->group-windows->tooltip
 #. 6.0->settings-schema.json->group-windows->tooltip
 #. 6.4->settings-schema.json->group-windows->tooltip
+#, fuzzy
 msgid ""
 "Grouped: All windows for an application are managed by one button,\n"
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 "Gegroepeerd: Alle vensters voor één applicatie worden beheerd door één "
 "knop,\n"
@@ -822,12 +883,6 @@ msgstr ""
 "Eén op één: Elk venster krijgt zijn eigen knop zonder verplichte volgorde,\n"
 "Launcher: Alleen vastgemaakte knoppen worden weergegeven, gedraagt zich als "
 "een paneellauncher."
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
-msgstr "Uitgeschakeld"
 
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
@@ -871,9 +926,10 @@ msgstr "Synchroniseer launcherknoppen over alle werkruimtes heen"
 #. 4.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
+#, fuzzy
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 "Indien ingeschakeld, wordt het aantal en de volgorde van launcherknoppen op "
 "het paneel gesynchroniseerd over alle werkruimtes heen."
@@ -967,9 +1023,10 @@ msgstr ""
 #. 4.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.0->settings-schema.json->hover-peek-windowlist->tooltip
 #. 6.4->settings-schema.json->hover-peek-windowlist->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 "Indien ingeschakeld, verschijnt een volledige grootte voorbeeldvenster "
@@ -986,9 +1043,10 @@ msgstr "Automatische focuswijziging bij het verlaten van het paneel"
 #. 4.0->settings-schema.json->no-click-activate->tooltip
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -1080,10 +1138,11 @@ msgstr "Sorteer gegroepeerde knop-miniatuurmenu-items"
 #. 4.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
+#, fuzzy
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1109,9 +1168,10 @@ msgstr "Miniaturen weergeven voor alle vensters van een applicatiepool"
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 "Indien ingeschakeld, zal een popupmenu alle vensters van de applicatiepool "
@@ -2119,7 +2179,8 @@ msgstr "Verander venstertegelen"
 #. 4.0->settings-schema.json->mouse-action-scroll->options
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
-msgid "Cycle all window-list button windows"
+#, fuzzy
+msgid "Cycle all window list button windows"
 msgstr "Doorloop alle vensters van de vensterlijstknop"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2276,10 +2337,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.4->settings-schema.json->hotkey-sequence->tooltip
+#, fuzzy
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 "Indien ingeschakeld, dan doen sneltoetsen eindigend met de '1' toets (bijv. "
@@ -2297,10 +2359,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.0->settings-schema.json->hotkey-grave-help->tooltip
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
+#, fuzzy
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 "Indien ingeschakeld, wordt de sneltoets modifier(s) + ` geregistreerd voor "
 "elke unieke modifierset gedefinieerd in de sneltoetsenlijst. Met behulp van "
@@ -2462,7 +2525,8 @@ msgstr "Knoppen voor vensters op andere beeldschermen"
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+#, fuzzy
+msgid "All buttons except the focused window"
 msgstr "Alle knoppen behalve gefocust venster"
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2503,9 +2567,10 @@ msgstr ""
 "Paneelknoppen voor alle uitgevoerde vensters."
 
 #. SetupWizard.ui:125
+#, fuzzy
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 "Paneellauncher (Snelle launcher)\n"
@@ -2523,9 +2588,10 @@ msgid "How do you want your Window List to operate?"
 msgstr "Hoe wilt u dat uw vensterlijst werkt?"
 
 #. SetupWizard.ui:192
+#, fuzzy
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 "Basis  -  Snelle toegang tot vensters\n"
@@ -2545,10 +2611,11 @@ msgstr ""
 "Knoplabels zijn venstertitels."
 
 #. SetupWizard.ui:236
+#, fuzzy
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2579,8 +2646,9 @@ msgid "Panel Launcher Setup"
 msgstr "Paneellauncher Instellen"
 
 #. SetupWizard.ui:370
+#, fuzzy
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2620,8 +2688,9 @@ msgid "All done!"
 msgstr "Alles klaar!"
 
 #. SetupWizard.ui:508
+#, fuzzy
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-09 22:44-0400\n"
+"POT-Creation-Date: 2025-07-05 00:09-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -14,32 +14,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.1\n"
 
-#. 4.0/applet.js:584 6.0/applet.js:584 6.4/applet.js:562
+#. 4.0/applet.js:611 6.0/applet.js:611 6.4/applet.js:589
 msgid "all buttons"
 msgstr "все кнопки"
 
-#. 4.0/applet.js:3266 6.0/applet.js:3266 6.4/applet.js:3238
+#. 4.0/applet.js:1955 6.0/applet.js:1955 6.4/applet.js:1933
+msgid "windows in this group"
+msgstr ""
+
+#. 4.0/applet.js:3341 6.0/applet.js:3341 6.4/applet.js:3313
 msgid "Applet Preferences"
 msgstr "Настройки Апплета"
 
-#. 4.0/applet.js:3270 6.0/applet.js:3270 6.4/applet.js:3242
+#. 4.0/applet.js:3345 6.0/applet.js:3345 6.4/applet.js:3317
 msgid "About..."
 msgstr "О Апплете..."
 
-#. 4.0/applet.js:3274 6.0/applet.js:3274 6.4/applet.js:3246
+#. 4.0/applet.js:3349 6.0/applet.js:3349 6.4/applet.js:3321
 msgid "Configure..."
 msgstr "Настроить..."
 
-#. 4.0/applet.js:3278 6.0/applet.js:3278 6.4/applet.js:3250
+#. 4.0/applet.js:3353 6.0/applet.js:3353 6.4/applet.js:3325
 msgid "Website"
 msgstr ""
 
-#. 4.0/applet.js:3282 6.0/applet.js:3282 6.4/applet.js:3254
+#. 4.0/applet.js:3357 6.0/applet.js:3357 6.4/applet.js:3329
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Удалить '%s'"
 
-#. 4.0/applet.js:3284 6.0/applet.js:3284 6.4/applet.js:3256
+#. 4.0/applet.js:3359 6.0/applet.js:3359 6.4/applet.js:3331
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Вы действительно хотите удалить этот экземпляр CassiaWindowList?"
 
@@ -61,78 +65,78 @@ msgstr "Вы действительно хотите удалить этот э�
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3293 6.0/applet.js:3293 6.4/applet.js:3265
+#. 4.0/applet.js:3368 6.0/applet.js:3368 6.4/applet.js:3340
 msgid "Open new window"
 msgstr "Открыть новое окно"
 
-#. 4.0/applet.js:3301 6.0/applet.js:3301 6.4/applet.js:3273
+#. 4.0/applet.js:3376 6.0/applet.js:3376 6.4/applet.js:3348
 msgid "Remove from panel"
 msgstr "Удалить с панели"
 
-#. 4.0/applet.js:3303 6.0/applet.js:3303 6.4/applet.js:3275
+#. 4.0/applet.js:3378 6.0/applet.js:3378 6.4/applet.js:3350
 msgid "Remove from this workspace"
 msgstr "Удалить из этого рабочего стола"
 
-#. 4.0/applet.js:3309 6.0/applet.js:3309 6.4/applet.js:3281
+#. 4.0/applet.js:3384 6.0/applet.js:3384 6.4/applet.js:3356
 msgid "Pin to panel"
 msgstr "Закрепить на панели"
 
-#. 4.0/applet.js:3311 6.0/applet.js:3311 6.4/applet.js:3283
+#. 4.0/applet.js:3386 6.0/applet.js:3386 6.4/applet.js:3358
 msgid "Pin to this workspace"
 msgstr "Закрепить на этом рабочем столе"
 
-#. 4.0/applet.js:3352 6.0/applet.js:3352 6.4/applet.js:3324
+#. 4.0/applet.js:3427 6.0/applet.js:3427 6.4/applet.js:3399
 msgid "Pin to other workspaces"
 msgstr "Закрепить на другом рабочем столе"
 
-#. 4.0/applet.js:3373 6.0/applet.js:3373 6.4/applet.js:3345
+#. 4.0/applet.js:3448 6.0/applet.js:3448 6.4/applet.js:3420
 msgid "Pin to all workspaces"
 msgstr "Закрепить на всех рабочих столах"
 
-#. 4.0/applet.js:3391 6.0/applet.js:3391 6.4/applet.js:3363
+#. 4.0/applet.js:3466 6.0/applet.js:3466 6.4/applet.js:3438
 msgid "Pin to launcher"
 msgstr "Закрепить в лаунчере"
 
-#. 4.0/applet.js:3409 4.0/applet.js:3614 6.0/applet.js:3409 6.0/applet.js:3614
-#. 6.4/applet.js:3381 6.4/applet.js:3583
+#. 4.0/applet.js:3484 4.0/applet.js:3689 6.0/applet.js:3484 6.0/applet.js:3689
+#. 6.4/applet.js:3456 6.4/applet.js:3658
 msgid "Add new Hotkey for"
 msgstr "Добавить новую горячую клавишу для"
 
-#. 4.0/applet.js:3423 6.0/applet.js:3423 6.4/applet.js:3395
+#. 4.0/applet.js:3498 6.0/applet.js:3498 6.4/applet.js:3470
 msgid "Recent files"
 msgstr "Недавние файлы"
 
-#. 4.0/applet.js:3447 6.0/applet.js:3447 6.4/applet.js:3419
+#. 4.0/applet.js:3522 6.0/applet.js:3522 6.4/applet.js:3494
 msgid "Places"
 msgstr "Места"
 
-#. 4.0/applet.js:3490 6.0/applet.js:3490 6.4/applet.js:3462
+#. 4.0/applet.js:3565 6.0/applet.js:3565 6.4/applet.js:3537
 #, fuzzy
 msgid "Always on top"
 msgstr "Всегда"
 
-#. 4.0/applet.js:3502 6.0/applet.js:3502 6.4/applet.js:3474
+#. 4.0/applet.js:3577 6.0/applet.js:3577 6.4/applet.js:3549
 msgid "Only on this workspace"
 msgstr "Только на этом рабочем столе"
 
-#. 4.0/applet.js:3504 6.0/applet.js:3504 6.4/applet.js:3476
+#. 4.0/applet.js:3579 6.0/applet.js:3579 6.4/applet.js:3551
 msgid "Visible on all workspaces"
 msgstr "Видно на всех рабочих столах"
 
-#. 4.0/applet.js:3505 6.0/applet.js:3505 6.4/applet.js:3477
+#. 4.0/applet.js:3580 6.0/applet.js:3580 6.4/applet.js:3552
 msgid "Move to another workspace"
 msgstr "Переместить на другой рабочий стол"
 
-#. 4.0/applet.js:3514 6.0/applet.js:3514 6.4/applet.js:3486
+#. 4.0/applet.js:3589 6.0/applet.js:3589 6.4/applet.js:3561
 #, fuzzy
 msgid " (this workspace)"
 msgstr "Закрепить на этом рабочем столе"
 
-#. 4.0/applet.js:3527 6.0/applet.js:3527 6.4/applet.js:3499
+#. 4.0/applet.js:3602 6.0/applet.js:3602 6.4/applet.js:3574
 msgid "Move to another monitor"
 msgstr "Переместить на другой монитор"
 
-#. 4.0/applet.js:3535 6.0/applet.js:3535 6.4/applet.js:3507
+#. 4.0/applet.js:3610 6.0/applet.js:3610 6.4/applet.js:3582
 msgid "Monitor"
 msgstr "Монитор"
 
@@ -154,49 +158,49 @@ msgstr "Монитор"
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3552 6.0/applet.js:3552 6.4/applet.js:3521
+#. 4.0/applet.js:3627 6.0/applet.js:3627 6.4/applet.js:3596
 #, fuzzy
 msgid "Move window here"
 msgstr "Закрой окно"
 
-#. 4.0/applet.js:3569 6.0/applet.js:3569 6.4/applet.js:3538
+#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
 msgid "unassigned"
 msgstr "не назначено"
 
-#. 4.0/applet.js:3580 4.0/applet.js:3611 6.0/applet.js:3580 6.0/applet.js:3611
-#. 6.4/applet.js:3549 6.4/applet.js:3580
+#. 4.0/applet.js:3655 4.0/applet.js:3686 6.0/applet.js:3655 6.0/applet.js:3686
+#. 6.4/applet.js:3624 6.4/applet.js:3655
 msgid "Assign window to a hotkey"
 msgstr "Назначить окно горячей клавише"
 
-#. 4.0/applet.js:3634 6.0/applet.js:3634 6.4/applet.js:3603
+#. 4.0/applet.js:3709 6.0/applet.js:3709 6.4/applet.js:3678
 msgid "Change application label contents"
 msgstr "Изменить текст названия приложения"
 
-#. 4.0/applet.js:3637 6.0/applet.js:3637 6.4/applet.js:3606
+#. 4.0/applet.js:3712 6.0/applet.js:3712 6.4/applet.js:3681
 msgid "Remove custom setting"
 msgstr "Удалить свои настройки"
 
-#. 4.0/applet.js:3644 6.0/applet.js:3644 6.4/applet.js:3613
+#. 4.0/applet.js:3719 6.0/applet.js:3719 6.4/applet.js:3688
 msgid "Use window title"
 msgstr "Использовать заголовок окон"
 
-#. 4.0/applet.js:3651 6.0/applet.js:3651 6.4/applet.js:3620
+#. 4.0/applet.js:3726 6.0/applet.js:3726 6.4/applet.js:3695
 msgid "Use application name"
 msgstr "Использовать названия программ"
 
-#. 4.0/applet.js:3658 6.0/applet.js:3658 6.4/applet.js:3627
+#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
 msgid "No label"
 msgstr "Без названий"
 
-#. 4.0/applet.js:3669 6.0/applet.js:3669 6.4/applet.js:3638
+#. 4.0/applet.js:3744 6.0/applet.js:3744 6.4/applet.js:3713
 msgid "Ungroup application windows"
 msgstr "Не группировать окна приложений"
 
-#. 4.0/applet.js:3677 6.0/applet.js:3677 6.4/applet.js:3646
+#. 4.0/applet.js:3752 6.0/applet.js:3752 6.4/applet.js:3721
 msgid "Group application windows"
 msgstr "Группировать окна приложений"
 
-#. 4.0/applet.js:3690 6.0/applet.js:3690 6.4/applet.js:3659
+#. 4.0/applet.js:3765 6.0/applet.js:3765 6.4/applet.js:3734
 msgid "Automatic grouping/ungrouping"
 msgstr "Автоматически группировать/разгруппировать"
 
@@ -218,41 +222,41 @@ msgstr "Автоматически группировать/разгруппир
 #. 6.4->settings-schema.json->mouse-action-btn2->options
 #. 6.4->settings-schema.json->mouse-action-btn8->options
 #. 6.4->settings-schema.json->mouse-action-btn9->options
-#. 4.0/applet.js:3718 6.0/applet.js:3718 6.4/applet.js:3687
+#. 4.0/applet.js:3793 6.0/applet.js:3793 6.4/applet.js:3762
 msgid "Move titlebar on to screen"
 msgstr "Переместить на другой экран"
 
-#. 4.0/applet.js:3723 6.0/applet.js:3723 6.4/applet.js:3692
+#. 4.0/applet.js:3798 6.0/applet.js:3798 6.4/applet.js:3767
 msgid "Restore"
 msgstr "Восстановить"
 
-#. 4.0/applet.js:3727 6.0/applet.js:3727 6.4/applet.js:3696
+#. 4.0/applet.js:3802 6.0/applet.js:3802 6.4/applet.js:3771
 msgid "Minimize"
 msgstr "Свернуть"
 
-#. 4.0/applet.js:3733 6.0/applet.js:3733 6.4/applet.js:3702
+#. 4.0/applet.js:3808 6.0/applet.js:3808 6.4/applet.js:3777
 msgid "Unmaximize"
 msgstr "Обычный размер"
 
-#. 4.0/applet.js:3741 6.0/applet.js:3741 6.4/applet.js:3710
+#. 4.0/applet.js:3816 6.0/applet.js:3816 6.4/applet.js:3785
 msgid "Close others"
 msgstr "Закрыть другие"
 
-#. 4.0/applet.js:3743 6.0/applet.js:3743 6.4/applet.js:3712
+#. 4.0/applet.js:3818 6.0/applet.js:3818 6.4/applet.js:3787
 #, fuzzy
 msgid "Close other windows for application"
 msgstr "Показать миниатюры для всех окон пула приложений"
 
-#. 4.0/applet.js:3764 6.0/applet.js:3764 6.4/applet.js:3733
+#. 4.0/applet.js:3839 6.0/applet.js:3839 6.4/applet.js:3808
 msgid "Close all"
 msgstr "Закрыть всё"
 
-#. 4.0/applet.js:3766 6.0/applet.js:3766 6.4/applet.js:3735
+#. 4.0/applet.js:3841 6.0/applet.js:3841 6.4/applet.js:3810
 #, fuzzy
 msgid "Close all windows for application"
 msgstr "Показать миниатюры для всех окон пула приложений"
 
-#. 4.0/applet.js:3782 6.0/applet.js:3782 6.4/applet.js:3751
+#. 4.0/applet.js:3857 6.0/applet.js:3857 6.4/applet.js:3826
 msgid "Close"
 msgstr "Закрыть"
 
@@ -320,8 +324,15 @@ msgstr "Настройки списка окон"
 #. 6.0->settings-schema.json->caption-number-settings->title
 #. 6.4->settings-schema.json->caption-number-settings->title
 #, fuzzy
-msgid "Number label settings"
+msgid "Icon overlay label settings"
 msgstr "Настройки надписей номеров группировки"
+
+#. 4.0->settings-schema.json->caption-progress-settings->title
+#. 6.0->settings-schema.json->caption-progress-settings->title
+#. 6.4->settings-schema.json->caption-progress-settings->title
+#, fuzzy
+msgid "Progress settings"
+msgstr "Настройка горячих клавиш"
 
 #. 4.0->settings-schema.json->general-settings->title
 #. 6.0->settings-schema.json->general-settings->title
@@ -397,13 +408,10 @@ msgstr "Никогда"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 #. 6.4->settings-schema.json->display-caption-for->options
 #. 6.4->settings-schema.json->display-caption-for-pined->options
-#. 6.4->settings-schema.json->display-number->options
 msgid "Always"
 msgstr "Всегда"
 
@@ -459,10 +467,11 @@ msgstr "Показывать надписи для закреплённых кн
 #. 4.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.0->settings-schema.json->display-caption-for-pined->tooltip
 #. 6.4->settings-schema.json->display-caption-for-pined->tooltip
+#, fuzzy
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 "Никогда: ни у одного закрепленного окна не будет надписи\n"
@@ -531,13 +540,35 @@ msgid "Minimized and pinned"
 msgstr "Свёрнутые и закреплённые"
 
 #. 4.0->settings-schema.json->display-indicators->options
-#. 4.0->settings-schema.json->group-windows->options
+#. 4.0->settings-schema.json->number-type->options
 #. 6.0->settings-schema.json->display-indicators->options
-#. 6.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->display-indicators->options
-#. 6.4->settings-schema.json->group-windows->options
-msgid "Automatic"
-msgstr "Автоматически"
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group window count"
+msgstr "Группировать окна приложений"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Application group indicator (⋮)"
+msgstr "Группировать окна приложений"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Workspace number (smart)"
+msgstr "Номер дисплея"
+
+#. 4.0->settings-schema.json->display-indicators->options
+#. 6.0->settings-schema.json->display-indicators->options
+#. 6.4->settings-schema.json->display-indicators->options
+#, fuzzy
+msgid "Monitor number (smart)"
+msgstr "Монитор"
 
 #. 4.0->settings-schema.json->display-indicators->description
 #. 6.0->settings-schema.json->display-indicators->description
@@ -549,30 +580,24 @@ msgstr "Отображать индикацию статуса"
 #. 6.0->settings-schema.json->display-indicators->tooltip
 #. 6.4->settings-schema.json->display-indicators->tooltip
 msgid ""
-"Choose if the minimized and the pinned indicator characters will be "
-"prepended to button label text. Buttons without a text label will not "
-"reserve as much space.\n"
-"Automatic: The minimized and pinned indicators will only show when space is "
-"not constrained."
-msgstr ""
-"Выберите будет ли индикация свёрнутого и закреплённого окна добавляться к "
-"тексту надписи. Кнопки без надписей.\n"
-"Автоматически: Индикация свёрнутых и закреплённых окон отображается только "
-"если есть место."
-
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->description
-msgid "Show a vertical ellipsis (...) for grouped buttons"
+"Controls what information is prepended to the button label text. On "
+"horizontal panels this data is shown even when the primary label contents "
+"are removed. Setting this to None will allow for the smallest button size. "
+"When on vertical panels this setting is ignored."
 msgstr ""
 
-#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
-#. 6.4->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 4.0->settings-schema.json->auto-hide-indicators->description
+#. 6.0->settings-schema.json->auto-hide-indicators->description
+#. 6.4->settings-schema.json->auto-hide-indicators->description
+msgid "Hide status indicators when space is limited"
+msgstr ""
+
+#. 4.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.0->settings-schema.json->auto-hide-indicators->tooltip
+#. 6.4->settings-schema.json->auto-hide-indicators->tooltip
 msgid ""
-"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
-"list buttons with more then one window. When on a vertical panel this option "
-"is not possible and the setting will be ignored."
+"Hide status indicators when window list space is limited causing button "
+"labels to shrink"
 msgstr ""
 
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
@@ -637,7 +662,7 @@ msgstr "Задержка отображения меню после наведе
 #. 6.4->settings-schema.json->hover-peek-delay->tooltip
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies when hovering over either window-list buttons or "
+"appear. It applies when hovering over either window list buttons or "
 "thumbnail menu items (of course one of the full size window preview options "
 "must be enabled for this option to have any effect)"
 msgstr ""
@@ -687,7 +712,7 @@ msgstr "Ничего не делать"
 #. 6.0->settings-schema.json->number-type->options
 #. 6.4->settings-schema.json->number-type->options
 #, fuzzy
-msgid "Application group window count"
+msgid "Application group indicator (…)"
 msgstr "Группировать окна приложений"
 
 #. 4.0->settings-schema.json->number-type->options
@@ -704,62 +729,93 @@ msgstr "Номер дисплея"
 msgid "Monitor number"
 msgstr "Монитор"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+msgid "Two characters from the window title"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized indicator"
+msgstr "Свёрнутые окна"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Pinned indicator"
+msgstr "Закреплённые приложения"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#. 6.4->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Minimized and pinned indicators"
+msgstr "Свёрнутые и закреплённые"
+
 #. 4.0->settings-schema.json->number-type->description
 #. 6.0->settings-schema.json->number-type->description
 #. 6.4->settings-schema.json->number-type->description
 #, fuzzy
-msgid "Number label contents"
+msgid "Icon overlay label contents"
 msgstr "Текст надписей"
-
-#. 4.0->settings-schema.json->display-number->options
-#. 6.0->settings-schema.json->display-number->options
-#. 6.4->settings-schema.json->display-number->options
-msgid "Smart"
-msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 #. 6.4->settings-schema.json->display-number->description
-msgid "Display number"
-msgstr "Номер дисплея"
+msgid "Only display label when needed"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->tooltip
 #. 6.0->settings-schema.json->display-number->tooltip
 #. 6.4->settings-schema.json->display-number->tooltip
 msgid ""
-"Controls when the number label is used. Smart means the the label will only "
-"appear when it is appropriate depending on the number label contents setting "
-"above. i.e. When there is two or more windows in a group, or when the "
-"windows workspace or monitor does not match the current one."
+"With this option enabled, the icon overlay label will only appear when it is "
+"appropriate depending on the label content (i.e. When there are two or more "
+"windows in a group, or when the windows workspace or monitor does not match "
+"the current one). When this option is disabled the label is always shown"
 msgstr ""
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Icon overlay"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 4.0->settings-schema.json->display-pinned->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->display-pinned->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr "Отключено"
+
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+#, fuzzy
+msgid "Using icon overlay label"
 msgstr "Наложение значков"
 
-#. 4.0->settings-schema.json->number-style->options
-#. 6.0->settings-schema.json->number-style->options
-#. 6.4->settings-schema.json->number-style->options
-msgid "Label prepend"
-msgstr "Надпись в начале"
+#. 4.0->settings-schema.json->progress-display-type->options
+#. 6.0->settings-schema.json->progress-display-type->options
+#. 6.4->settings-schema.json->progress-display-type->options
+msgid "Prepended to button label"
+msgstr ""
 
-#. 4.0->settings-schema.json->number-style->description
-#. 6.0->settings-schema.json->number-style->description
-#. 6.4->settings-schema.json->number-style->description
-msgid "Number style"
-msgstr "Стиль чисел"
+#. 4.0->settings-schema.json->progress-display-type->description
+#. 6.0->settings-schema.json->progress-display-type->description
+#. 6.4->settings-schema.json->progress-display-type->description
+msgid "Display window progress information (%)"
+msgstr ""
 
-#. 4.0->settings-schema.json->number-style->tooltip
-#. 6.0->settings-schema.json->number-style->tooltip
-#. 6.4->settings-schema.json->number-style->tooltip
-#, fuzzy
+#. 4.0->settings-schema.json->progress-display-type->tooltip
+#. 6.0->settings-schema.json->progress-display-type->tooltip
+#. 6.4->settings-schema.json->progress-display-type->tooltip
 msgid ""
-"Controls how the number label is presented. When on a vertical panel or when "
-"in launcher mode, the \"label prepend\" option is not possible so \"icon "
-"overlay\" will be used instead"
-msgstr "Определяет вид на вертикальной панели"
+"Controls how a windows progress information is presented on the window list "
+"(i.e copying in File Manager, downloading in Firefox, updating in Update "
+"Manager, etc.). When on vertical panels the \"Prepended to button label\" "
+"option will be ignored and icon overlay will be used in its place."
+msgstr ""
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -772,6 +828,12 @@ msgstr "Сгруппировано"
 #. 6.4->settings-schema.json->group-windows->options
 msgid "Pooled"
 msgstr "Объединение"
+
+#. 4.0->settings-schema.json->group-windows->options
+#. 6.0->settings-schema.json->group-windows->options
+#. 6.4->settings-schema.json->group-windows->options
+msgid "Automatic"
+msgstr "Автоматически"
 
 #. 4.0->settings-schema.json->group-windows->options
 #. 6.0->settings-schema.json->group-windows->options
@@ -794,12 +856,13 @@ msgstr "Поведение списка окон"
 #. 4.0->settings-schema.json->group-windows->tooltip
 #. 6.0->settings-schema.json->group-windows->tooltip
 #. 6.4->settings-schema.json->group-windows->tooltip
+#, fuzzy
 msgid ""
 "Grouped: All windows for an application are managed by one button,\n"
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 "Сгруппировано: все окна приложения управляются одной кнопкой,\n"
 "Объединено: все кнопки списка окон для приложения располагаются рядом,\n"
@@ -809,12 +872,6 @@ msgstr ""
 "порядка,\n"
 "Лаунчер: отображаются только закрепленные кнопки, ведет себя как панель "
 "запуска."
-
-#. 4.0->settings-schema.json->display-pinned->options
-#. 6.0->settings-schema.json->display-pinned->options
-#. 6.4->settings-schema.json->display-pinned->options
-msgid "Disabled"
-msgstr "Отключено"
 
 #. 4.0->settings-schema.json->display-pinned->options
 #. 6.0->settings-schema.json->display-pinned->options
@@ -856,9 +913,10 @@ msgstr "Синхронизируйте кнопки запуска во всех
 #. 4.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.0->settings-schema.json->synchronize-pinned->tooltip
 #. 6.4->settings-schema.json->synchronize-pinned->tooltip
+#, fuzzy
 msgid ""
 "If enabled, the number and order of launcher buttons on the panel will be "
-"synchronize across all workspaces."
+"synchronized across all workspaces."
 msgstr ""
 "Если этот параметр включен, количество и порядок кнопок запуска на панели "
 "будут синхронизированы во всех рабочих областях."
@@ -949,7 +1007,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "If enabled, a full size preview window will appear when the mouse pointer is "
-"hovering over a window-list button. The delay before the preview appears is "
+"hovering over a window list button. The delay before the preview appears is "
 "controlled by an option under the Advanced tab"
 msgstr ""
 "Включите отображение всплывающих подсказок с использованием заголовка окна "
@@ -965,8 +1023,8 @@ msgstr ""
 #. 6.0->settings-schema.json->no-click-activate->tooltip
 #. 6.4->settings-schema.json->no-click-activate->tooltip
 msgid ""
-"If enabled, the current window for a window-list button will get the focus "
-"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"If enabled, the current window for a window list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window list with Ctrl "
 "or Shift held or while remaining on the panel will leave the focus "
 "unchanged. This option is typically used in conjunction with the preview "
 "hovering option above."
@@ -1054,9 +1112,9 @@ msgstr "Восстановить или удерживать меню миниа
 #. 6.0->settings-schema.json->menu-sort-groups->tooltip
 #. 6.4->settings-schema.json->menu-sort-groups->tooltip
 msgid ""
-"If enabled, the thumbnail menu will be sorted first by workspace and the by "
+"If enabled, the thumbnail menu will be sorted first by workspace and then by "
 "monitor number for grouped buttons. Pooled windows can not be sorted since "
-"the order is the same as the order on the window-list panel. With this "
+"the order is the same as the order on the window list panel. With this "
 "option enabled, the thumbnail menu drag-and-drop reordering feature will be "
 "disabled for grouped button thumbnail menus."
 msgstr ""
@@ -1076,9 +1134,10 @@ msgstr "Показать миниатюры для всех окон пула п
 #. 6.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-pool->tooltip
 #. 6.4->settings-schema.json->menu-all-windows-of-auto->tooltip
+#, fuzzy
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 "Если этот параметр включен, всплывающее меню будет содержать все окна "
@@ -2081,7 +2140,7 @@ msgstr "Использовать заголовок окон"
 #. 6.0->settings-schema.json->mouse-action-scroll->options
 #. 6.4->settings-schema.json->mouse-action-scroll->options
 #, fuzzy
-msgid "Cycle all window-list button windows"
+msgid "Cycle all window list button windows"
 msgstr "Циклическое переключение окон"
 
 #. 4.0->settings-schema.json->mouse-action-scroll->options
@@ -2236,10 +2295,11 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.0->settings-schema.json->hotkey-sequence->tooltip
 #. 6.4->settings-schema.json->hotkey-sequence->tooltip
+#, fuzzy
 msgid ""
 "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
 "automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
-"first 9 windows of the assigned application, as ordered on the window-list, "
+"first 9 windows of the assigned application, as ordered on the window list, "
 "will be activated by the 9 hotkeys."
 msgstr ""
 "Если этот параметр включен, горячие клавиши, оканчивающиеся на клавишу 1 (т. "
@@ -2260,8 +2320,8 @@ msgstr ""
 #. 6.4->settings-schema.json->hotkey-grave-help->tooltip
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
-"show a hotkey hint bubble over the button icons."
+"modifier set defined in the hotkey list. Using these hotkeys will "
+"temporarily show a hotkey hint bubble over the button icons."
 msgstr ""
 
 #. 4.0->settings-schema.json->hotkey-help->description
@@ -2405,7 +2465,7 @@ msgstr "Показывать окна только на одном монито�
 #. 4.0->settings-schema.json->saturation-application->options
 #. 6.0->settings-schema.json->saturation-application->options
 #. 6.4->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+msgid "All buttons except the focused window"
 msgstr ""
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -2443,9 +2503,10 @@ msgstr ""
 "Кнопки на панели для всех работающих окон."
 
 #. SetupWizard.ui:125
+#, fuzzy
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel buttons only appear when you pin items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 "Панель запуска (быстрый запуск)\n"
@@ -2465,9 +2526,10 @@ msgid "How do you want your Window List to operate?"
 msgstr "Как вы хотите, чтобы работал ваш список окон?"
 
 #. SetupWizard.ui:192
+#, fuzzy
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 "Базовый - Быстрый доступ к окну\n"
@@ -2487,10 +2549,11 @@ msgstr ""
 "Надписи кнопок - это заголовки окон."
 
 #. SetupWizard.ui:236
+#, fuzzy
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -2524,7 +2587,7 @@ msgstr "Главная Панель Лаунчера"
 #. SetupWizard.ui:370
 #, fuzzy
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -2571,7 +2634,7 @@ msgstr "Все сделано!"
 #. SetupWizard.ui:508
 #, fuzzy
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"


### PR DESCRIPTION
- Renamed the "Number label" to "Icon overlay label" since it no longer only shows numbers
- Added 5 new icon overlay label content options
- Changed the icon overlay "smart" option into a toggle switch rather than a drop-down list
- Hide the "smart" icon overlay options when it does not make sense for the type of icon overlay setting
- Move the Ellipsis group indicator option to the status indicator drop-down list
- Added 3 new status indicator types (app group count, monitor number, workspace number)
- Added window progress support, shown using the icon overlay label or button label prepend
- Added an "Hide status indicators when space is limited" option to replace the "Auto" drop-down list option
- Fixed the minimized indicator character to use the down arrow for all cases except when on a top panel
- Moved some options that were under the "Number label" options into the "Display status indicator" drop-down list
- Show a group count in the tooltip text if a button has more than one window associated with it
- Use the "Negative circled" number unicode characters for the "Application group count" status indicators since the bracketed numbers (which were used previously) are oddly sized and hard to read for many font sets
- Fix a number of typos and grammar mistakes (thanks to RupinderM)

Note: Due to reworking a several options under the "Label" tab in the configuration dialog, some options may need to be changed to restore the window list behave to what it was before upgrading to version 2.4.2. Sorry for the inconvenience.