### PR TITLE
multicore-sys-monitor@ccadeptic23: optimize the bash script get-cpu-data3.sh

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data3.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data3.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #~ sleepDurationSeconds=$1
 sleepDurationSeconds=1
@@ -9,36 +9,14 @@ previousStats=$(cat /proc/stat)
 sleep $sleepDurationSeconds
 
 currentDate=$(date +%s%N | cut -b1-13)
-currentStats=$(cat /proc/stat)
 
-cpus=$(echo "$currentStats" | grep -P 'cpu' | awk -F " " '{print $1}')
 ret=""
 
-for cpu in $cpus
+while IFS=' ' read -r cpu user nice system idle iowait irq softirq steal guest guest_nice rest
 do {
-    currentLine=$(echo "$currentStats" | grep "$cpu ")
-    user=$(echo "$currentLine" | awk -F " " '{print $2}')
-    nice=$(echo "$currentLine" | awk -F " " '{print $3}')
-    system=$(echo "$currentLine" | awk -F " " '{print $4}')
-    idle=$(echo "$currentLine" | awk -F " " '{print $5}')
-    iowait=$(echo "$currentLine" | awk -F " " '{print $6}')
-    irq=$(echo "$currentLine" | awk -F " " '{print $7}')
-    softirq=$(echo "$currentLine" | awk -F " " '{print $8}')
-    steal=$(echo "$currentLine" | awk -F " " '{print $9}')
-    guest=$(echo "$currentLine" | awk -F " " '{print $10}')
-    guest_nice=$(echo "$currentLine" | awk -F " " '{print $11}')
+    [[ "$cpu" =~ ^cpu ]] || continue
 
-    previousLine=$(echo "$previousStats" | grep "$cpu ")
-    prevuser=$(echo "$previousLine" | awk -F " " '{print $2}')
-    prevnice=$(echo "$previousLine" | awk -F " " '{print $3}')
-    prevsystem=$(echo "$previousLine" | awk -F " " '{print $4}')
-    previdle=$(echo "$previousLine" | awk -F " " '{print $5}')
-    previowait=$(echo "$previousLine" | awk -F " " '{print $6}')
-    previrq=$(echo "$previousLine" | awk -F " " '{print $7}')
-    prevsoftirq=$(echo "$previousLine" | awk -F " " '{print $8}')
-    prevsteal=$(echo "$previousLine" | awk -F " " '{print $9}')
-    prevguest=$(echo "$previousLine" | awk -F " " '{print $10}')
-    prevguest_nice=$(echo "$previousLine" | awk -F " " '{print $11}')
+    IFS=' ' read -r prevcpu prevuser prevnice prevsystem previdle previowait previrq prevsoftirq prevsteal prevguest prevguest_nice rest < <(echo "$previousStats" | grep "^$cpu ")
 
     PrevIdle=$((previdle + previowait))
     Idle=$((idle + iowait))
@@ -52,16 +30,16 @@ do {
     totald=$((Total - PrevTotal))
     idled=$((Idle - PrevIdle))
 
-    CPU_Percentage=$(awk "BEGIN {print ($totald - $idled)/$totald*100}")
+    CPU_Percentage=$((100 * ($totald - $idled) / $totald))
 
     #~ [[ "$cpu" = "cpu" ]] && {
         #~ echo "total "$CPU_Percentage
     #~ } || {
         #~ echo $cpu" "$CPU_Percentage
     #~ }
-    ret=$ret" "$CPU_Percentage
+    test "$ret" && ret="$ret $CPU_Percentage" || ret="$CPU_Percentage"
     #~ echo $cpu" "$CPU_Percentage
-}; done
+}; done < /proc/stat
 
-echo -n $ret
+echo -n "$ret"
 exit 0


### PR DESCRIPTION
The script get-cpu-data3.sh was starting many awk processes, which made it slow and unnecessarily increased the CPU load.