### PR TITLE
updates-notifier: fix TextDecoder error on old cjs

### DIFF
--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/info-window.js
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/info-window.js
@@ -176,22 +176,25 @@ function showDetails(item) {
 Gtk.init(null);
 
 // main window
-let win = new Gtk.Window({ title: ARGV[0] });
+let win = new Gtk.Window({ title: "Updates" });
 win.set_default_size(640, 640);
 
 let scroll = new Gtk.ScrolledWindow();
 let listbox = new Gtk.ListBox();
 
-// parse updates from ARGV[1]
-let text = new TextDecoder().decode(GLib.file_get_contents(ARGV[1])[1]);
-let updates = parseUpdates(text);
-
-for (let u of updates) {
-    let row = new Gtk.ListBoxRow();
-    let label = new Gtk.Label({ label: u.line, xalign: 0 });
-    row.add(label);
-    row._item = u;
-    listbox.add(row);
+// parse updates from ARGV[0]
+let [success, buffer] = GLib.file_get_contents(ARGV[0]);
+if (success) {
+    let text = typeof TextDecoder !== "undefined" ? new TextDecoder().decode(buffer) : String(buffer); // workaround for older cjs versions
+    let updates = parseUpdates(text);
+    win.title = `${updates.length} updates`;
+    for (let u of updates) {
+        let row = new Gtk.ListBoxRow();
+        let label = new Gtk.Label({ label: u.line, xalign: 0 });
+        row.add(label);
+        row._item = u;
+        listbox.add(row);
+    }
 }
 
 listbox.connect("row-activated", (box, row) => {

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
@@ -2,5 +2,5 @@
     "uuid": "updates-notifier@zamszowy",
     "name": "Updates notifier",
     "description": "Shows icons for pending update packages",
-    "version": "1.1.0"
+    "version": "1.1.1"
 }

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/updates.sh
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/updates.sh
@@ -15,7 +15,7 @@ check)
     fi
     ;;
 view)
-    /usr/bin/cjs "$DIR"/info-window.js "$(wc -l <"$DIR"/updates) updates" "$DIR"/updates
+    /usr/bin/cjs "$DIR"/info-window.js "$DIR"/updates
     ;;
 command)
     readonly cmd=$2


### PR DESCRIPTION
looks like on cjs@4.4.0 TextDecoder is not yet available, but old-good String(byte[]) constructor works fine.

Implemented fallback to String ctor if TextDecoder is not available. Guess for such a simple output as pkcon produces String constructor should be good enough.

Bonus: moved updates count title calculation into the info-window.js and slightly simplified "view" script.

owner: @zamszowy 