### PR TITLE
mouse-keys-shortcut@GabrielCamara3526: Improves sliders

### DIFF
--- a/mouse-keys-shortcut@GabrielCamara3526/files/mouse-keys-shortcut@GabrielCamara3526/applet.js
+++ b/mouse-keys-shortcut@GabrielCamara3526/files/mouse-keys-shortcut@GabrielCamara3526/applet.js
@@ -182,31 +182,35 @@ class MyApplet extends Applet.IconApplet {
   initDelaySlider() {
     this.keyboardSettings = new Gio.Settings({ schema: 'org.cinnamon.desktop.a11y.keyboard' });
     let userInitDelay = this.keyboardSettings.get_int('mousekeys-init-delay');
-    let initDelayLabel = new PopupMenu.PopupMenuItem("Initial delay", {reactive: false});
+    let initDelayLabel = new PopupMenu.PopupMenuItem(_("Initial delay"), {reactive: false});
     let initDelaySlider = new PopupMenu.PopupSliderMenuItem(userInitDelay / 2000); // 2000 is maximum
-    this.initDelaytooltip = new Tooltips.Tooltip(initDelaySlider.actor, "Initial delay");
+    initDelaySlider.set_mark(0.15); // default value is 300, and 300/2000=0.15.
+    this.initDelaytooltip = new Tooltips.Tooltip(initDelaySlider.actor, _("Initial delay") + " " + userInitDelay.toString() + _(" ms"));
     this._applet_context_menu.addMenuItem(initDelayLabel)
     this._applet_context_menu.addMenuItem(initDelaySlider);
 
     initDelaySlider.connect('value-changed', (slider) => {
-      let updatedInitDelay = Math.round(slider.value * 2000);
+      let updatedInitDelay = Math.max(Math.round(slider.value * 20) * 100, 10); // 100-multiple; with 10 as minimum value.
       this.settings.setValue("initial-delay", updatedInitDelay);
+      this.initDelaytooltip.set_text(_("Initial delay") + " " + updatedInitDelay.toString() + _(" ms"));
       this.on_delay_changed();
-    }); 
+    });
     this.initDelaySlider = initDelaySlider;
   }
   accelTimeSlider(){
     this.keyboardSettings = new Gio.Settings({ schema: 'org.cinnamon.desktop.a11y.keyboard' });
     let userAccelTime = this.keyboardSettings.get_int('mousekeys-accel-time');
-    let accelTimeLabel = new PopupMenu.PopupMenuItem("Acceleration time", {reactive: false});
+    let accelTimeLabel = new PopupMenu.PopupMenuItem(_("Acceleration time"), {reactive: false});
     let accelTimeSlider = new PopupMenu.PopupSliderMenuItem(userAccelTime / 2000);
-    this.accelTimeTooltip = new Tooltips.Tooltip(accelTimeSlider.actor, "Acceleration time");
+    accelTimeSlider.set_mark(0.15);
+    this.accelTimeTooltip = new Tooltips.Tooltip(accelTimeSlider.actor, _("Acceleration time") + " " + userAccelTime.toString() + _(" ms"));
     this._applet_context_menu.addMenuItem(accelTimeLabel);
     this._applet_context_menu.addMenuItem(accelTimeSlider);
 
     accelTimeSlider.connect('value-changed', (slider) => {
-      let updatedAccelTime = Math.round(slider.value * 2000);
+      let updatedAccelTime = Math.max(Math.round(slider.value * 20) * 100, 10);
       this.settings.setValue("acceleration-time", updatedAccelTime);
+      this.accelTimeTooltip.set_text(_("Acceleration time") + " " + updatedAccelTime.toString() + _(" ms"));
       this.on_acceleration_changed();
     });
     this.accelTimeSlider = accelTimeSlider;
@@ -214,15 +218,33 @@ class MyApplet extends Applet.IconApplet {
   maxSpeedSlider(){
     this.keyboardSettings = new Gio.Settings({ schema: 'org.cinnamon.desktop.a11y.keyboard' });
     let userMaxSpeed = this.keyboardSettings.get_int('mousekeys-max-speed');
-    let maxSpeedLabel = new PopupMenu.PopupMenuItem("Maximum speed", {reactive: false});
+    let maxSpeedLabel = new PopupMenu.PopupMenuItem(_("Maximum speed"), {reactive: false});
     let maxSpeedSlider = new PopupMenu.PopupSliderMenuItem(userMaxSpeed / 500); // 500 is maximum
-    this.maxSpeedTooltip = new Tooltips.Tooltip(maxSpeedSlider.actor, "Maximum speed");
+    maxSpeedSlider.set_mark(0.02); // default value is 10, and 10/500=0.02.
+    this.maxSpeedSliderOldValue = 500 * maxSpeedSlider._value;
+    //~ global.log(UUID + " - this.maxSpeedSliderOldValue: " + this.maxSpeedSliderOldValue);
+    this.maxSpeedTooltip = new Tooltips.Tooltip(maxSpeedSlider.actor, _("Maximum speed") + " " + userMaxSpeed.toString() + _(" px/s"));
     this._applet_context_menu.addMenuItem(maxSpeedLabel);
     this._applet_context_menu.addMenuItem(maxSpeedSlider);
 
     maxSpeedSlider.connect('value-changed', (slider) => {
-      let updatedMaxSpeed = Math.round(slider.value * 500); 
+      // 1 is minimum value.
+      // 500 is maximum value.
+      // The default value 10 must be magnetic:
+      let _realValue = 500 * slider.value;
+      let updatedMaxSpeed;
+      if (_realValue >= 2 && _realValue <= 18)
+        updatedMaxSpeed = 10; // 10 is magnetic.
+      else
+        updatedMaxSpeed = Math.max(Math.round(slider.value * 20) * 25, 1); // 25-multiple. 1 is minimum value.
+      if (  (updatedMaxSpeed === 1 && this.maxSpeedSliderOldValue === 25) ||
+            (updatedMaxSpeed === 25 && this.maxSpeedSliderOldValue === 1)
+      ) {
+        updatedMaxSpeed = 10; // 10 is magnetic.
+      }
       this.settings.setValue("maximum-speed", updatedMaxSpeed);
+      this.maxSpeedTooltip.set_text(_("Maximum speed") + " " + updatedMaxSpeed.toString() + _(" px/s"));
+      this.maxSpeedSliderOldValue = updatedMaxSpeed;
       this.on_speed_changed();
     });
     this.maxSpeedSlider = maxSpeedSlider;

--- a/mouse-keys-shortcut@GabrielCamara3526/files/mouse-keys-shortcut@GabrielCamara3526/metadata.json
+++ b/mouse-keys-shortcut@GabrielCamara3526/files/mouse-keys-shortcut@GabrielCamara3526/metadata.json
@@ -3,6 +3,6 @@
     "name": "Mouse Keys Shortcut",
     "description": "Trigger this applet to control the pointer using the keypad",
     "max-instances": -1,
-    "version": "1.1.0",
+    "version": "1.2.0",
     "author": "GabrielCamara3526"
 }

--- a/mouse-keys-shortcut@GabrielCamara3526/files/mouse-keys-shortcut@GabrielCamara3526/po/fr.po
+++ b/mouse-keys-shortcut@GabrielCamara3526/files/mouse-keys-shortcut@GabrielCamara3526/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: mouse-keys-shortcut@GabrielCamara3526 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-28 15:41+0200\n"
+"POT-Creation-Date: 2025-08-30 17:07+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,21 +18,44 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. applet.js:29 applet.js:149
+#. applet.js:30 applet.js:155
 msgid "Control the pointer using the keypad"
 msgstr "Contrôler le curseur à l'aide du clavier numérique"
 
-#. applet.js:149 applet.js:152
+#. applet.js:155 applet.js:158
 msgid "Mouse Keys: ON"
 msgstr "Touches de la souris : ACTIVÉ"
 
-#. applet.js:158 applet.js:161
+#. applet.js:164 applet.js:167
 msgid "Mouse Keys: OFF"
 msgstr "Touches de la souris : DÉSACTIVÉ"
 
-#. applet.js:158
+#. applet.js:164
 msgid "Control the pointer using the mouse"
 msgstr "Contrôler le curseur avec la souris"
+
+#. settings-schema.json->initial-delay->description
+#. applet.js:185 applet.js:188 applet.js:195
+msgid "Initial delay"
+msgstr "Délai initial"
+
+#. applet.js:188 applet.js:195 applet.js:206 applet.js:213
+msgid " ms"
+msgstr " ms"
+
+#. settings-schema.json->acceleration-time->description
+#. applet.js:203 applet.js:206 applet.js:213
+msgid "Acceleration time"
+msgstr "Temps d'accélération"
+
+#. settings-schema.json->maximum-speed->description
+#. applet.js:221 applet.js:226 applet.js:246
+msgid "Maximum speed"
+msgstr "Vitesse maximale"
+
+#. applet.js:226 applet.js:246
+msgid " px/s"
+msgstr " px/s"
 
 #. metadata.json->name
 msgid "Mouse Keys Shortcut"
@@ -64,18 +87,6 @@ msgstr ""
 #. settings-schema.json->section2->description
 msgid "Mouse Keys"
 msgstr "Touches de la souris"
-
-#. settings-schema.json->initial-delay->description
-msgid "Initial delay"
-msgstr "Délai initial"
-
-#. settings-schema.json->acceleration-time->description
-msgid "Acceleration time"
-msgstr "Temps d'accélération"
-
-#. settings-schema.json->maximum-speed->description
-msgid "Maximum speed"
-msgstr "Vitesse maximale"
 
 #. settings-schema.json->section->description
 msgid "Notifications"

--- a/mouse-keys-shortcut@GabrielCamara3526/files/mouse-keys-shortcut@GabrielCamara3526/po/mouse-keys-shortcut@GabrielCamara3526.pot
+++ b/mouse-keys-shortcut@GabrielCamara3526/files/mouse-keys-shortcut@GabrielCamara3526/po/mouse-keys-shortcut@GabrielCamara3526.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: mouse-keys-shortcut@GabrielCamara3526 1.1.0\n"
+"Project-Id-Version: mouse-keys-shortcut@GabrielCamara3526 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-08-28 15:41+0200\n"
+"POT-Creation-Date: 2025-08-30 17:07+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,20 +17,43 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. applet.js:29 applet.js:149
+#. applet.js:30 applet.js:155
 msgid "Control the pointer using the keypad"
 msgstr ""
 
-#. applet.js:149 applet.js:152
+#. applet.js:155 applet.js:158
 msgid "Mouse Keys: ON"
 msgstr ""
 
-#. applet.js:158 applet.js:161
+#. applet.js:164 applet.js:167
 msgid "Mouse Keys: OFF"
 msgstr ""
 
-#. applet.js:158
+#. applet.js:164
 msgid "Control the pointer using the mouse"
+msgstr ""
+
+#. settings-schema.json->initial-delay->description
+#. applet.js:185 applet.js:188 applet.js:195
+msgid "Initial delay"
+msgstr ""
+
+#. applet.js:188 applet.js:195 applet.js:206 applet.js:213
+msgid " ms"
+msgstr ""
+
+#. settings-schema.json->acceleration-time->description
+#. applet.js:203 applet.js:206 applet.js:213
+msgid "Acceleration time"
+msgstr ""
+
+#. settings-schema.json->maximum-speed->description
+#. applet.js:221 applet.js:226 applet.js:246
+msgid "Maximum speed"
+msgstr ""
+
+#. applet.js:226 applet.js:246
+msgid " px/s"
 msgstr ""
 
 #. metadata.json->name
@@ -59,18 +82,6 @@ msgstr ""
 
 #. settings-schema.json->section2->description
 msgid "Mouse Keys"
-msgstr ""
-
-#. settings-schema.json->initial-delay->description
-msgid "Initial delay"
-msgstr ""
-
-#. settings-schema.json->acceleration-time->description
-msgid "Acceleration time"
-msgstr ""
-
-#. settings-schema.json->maximum-speed->description
-msgid "Maximum speed"
 msgstr ""
 
 #. settings-schema.json->section->description


### PR DESCRIPTION
@GabrielCamara3526
Your applet is a real gem!

This PR improves the sliders:

- Setting a mark for each default value.
- Translating messages, adding current value and unit.
- Making magnetic each default value.

I hope you'll like this PR.