### PR TITLE
test-spice: add watch option

### DIFF
--- a/test-spice
+++ b/test-spice
@@ -6,6 +6,7 @@ import os
 import sys
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 DEV_PREFIX = "devtest-"
@@ -62,6 +63,26 @@ def reload_xlet(uuid):
         print(out.stderr.decode('ascii') + '\nReload error!')
 
 
+def watch(uuid, action):
+    print('Watching for changes. Press Ctrl+C to stop.')
+    cmd = ["inotifywait", "--recursive", "--quiet", "--event", "modify", "--monitor", uuid]
+    last_run = 0
+    try:
+        with subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True) as proc:
+            for line in proc.stdout:
+                now = time.time()
+                if (now - last_run) > 1:
+                    action(uuid)
+                    last_run = now
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+def validate_and_copy(uuid):
+    if validate_spice(uuid):
+        copy_xlet(uuid)
+
+
 def main():
     """
     Simpler testing of Spices for developers
@@ -72,9 +93,12 @@ def main():
                         help='Remove all test Spices')
     parser.add_argument('-s', '--skip', action='store_true',
                         help='Skip Spice validation with validate-spice')
+    parser.add_argument('-w', '--watch', action='store_true',
+                        help='Watch for changes in the spice directory and reload the applet')
     parser.add_argument('uuid', type=str, metavar='UUID', nargs='?',
                         help='the UUID of the Spice')
     args = parser.parse_args()
+    uuid = args.uuid.rstrip('/') if args.uuid else None
 
     if args.remove and not args.uuid:
         for file_path in os.listdir(APPLETS_PATH):
@@ -84,10 +108,13 @@ def main():
                     shutil.rmtree(rm_path)
         sys.exit(0)
     elif args.skip and args.uuid:
-        copy_xlet(args.uuid.rstrip('/'))
+        copy_xlet(uuid)
     elif args.uuid and not args.remove:
-        if validate_spice(args.uuid.rstrip('/')):
-            copy_xlet(args.uuid.rstrip('/'))
+        if args.watch:
+            validate_and_copy(uuid)
+            watch(uuid, validate_and_copy)
+        else:
+            validate_and_copy(uuid)
     else:
         parser.print_help()
         sys.exit(2)

--- a/test-spice
+++ b/test-spice
@@ -100,7 +100,7 @@ def main():
     parser.add_argument('-s', '--skip', action='store_true',
                         help='Skip Spice validation with validate-spice')
     parser.add_argument('-w', '--watch', action='store_true',
-                        help='Watch for changes in the spice directory and reload the applet')
+                        help='Watch the Spice directory for changes and update the applet with reload')
     parser.add_argument('uuid', type=str, metavar='UUID', nargs='?',
                         help='the UUID of the Spice')
     args = parser.parse_args()

--- a/test-spice
+++ b/test-spice
@@ -64,16 +64,19 @@ def reload_xlet(uuid):
 
 
 def watch(uuid, action):
-    print('Watching for changes. Press Ctrl+C to stop.')
     cmd = ["inotifywait", "--recursive", "--quiet", "--event", "modify", "--monitor", uuid]
     last_run = 0
     try:
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True) as proc:
+            print('Watching for changes. Press Ctrl+C to stop.')
             for line in proc.stdout:
                 now = time.time()
                 if (now - last_run) > 1:
                     action(uuid)
                     last_run = now
+    except FileNotFoundError:
+        print('Failed to start watcher. Make sure inotify-tools package is installed.')
+        sys.exit(3)
     except KeyboardInterrupt:
         sys.exit(0)
 
@@ -81,6 +84,9 @@ def watch(uuid, action):
 def validate_and_copy(uuid):
     if validate_spice(uuid):
         copy_xlet(uuid)
+        return True
+    else:
+        return False
 
 
 def main():
@@ -111,8 +117,8 @@ def main():
         copy_xlet(uuid)
     elif args.uuid and not args.remove:
         if args.watch:
-            validate_and_copy(uuid)
-            watch(uuid, validate_and_copy)
+            if validate_and_copy(uuid):
+                watch(uuid, validate_and_copy)
         else:
             validate_and_copy(uuid)
     else:


### PR DESCRIPTION
adds -w / --watch option to the test-spice tool allowing faster checking of applet changes
if watch is requested, next will happen:
1. applet is validated and installed (as in default mode)
2. applet uuid folder is monitored with inotifywait tool (standard inotify-tools package must be installed)
3. on each file change under uuid folder validate, copy and reload are performed (no more than once in a 1 sec)