### PR TITLE
Replaces /bin/bash with /usr/bin/env bash in the scripts of many applets

### DIFF
--- a/Bps@claudiux/files/Bps@claudiux/scripts/get-network-data.sh
+++ b/Bps@claudiux/files/Bps@claudiux/scripts/get-network-data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 data=""
 for i in $(ls /sys/class/net); do {
         status=$(cat /sys/class/net/$i/operstate)

--- a/Bps@claudiux/files/Bps@claudiux/scripts/unplugged-network-devices.sh
+++ b/Bps@claudiux/files/Bps@claudiux/scripts/unplugged-network-devices.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 unplugged=""
 for i in $(ls /sys/class/net); do {
         status=$(cat /sys/class/net/$i/operstate)

--- a/CinnaMame@claudiux/files/CinnaMame@claudiux/applet.js
+++ b/CinnaMame@claudiux/files/CinnaMame@claudiux/applet.js
@@ -55,8 +55,8 @@ class CinnaMame extends Applet.IconApplet {
 
         this.setIcon();
 
-        Util.spawnCommandLineAsync("bash -c 'cd %s && chmod 755 *.sh'".format(PATH2SCRIPTS));
-        Util.spawnCommandLineAsync("bash -C '%s/ensure_mame.sh'".format(PATH2SCRIPTS));
+        Util.spawnCommandLineAsync("/usr/bin/env bash -c 'cd %s && chmod 755 *.sh'".format(PATH2SCRIPTS));
+        Util.spawnCommandLineAsync("/usr/bin/env bash -C '%s/ensure_mame.sh'".format(PATH2SCRIPTS));
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -76,7 +76,7 @@ class CinnaMame extends Applet.IconApplet {
 
         if (this._mame === null) {
             let mameItem = this.menu.addAction(_("Install mame"), () => {
-                Util.spawnCommandLineAsync("bash -C '%s/install_mame.sh'".format(PATH2SCRIPTS));
+                Util.spawnCommandLineAsync("/usr/bin/env bash -C '%s/install_mame.sh'".format(PATH2SCRIPTS));
             });
         } else {
             var games = {};

--- a/CinnaMame@claudiux/files/CinnaMame@claudiux/scripts/ensure_mame.sh
+++ b/CinnaMame@claudiux/files/CinnaMame@claudiux/scripts/ensure_mame.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ### Create ~/mame/roms if necessary:
 mkdir -p $HOME/mame/roms
 ### Create ~/.mame/cfg if necessary:

--- a/CinnaMame@claudiux/files/CinnaMame@claudiux/scripts/install_mame.sh
+++ b/CinnaMame@claudiux/files/CinnaMame@claudiux/scripts/install_mame.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ### Installs mame with password dialog:
 pkexec pkcon -y install mame
 ### Pause 1 second:

--- a/Exit@claudiux/files/Exit@claudiux/6.4/applet.js
+++ b/Exit@claudiux/files/Exit@claudiux/6.4/applet.js
@@ -175,7 +175,7 @@ class ExitApplet extends Applet.IconApplet {
                     setTimeoutInSeconds(
                         () => {
                             Util.spawn_async(
-                                ['/bin/bash', '-c',
+                                ['/usr/bin/env bash', '-c',
                                 'for m in $(xinput | grep -i Mouse | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
                                 xinput enable $m; done'],
                                 null);

--- a/Exit@claudiux/files/Exit@claudiux/scripts/can-shutdown.sh
+++ b/Exit@claudiux/files/Exit@claudiux/scripts/can-shutdown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 result=$(dbus-send --session --type=method_call --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.CanShutdown | grep boolean | awk '{print $2}')
 
 [[ "$result" == "true" ]] && exit 0;

--- a/ProcessMemoryMonitor@claudiux/files/ProcessMemoryMonitor@claudiux/scripts/get-mem.sh
+++ b/ProcessMemoryMonitor@claudiux/files/ProcessMemoryMonitor@claudiux/scripts/get-mem.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 MYPROC=$1
 ret=$(cat /proc/${MYPROC}/status | grep VmRSS | awk '{print $2}')
 echo -n $ret

--- a/ProcessMemoryMonitor@claudiux/files/ProcessMemoryMonitor@claudiux/scripts/get-pid-from-process-name.sh
+++ b/ProcessMemoryMonitor@claudiux/files/ProcessMemoryMonitor@claudiux/scripts/get-pid-from-process-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 processname=$1
 echo -n $(ps -C ${processname} -o pid=)
 

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/create-db-server-list.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/create-db-server-list.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 UUID="Radio3.0@claudiux"
 #~ RCONFIGDIR="$HOME/.cinnamon/configs/$UUID"
 RCONFIGDIR="$HOME/.local/share/cinnamon/applets/$UUID/radiodb"

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/create-job.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/create-job.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo $(at -M -f "$1" -t "$2" 2>&1 | tail -1 | cut -f2 -d" ")
 exit 0

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/db-server-list.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/db-server-list.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo -n $(host -t SRV _api._tcp.radio-browser.info | awk '{print $8}' | sed -e "s/\.$//")
 exit 0

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/del_song_arts.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/del_song_arts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DIRART=${XDG_RUNTIME_DIR}/AlbumArt/song-art
 
 [[ -d $DIRART ]] && rm -f ${DIRART}/R3SongArt*

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/download-favicon.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/download-favicon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 URL=$1
 NAME=$2
 

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/ensure-mpv-config.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/ensure-mpv-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is a part of the Radio3.0@claudiux applet.
 
 APP_NAME="Radio3.0"

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/fix-desklet-translations.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/fix-desklet-translations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$HOME/.local/share/locale"
 
 for lang in $(ls -1A); do {

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/get-score.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/get-score.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo -n $(curl -s https://cinnamon-spices.linuxmint.com/json/applets.json |  python3 -c "import json,sys;obj=json.load(sys.stdin);print(obj['Radio3.0@claudiux']['score']);")

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/get_song_art.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/get_song_art.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TITLE="$1"
 RES="$2"
 

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/mpvWatchBitrate.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/mpvWatchBitrate.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 SOCKET="${XDG_RUNTIME_DIR}/mpvradiosocket"
 
 RESULT=$(echo '{ "command": ["get_property", "audio-bitrate"] }' | socat - $SOCKET | jq ".data")

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/mpvWatchTitle.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/mpvWatchTitle.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 SOCKET="${XDG_RUNTIME_DIR}/mpvradiosocket"
 
 RESULT=$(echo '{ "command": ["get_property", "media-title"] }' | socat - $SOCKET | jq ".data")

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/progress.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/progress.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 [ $# -eq 1 ] || exit 1
 
 PID=$1

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/stop-mpv-else-recordings.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/stop-mpv-else-recordings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 MPV_PROCESS=$(ps x | grep mpvWatchTitle | grep scripts | echo -n `awk '{print $1}'`)
 
 if [ "x${MPV_PROCESS}" != "x" ]; then {

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/tink.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/tink.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TINK=$HOME/.local/share/cinnamon/applets/Radio3.0@claudiux/sounds/tink.ogg
 

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/update-yt-dlp.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/update-yt-dlp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OLDOWNBIN="$HOME/bin"
 OLDYTDLP="$OLDOWNBIN/yt-dlp"

--- a/Sensors@claudiux/files/Sensors@claudiux/applet.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/applet.js
@@ -205,7 +205,7 @@ class SensorsApplet extends Applet.Applet {
     spawnCommandLineAsync(`/bin/bash -c 'cd ${SCRIPTS_DIR} && chmod 755 *.py *.sh'`, null, null);
 
     this.sudo_or_wheel = "none";
-    let subProcess = spawnCommandLineAsyncIO("/bin/bash -c 'groups'", (out, err, exitCode) => {
+    let subProcess = spawnCommandLineAsyncIO("/usr/bin/env bash -c 'groups'", (out, err, exitCode) => {
       if (exitCode == 0) {
         let groups = out.trim().split(' ');
         if (groups.indexOf("wheel") > -1) this.sudo_or_wheel = "wheel";
@@ -624,7 +624,7 @@ class SensorsApplet extends Applet.Applet {
         if (!disk["show_in_tooltip"] && !disk["show_in_panel"]) continue;
 
         let _disk_name = disk["disk"].trim();
-        let command = "bash -c '"+SCRIPTS_DIR+"/get_disk_temp.sh "+_disk_name+"'";
+        let command = "/usr/bin/env bash -c '"+SCRIPTS_DIR+"/get_disk_temp.sh "+_disk_name+"'";
 
         if (!this._temp[_disk_name]) this._temp[_disk_name] = "??";
         let _temp;
@@ -1726,7 +1726,7 @@ class SensorsApplet extends Applet.Applet {
 
   _on_disktemp_button_pressed() {
     let subProcess = spawnCommandLineAsyncIO(
-      "/bin/bash -c '%s/pkexec_make_smartctl_usable_by_sudoers.sh %s'".format(SCRIPTS_DIR, this.sudo_or_wheel),
+      "/usr/bin/env bash -c '%s/pkexec_make_smartctl_usable_by_sudoers.sh %s'".format(SCRIPTS_DIR, this.sudo_or_wheel),
       (out, err, exitCode) => {
         this.s.setValue("disktemp_is_user_readable", this.is_disktemp_user_readable());
         subProcess.send_signal(9);

--- a/Sensors@claudiux/files/Sensors@claudiux/po/makepot
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/makepot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 UUID="Sensors@claudiux"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/detect_temp.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/detect_temp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 OF="sensors_detected.json"
 echo "{" > $OF
 LHWMON=( $(ls -1 /sys/class/hwmon) )

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/gen-customexec.conf-hddtemp.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/gen-customexec.conf-hddtemp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 Gsm=($(lsblk | grep -v -e '├─' -e '└─' -e 'NAME' | awk '{print $1}'))
 
 Titems=${#Gsm[@]}
@@ -11,10 +11,10 @@ while [ $Count -lt $Titems ];do
 IFS="
 "
 CSmrt=($(smartctl --info '/dev/'${Gsm[Count]} |
-grep -e 'SMART support' -e 'Device Model' -e 'User Capacity' | 
+grep -e 'SMART support' -e 'Device Model' -e 'User Capacity' |
 cut -d: -f2 |
 sed  -e 's/^ //m;s/^    //m;s/^   //m' |
-cut -d "[" -f2 | 
+cut -d "[" -f2 |
 sed 's/\]//m'))
 
 Dtmp=${CSmrt[3]}
@@ -27,4 +27,4 @@ fi;fi;
 Count=$((Count+1))
 unset CSmrt
 done;
-printf "\n" 
+printf "\n"

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/get_disk_list.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/get_disk_list.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 echo -n $(lsblk | grep disk | awk '{print $1}' | tr '\n' ' ')
 exit 0

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/get_disk_temp.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/get_disk_temp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Author: @claudiux
 # Contributor (NVMe devices): @kriegcc
 

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/get_disk_temp_ORIG.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/get_disk_temp_ORIG.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 echo -n $(sudo smartctl -A /dev/$1 | grep 'Temperature_Cel' | awk '{print $10}')
 exit 0

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/install_symbola_on_Arch.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/install_symbola_on_Arch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 USRFONTSDIR="$HOME/.local/share/fonts"
 APPLETFONTSDIR="$HOME/.local/share/cinnamon/applets/Sensors@claudiux/fonts/Symbola"
 URLDOWNLOAD="https://raw.githubusercontent.com/claudiux/fonts/master/Symbola/Symbola.tar.gz"

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/is_hddtemp_usable_by_user.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/is_hddtemp_usable_by_user.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 HDDTEMP=/usr/sbin/hddtemp
 [ -f $HDDTEMP ] || exit 2

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/log_crit_value.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/log_crit_value.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 CATEGORY=$1
 SENSOR=$2
 SENSOR="${SENSOR//_/ }"

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/log_high_value.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/log_high_value.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 CATEGORY=$1
 SENSOR=$2
 SENSOR="${SENSOR//_/ }"

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/make_hddtemp_usable_by_user.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/make_hddtemp_usable_by_user.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 [[ $UID -eq 0 ]] || exit 1
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 RIGHTS=$(ls -l /usr/sbin/hddtemp | awk '{print $1}')

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/make_smartctl_usable_by_sudoers.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/make_smartctl_usable_by_sudoers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 [[ $UID -eq 0 ]] || exit 1
 
 GROUP=$1

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/pkexec_make_hddtemp_usable_by_user.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/pkexec_make_hddtemp_usable_by_user.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 /usr/bin/pkexec $SCRIPT_DIR/make_hddtemp_usable_by_user.sh
 

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/pkexec_make_smartctl_usable_by_sudoers.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/pkexec_make_smartctl_usable_by_sudoers.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 /usr/bin/pkexec $SCRIPT_DIR/make_smartctl_usable_by_sudoers.sh $1

--- a/Sensors@claudiux/files/Sensors@claudiux/scripts/show_sensor_values.sh
+++ b/Sensors@claudiux/files/Sensors@claudiux/scripts/show_sensor_values.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 export TEXTDOMAIN="Sensors@claudiux"
 export TEXTDOMAINDIR="${HOME}/.local/share/locale"
 ICON=$HOME/.local/share/cinnamon/applets/Sensors@claudiux/icon.png

--- a/SpiceSpy@claudiux/files/SpiceSpy@claudiux/scripts/get-issues.sh
+++ b/SpiceSpy@claudiux/files/SpiceSpy@claudiux/scripts/get-issues.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SPTYPE=$1
 SPUUID=$2
 PAGE="https://github.com/linuxmint/cinnamon-spices-${SPTYPE}/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+${SPUUID}";

--- a/SpiceSpy@claudiux/files/SpiceSpy@claudiux/scripts/get_issues_json.sh
+++ b/SpiceSpy@claudiux/files/SpiceSpy@claudiux/scripts/get_issues_json.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Doc:
 #   https://stackoverflow.com/questions/33374778/how-can-i-get-the-number-of-github-issues-using-the-github-api

--- a/SpiceSpy@claudiux/files/SpiceSpy@claudiux/scripts/spices-cache-init.sh
+++ b/SpiceSpy@claudiux/files/SpiceSpy@claudiux/scripts/spices-cache-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 UUID="SpiceSpy@claudiux"
 for type in action applet desklet extension theme; do {
         [[ -d ${HOME}/.cache/cinnamon/spices/${type} ]] || {

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/6.0/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/6.0/applet.js
@@ -258,7 +258,7 @@ class SpicesUpdate extends IconApplet {
 
     // To be sure that the scripts will be executable:
     spawnCommandLineAsync(
-      "/bin/bash -c 'cd %s && chmod 755 *.py *.sh'".format(SCRIPTS_DIR),
+      "/usr/bin/env bash -c 'cd %s && chmod 755 *.py *.sh'".format(SCRIPTS_DIR),
       null,
       null,
     );
@@ -550,12 +550,18 @@ class SpicesUpdate extends IconApplet {
       this.on_settings_changed();
     });
 
-    this.settings.bind("exp_applets", "exp_applets", null);
-    this.exp_applets = "%s\n%s\n%s".format(
-      EXP1["applets"],
-      EXP2["applets"],
-      EXP3,
-    );
+    //~ this.settings.bind("exp_applets", "exp_applets", null);
+    //~ this.exp_applets = "%s\n%s\n%s".format(
+      //~ EXP1["applets"],
+      //~ EXP2["applets"],
+      //~ EXP3,
+    //~ );
+
+    //~ this.settings.setValue("exp_applets", "%s\n%s\n%s".format(
+      //~ EXP1["applets"],
+      //~ EXP2["applets"],
+      //~ EXP3,
+    //~ ));
 
     this.settings.bind("unprotected_applets", "unprotected_applets", () => {
       this.populateSettingsUnprotectedApplets();
@@ -570,12 +576,17 @@ class SpicesUpdate extends IconApplet {
       this.on_settings_changed();
     });
 
-    this.settings.bind("exp_desklets", "exp_desklets", null);
-    this.exp_desklets = "%s\n%s\n%s".format(
-      EXP1["desklets"],
-      EXP2["desklets"],
-      EXP3,
-    );
+    //~ this.settings.bind("exp_desklets", "exp_desklets", null);
+    //~ this.exp_desklets = "%s\n%s\n%s".format(
+      //~ EXP1["desklets"],
+      //~ EXP2["desklets"],
+      //~ EXP3,
+    //~ );
+    //~ this.settings.setValue("exp_desklets", "%s\n%s\n%s".format(
+      //~ EXP1["desklets"],
+      //~ EXP2["desklets"],
+      //~ EXP3,
+    //~ ));
 
     this.settings.bind("unprotected_desklets", "unprotected_desklets", () => {
       this.populateSettingsUnprotectedDesklets();
@@ -590,12 +601,17 @@ class SpicesUpdate extends IconApplet {
       this.on_settings_changed();
     });
 
-    this.settings.bind("exp_extensions", "exp_extensions");
-    this.exp_extensions = "%s\n%s\n%s".format(
-      EXP1["extensions"],
-      EXP2["extensions"],
-      EXP3,
-    );
+    //~ this.settings.bind("exp_extensions", "exp_extensions");
+    //~ this.exp_extensions = "%s\n%s\n%s".format(
+      //~ EXP1["extensions"],
+      //~ EXP2["extensions"],
+      //~ EXP3,
+    //~ );
+    //~ this.settings.setValue("exp_extensions", "%s\n%s\n%s".format(
+      //~ EXP1["extensions"],
+      //~ EXP2["extensions"],
+      //~ EXP3,
+    //~ ));
 
     this.settings.bind(
       "unprotected_extensions",
@@ -614,12 +630,14 @@ class SpicesUpdate extends IconApplet {
       this.on_settings_changed();
     });
 
-    this.settings.bind("exp_themes", "exp_themes");
-    this.exp_themes = "%s\n%s\n%s".format(EXP1["themes"], EXP2["themes"], EXP3);
+    //~ this.settings.bind("exp_themes", "exp_themes");
+    //~ this.exp_themes = "%s\n%s\n%s".format(EXP1["themes"], EXP2["themes"], EXP3);
+    //~ this.settings.setValue("exp_themes", "%s\n%s\n%s".format(EXP1["themes"], EXP2["themes"], EXP3));
 
     this.settings.bind("unprotected_themes", "unprotected_themes", () => {
       this.populateSettingsUnprotectedThemes();
     });
+
 
     // Nemo actions
     this.settings.bind("check_actions", "check_actions", () => {
@@ -630,16 +648,29 @@ class SpicesUpdate extends IconApplet {
       this.on_settings_changed();
     });
 
-    this.settings.bind("exp_actions", "exp_actions");
-    this.exp_actions = "%s\n%s\n%s".format(
-      EXP1["actions"],
-      EXP2["actions"],
-      EXP3,
-    );
+    //~ this.settings.bind("exp_actions", "exp_actions");
+    //~ this.exp_actions = "%s\n%s\n%s".format(
+      //~ EXP1["actions"],
+      //~ EXP2["actions"],
+      //~ EXP3,
+    //~ );
+    //~ this.settings.setValue("exp_actions", "%s\n%s\n%s".format(
+      //~ EXP1["actions"],
+      //~ EXP2["actions"],
+      //~ EXP3,
+    //~ ));
 
     this.settings.bind("unprotected_actions", "unprotected_actions", () => {
       this.populateSettingsUnprotectedActions();
     });
+
+    for (let t of TYPES) {
+      this.settings.setValue(`exp_${t}`, "%s\n%s\n%s".format(
+      EXP1[t],
+      EXP2[t],
+      EXP3,
+    ));
+    }
   } // End of get_SU_settings
 
   /**
@@ -1557,9 +1588,9 @@ class SpicesUpdate extends IconApplet {
           spawnCommandLineAsync(terminal);
           // TRANSLATORS: The next messages should not be translated.
           //~ if (_isDebian === true) {
-          //~ spawnCommandLineAsync(terminal + " " + term_sep + " " + " '/bin/bash -c \"echo Spices Update message: Some packages needed!; echo To complete the installation, please become root with su then execute the command: ; echo "+ _apt_update + _and + _apt_install + "; sleep 1; exec bash\"'", null, null);
+          //~ spawnCommandLineAsync(terminal + " " + term_sep + " " + " '/usr/bin/env bash -c \"echo Spices Update message: Some packages needed!; echo To complete the installation, please become root with su then execute the command: ; echo "+ _apt_update + _and + _apt_install + "; sleep 1; exec bash\"'", null, null);
           //~ } else {
-          //~ spawnCommandLineAsync(terminal + " " + term_sep + " " + `'/bin/bash -c \"echo Spices Update message: Some packages needed!; echo To complete the installation, please enter and execute the command: ; echo ${_apt_update} ${_and} ${_apt_install}; sleep 1; exec bash\"'`, null, null);
+          //~ spawnCommandLineAsync(terminal + " " + term_sep + " " + `'/usr/bin/env bash -c \"echo Spices Update message: Some packages needed!; echo To complete the installation, please enter and execute the command: ; echo ${_apt_update} ${_and} ${_apt_install}; sleep 1; exec bash\"'`, null, null);
           //~ }
         }
       } else {

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/generate_mo.sh
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/generate_mo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Create .mo files (or replace older .mo files) into the right directories, from the .po existing files.
 UUID="SpicesUpdate@claudiux"

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/install_symbola_on_Arch.sh
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/install_symbola_on_Arch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 USRFONTSDIR="$HOME/.local/share/fonts"
 APPLETFONTSDIR="$HOME/.local/share/cinnamon/applets/SpicesUpdate@claudiux/fonts/Symbola"
 URLDOWNLOAD="https://raw.githubusercontent.com/claudiux/fonts/master/Symbola/Symbola.tar.gz"

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/move_themes.sh
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/move_themes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #####
 # Moves themes to their new location,
 # creating symbolic links to avoid any crash.
@@ -13,9 +13,9 @@ OLDDIR=$HOME/.themes
 cd $OLDDIR
 for f in $(ls -1A); do {
         [[ -d $f && ! -L $f ]] && {
-				[[ -L $NEWDIR/$f ]] && rm -f $NEWDIR/$f
-				mv $f $NEWDIR/
-				ln -s $NEWDIR/$f
+                                [[ -L $NEWDIR/$f ]] && rm -f $NEWDIR/$f
+                                mv $f $NEWDIR/
+                                ln -s $NEWDIR/$f
         }
 }; done
 

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/thumb-downloader.sh
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/thumb-downloader.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 THUMB=$1
 TYPE=$2
 DEST=$HOME/.cache/cinnamon/spices/$TYPE/

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/witness-debian.sh
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/scripts/witness-debian.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 ret=$(hostnamectl | grep System | sed "s/: /%/" | cut -d'%' -f2 | cut -d' ' -f1)
 if [ "$ret" = "Debian" ]; then
     touch /tmp/DEBIAN;

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/lib/activityLogging.js
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/lib/activityLogging.js
@@ -8,18 +8,18 @@ const NAME = "VPN-Sentinel";
 const UUID = NAME + "@claudiux";
 const HOME_DIR = GLib.get_home_dir();
 const LOG_DIR = HOME_DIR + "/.config/" + NAME;
-GLib.spawn_command_line_async("bash -c 'mkdir -p "+ LOG_DIR +"'");
+GLib.spawn_command_line_async("/usr/bin/env bash -c 'mkdir -p "+ LOG_DIR +"'");
 const OLD_LOG_FILE_PATH = HOME_DIR + "/.cinnamon/configs/" + UUID + "/vpn_activity.log";
 const LOG_FILE_PATH = LOG_DIR + "/vpn_activity.log";
 if (GLib.file_test(OLD_LOG_FILE_PATH, GLib.FileTest.EXISTS))
-  GLib.spawn_command_line_async("bash -c 'mv -u " + OLD_LOG_FILE_PATH + " " + LOG_FILE_PATH +"'");
+  GLib.spawn_command_line_async("/usr/bin/env bash -c 'mv -u " + OLD_LOG_FILE_PATH + " " + LOG_FILE_PATH +"'");
 
 class ActivityLogging {
   constructor(metadata, nbdays=30, active=true) {
     this.metadata = metadata;
     this.user_language = this._get_user_language;
     //this.uuid = metadata.uuid;
-    GLib.spawn_command_line_async("bash -c 'touch "+ LOG_FILE_PATH +"'");
+    GLib.spawn_command_line_async("/usr/bin/env bash -c 'touch "+ LOG_FILE_PATH +"'");
     this.time_options = {
       year: "numeric", month: "numeric", day: "numeric",
       hour: "numeric", minute: "numeric", second: "numeric",
@@ -109,7 +109,7 @@ class ActivityLogging {
   } // End of truncate_log_file
 
   display_logs() {
-    let command = `bash -c '%s/scripts/watch-log2.sh'`.format(this.metadata.path);
+    let command = `/usr/bin/env bash -c '%s/scripts/watch-log2.sh'`.format(this.metadata.path);
     GLib.spawn_command_line_async(command);
   } // End of display_logs
 
@@ -151,7 +151,7 @@ class ActivityLogging {
       LOG_FILE_PATH
     );
 
-    GLib.spawn_command_line_async(`bash -c '%s'`.format(command));
+    GLib.spawn_command_line_async(`/usr/bin/env bash -c '%s'`.format(command));
 
     return this.is_active
   } // End of treat_waiting_messages

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/lib/checkDependencies.js
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/lib/checkDependencies.js
@@ -332,7 +332,7 @@ Dependencies.prototype = {
       this.alertNotif = criticalNotify(_("Some dependencies are not installed!"), criticalMessage, icon);
 
       if (_is_pkcon_present && _is_pkexec_present) {
-        GLib.spawn_command_line_async(terminal + " -e 'sh -c \"echo VPN-Sentinel message: Some packages needed!; echo List of needed packages: %s; pkexec pkcon -y install %s\"'".format(_pkg_to_install.join(", "), _pkg_to_install.join(" ")));
+        GLib.spawn_command_line_async(terminal + " -e '/usr/bin/env sh -c \"echo VPN-Sentinel message: Some packages needed!; echo List of needed packages: %s; pkexec pkcon -y install %s\"'".format(_pkg_to_install.join(", "), _pkg_to_install.join(" ")));
         this.depAreMet = false;
         return
       }
@@ -341,9 +341,9 @@ Dependencies.prototype = {
         if (terminal != "") {
           // TRANSLATORS: The next messages should not be translated.
           if (_isDebian === true) {
-            GLib.spawn_command_line_async(terminal + " -e 'sh -c \"echo VPN-Sentinel message: Some packages needed!; echo To complete the installation, please become root with su then execute the command: ; echo "+ _apt_update + _and + _apt_install + "; sleep 1; exec bash\"'");
+            GLib.spawn_command_line_async(terminal + " -e '/usr/bin/env sh -c \"echo VPN-Sentinel message: Some packages needed!; echo To complete the installation, please become root with su then execute the command: ; echo "+ _apt_update + _and + _apt_install + "; sleep 1; exec bash\"'");
           } else {
-            GLib.spawn_command_line_async(terminal + " -e 'sh -c \"echo VPN-Sentinel message: Some packages needed!; echo To complete the installation, please enter and execute the command: ; echo "+ _apt_update + _and + _apt_install + "; sleep 1; exec bash\"'");
+            GLib.spawn_command_line_async(terminal + " -e '/usr/bin/env sh -c \"echo VPN-Sentinel message: Some packages needed!; echo To complete the installation, please enter and execute the command: ; echo "+ _apt_update + _and + _apt_install + "; sleep 1; exec bash\"'");
           }
         }
       } else {

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/po/makepot
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/po/makepot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 UUID="VPN-Sentinel@claudiux"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/apply-bypass-list.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/apply-bypass-list.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NAME="VPN-Sentinel"
 UUID="VPN-Sentinel@claudiux"
@@ -18,7 +18,7 @@ domains=$(cat ${DOMAINS_FILE})
 gatewayIP=$(echo -n $(ip route | grep default | awk '{print $3}'))
 interface=$(echo -n $(nmcli -t -g TYPE,DEVICE,NAME connection show | grep -E "ethernet|wireless" | awk -F":" '{print $3}' | tr "\n" "|" | awk -F"|" '{print $1}'))
 
-echo '#!/bin/bash' > ${RESET_FILE}
+echo '#!/usr/bin/env bash' > ${RESET_FILE}
 
 for d in $domains; do {
     #for anip in $(host -c IN $d | awk '{print $4}' | tr "\n" " "); do {

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/generate_mo.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/generate_mo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Create .mo files (or replace older .mo files) into the right directories, from the .po existing files.
 UUID="VPN-Sentinel@claudiux"

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/getTZ.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/getTZ.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo $(timedatectl | grep Time | sed s/^\ *//g |awk '{print $3}')
 exit 0

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/kill_all_pids_of.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/kill_all_pids_of.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 PROGRAM=$(echo -n $(basename $1))
 PROGRAM=${PROGRAM:0:15}
 #sleep 1

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/reload_ext.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/reload_ext.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Reload an applet.
 # Many thanks to hyOzd for this tip !
 # replace the EXTENSION_UUID with your extension/applet/desklet name

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/start_client.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/start_client.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 CLIENT=$1
 if [ "$CLIENT" = "" ]; then {

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/stop_client.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/stop_client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 CLIENT=$1
 if [ "$CLIENT" = "" ]; then {

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/vpn_iface_detect.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/vpn_iface_detect.sh
@@ -1,15 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 VPN_IFACE=""
 ret=1
 for iface in $(ls -1 /sys/class/net/); do
-	# Check if interface is a VPN
-	if [ -f "/sys/class/net/$iface/tun_flags" ]; then
-		VPN_IFACE=$iface
-		echo -n $VPN_IFACE
-		echo -n $VPN_IFACE > /tmp/.vpn_iface
-		ret=0
-	fi
+    # Check if interface is a VPN
+    if [ -f "/sys/class/net/$iface/tun_flags" ]; then
+        VPN_IFACE=$iface
+        echo -n $VPN_IFACE
+        echo -n $VPN_IFACE > /tmp/.vpn_iface
+        ret=0
+    fi
 done
 
 exit $ret

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/vpn_names.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/vpn_names.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Get all the names of the VPN connection
 # Return a list of items separated by ;
 ret=$(nmcli -t -f NAME,TYPE connection show | egrep "vpn|wireguard" | sed -e "s/:.*$//" | tr "\n" ";" | sed s/";$"/""/)

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/vpn_status.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/vpn_status.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # This script verifies if vpn interface is connected and writes state ("on" or "off") to temporary files
 # which can be read by the VPNstatus applet

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/vpn_status_sentinel.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/vpn_status_sentinel.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Example of return:
 #vpn:enp2s0:30c15256-2838-4aa0-888e-4544f4d7cbff:yes:1658929072:Czech_Republic-Prague (IPv6);wireguard:Es-Madrid(W):6711baa7-4137-477d-856c-a2cd5736812d:no:1658929090:Es-Madrid(W)

--- a/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/watch-log2.sh
+++ b/VPN-Sentinel@claudiux/files/VPN-Sentinel@claudiux/scripts/watch-log2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Source : https://sourceforge.net/p/yad-dialog/wiki/LogViewer/
 
@@ -27,8 +27,8 @@ OFS="\n" {print $1, $2, $3, font, color; fflush()}'
 
 tail --lines=+1 -f $LOGFILE | awk -F"|" "$PARSER" | \
 yad --title="$TITLE" --window-icon="$ICON" \
-    --button=gtk-delete:"/bin/bash -c 'rm -f $LOGFILE; touch $LOGFILE; $0 $THISPID &'" \
-    --button=gtk-refresh:"/bin/bash -c '$0 $THISPID &'" --button=gtk-close:"/usr/bin/pkill -P $THISPID" --kill-parent=15 --width 900 --height 900 \
+    --button=gtk-delete:"/usr/bin/env bash -c 'rm -f $LOGFILE; touch $LOGFILE; $0 $THISPID &'" \
+    --button=gtk-refresh:"/usr/bin/env bash -c '$0 $THISPID &'" --button=gtk-close:"/usr/bin/pkill -P $THISPID" --kill-parent=15 --width 900 --height 900 \
     --list --text="$LOGFILE" --grid-lines=hor \
     --column "$(gettext -d timeshift 'Timestamp')":HD --column "$(gettext -d cinnamon 'Date and Time')" --column "$(gettext -d cinnamon 'Message')" \
     --column @font@ --column @back@ \

--- a/brightness-and-gamma-applet@cardsurf/files/brightness-and-gamma-applet@cardsurf/6.4/lib/shellUtils.js
+++ b/brightness-and-gamma-applet@cardsurf/files/brightness-and-gamma-applet@cardsurf/6.4/lib/shellUtils.js
@@ -460,7 +460,7 @@ class TerminalProcess {
     }
 
     get_full_bash_command() {
-        let start_bash = "bash -c \"";
+        let start_bash = "/usr/bin/env bash -c \"";
         let write_terminal_pid = "echo $$ > " + this.tmp_filepath + ";"
         let exec_user_command = this._bash_command;
         let keep_terminal_opened = "exec bash\"";

--- a/brightness-and-gamma-applet@cardsurf/files/brightness-and-gamma-applet@cardsurf/6.4/scripts/number-of-monitors.sh
+++ b/brightness-and-gamma-applet@cardsurf/files/brightness-and-gamma-applet@cardsurf/6.4/scripts/number-of-monitors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 nbmon=$(xrandr --query | grep connected | grep -v disconnected | wc -l)
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/6.4/applet.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/6.4/applet.js
@@ -116,7 +116,7 @@ class MCSM extends Applet.TextIconApplet {
         this.metadata = metadata;
         this.instance_id = instance_id;
 
-        Util.spawnCommandLineAsync("bash -c 'cd %s && chmod 755 *.sh'".format(PATH2SCRIPTS));
+        Util.spawnCommandLineAsync("/usr/bin/env bash -c 'cd %s && chmod 755 *.sh'".format(PATH2SCRIPTS));
 
         if (St.Widget.get_default_direction() === St.TextDirection.RTL) {
             this._applet_tooltip._tooltip.set_style('text-align: right; font-family: monospace;');

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-all-data.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-all-data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #~ sleepDurationSeconds=$1
 sleepDurationSeconds=1

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo -n $(cat /proc/cpuinfo | grep -E "MHz|bogomips")
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data2.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo -n $(grep 'cpu' /proc/stat | sed -n '2~1p' | sed s/cpu//g | awk '{cpu_usage=($2+$4)/($2+$4+$5)} {print cpu_usage}' FS=' ' OFS=' ')
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data3 (copie).sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data3 (copie).sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #~ sleepDurationSeconds=$1
 sleepDurationSeconds=1

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data3.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-cpu-data3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #~ sleepDurationSeconds=$1
 sleepDurationSeconds=1

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-disk-info.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-disk-info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #~ echo -n $(lsblk -A -b -f -t -J)
 echo -n $(lsblk -A -b -O -J)

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-mem-data.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-mem-data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo -n $(free -b -w)
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-network-data.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-network-data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 data=""
 for i in $(ls /sys/class/net); do {
         status=$(cat /sys/class/net/$i/operstate)

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-network-devices.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-network-devices.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 data=""
 for i in $(ls /sys/class/net); do {
         status=$(cat /sys/class/net/$i/operstate)

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-sudoers.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-sudoers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ###
 # Returns the comma-separated list of sudoers.
 ###

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-swap.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/scripts/get-swap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ###
 # Get swap usage
 ###

--- a/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
@@ -109,11 +109,11 @@ const IS_OSD150_INSTALLED = () => {
 }
 
 function run_playerctld() {
-    Util.spawnCommandLineAsync("bash -C '" + PATH2SCRIPTS + "/run_playerctld.sh'");
+    Util.spawnCommandLineAsync("/usr/bin/env bash -C '" + PATH2SCRIPTS + "/run_playerctld.sh'");
 }
 
 function kill_playerctld() {
-    Util.spawnCommandLineAsync("bash -C '" + PATH2SCRIPTS + "/kill_playerctld.sh'");
+    Util.spawnCommandLineAsync("/usr/bin/env bash -C '" + PATH2SCRIPTS + "/kill_playerctld.sh'");
 }
 
 //~ function getImageAtScale(imageFileName, width, height) {
@@ -220,10 +220,10 @@ class Sound150Applet extends Applet.TextIconApplet {
     constructor(metadata, orientation, panel_height, instanceId) {
         super(orientation, panel_height, instanceId);
 
-        Util.spawnCommandLineAsync("bash -c 'cd %s && chmod 755 *.sh'".format(PATH2SCRIPTS));
-        Util.spawnCommandLineAsync("bash -c '[[ -d %s ]] || mkdir -p %s'".format(ALBUMART_PICS_DIR, ALBUMART_PICS_DIR));
-        Util.spawnCommandLineAsync("bash -c '[[ -d %s ]] || mkdir -p %s'".format(ICONDIR, ICONDIR));
-        Util.spawnCommandLineAsync("bash -C '" + PATH2SCRIPTS + "/rm_tmp_files.sh'");
+        Util.spawnCommandLineAsync("/usr/bin/env bash -c 'cd %s && chmod 755 *.sh'".format(PATH2SCRIPTS));
+        Util.spawnCommandLineAsync("/usr/bin/env bash -c '[[ -d %s ]] || mkdir -p %s'".format(ALBUMART_PICS_DIR, ALBUMART_PICS_DIR));
+        Util.spawnCommandLineAsync("/usr/bin/env bash -c '[[ -d %s ]] || mkdir -p %s'".format(ICONDIR, ICONDIR));
+        Util.spawnCommandLineAsync("/usr/bin/env bash -C '" + PATH2SCRIPTS + "/rm_tmp_files.sh'");
 
         this.orientation = orientation;
         this.isHorizontal = !(this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT);
@@ -1276,7 +1276,7 @@ class Sound150Applet extends Applet.TextIconApplet {
 
         if (!GLib.file_test(MPV_RADIO_PID, GLib.FileTest.EXISTS)) { // Radio3.0 is not running.
             //~ logDebug("on_applet_removed_from_panel(): Radio3.0 is not running.");
-            Util.spawnCommandLineAsync("bash -c 'rm -f %s/R3SongArt*'".format(ALBUMART_PICS_DIR));
+            Util.spawnCommandLineAsync("/usr/bin/env bash -c 'rm -f %s/R3SongArt*'".format(ALBUMART_PICS_DIR));
         }
     }
 
@@ -1708,7 +1708,7 @@ class Sound150Applet extends Applet.TextIconApplet {
         if (!this._artLooping) return;
 
         if (this._playerctl && this._imagemagick && this.is_empty(ALBUMART_PICS_DIR))
-            Util.spawnCommandLineAsync("bash -c %s/get_album_art.sh".format(PATH2SCRIPTS));
+            Util.spawnCommandLineAsync("/usr/bin/env bash -c %s/get_album_art.sh".format(PATH2SCRIPTS));
 
         if (!this._playerctl || this.title_text_old == this.title_text) {
             this._loopArtId = timeout_add_seconds(10, () => {
@@ -1717,7 +1717,7 @@ class Sound150Applet extends Applet.TextIconApplet {
             return
         }
 
-        let subProcess = Util.spawnCommandLineAsyncIO("bash -c %s/get_album_art.sh".format(PATH2SCRIPTS), (stdout, stderr, exitCode) => {
+        let subProcess = Util.spawnCommandLineAsyncIO("/usr/bin/env bash -c %s/get_album_art.sh".format(PATH2SCRIPTS), (stdout, stderr, exitCode) => {
             if (exitCode === 0) {
                 this._trackCoverFile = "file://" + stdout;
                 let cover_path = decodeURIComponent(this._trackCoverFile);
@@ -1777,7 +1777,7 @@ class Sound150Applet extends Applet.TextIconApplet {
                 this.setIcon(path, "player-path");
                 //~ if (!path.startsWith(ALBUMART_PICS_DIR)) {
                     //~ let target = ALBUMART_PICS_DIR + "/R3SongArt" + randomIntegerInInterval(0, superRND).toString()
-                    //~ Util.spawnCommandLineAsync(`bash -c "rm -f ${ALBUMART_PICS_DIR}/R3SongArt* ; sleep 1 ; cp -a ${path} ${target}"`);
+                    //~ Util.spawnCommandLineAsync(`/usr/bin/env bash -c "rm -f ${ALBUMART_PICS_DIR}/R3SongArt* ; sleep 1 ; cp -a ${path} ${target}"`);
                 //~ }
             } else {
                 if (this.showMicMutedOnIcon && (!this.mute_in_switch || this.mute_in_switch.state))
@@ -2081,12 +2081,12 @@ class Sound150Applet extends Applet.TextIconApplet {
         if (this._playerctl === null) {
             //~ let _install_playerctl_button = new PopupMenu.PopupIconMenuItem(_("Install playerctl"), "system-software-install", St.IconType.SYMBOLIC);
             let _install_playerctl_button = this.menu.addAction(_("Install playerctl"), () => {
-                Util.spawnCommandLineAsync("bash -C '%s/install_playerctl.sh'".format(PATH2SCRIPTS));
+                Util.spawnCommandLineAsync("/usr/bin/env bash -C '%s/install_playerctl.sh'".format(PATH2SCRIPTS));
             });
         }
         if (!this._imagemagick) {
             let _install_imagemagick_button = this.menu.addAction(_("Install imagemagick"), () => {
-                Util.spawnCommandLineAsync("bash -C '%s/install_imagemagick.sh'".format(PATH2SCRIPTS));
+                Util.spawnCommandLineAsync("/usr/bin/env bash -C '%s/install_imagemagick.sh'".format(PATH2SCRIPTS));
             });
         }
     }

--- a/sound150@claudiux/files/sound150@claudiux/6.4/lib/s150PopupMenu.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/lib/s150PopupMenu.js
@@ -50,11 +50,11 @@ const COVERBOX_LAYOUT_MANAGER = new Clutter.BinLayout({
 
 // playerctld:
 function run_playerctld() {
-    Util.spawnCommandLineAsync("bash -C '" + PATH2SCRIPTS + "/run_playerctld.sh'");
+    Util.spawnCommandLineAsync("/usr/bin/env bash -C '" + PATH2SCRIPTS + "/run_playerctld.sh'");
 }
 
 function kill_playerctld() {
-    Util.spawnCommandLineAsync("bash -C '" + PATH2SCRIPTS + "/kill_playerctld.sh'");
+    Util.spawnCommandLineAsync("/usr/bin/env bash -C '" + PATH2SCRIPTS + "/kill_playerctld.sh'");
 }
 
 
@@ -352,7 +352,7 @@ class Player extends PopupMenu.PopupMenuSection {
         this._prevButton = new ControlButton("media-skip-backward",
             _("Previous"),
             () => {
-                //~ Util.spawnCommandLine("bash -c '%s'".format(DEL_SONG_ARTS_SCRIPT));
+                //~ Util.spawnCommandLine("/usr/bin/env bash -c '%s'".format(DEL_SONG_ARTS_SCRIPT));
 
                 if (this._seeker) {
                     if (this._seeker.status === "Playing" && this._seeker.posLabel) this._seeker.posLabel.set_text(" 00:00 ");
@@ -374,7 +374,7 @@ class Player extends PopupMenu.PopupMenuSection {
         this._stopButton = new ControlButton("media-playback-stop",
             _("Stop"),
             () => {
-                //~ Util.spawnCommandLine("bash -c '%s'".format(DEL_SONG_ARTS_SCRIPT));
+                //~ Util.spawnCommandLine("/usr/bin/env bash -c '%s'".format(DEL_SONG_ARTS_SCRIPT));
 
                 if (this._name.toLowerCase() === "mpv" &&
                     GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
@@ -387,7 +387,7 @@ class Player extends PopupMenu.PopupMenuSection {
         this._nextButton = new ControlButton("media-skip-forward",
             _("Next"),
             () => {
-                //~ Util.spawnCommandLine("bash -c '%s'".format(DEL_SONG_ARTS_SCRIPT));
+                //~ Util.spawnCommandLine("/usr/bin/env bash -c '%s'".format(DEL_SONG_ARTS_SCRIPT));
 
                 if (this._name.toLowerCase() === "mpv" &&
                     GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
@@ -644,7 +644,7 @@ class Player extends PopupMenu.PopupMenuSection {
 
         if (old_title != this._title) {
             del_song_arts();
-            Util.spawnCommandLineAsync("bash -c %s/get_album_art.sh".format(PATH2SCRIPTS));
+            Util.spawnCommandLineAsync("/usr/bin/env bash -c %s/get_album_art.sh".format(PATH2SCRIPTS));
         }
 
         this.titleLabel.set_text(this._title);
@@ -658,11 +658,11 @@ class Player extends PopupMenu.PopupMenuSection {
                     this._trackCoverFile = artUrl;
                     change = true;
                 }
-                Util.spawnCommandLineAsync("bash -c %s/get_album_art.sh".format(PATH2SCRIPTS));
+                Util.spawnCommandLineAsync("/usr/bin/env bash -c %s/get_album_art.sh".format(PATH2SCRIPTS));
             }
         } else if (metadata["xesam:url"]) {
             if (this._oldTitle != this._title) {
-                Util.spawnCommandLineAsyncIO("bash -c %s/get_album_art.sh".format(PATH2SCRIPTS), (stdout, stderr, exitCode) => {
+                Util.spawnCommandLineAsyncIO("/usr/bin/env bash -c %s/get_album_art.sh".format(PATH2SCRIPTS), (stdout, stderr, exitCode) => {
                     if (exitCode === 0) {
                         this._trackCoverFile = "file://" + stdout;
                         if (this._oldTrackCoverFile != this._trackCoverFile) {
@@ -692,7 +692,7 @@ class Player extends PopupMenu.PopupMenuSection {
                 });
             }
         } else {
-            Util.spawnCommandLineAsync("bash -c %s/get_album_art.sh".format(PATH2SCRIPTS));
+            Util.spawnCommandLineAsync("/usr/bin/env bash -c %s/get_album_art.sh".format(PATH2SCRIPTS));
             if (this._trackCoverFile != false) {
                 this._trackCoverFile = false;
                 change = true;

--- a/sound150@claudiux/files/sound150@claudiux/scripts/del_song_arts.sh
+++ b/sound150@claudiux/files/sound150@claudiux/scripts/del_song_arts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DIRART=${XDG_RUNTIME_DIR}/AlbumArt/song-art
 [[ -d $DIRART ]] && rm -f ${DIRART}/R3SongArt*
 

--- a/sound150@claudiux/files/sound150@claudiux/scripts/generate_mo.sh
+++ b/sound150@claudiux/files/sound150@claudiux/scripts/generate_mo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Create .mo files (or replace older .mo files) into the right directories, from the .po existing files.
 #

--- a/sound150@claudiux/files/sound150@claudiux/scripts/get_album_art.sh
+++ b/sound150@claudiux/files/sound150@claudiux/scripts/get_album_art.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DEBUG=false
 #~ DEBUG=true
 

--- a/sound150@claudiux/files/sound150@claudiux/scripts/install_imagemagick.sh
+++ b/sound150@claudiux/files/sound150@claudiux/scripts/install_imagemagick.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ### Installs playerctl with password dialog:
 pkexec pkcon -y install imagemagick
 ### Pause 1 second:

--- a/sound150@claudiux/files/sound150@claudiux/scripts/install_playerctl.sh
+++ b/sound150@claudiux/files/sound150@claudiux/scripts/install_playerctl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ### Installs playerctl with password dialog:
 pkexec pkcon -y install playerctl
 ### Pause 1 second:

--- a/sound150@claudiux/files/sound150@claudiux/scripts/kill_playerctld.sh
+++ b/sound150@claudiux/files/sound150@claudiux/scripts/kill_playerctld.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 PCDPID=$(pidof playerctld)
 PCDPATH=$(which playerctld)
 

--- a/sound150@claudiux/files/sound150@claudiux/scripts/make_icon.sh
+++ b/sound150@claudiux/files/sound150@claudiux/scripts/make_icon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 path=$1
 [[ -z $path ]] && exit 1
 bn=$(basename $path)

--- a/sound150@claudiux/files/sound150@claudiux/scripts/rm_tmp_files.sh
+++ b/sound150@claudiux/files/sound150@claudiux/scripts/rm_tmp_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ### Removes cover art files.
 
 rm -f /tmp/*.mediaplayer-cover

--- a/sound150@claudiux/files/sound150@claudiux/scripts/run_playerctld.sh
+++ b/sound150@claudiux/files/sound150@claudiux/scripts/run_playerctld.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 PCDPID=$(pidof playerctld)
 PCDPATH=$(which playerctld)
 

--- a/xsession@claudiux/files/xsession@claudiux/applet.js
+++ b/xsession@claudiux/files/xsession@claudiux/applet.js
@@ -320,7 +320,7 @@ class LGS extends Applet.IconApplet {
             () => {
                 let id = setTimeout( () => {
                     clearTimeout(id);
-                    Util.spawnCommandLineAsync("bash -c '"+WATCHXSE_SCRIPT+"'");
+                    Util.spawnCommandLineAsync("/usr/bin/env bash -c '"+WATCHXSE_SCRIPT+"'");
                 },
                 300);
             }
@@ -334,7 +334,7 @@ class LGS extends Applet.IconApplet {
             () => {
                 let id = setTimeout( () => {
                     clearTimeout(id);
-                    Util.spawnCommandLineAsync("bash -c '"+WATCHXSE_LATEST_SCRIPT+ " " + this.number_latest +"'");
+                    Util.spawnCommandLineAsync("/usr/bin/env bash -c '"+WATCHXSE_LATEST_SCRIPT+ " " + this.number_latest +"'");
                 },
                 300);
             }
@@ -471,7 +471,7 @@ class LGS extends Applet.IconApplet {
         sectionSettings.addMenuItem(subMenuSettingsApplets);
 
         for (let applet of this.get_active_spices("applets")) {
-            let s = new LGSMenuItem(this, "applets", applet, () => {Util.spawnCommandLineAsync(`bash -c "cinnamon-settings applets ${applet}"`)}, null);
+            let s = new LGSMenuItem(this, "applets", applet, () => {Util.spawnCommandLineAsync(`/usr/bin/env bash -c "cinnamon-settings applets ${applet}"`)}, null);
             subMenuSettingsApplets.menu.addMenuItem(s);
         }
 
@@ -480,7 +480,7 @@ class LGS extends Applet.IconApplet {
         sectionSettings.addMenuItem(subMenuSettingsDesklets);
 
         for (let desklet of this.get_active_spices("desklets")) {
-            let s = new LGSMenuItem(this, "desklets", desklet, () => {Util.spawnCommandLineAsync(`bash -c "cinnamon-settings desklets ${desklet}"`)}, null);
+            let s = new LGSMenuItem(this, "desklets", desklet, () => {Util.spawnCommandLineAsync(`/usr/bin/env bash -c "cinnamon-settings desklets ${desklet}"`)}, null);
             subMenuSettingsDesklets.menu.addMenuItem(s);
         }
 
@@ -489,7 +489,7 @@ class LGS extends Applet.IconApplet {
         sectionSettings.addMenuItem(subMenuSettingsExtensions);
 
         for (let extension of this.get_active_spices("extensions")) {
-            let s = new LGSMenuItem(this, "extensions", extension, () => {Util.spawnCommandLineAsync(`bash -c "cinnamon-settings extensions ${extension}"`)}, null);
+            let s = new LGSMenuItem(this, "extensions", extension, () => {Util.spawnCommandLineAsync(`/usr/bin/env bash -c "cinnamon-settings extensions ${extension}"`)}, null);
             subMenuSettingsExtensions.menu.addMenuItem(s);
         }
 
@@ -504,7 +504,7 @@ class LGS extends Applet.IconApplet {
         sectionSource.addMenuItem(subMenuCodeApplets);
 
         for (let applet of this.get_active_spices("applets")) {
-            let s = new LGSMenuItem(this, "applets", applet, () => {Util.spawnCommandLineAsync(`bash -c "xdg-open ${SPICES_DIR}/applets/${applet}/ "`)}, null);
+            let s = new LGSMenuItem(this, "applets", applet, () => {Util.spawnCommandLineAsync(`/usr/bin/env bash -c "xdg-open ${SPICES_DIR}/applets/${applet}/ "`)}, null);
             subMenuCodeApplets.menu.addMenuItem(s);
         }
 
@@ -513,7 +513,7 @@ class LGS extends Applet.IconApplet {
         sectionSource.addMenuItem(subMenuCodeDesklets);
 
         for (let desklet of this.get_active_spices("desklets")) {
-            let s = new LGSMenuItem(this, "desklets", desklet, () => {Util.spawnCommandLineAsync(`bash -c "xdg-open ${SPICES_DIR}/desklets/${desklet}/ "`)}, null);
+            let s = new LGSMenuItem(this, "desklets", desklet, () => {Util.spawnCommandLineAsync(`/usr/bin/env bash -c "xdg-open ${SPICES_DIR}/desklets/${desklet}/ "`)}, null);
             subMenuCodeDesklets.menu.addMenuItem(s);
         }
 
@@ -522,7 +522,7 @@ class LGS extends Applet.IconApplet {
         sectionSource.addMenuItem(subMenuCodeExtensions);
 
         for (let extension of this.get_active_spices("extensions")) {
-            let s = new LGSMenuItem(this, "extensions", extension, () => {Util.spawnCommandLineAsync(`bash -c "xdg-open ${SPICES_DIR}/extensions/${extension}/ "`)}, null);
+            let s = new LGSMenuItem(this, "extensions", extension, () => {Util.spawnCommandLineAsync(`/usr/bin/env bash -c "xdg-open ${SPICES_DIR}/extensions/${extension}/ "`)}, null);
             subMenuCodeExtensions.menu.addMenuItem(s);
         }
 
@@ -548,9 +548,9 @@ class LGS extends Applet.IconApplet {
         let id = setTimeout( () => {
             clearTimeout(id);
             if (shiftPressed || ctrlPressed) {
-                Util.spawnCommandLineAsync("bash -c '"+WATCHXSE_LATEST_SCRIPT+ " " + this.number_latest +"'");
+                Util.spawnCommandLineAsync("/usr/bin/env bash -c '"+WATCHXSE_LATEST_SCRIPT+ " " + this.number_latest +"'");
             } else {
-                Util.spawnCommandLineAsync("bash -c '"+WATCHXSE_SCRIPT+"'");
+                Util.spawnCommandLineAsync("/usr/bin/env bash -c '"+WATCHXSE_SCRIPT+"'");
             }
         },
         300);

--- a/xsession@claudiux/files/xsession@claudiux/po/makepot
+++ b/xsession@claudiux/files/xsession@claudiux/po/makepot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 UUID="xsession@claudiux"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/xsession@claudiux/files/xsession@claudiux/scripts/watch-xse-latest.sh
+++ b/xsession@claudiux/files/xsession@claudiux/scripts/watch-xse-latest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 NBLINES=$1
 [[ -z $NBLINES ]] && NBLINES=50
 LOGFILE=$HOME/.xsession-errors

--- a/xsession@claudiux/files/xsession@claudiux/scripts/watch-xse.sh
+++ b/xsession@claudiux/files/xsession@claudiux/scripts/watch-xse.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 LOGFILE=$HOME/.xsession-errors
 APPLET="xsession@claudiux"
 ICON=$HOME/.local/share/cinnamon/applets/$APPLET/icons/face-glasses-symbolic.svg


### PR DESCRIPTION
Also replacing `/bin/sh` with `/usr/bin/env sh`.
Fixes #7506.
Avoids many errors of the same type.