### PR TITLE
multicore-sys-monitor@ccadeptic23: optimize the bash script get-cpu-data3.sh even more

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data3.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data3.sh
@@ -3,20 +3,22 @@
 #~ sleepDurationSeconds=$1
 sleepDurationSeconds=1
 
-previousDate=$(date +%s%N | cut -b1-13)
-previousStats=$(cat /proc/stat)
+declare -A prevstat
+
+while IFS=' ' read -r cpu rest
+do
+    [[ "$cpu" =~ ^cpu ]] && prevstat["$cpu"]="$rest"
+done < /proc/stat
 
 sleep $sleepDurationSeconds
-
-currentDate=$(date +%s%N | cut -b1-13)
 
 ret=""
 
 while IFS=' ' read -r cpu user nice system idle iowait irq softirq steal guest guest_nice rest
-do {
+do
     [[ "$cpu" =~ ^cpu ]] || continue
 
-    IFS=' ' read -r prevcpu prevuser prevnice prevsystem previdle previowait previrq prevsoftirq prevsteal prevguest prevguest_nice rest < <(echo "$previousStats" | grep "^$cpu ")
+    IFS=' ' read -r prevuser prevnice prevsystem previdle previowait previrq prevsoftirq prevsteal prevguest prevguest_nice rest <<< ${prevstat["$cpu"]}
 
     PrevIdle=$((previdle + previowait))
     Idle=$((idle + iowait))
@@ -39,7 +41,7 @@ do {
     #~ }
     test "$ret" && ret="$ret $CPU_Percentage" || ret="$CPU_Percentage"
     #~ echo $cpu" "$CPU_Percentage
-}; done < /proc/stat
+done < /proc/stat
 
 echo -n "$ret"
 exit 0


### PR DESCRIPTION
After removig many calls to awk I have removed calls to all other external commands as well, so now this script should be as fast as possible (in bash).