### PR TITLE
notifications-enhanced@hilyxx: Add applet conflict detection

### DIFF
--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/metadata.json
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/metadata.json
@@ -3,7 +3,7 @@
     "name": "Notifications-Enhanced",
     "description": "A notification applet but with more options",
     "website": "https://github.com/linuxmint/cinnamon-spices-applets",
-    "version": "1.21",
-    "author": "Hilyxx",
+    "version": "1.22",
+    "author": "hilyxx",
     "role": "notifications"
 }

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/ca.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/ca.po
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.2\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: 2024-07-14 04:06+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -19,54 +19,65 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. applet.js:95
+#. applet.js:44
+#, fuzzy
+msgid "Notifications applet conflict"
+msgstr "Notificacions desactivades"
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr "No molestar"
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr "No hi ha notificacions"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr "Netejar notificacions"
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr "Activar notificacions"
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr "Configuració de notificacions"
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notificació"
 msgstr[1] "%d notificacions"
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr "Notificacions"
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr "Notificacions desactivades"
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr "ara mateix"
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "fa %d segon"
 msgstr[1] "fa %d segons"
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/es.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/es.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.2\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: 2025-07-10 17:39-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,54 +18,67 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:95
+#. applet.js:44
+msgid "Notifications applet conflict"
+msgstr "Conflicto del applet de notificaciones"
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+"Se ha detectado un conflicto: notifications@cinnamon.org está activo.\n"
+"Elimínalo y reinicia Cinnamon antes de usar el applet Notificaciones-"
+"Mejoradas."
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr "No molestar"
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr "Sin notificaciones"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr "Borrar notificaciones"
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr "Habilitar notificaciones"
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr "Configuración de notificaciones"
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notificación"
 msgstr[1] "%d notificaciones"
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr "Notificaciones"
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr "Notificaciones desactivadas"
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr "ahora mismo"
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "hace %d segundo"
 msgstr[1] "hace %d segundos"
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/fi.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/fi.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.2\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: 2025-05-18 13:52+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,54 +18,65 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#. applet.js:95
+#. applet.js:44
+#, fuzzy
+msgid "Notifications applet conflict"
+msgstr "Ilmoitukset pois"
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr "Älä häiritse"
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr "Ei ilmoituksia"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr "Tyhjennä ilmoitukset"
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr "Näytä ilmoitukset"
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr "Ilmoitusten asetukset"
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d ilmoitus"
 msgstr[1] "%d ilmoitusta"
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr "Ilmoitukset"
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr "Ilmoitukset pois"
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr "juuri nyt"
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d sekunti sitten"
 msgstr[1] "%d sekuntia sitten"
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/fr.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/fr.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.21\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,54 +18,67 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#. applet.js:95
+#. applet.js:44
+msgid "Notifications applet conflict"
+msgstr "Conflit d'applets de notifications"
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+"Conflit détecté : notifications@cinnamon.org est actif.\n"
+"Retirez-le et redémarrez Cinnamon avant d'utiliser l'applet Notifications-"
+"Enhanced."
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr "Ne pas déranger"
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr "Aucune notification"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr "Effacer les notifications"
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr "Activer les notifications"
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr "Paramètres des notifications"
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notification"
 msgstr[1] "%d notifications"
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr "Notifications"
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr "Notifications désactivées"
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr "à l'instant"
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "il y a %d seconde"
 msgstr[1] "il y a %d secondes"
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/hu.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/hu.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.2\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: 2025-08-03 20:51+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,54 +18,65 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:95
+#. applet.js:44
+#, fuzzy
+msgid "Notifications applet conflict"
+msgstr "Értesítések letiltva"
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr "Ne zavarj"
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr "Nincsenek értesítések"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr "Értesítések törlése"
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr "Értesítések engedélyezése"
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr "Értesítési beállítások"
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d értesítés"
 msgstr[1] "%d értesítések"
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr "Értesítések"
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr "Értesítések letiltva"
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr "épp most"
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d másodperce"
 msgstr[1] "%d másodperce"
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/it.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/it.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.2\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: 2025-05-18 13:52+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,54 +18,65 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. applet.js:95
+#. applet.js:44
+#, fuzzy
+msgid "Notifications applet conflict"
+msgstr "Notifiche disattivate"
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr "Non disturbare"
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr "Nessuna notifica"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr "Svuota notifiche"
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr "Abilita notifiche"
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr "Impostazioni notifica"
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notifica"
 msgstr[1] "%d notifiche"
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr "Notifiche"
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr "Notifiche disattivate"
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr "adesso"
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d secondo fa"
 msgstr[1] "%d secondi fa"
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/nl.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/nl.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.2\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: 2025-06-13 18:24+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -17,54 +17,65 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. applet.js:95
+#. applet.js:44
+#, fuzzy
+msgid "Notifications applet conflict"
+msgstr "Meldingen uitgeschakeld"
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr "Niet storen"
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr "Geen meldingen"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr "Wis meldingen"
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr "Schakel meldingen in"
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr "Melding Instellingen"
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d melding"
 msgstr[1] "%d meldingen"
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr "Meldingen"
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr "Meldingen uitgeschakeld"
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr "zojuist"
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d seconde geleden"
 msgstr[1] "%d seconden geleden"
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/notifications-enhanced@hilyxx.pot
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/notifications-enhanced@hilyxx.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.21\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,54 +18,64 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#. applet.js:95
+#. applet.js:44
+msgid "Notifications applet conflict"
+msgstr ""
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr ""
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr ""
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr ""
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr ""
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr ""
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr ""
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr ""
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr ""
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/pt_BR.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/pt_BR.po
@@ -5,10 +5,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.2\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: 2025-05-18 13:52+0200\n"
 "Last-Translator: Renan Lazarotto <renanlazarotto@gmail.com>\n"
 "Language-Team: Renan Lazarotto <renanlazarotto@gmail.com>\n"
@@ -18,54 +18,65 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. applet.js:95
+#. applet.js:44
+#, fuzzy
+msgid "Notifications applet conflict"
+msgstr "Notificações desabilitadas"
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr "Não perturbe"
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr "Sem notificações"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr "Limpar notificações"
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr "Habilitar notificações"
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr "Configurações de notificação"
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notificação"
 msgstr[1] "%d notificações"
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr "Notificações"
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr "Notificações desabilitadas"
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr "agora"
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "há %d segundo"
 msgstr[1] "há %d segundos"
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/zh_TW.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/zh_TW.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.2\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-10 05:28+0200\n"
+"POT-Creation-Date: 2025-08-05 12:43+0200\n"
 "PO-Revision-Date: 2025-06-15 23:57+08:00\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -17,52 +17,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. applet.js:95
+#. applet.js:44
+#, fuzzy
+msgid "Notifications applet conflict"
+msgstr "通知已停用"
+
+#. applet.js:45
+msgid ""
+"Conflict detected: notifications@cinnamon.org is active.\n"
+"Remove it and restart Cinnamon before using Notifications-Enhanced applet."
+msgstr ""
+
+#. applet.js:120
 msgid "Do not disturb"
 msgstr "請勿打擾"
 
-#. applet.js:101
+#. applet.js:126
 msgid "No notifications"
 msgstr "沒有通知"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:109
+#. applet.js:134
 msgid "Clear notifications"
 msgstr "清除通知"
 
-#. applet.js:132
+#. applet.js:157
 msgid "Enable notifications"
 msgstr "啟用通知"
 
-#. applet.js:143
+#. applet.js:168
 msgid "Notification Settings"
 msgstr "通知設定"
 
-#. applet.js:232 applet.js:406
+#. applet.js:257 applet.js:431
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d 則通知"
 
-#. applet.js:262
+#. applet.js:287
 msgid "Notifications"
 msgstr "通知"
 
-#. applet.js:275
+#. applet.js:300
 msgid "Notifications disabled"
 msgstr "通知已停用"
 
-#. applet.js:422
+#. applet.js:447
 msgid "just now"
 msgstr "剛剛"
 
-#. applet.js:425
+#. applet.js:450
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d 秒前"
 
-#. applet.js:429
+#. applet.js:454
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"


### PR DESCRIPTION
Add conflict detection to prevent simultaneous use with notifications@cinnamon.org applet.
https://github.com/linuxmint/cinnamon-spices-applets/issues/6490