### PR TITLE
bluetooth-battery@zamszowy: don't trim spaces from the override device name

### DIFF
--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
@@ -140,7 +140,7 @@ BtBattery.prototype = {
         }
 
         Util.spawn_async(args, Lang.bind(this, function(stdout) {
-            const trimmed_out = stdout.trim();
+            const trimmed_out = stdout.replace(/\n/g, '');
 
             if (trimmed_out != "") {
                 this.override_entry = trimmed_out;


### PR DESCRIPTION
There are bluetooth devices which have spaces in their names (e.g. "Some Device "). While the full name with spaces was saved internally, selecting such device as an override device would remove those spaces and there would be no match - device would not be displayed.

Fix this by removing only new line characters from the name, which was the intent for the trim anyway.