### PR TITLE
multicore-sys-monitor@ccadeptic23 - v2.5.0

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/6.4/settings-schema_OLD.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/6.4/settings-schema_OLD.json
@@ -130,6 +130,8 @@
       "title": "Colors",
       "keys": [
         "Mem_colorUsedup",
+        "Mem_colorCached",
+        "Mem_colorBuffer",
         "Mem_colorFree",
         "Mem_colorSwap"
       ]
@@ -395,6 +397,16 @@
     "type": "colorchooser",
     "default": "rgba(255, 255, 255, 1)",
     "description": "Usedup"
+  },
+  "Mem_colorCached": {
+    "type": "colorchooser",
+    "default": "rgba(153, 153, 153, 0.8)",
+    "description": "Cached"
+  },
+  "Mem_colorBuffer": {
+    "type": "colorchooser",
+    "default": "rgba(204, 204, 204, 0.8)",
+    "description": "Buffer"
   },
   "Mem_colorFree": {
     "type": "colorchooser",

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
@@ -1,6 +1,13 @@
+### v2.5.0~20250809
+  * Fixes [#7460](https://github.com/linuxmint/cinnamon-spices-applets/issues/7460)
+  * Fixes [#7505](https://github.com/linuxmint/cinnamon-spices-applets/issues/7505)
+  * Calculates the percentage of memory used, as does `gnome-system-monitor`.
+  * No longer includes cache memory or buffer memory in the statistics.
+  * Improved calculation of tooltip width based on translations of displayed messages.
+
 ### v2.4.0~20250808
   * Improved memory calculation.
-  * Fixes [#7460](https://github.com/linuxmint/cinnamon-spices-applets/issues/7460
+  * Fixes [#7460](https://github.com/linuxmint/cinnamon-spices-applets/issues/7460)
 
 ### v2.3.5~20250808
   * Speed improvement.

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "multicore-sys-monitor@ccadeptic23",
   "name": "Multi-Core System Monitor",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
   "multiversion": true,
   "cinnamon-version": [

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/bg.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/bg.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2017-11-19 20:23+0200\n"
 "Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -31,87 +31,81 @@ msgid "CPU"
 msgstr "ЦПУ"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- ЦПУ ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Ядро"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "ПМТ"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Памет ------------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Използвана:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Кеширана:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Буфер:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Свободна:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "МРЖ"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "----------- Мрежи ------------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Сваляне:"
 
@@ -121,26 +115,25 @@ msgid "(KiB/s)"
 msgstr "(КиБ/с)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Качване:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "ДИСК"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "----------- Дискове ----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Четене:"
 
@@ -150,8 +143,8 @@ msgid "(MiB/s)"
 msgstr "(МиБ/с)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Запис:"
 
@@ -220,8 +213,8 @@ msgstr "Грешка при запазването на файла:"
 msgid "/s"
 msgstr "/с"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Използвани:"
 
@@ -244,15 +237,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Време на освежаване (мс)"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -285,26 +278,59 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Ядро"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Време на освежаване (мс)"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Мрежа"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Диск В/И"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Памет"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Мрежа"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -332,12 +358,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Общи"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Памет"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -510,18 +530,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Използвани"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Кеширани"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Буфер"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -772,6 +780,16 @@ msgstr "Настройки на многоядрения системен мон
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Височина"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Кеширани"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Буфер"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/ca.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: multicore-sys-monitor@ccadeptic23 1.9.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2024-11-20 02:12+0100\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -20,8 +20,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -30,87 +30,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Nucli"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEMÒRIA"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Memòria -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Utilitzat:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "A la cau:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Buffer:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Lliure:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "INTERCANVI"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Intercanvi ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Intercanvi"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "XARXA"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "---------- Xarxes ----------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Baixada:"
 
@@ -120,26 +114,25 @@ msgid "(KiB/s)"
 msgstr "(KB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Pujada:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISC"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------ Discs -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Lectura:"
 
@@ -149,8 +142,8 @@ msgid "(MiB/s)"
 msgstr "(MB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Escriptura:"
 
@@ -219,8 +212,8 @@ msgstr "Error en guardar el fitxer:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "En ús:"
 
@@ -248,15 +241,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Refrescar els gràfics"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr "Sense gràfics"
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr "Amb gràfics"
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr "Buidar la memòria cau (necessita privilegis de root)"
 
@@ -289,26 +282,59 @@ msgstr "80-100"
 msgid "Execution of '%s' failed:"
 msgstr "Ha fallat l'execució de '%s':"
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Nucli"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Refrescar els gràfics"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Xarxa"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Disc IO"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Memòria"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Xarxa"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -339,12 +365,6 @@ msgstr "Mostra l'ús de CPU (per a tots els nuclis) i de la memòria."
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "General"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Memòria"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -518,18 +538,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Utilitzat"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Cached"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Buffer"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -780,6 +788,16 @@ msgstr "Preferències del monitor de sistema multi-nucli"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Alçada"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Cached"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Buffer"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/da.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2023-12-25 10:39+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -24,8 +24,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -34,87 +34,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Kerne"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "HUK"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Hukommelse -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Brugt:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Cached:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Buffer:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Ledig:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "NET"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "---------- Netværk ----------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Ned:"
 
@@ -124,26 +118,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Op:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISK"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------ Diske -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Læs:"
 
@@ -153,8 +146,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Skriv:"
 
@@ -223,8 +216,8 @@ msgstr "Der opstod en fejl, da filen skulle gemmes:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Brugt:"
 
@@ -252,15 +245,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Opdatér grafer"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -293,24 +286,56 @@ msgstr "80–100"
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Kerne"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Opdatér grafer"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr ""
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 msgid "Disks"
+msgstr ""
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr ""
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+msgid "Networks"
 msgstr ""
 
 #. 3.4/applet.js:62
@@ -343,12 +368,6 @@ msgstr ""
 #. 3.0/prefsui.glade:281 3.2/prefsui.glade:333 6.0/prefsui.glade:299
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
-msgstr ""
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageDisk->title
@@ -520,20 +539,6 @@ msgstr ""
 #, fuzzy
 msgid "Usedup"
 msgstr "Brugt:"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-#, fuzzy
-msgid "Cached"
-msgstr "Cached:"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-#, fuzzy
-msgid "Buffer"
-msgstr "Buffer:"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -767,6 +772,18 @@ msgstr "Fejl i Flerkernet systemovervågning."
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr ""
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+#, fuzzy
+msgid "Cached"
+msgstr "Cached:"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+#, fuzzy
+msgid "Buffer"
+msgstr "Buffer:"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/de.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2025-08-08 07:22+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -31,87 +31,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------- Prozessor (CPU) ------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Kern"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "------- Speicher (MEM) -------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Benutzt:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Cache:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Buffer:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Frei:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "--------- Swap (SWAP) --------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "NET"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "------- Networks (NET) -------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Download:"
 
@@ -121,26 +115,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Upload:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISK"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "----- Festplatte (DISK) ------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Lesen:"
 
@@ -150,8 +143,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Schreiben:"
 
@@ -220,8 +213,8 @@ msgstr "Fehler beim Speichern der Datei:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Benutzt:"
 
@@ -249,15 +242,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Diagramme aktualisieren"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr "Keine Diagramme"
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr "Mit Diagrammen"
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr "Speicher-Cache leeren (benötigt Root-Rechte)"
 
@@ -290,24 +283,57 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr "Ausführen von '%s' fehlgeschlagen:"
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Kern"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 msgid "Refresh All"
 msgstr "Alles aktualisieren"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Netzwerk"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 msgid "Disks"
 msgstr "Festplatten"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Speicher"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Netzwerk"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -340,12 +366,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Allgemein"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Speicher"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -517,18 +537,6 @@ msgstr "Ursprung bei 12 Uhr"
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Benutzt"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Cache"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Buffer"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -743,6 +751,16 @@ msgstr "Einstellungen für Multikern-Systemmonitor"
 msgid "Height"
 msgstr "Höhe"
 
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Cache"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Buffer"
+
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695
 msgid "Scaling Description"
@@ -761,8 +779,7 @@ msgid ""
 "\tthe next largest becomes the new value by which the readings\n"
 "\tare scaled. This lets the plot \"zoom\" to show details of the graph.\n"
 "\tHowever, it also means that if there is a large reading small readings\n"
-"\tmay become indistinguishable from 0. And if there are only small "
-"readings\n"
+"\tmay become indistinguishable from 0. And if there are only small readings\n"
 "\tthen slightly larger readings may appear larger than they should.\n"
 "\tIf not enabled the largest value used will be the largest reading since\n"
 "\tcinnamon was started.\n"
@@ -777,8 +794,7 @@ msgstr ""
 "\tdes angezeigten Bereichs skaliert. Sobald der größte Messwert nicht\n"
 "\tmehr angezeigt wird, wird der nächstgrößere Wert der neue Wert mit\n"
 "\tdem die Messwerte skaliert werden. Dies lässt den Plot »zoomen«, um\n"
-"\tDetails des Diagramms zu zeigen. Allerdings bedeutet es auch, dass, "
-"wenn\n"
+"\tDetails des Diagramms zu zeigen. Allerdings bedeutet es auch, dass, wenn\n"
 "\tes einen großen Messwert gibt, kleine Messwerte von 0 womöglich nicht\n"
 "\tunterschieden werden können. Und wenn es nur kleine Messwerte gibt,\n"
 "\tdann können leicht größere Messwerte größer erscheinen als sie sollten.\n"
@@ -788,8 +804,7 @@ msgstr ""
 "Logarithmische Skalierung:\n"
 "\tDies transformiert die Messwerte so, dass sie mit einer logarithmischen "
 "Skala\n"
-"\tangezeigt werden. Dies heißt im Grunde, dass die großen Werte "
-"verkleinert\n"
+"\tangezeigt werden. Dies heißt im Grunde, dass die großen Werte verkleinert\n"
 "\twerden, damit sie die kleineren Messwerte nicht unterdrücken."
 
 #. 6.0/prefsui.glade:508 5.6/prefsui.glade:508 4.0/prefsui.glade:508
@@ -803,13 +818,11 @@ msgid ""
 "    displayed area. Once the largest reading is no longer displayed\n"
 "    the next largest becomes the new value by which the readings\n"
 "    are scaled. This lets the plot \"zoom\" to show details of the graph.\n"
-"    However, it also means that if there is a large reading small "
-"readings\n"
+"    However, it also means that if there is a large reading small readings\n"
 "    may become indistinguishable from 0. And if there are only small "
 "readings\n"
 "    then slightly larger readings may appear larger than they should.\n"
-"    If not enabled the largest value used will be the largest reading "
-"since\n"
+"    If not enabled the largest value used will be the largest reading since\n"
 "    cinnamon was started.\n"
 "\n"
 "Logarithmic Scaling:\n"
@@ -822,8 +835,7 @@ msgstr ""
 "\tdes angezeigten Bereichs skaliert. Sobald der größte Messwert nicht\n"
 "\tmehr angezeigt wird, wird der nächstgrößere Wert der neue Wert mit\n"
 "\tdem die Messwerte skaliert werden. Dies lässt den Plot »zoomen«, um\n"
-"\tDetails des Diagramms zu zeigen. Allerdings bedeutet es auch, dass, "
-"wenn\n"
+"\tDetails des Diagramms zu zeigen. Allerdings bedeutet es auch, dass, wenn\n"
 "\tes einen großen Messwert gibt, kleine Messwerte von 0 womöglich nicht\n"
 "\tunterschieden werden können. Und wenn es nur kleine Messwerte gibt,\n"
 "\tdann können leicht größere Messwerte größer erscheinen als sie sollten.\n"
@@ -833,6 +845,5 @@ msgstr ""
 "Logarithmische Skalierung:\n"
 "\tDies transformiert die Messwerte so, dass sie mit einer logarithmischen "
 "Skala\n"
-"\tangezeigt werden. Dies heißt im Grunde, dass die großen Werte "
-"verkleinert\n"
+"\tangezeigt werden. Dies heißt im Grunde, dass die großen Werte verkleinert\n"
 "\twerden, damit sie die kleineren Messwerte nicht unterdrücken."

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/es.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2025-08-07 18:33-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -31,87 +31,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Núcleo"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Memoria ----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Usado:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "En caché:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Buffer:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Libre:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "RED"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "------------ Redes -----------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Descarga:"
 
@@ -121,26 +115,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Subida:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISCO"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "----------- Discos -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Lectura:"
 
@@ -150,8 +143,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Escritura:"
 
@@ -220,8 +213,8 @@ msgstr "Error al guardar el archivo:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Usada:"
 
@@ -248,15 +241,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Actualizar gráficos"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr "Sin gráficos"
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr "Con gráficos"
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr "Eliminar caché de memoria (necesita derechos de root)"
 
@@ -289,24 +282,57 @@ msgstr "80-100"
 msgid "Execution of '%s' failed:"
 msgstr "Error en la ejecución de '%s':"
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Núcleo"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 msgid "Refresh All"
 msgstr "Actualizar todo"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr "root"
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Red"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 msgid "Disks"
 msgstr "Disco"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Memoria"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Red"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -338,12 +364,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "General"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Memoria"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -514,18 +534,6 @@ msgstr "Origen a las 12 horas"
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Usado"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "En caché"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Buffer"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -739,6 +747,16 @@ msgstr "Preferencias del monitor del sistema multinúcleo"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Altura"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "En caché"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Buffer"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/fi.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2024-11-15 23:57+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -31,87 +31,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Core"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Muisti -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Käytetty:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Välimuisti:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Puskuri:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Vapaa:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "LAN"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "----------- Verkko -----------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Alas:"
 
@@ -121,26 +115,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Ylös:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISK"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------ Levyt -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Luku:"
 
@@ -150,8 +143,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Kirjoitus:"
 
@@ -220,8 +213,8 @@ msgstr "Virhe tiedoston tallennuksessa:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Käytetty:"
 
@@ -249,15 +242,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Päivitä kaaviot"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr "Ilman grafiikkaa"
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr "Grafiikan kanssa"
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -290,26 +283,59 @@ msgstr "80-100"
 msgid "Execution of '%s' failed:"
 msgstr "Kohteen \"%s\" suoritus epäonnistui:"
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Core"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Päivitä kaaviot"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Verkko"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Kiintolevy"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Muisti"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Verkko"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -340,12 +366,6 @@ msgstr "Näyttää reaaliajassa prosessorin, muistin ja kiintolevyn käyttöaste
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Yleinen"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Muisti"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -519,18 +539,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Käytetty"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Välimuisti"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Puskuri"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -781,6 +789,16 @@ msgstr "Multi-Core System Monitor asetukset"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Korkeus"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Välimuisti"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Puskuri"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/fr.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/fr.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
-"PO-Revision-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
+"PO-Revision-Date: 2025-08-09 20:46+0200\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -31,89 +31,83 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "--------- Processeurs --------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Cœur"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MÉM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "---------- Mémoire -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Utilisée :"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
-msgstr "Cache:"
+msgstr "Cache :"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
-msgstr "Tampon:"
+msgstr "Tampon :"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
-msgstr "Libre:"
+msgstr "Libre :"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "RÉSEAU"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "---------- Réseaux -----------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
-msgstr "Reçu:"
+msgstr "Reçu :"
 
 #. 3.0/DataProviders.js:308 3.0/DataProviders.js:309 3.2/DataProviders.js:308
 #. 3.2/DataProviders.js:309
@@ -121,28 +115,27 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
-msgstr "Envoyé:"
+msgstr "Envoyé :"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISQUES"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "---------- Disques -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
-msgstr "Lecture:"
+msgstr "Lecture :"
 
 #. 3.0/DataProviders.js:411 3.0/DataProviders.js:412 3.2/DataProviders.js:411
 #. 3.2/DataProviders.js:412
@@ -150,10 +143,10 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
-msgstr "Écriture:"
+msgstr "Écriture :"
 
 #. 3.0/ErrorApplet.js:28 3.0/ErrorApplet.js:34 3.2/ErrorApplet.js:28
 #. 3.2/ErrorApplet.js:34
@@ -220,10 +213,10 @@ msgstr "Erreur durant la sauvegarde du fichier :"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
-msgstr "Utilisée:"
+msgstr "Utilisée :"
 
 #. 6.0/applet.js:72 3.4/applet.js:60 5.6/applet.js:70 4.0/applet.js:64
 msgid "Dependency missing"
@@ -249,15 +242,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Rafraîchir les graphiques"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr "Sans aucun graphique"
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr "Avec graphiques"
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr "Diminuer la Mémoire Cache (nécessite les droits root)"
 
@@ -290,24 +283,55 @@ msgstr "80-100"
 msgid "Execution of '%s' failed:"
 msgstr "L'exécution de '%s' a échoué :"
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+msgid "Core 128:"
+msgstr "Cœur 128 :"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr "Irrécupérable :"
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr "Récupérable :"
+
+#. 6.4/applet.js:311
 msgid "Refresh All"
 msgstr "Tout rafraîchir"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr "racine"
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Réseau"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 msgid "Disks"
 msgstr "Disques"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Mémoire"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr "Processeurs"
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr " :"
+
+#. 6.4/applet.js:1001
+msgid "Networks"
+msgstr "Réseaux"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -340,12 +364,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Général"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Mémoire"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -517,18 +535,6 @@ msgstr "Origine à midi"
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Utilisée"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Cache"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Tampon"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -743,6 +749,16 @@ msgstr "Préférences de Multi-Core System Monitor"
 msgid "Height"
 msgstr "Hauteur"
 
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Cache"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Tampon"
+
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695
 msgid "Scaling Description"
@@ -772,7 +788,7 @@ msgid ""
 "\tlogarithmic scale. If you are not familiar basically, it reduces the\n"
 "\tlarge values so that they dont dominate the smaller readings."
 msgstr ""
-"Mise à l'échelle automatique:\n"
+"Mise à l'échelle automatique :\n"
 "\tCela permet de mettre à l'échelle le graphique linéaire en fonction\n"
 "\tde la valeur maximale présente dans la zone d'affichage. Une fois\n"
 "\tque cette valeur maximale n'est plus affichée, la valeur maximale\n"
@@ -817,7 +833,7 @@ msgid ""
 "    logarithmic scale. If you are not familiar basically, it reduces the\n"
 "    large values so that they dont dominate the smaller readings."
 msgstr ""
-"Mise à l'échelle automatique:\n"
+"Mise à l'échelle automatique :\n"
 "\tCela permet de mettre à l'échelle le graphique linéaire en fonction\n"
 "\tde la valeur maximale présente dans la zone d'affichage. Une fois\n"
 "\tque cette valeur maximale n'est plus affichée, la valeur maximale\n"

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/hr.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/hr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Multi-Core System Monitor 1.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2019-01-22 23:49+0100\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian\n"
@@ -22,8 +22,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -32,87 +32,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "--------------CPU-------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Jezgra"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "-----------MEMORIJA-----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Iskorišteno:\t\t"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Predmemorija:\t"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Međuspremnik:\t"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Slobodno:\t\t"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "-------------SWAP-------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap:"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "MREŽA"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "------------MREŽA-------------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Preuzimanje:"
 
@@ -122,26 +116,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Slanje:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISK"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------DISKOVI-----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Čitanje:"
 
@@ -151,8 +144,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Zapisivanje:"
 
@@ -221,8 +214,8 @@ msgstr "Greška spremanja datoteke:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Iskorišteno:"
 
@@ -251,15 +244,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Brzina osvježavanja (ms)"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -292,26 +285,59 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Jezgra"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Brzina osvježavanja (ms)"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Mreža"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Disk U/I"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Memorija"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Mreža"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -343,12 +369,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Općenito"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Memorija"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -521,18 +541,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Iskorišteno:\t\t"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Predmemorija:"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Međuspremnik:\t"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -783,6 +791,16 @@ msgstr "Osobitosti višejezgrenog nadgledatelja sustava"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Visina"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Predmemorija:"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Međuspremnik:\t"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/hu.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: multicore-sys-monitor@ccadeptic23 1.9.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2025-08-03 20:47+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -20,8 +20,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -30,87 +30,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Mag"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Memória -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Felhasznált:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Gyorsítótárazott:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Puffer:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Szabad:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "Cserehely"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Cserehely ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Cserehely"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "NET"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "---------- Hálózatok ----------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Le:"
 
@@ -120,26 +114,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Fel:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "LEMEZ"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------ Lemezek -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Olvasás:"
 
@@ -149,8 +142,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Írás:"
 
@@ -219,8 +212,8 @@ msgstr "Hiba a fájl mentése közben:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Használt:"
 
@@ -248,15 +241,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Grafikonok frissítése"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr "Mindenféle grafika nélkül"
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr "Grfikával"
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr "Memória gyorsítótár elvetése (rendszergazdai jogosultság szükséges)"
 
@@ -289,25 +282,58 @@ msgstr "80-100"
 msgid "Execution of '%s' failed:"
 msgstr "A '%s' végrehajtása sikertelen:"
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Mag"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 msgid "Refresh All"
 msgstr "Összes frissítése"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr "root"
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Hálózat"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Lemez IO"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Memória"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Hálózat"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -340,12 +366,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Általános"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Memória"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -517,18 +537,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Felhasznált"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Gyorsítótárazott"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Puffer"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -758,6 +766,16 @@ msgstr "Többmagos rendszerfigyelő beállításai"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Magasság"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Gyorsítótárazott"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Puffer"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/it.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2025-01-03 15:12+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -31,87 +31,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Core"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Memoria ----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Esaurita:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Cache:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Buffer:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Libera:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "RETE"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "------------ Reti ------------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Down:"
 
@@ -121,26 +115,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Up:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISCO"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "----------- Dischi -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Lettura:"
 
@@ -150,8 +143,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Scrittura:"
 
@@ -220,8 +213,8 @@ msgstr "Errore durante il salvataggio del file:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Usata:"
 
@@ -249,15 +242,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Ricarica grafici"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr "Senza alcuna grafica"
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr "Con grafica"
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr "Elimina cache di memoria (richiede privilegi di root)"
 
@@ -290,26 +283,59 @@ msgstr "80-100"
 msgid "Execution of '%s' failed:"
 msgstr "Esecuzione di '%s' fallita:"
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Core"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Ricarica grafici"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Rete"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "IO Disco"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Memoria"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Rete"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -342,12 +368,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Generale"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Memoria"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -521,18 +541,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Esaurita"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Cache"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Buffer"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -783,6 +791,16 @@ msgstr "Preferenze di monitoraggio del sistema multi-core"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Altezza"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Cache"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Buffer"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/ja.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/ja.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2022-12-03 23:57+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -31,87 +31,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Core"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- メモリ -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Usedup:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Cached:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Buffer:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Free:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "スワップ"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "NET"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "---------- Networks ----------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Down:"
 
@@ -121,26 +115,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Up:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISK"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------ Disks -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Read:"
 
@@ -150,8 +143,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Write:"
 
@@ -220,8 +213,8 @@ msgstr "ファイル保存エラー:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Used:"
 
@@ -250,15 +243,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "更新頻度（ms）"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -291,26 +284,59 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Core"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "更新頻度（ms）"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "ネットワーク"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "ディスク入出力"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "メモリ"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "ネットワーク"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -342,12 +368,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "一般"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "メモリ"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -520,18 +540,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "使用中"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "キャッシュ"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "バッファ"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -782,6 +790,16 @@ msgstr "Multi-Core System Monitor 設定"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "高さ"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "キャッシュ"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "バッファ"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/multicore-sys-monitor@ccadeptic23.pot
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/multicore-sys-monitor@ccadeptic23.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: multicore-sys-monitor@ccadeptic23 2.3.4\n"
+"Project-Id-Version: multicore-sys-monitor@ccadeptic23 2.5.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,8 +19,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -29,87 +29,81 @@ msgid "CPU"
 msgstr ""
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr ""
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr ""
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr ""
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr ""
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr ""
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr ""
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr ""
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr ""
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr ""
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr ""
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr ""
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr ""
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr ""
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr ""
 
@@ -119,26 +113,25 @@ msgid "(KiB/s)"
 msgstr ""
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr ""
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr ""
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr ""
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr ""
 
@@ -148,8 +141,8 @@ msgid "(MiB/s)"
 msgstr ""
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr ""
 
@@ -218,8 +211,8 @@ msgstr ""
 msgid "/s"
 msgstr ""
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr ""
 
@@ -241,15 +234,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr ""
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -282,23 +275,54 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+msgid "Core 128:"
+msgstr ""
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 msgid "Refresh All"
 msgstr ""
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr ""
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 msgid "Disks"
+msgstr ""
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr ""
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+msgid "Networks"
 msgstr ""
 
 #. 3.4/applet.js:62
@@ -324,12 +348,6 @@ msgstr ""
 #. 3.0/prefsui.glade:281 3.2/prefsui.glade:333 6.0/prefsui.glade:299
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
-msgstr ""
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageDisk->title
@@ -497,18 +515,6 @@ msgstr ""
 #. 3.0/prefsui.glade:606 3.2/prefsui.glade:658 6.0/prefsui.glade:733
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
-msgstr ""
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr ""
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
 msgstr ""
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
@@ -722,6 +728,16 @@ msgstr ""
 
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
+msgstr ""
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr ""
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
 msgstr ""
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/nl.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: multicore-sys-monitor@ccadeptic23 1.9.4\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2024-11-28 17:46+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -18,8 +18,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -28,87 +28,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Kern"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Geheugen -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Gebruikt:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "In cache:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "In buffer:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Vrij:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "NET"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "---------- Netwerken ----------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Down:"
 
@@ -118,26 +112,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Up:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "SCHIJVEN"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------ Schijven -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Lezen:"
 
@@ -147,8 +140,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Schrijven:"
 
@@ -217,8 +210,8 @@ msgstr "Fout bij het opslaan van het bestand:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Gebruikt:"
 
@@ -246,15 +239,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Vernieuw grafieken"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr "Zonder enige grafieken"
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr "Met grafieken"
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr "Geheugenbuffer legen (rootrechten vereist)"
 
@@ -287,26 +280,59 @@ msgstr "80-100"
 msgid "Execution of '%s' failed:"
 msgstr "Uitvoering van '%s' is mislukt:"
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Kern"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Vernieuw grafieken"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Netwerk"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Schijf I/O"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Geheugen"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Netwerk"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -339,12 +365,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Algemeen"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Geheugen"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -518,18 +538,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Gebruikt"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "In cache"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "In buffer"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -780,6 +788,16 @@ msgstr "Voorkeuren Multi-Core Systeemmonitor"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Hoogte"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "In cache"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "In buffer"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/pl.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/pl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2018-04-06 23:29+0200\n"
 "Last-Translator: xearonet\n"
 "Language-Team: \n"
@@ -22,8 +22,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -32,87 +32,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Rdzeń"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Pamięć -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Użyta:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Podręczna:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Buforowa:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Wolna:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "NET"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "----------- Sieci ------------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Pobieranie:"
 
@@ -122,26 +116,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Wysyłanie:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISK"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------ Dyski -----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Odczyt:"
 
@@ -151,8 +144,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Zapis:"
 
@@ -221,8 +214,8 @@ msgstr "Błąd podczas zapisywania pliku:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Użyta:"
 
@@ -245,15 +238,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Czas odświeżania"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -286,26 +279,59 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Rdzeń"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Czas odświeżania"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Sieć"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Dysk"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Pamięć"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Sieć"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -333,12 +359,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Ogólne"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Pamięć"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -511,18 +531,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Użyta"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Podręczna"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Buforowa"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -773,6 +781,16 @@ msgstr "Ustawienia dla Multi-Core System Monitor"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Wysokość"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Podręczna"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Buforowa"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/ro.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/ro.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2020-04-19 18:49+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,8 +22,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -32,87 +32,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Nucleu"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Memorie ----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Utilizat:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "În cache:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Tampon:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Liber:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Swap"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "NET"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "---------- Rețele ------------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Descărcare:"
 
@@ -122,26 +116,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Încărcare:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISC"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------ Discuri ---------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Citire:"
 
@@ -151,8 +144,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Scriere:"
 
@@ -221,8 +214,8 @@ msgstr "Eroare la salvarea fișierului:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Utilizat:"
 
@@ -251,15 +244,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Rata de reîmprospătare (ms)"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -292,26 +285,59 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Nucleu"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Rata de reîmprospătare (ms)"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Rețea"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Scriere/citire disc"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Memorie"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Rețea"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -343,12 +369,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "General"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Memorie"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -521,18 +541,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Utilizat"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "În cache"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Tampon"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -783,6 +791,16 @@ msgstr ""
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Înălțime"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "În cache"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Tampon"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/ru.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2017-05-03 21:10+0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -25,8 +25,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -35,95 +35,89 @@ msgid "CPU"
 msgstr "ЦП"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 #, fuzzy
 msgid "------------- CPU ------------"
 msgstr "--------------ЦП-------------- \n"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr ""
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "Память"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 #, fuzzy
 msgid "----------- Memory -----------"
 msgstr "------------Память------------ \n"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 #, fuzzy
 msgid "Usedup:"
 msgstr "использовано:\t"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 #, fuzzy
 msgid "Cached:"
 msgstr "Кешировано"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 #, fuzzy
 msgid "Buffer:"
 msgstr "Буферы"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 #, fuzzy
 msgid "Free:"
 msgstr "Свободно"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "Подкачка"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 #, fuzzy
 msgid "------------ Swap ------------"
 msgstr "-----------Подкачка----------- \n"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Подкачка"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "Сеть"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 #, fuzzy
 msgid "---------- Networks ----------"
 msgstr "-------------Сеть------------- \n"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 #, fuzzy
 msgid "Down:"
 msgstr "Получено"
@@ -135,28 +129,27 @@ msgid "(KiB/s)"
 msgstr "(КиБ/с)\n"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 #, fuzzy
 msgid "Up:"
 msgstr "Отправлено"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "Диск"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 #, fuzzy
 msgid "------------ Disks -----------"
 msgstr "-------------Диск------------- \n"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 #, fuzzy
 msgid "Read:"
 msgstr "Чтение"
@@ -168,8 +161,8 @@ msgid "(MiB/s)"
 msgstr " (МиБ/с)\n"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 #, fuzzy
 msgid "Write:"
 msgstr "Запись"
@@ -241,8 +234,8 @@ msgstr "Ошибка сохранения файла: "
 msgid "/s"
 msgstr ""
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 #, fuzzy
 msgid "Used:"
 msgstr "Использовано"
@@ -266,15 +259,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Частота обновления (мс)"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -307,26 +300,58 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+msgid "Core 128:"
+msgstr ""
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Частота обновления (мс)"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Сеть"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Дисковый ввод-вывод"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Память"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Сеть"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -354,12 +379,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Общие"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Память"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -533,20 +552,6 @@ msgstr ""
 #, fuzzy
 msgid "Usedup"
 msgstr "использовано:\t"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-#, fuzzy
-msgid "Cached"
-msgstr "Кешировано"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-#, fuzzy
-msgid "Buffer"
-msgstr "Буферы"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -799,6 +804,18 @@ msgstr "Параметры Multi-core System Monitor"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Высота"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+#, fuzzy
+msgid "Cached"
+msgstr "Кешировано"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+#, fuzzy
+msgid "Buffer"
+msgstr "Буферы"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/sv.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/sv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2019-02-09 16:12+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -24,8 +24,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -34,87 +34,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "--------------CPU-------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Kärna"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MINNE"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Minne ------------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Förbrukat:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Cache-lagrat:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Buffert:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Ledigt:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "VÄXLING"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "-------Växlingsutrymme--------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Växlingsutrymme"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "NÄT"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "-----------Nätverk------------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "Ner:"
 
@@ -124,26 +118,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Upp:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DISK"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------Diskar------------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Läs:"
 
@@ -153,8 +146,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Skriv:"
 
@@ -223,8 +216,8 @@ msgstr "Kunde inte spara filen:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Använt:"
 
@@ -253,15 +246,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Uppdateringsfrekvens (ms)"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -294,26 +287,59 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Kärna"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Uppdateringsfrekvens (ms)"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Nätverk"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Disk I/O"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Minne"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Nätverk"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -346,12 +372,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Allmänt"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Minne"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -524,18 +544,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Använt"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Cache-lagrat"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Buffert"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -786,6 +794,16 @@ msgstr "Inställningar för övervakare av flerkärniga system"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Höjd"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Cache-lagrat"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Buffert"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/tr.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2018-11-05 14:58+0300\n"
 "Last-Translator: Gökhan GÖKKAYA <gokhanlnx@gmail.com>\n"
 "Language-Team: Linux Mint Türkiye <gokhanlnx@gmail.com>\n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -31,87 +31,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "Çekirdek"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "RAM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- Hafıza -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "Kullanılan:"
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "Önbellek:"
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "Tampon:"
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "Boş:"
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "TAKAS"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "----------- Takas ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "Takas"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "AĞ"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "------------- Ağ -------------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "İndirilen:"
 
@@ -121,26 +115,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "Gönderilen:"
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "DİSK"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "----------- Diskler ----------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "Okuma:"
 
@@ -150,8 +143,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "Yazma:"
 
@@ -220,8 +213,8 @@ msgstr "Dosya kaydedilirken hata:"
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "Kullanılan:"
 
@@ -250,15 +243,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "Yenileme Hızı (ms)"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -291,26 +284,59 @@ msgstr ""
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "Çekirdek"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "Yenileme Hızı (ms)"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "Ağ"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "Disk GÇ"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "Hafıza"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "Ağ"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -342,12 +368,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "Genel"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "Hafıza"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -520,18 +540,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "Kullanılan"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "Önbellek"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "Tampon"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -782,6 +790,16 @@ msgstr "Çoklu-Çekirdek Sistem İzleyicisi Tercihleri"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "Yükseklik"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "Önbellek"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "Tampon"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/zh_CN.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/zh_CN.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2023-05-30 21:22+0800\n"
 "Last-Translator: Slinet6056 <slinet6056@gmail.com>\n"
 "Language-Team: \n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -31,87 +31,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "核心"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "内存"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "------------- 内存 ------------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "已使用："
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "已缓存："
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "缓冲："
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "可用："
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "交换分区"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "----------- 交换分区 ----------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "交换分区"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "网络"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "------------- 网络 ------------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "下行："
 
@@ -121,26 +115,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "上行："
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "磁盘"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------- 磁盘 ------------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "读取："
 
@@ -150,8 +143,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "写入："
 
@@ -220,8 +213,8 @@ msgstr "保存文件时出错："
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "已使用："
 
@@ -249,15 +242,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "刷新图表"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr ""
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr ""
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr ""
 
@@ -290,26 +283,59 @@ msgstr "80-100"
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "核心"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "刷新图表"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "网络"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "磁盘 IO"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "内存"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "网络"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -340,12 +366,6 @@ msgstr "实时显示每个核心/cpu的cpu使用率和总体内存使用情况�
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "常规"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "内存"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -519,18 +539,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "已使用"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "已缓存"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "缓冲"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -781,6 +789,16 @@ msgstr "多核系统监视器首选项"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "高度"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "已缓存"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "缓冲"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/zh_TW.po
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/po/zh_TW.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-06 17:41+0200\n"
+"POT-Creation-Date: 2025-08-09 20:46+0200\n"
 "PO-Revision-Date: 2025-06-15 23:34+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -19,8 +19,8 @@ msgstr ""
 
 #. 6.4->settings-schema.json->pageCPU->title
 #. 3.0/DataProviders.js:107 3.0/prefs.js:183 3.2/DataProviders.js:107
-#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:780
-#. 6.4/applet.js:809 3.4/DataProviders.js:58 3.4/prefs.js:195
+#. 3.2/prefs.js:187 6.0/DataProviders.js:60 6.0/prefs.js:303 6.4/applet.js:847
+#. 6.4/applet.js:883 3.4/DataProviders.js:58 3.4/prefs.js:195
 #. 5.6/DataProviders.js:55 5.6/prefs.js:303 4.0/DataProviders.js:55
 #. 4.0/prefs.js:303 3.0/prefsui.glade:452 3.2/prefsui.glade:504
 #. 6.0/prefsui.glade:580 3.4/prefsui.glade:434 5.6/prefsui.glade:580
@@ -29,87 +29,81 @@ msgid "CPU"
 msgstr "CPU"
 
 #. 3.0/DataProviders.js:113 3.2/DataProviders.js:113 6.0/DataProviders.js:128
-#. 6.4/applet.js:805 3.4/DataProviders.js:126 5.6/DataProviders.js:123
-#. 4.0/DataProviders.js:123
+#. 3.4/DataProviders.js:126 5.6/DataProviders.js:123 4.0/DataProviders.js:123
 msgid "------------- CPU ------------"
 msgstr "------------- CPU ------------"
 
 #. 3.0/DataProviders.js:117 3.2/DataProviders.js:117 6.0/DataProviders.js:131
-#. 6.4/applet.js:811 3.4/DataProviders.js:129 5.6/DataProviders.js:126
+#. 6.4/applet.js:885 3.4/DataProviders.js:129 5.6/DataProviders.js:126
 #. 4.0/DataProviders.js:126
 msgid "Core"
 msgstr "核心"
 
 #. 3.0/DataProviders.js:157 3.2/DataProviders.js:157 6.0/DataProviders.js:143
-#. 6.4/applet.js:688 3.4/DataProviders.js:141 5.6/DataProviders.js:138
+#. 6.4/applet.js:714 3.4/DataProviders.js:141 5.6/DataProviders.js:138
 #. 4.0/DataProviders.js:138
 msgid "MEM"
 msgstr "MEM"
 
 #. 3.0/DataProviders.js:163 3.2/DataProviders.js:163 6.0/DataProviders.js:163
-#. 6.4/applet.js:719 3.4/DataProviders.js:161 5.6/DataProviders.js:158
-#. 4.0/DataProviders.js:158
+#. 3.4/DataProviders.js:161 5.6/DataProviders.js:158 4.0/DataProviders.js:158
 msgid "----------- Memory -----------"
 msgstr "----------- 記憶體 -----------"
 
-#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164
+#. 3.0/DataProviders.js:164 3.2/DataProviders.js:164 6.4/applet.js:42
 msgid "Usedup:"
 msgstr "已使用："
 
 #. 3.0/DataProviders.js:165 3.2/DataProviders.js:165 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Cached:"
 msgstr "快取："
 
 #. 3.0/DataProviders.js:166 3.2/DataProviders.js:166 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Buffer:"
 msgstr "緩衝："
 
 #. 3.0/DataProviders.js:167 3.2/DataProviders.js:167 6.0/DataProviders.js:164
-#. 6.4/applet.js:720 3.4/DataProviders.js:162 5.6/DataProviders.js:159
-#. 4.0/DataProviders.js:159
+#. 6.4/applet.js:43 6.4/applet.js:773 3.4/DataProviders.js:162
+#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Free:"
 msgstr "可用："
 
 #. 3.0/DataProviders.js:194 3.2/DataProviders.js:194 6.0/DataProviders.js:178
-#. 6.4/applet.js:739 3.4/DataProviders.js:176 5.6/DataProviders.js:173
+#. 6.4/applet.js:802 3.4/DataProviders.js:176 5.6/DataProviders.js:173
 #. 4.0/DataProviders.js:173
 msgid "SWAP"
 msgstr "SWAP"
 
 #. 3.0/DataProviders.js:199 3.2/DataProviders.js:199 6.0/DataProviders.js:221
-#. 6.4/applet.js:763 3.4/DataProviders.js:194 5.6/DataProviders.js:193
-#. 4.0/DataProviders.js:193
+#. 3.4/DataProviders.js:194 5.6/DataProviders.js:193 4.0/DataProviders.js:193
 msgid "------------ Swap ------------"
 msgstr "------------ Swap ------------"
 
 #. 6.4->settings-schema.json->Mem_colorSwap->description
 #. 3.0/DataProviders.js:200 3.2/DataProviders.js:200 6.0/DataProviders.js:222
-#. 6.4/applet.js:764 3.4/DataProviders.js:195 5.6/DataProviders.js:194
-#. 4.0/DataProviders.js:194 3.0/prefsui.glade:785 3.2/prefsui.glade:837
-#. 6.0/prefsui.glade:907 3.4/prefsui.glade:761 5.6/prefsui.glade:907
-#. 4.0/prefsui.glade:907
+#. 6.4/applet.js:44 6.4/applet.js:827 3.4/DataProviders.js:195
+#. 5.6/DataProviders.js:194 4.0/DataProviders.js:194 3.0/prefsui.glade:785
+#. 3.2/prefsui.glade:837 6.0/prefsui.glade:907 3.4/prefsui.glade:761
+#. 5.6/prefsui.glade:907 4.0/prefsui.glade:907
 msgid "Swap"
 msgstr "虛擬記憶體"
 
 #. 3.0/DataProviders.js:264 3.2/DataProviders.js:264 6.0/DataProviders.js:232
-#. 6.4/applet.js:833 3.4/DataProviders.js:205 5.6/DataProviders.js:204
+#. 6.4/applet.js:907 3.4/DataProviders.js:205 5.6/DataProviders.js:204
 #. 4.0/DataProviders.js:204
 msgid "NET"
 msgstr "網路"
 
 #. 3.0/DataProviders.js:305 3.2/DataProviders.js:305 6.0/DataProviders.js:323
-#. 6.4/applet.js:926 3.4/DataProviders.js:289 5.6/DataProviders.js:287
-#. 4.0/DataProviders.js:287
+#. 3.4/DataProviders.js:289 5.6/DataProviders.js:287 4.0/DataProviders.js:287
 msgid "---------- Networks ----------"
 msgstr "------------ 網路 ------------"
 
 #. 3.0/DataProviders.js:308 3.2/DataProviders.js:308 6.0/DataProviders.js:334
-#. 6.4/applet.js:938 3.4/DataProviders.js:300 5.6/DataProviders.js:298
-#. 4.0/DataProviders.js:298
+#. 6.4/applet.js:45 6.4/applet.js:1016 3.4/DataProviders.js:300
+#. 5.6/DataProviders.js:298 4.0/DataProviders.js:298
 msgid "Down:"
 msgstr "下載："
 
@@ -119,26 +113,25 @@ msgid "(KiB/s)"
 msgstr "(KiB/s)"
 
 #. 3.0/DataProviders.js:309 3.2/DataProviders.js:309 6.0/DataProviders.js:335
-#. 6.4/applet.js:939 3.4/DataProviders.js:301 5.6/DataProviders.js:299
-#. 4.0/DataProviders.js:299
+#. 6.4/applet.js:46 6.4/applet.js:1017 3.4/DataProviders.js:301
+#. 5.6/DataProviders.js:299 4.0/DataProviders.js:299
 msgid "Up:"
 msgstr "上傳："
 
 #. 3.0/DataProviders.js:382 3.2/DataProviders.js:382 6.0/DataProviders.js:351
-#. 6.4/applet.js:956 3.4/DataProviders.js:317 5.6/DataProviders.js:315
+#. 6.4/applet.js:1034 3.4/DataProviders.js:317 5.6/DataProviders.js:315
 #. 4.0/DataProviders.js:315
 msgid "DISK"
 msgstr "磁碟"
 
 #. 3.0/DataProviders.js:408 3.2/DataProviders.js:408 6.0/DataProviders.js:412
-#. 6.4/applet.js:1049 3.4/DataProviders.js:378 5.6/DataProviders.js:376
-#. 4.0/DataProviders.js:376
+#. 3.4/DataProviders.js:378 5.6/DataProviders.js:376 4.0/DataProviders.js:376
 msgid "------------ Disks -----------"
 msgstr "------------ 磁碟 ------------"
 
 #. 3.0/DataProviders.js:411 3.2/DataProviders.js:411 6.0/DataProviders.js:420
-#. 6.4/applet.js:1061 3.4/DataProviders.js:386 5.6/DataProviders.js:384
-#. 4.0/DataProviders.js:384
+#. 6.4/applet.js:47 6.4/applet.js:1144 3.4/DataProviders.js:386
+#. 5.6/DataProviders.js:384 4.0/DataProviders.js:384
 msgid "Read:"
 msgstr "讀取："
 
@@ -148,8 +141,8 @@ msgid "(MiB/s)"
 msgstr "(MiB/s)"
 
 #. 3.0/DataProviders.js:412 3.2/DataProviders.js:412 6.0/DataProviders.js:421
-#. 6.4/applet.js:1062 3.4/DataProviders.js:387 5.6/DataProviders.js:385
-#. 4.0/DataProviders.js:385
+#. 6.4/applet.js:48 6.4/applet.js:1145 3.4/DataProviders.js:387
+#. 5.6/DataProviders.js:385 4.0/DataProviders.js:385
 msgid "Write:"
 msgstr "寫入："
 
@@ -218,8 +211,8 @@ msgstr "存檔時發生錯誤："
 msgid "/s"
 msgstr "/s"
 
-#. 6.0/DataProviders.js:164 6.4/applet.js:720 3.4/DataProviders.js:162
-#. 5.6/DataProviders.js:159 4.0/DataProviders.js:159
+#. 6.0/DataProviders.js:164 6.4/applet.js:41 6.4/applet.js:773
+#. 3.4/DataProviders.js:162 5.6/DataProviders.js:159 4.0/DataProviders.js:159
 msgid "Used:"
 msgstr "已使用："
 
@@ -246,15 +239,15 @@ msgstr ""
 msgid "Refresh graphs"
 msgstr "重新整理圖表"
 
-#. 6.0/applet.js:325 6.4/applet.js:302
+#. 6.0/applet.js:325 6.4/applet.js:321
 msgid "Without any graphics"
 msgstr "不顯示圖表"
 
-#. 6.0/applet.js:331 6.4/applet.js:308
+#. 6.0/applet.js:331 6.4/applet.js:327
 msgid "With graphics"
 msgstr "顯示圖表"
 
-#. 6.0/applet.js:341 6.4/applet.js:319
+#. 6.0/applet.js:341 6.4/applet.js:338
 msgid "Drop Memory Cache (needs root rights)"
 msgstr "清除記憶體快取 (需要 root 權限)"
 
@@ -287,26 +280,59 @@ msgstr "80-100"
 msgid "Execution of '%s' failed:"
 msgstr "執行 '%s' 失敗："
 
-#. 6.4/applet.js:292
+#. 6.4/applet.js:38
+#, fuzzy
+msgid "Core 128:"
+msgstr "核心"
+
+#. 6.4/applet.js:39
+msgid "Unrecoverable:"
+msgstr ""
+
+#. 6.4/applet.js:40
+msgid "Recoverable:"
+msgstr ""
+
+#. 6.4/applet.js:311
 #, fuzzy
 msgid "Refresh All"
 msgstr "重新整理圖表"
 
-#. 6.4/applet.js:398
+#. 6.4/applet.js:417
 msgid "root"
 msgstr ""
 
 #. 6.4->settings-schema.json->pageNetwork->title
-#. 6.4/applet.js:574 6.4/applet.js:840 3.0/prefsui.glade:1154
+#. 6.4/applet.js:599 6.4/applet.js:914 3.0/prefsui.glade:1154
 #. 3.2/prefsui.glade:1206 6.0/prefsui.glade:1289 3.4/prefsui.glade:1143
 #. 5.6/prefsui.glade:1289 4.0/prefsui.glade:1289
 msgid "Network"
 msgstr "網路"
 
-#. 6.4/applet.js:631 6.4/applet.js:965
+#. 6.4/applet.js:657 6.4/applet.js:1043 6.4/applet.js:1128
 #, fuzzy
 msgid "Disks"
 msgstr "磁碟讀寫"
+
+#. 6.4->settings-schema.json->pageMem->title
+#. 6.4/applet.js:768 3.0/prefsui.glade:832 3.2/prefsui.glade:884
+#. 6.0/prefsui.glade:954 3.4/prefsui.glade:808 5.6/prefsui.glade:954
+#. 4.0/prefsui.glade:954
+msgid "Memory"
+msgstr "記憶體"
+
+#. 6.4/applet.js:873
+msgid "CPUs"
+msgstr ""
+
+#. 6.4/applet.js:877
+msgid ":"
+msgstr ""
+
+#. 6.4/applet.js:1001
+#, fuzzy
+msgid "Networks"
+msgstr "網路"
 
 #. 3.4/applet.js:62
 msgid ""
@@ -337,12 +363,6 @@ msgstr ""
 #. 3.4/prefsui.glade:264 5.6/prefsui.glade:299 4.0/prefsui.glade:299
 msgid "General"
 msgstr "一般"
-
-#. 6.4->settings-schema.json->pageMem->title
-#. 3.0/prefsui.glade:832 3.2/prefsui.glade:884 6.0/prefsui.glade:954
-#. 3.4/prefsui.glade:808 5.6/prefsui.glade:954 4.0/prefsui.glade:954
-msgid "Memory"
-msgstr "記憶體"
 
 #. 6.4->settings-schema.json->pageDisk->title
 #. 3.0/prefsui.glade:1488 3.2/prefsui.glade:1540 6.0/prefsui.glade:1635
@@ -516,18 +536,6 @@ msgstr ""
 #. 3.4/prefsui.glade:587 5.6/prefsui.glade:733 4.0/prefsui.glade:733
 msgid "Usedup"
 msgstr "已使用"
-
-#. 6.4->settings-schema.json->Mem_colorCached->description
-#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
-#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
-msgid "Cached"
-msgstr "快取"
-
-#. 6.4->settings-schema.json->Mem_colorBuffer->description
-#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
-#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
-msgid "Buffer"
-msgstr "緩衝區"
 
 #. 6.4->settings-schema.json->Mem_colorFree->description
 #. 3.0/prefsui.glade:723 3.2/prefsui.glade:775 6.0/prefsui.glade:847
@@ -778,6 +786,16 @@ msgstr "Multi-Core System Monitor 偏好設定"
 #. 3.0/prefsui.glade:189 3.2/prefsui.glade:189
 msgid "Height"
 msgstr "高度"
+
+#. 3.0/prefsui.glade:645 3.2/prefsui.glade:697 6.0/prefsui.glade:771
+#. 3.4/prefsui.glade:625 5.6/prefsui.glade:771 4.0/prefsui.glade:771
+msgid "Cached"
+msgstr "快取"
+
+#. 3.0/prefsui.glade:684 3.2/prefsui.glade:736 6.0/prefsui.glade:809
+#. 3.4/prefsui.glade:663 5.6/prefsui.glade:809 4.0/prefsui.glade:809
+msgid "Buffer"
+msgstr "緩衝區"
 
 #. 3.0/prefsui.glade:1550 3.2/prefsui.glade:1602 6.0/prefsui.glade:1695
 #. 3.4/prefsui.glade:1549 5.6/prefsui.glade:1695 4.0/prefsui.glade:1695


### PR DESCRIPTION
  * Fixes #7460.
  * Fixes #7505.
  * Calculates the percentage of memory used, as does `gnome-system-monitor`.
  * No longer includes cache memory or buffer memory in the statistics.