### PR TITLE
bluetooth-battery/mic-level/updates-notifier@zamszowy: use correct method for detection of applet removal

### DIFF
--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
@@ -166,7 +166,7 @@ BtBattery.prototype = {
         }
     },
 
-    on_applet_removed: function() {
+    on_applet_removed_from_panel: function() {
         this.settings.finalize();
     },
 

--- a/mic-level@zamszowy/files/mic-level@zamszowy/applet.js
+++ b/mic-level@zamszowy/files/mic-level@zamszowy/applet.js
@@ -152,8 +152,10 @@ MicLevel.prototype = {
         }
     },
 
-    on_applet_removed: function() {
-        Mainloop.source_remove(this.tooltip_info);
+    on_applet_removed_from_panel: function() {
+        if (this.tooltip_info) {
+            Mainloop.source_remove(this.tooltip_info);
+        }
         this.settings.finalize();
         this.enabled = false;
         this.bt_only = false;

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/applet.js
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/applet.js
@@ -159,7 +159,7 @@ UpdatesNotifier.prototype = {
         this.menu.toggle();
     },
 
-    on_applet_removed: function () {
+    on_applet_removed_from_panel: function () {
         if (this.interval) {
             Util.clearInterval(this.interval);
         }

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
@@ -2,5 +2,5 @@
     "uuid": "updates-notifier@zamszowy",
     "name": "Updates notifier",
     "description": "Shows icons for pending update packages",
-    "version": "1.0.1"
+    "version": "1.0.2"
 }


### PR DESCRIPTION
This fixes subprocesses running in the background after applet removal.