### PR TITLE
updates-notifier@zamszowy: filter packages reported as 'Blocked'

### DIFF
--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
@@ -2,5 +2,5 @@
     "uuid": "updates-notifier@zamszowy",
     "name": "Updates notifier",
     "description": "Shows icons for pending update packages",
-    "version": "1.0.3"
+    "version": "1.0.4"
 }

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/updates.sh
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/updates.sh
@@ -8,7 +8,7 @@ readonly DIR
 case "$1" in
 check)
     if out=$(pkcon get-updates --plain 2>&1); then
-        awk '/^Results:/{flag=1; next} flag && NF' <<< "$out" >"$DIR"/updates
+        awk '/^Results:/{flag=1; next} flag && NF && $1 != "Blocked"' <<< "$out" >"$DIR"/updates
         wc -l <"$DIR"/updates
     else
         echo 0


### PR DESCRIPTION
In some scenarios, pkcon reports packages marked as blocked as available updates, which should not be taken into account when showing the updates.