### PR TITLE
updates-notifier@zamszowy: fix reporting updates when there are none

### DIFF
--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
@@ -1,5 +1,6 @@
 {
     "uuid": "updates-notifier@zamszowy",
     "name": "Updates notifier",
-    "description": "Shows icons for pending update packages"
+    "description": "Shows icons for pending update packages",
+    "version": "1.0.1"
 }

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/updates.sh
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/updates.sh
@@ -7,15 +7,19 @@ readonly DIR
 
 case "$1" in
 check)
-    pkcon get-updates | awk '/^Results:/{flag=1; next} flag && NF' &> "$DIR"/updates
-    wc -l <"$DIR"/updates
+    if out=$(pkcon get-updates --plain 2>&1); then
+        awk '/^Results:/{flag=1; next} flag && NF' <<< "$out" >"$DIR"/updates
+        wc -l <"$DIR"/updates
+    else
+        echo 0
+    fi
     ;;
 view)
     /usr/bin/cjs "$DIR"/info-window.js "$(wc -l <"$DIR"/updates) updates" "$DIR"/updates
     ;;
 command)
     readonly cmd=$2
-    gnome-terminal --wait --  /usr/bin/bash -c "echo \"Executing $cmd\"; $cmd; echo -en \"\nDone - press enter to exit\"; read"
+    gnome-terminal --wait -- /usr/bin/bash -c "echo \"Executing $cmd\"; $cmd; echo -en \"\nDone - press enter to exit\"; read"
     ;;
 *)
     exit 1


### PR DESCRIPTION
Process `pkcon` output only if the command reports success.
This fixes showing pending update even if the `pkcon` reports that no updates are available.

Closes #7554 