### PR TITLE
Fix workspace-grid@hernejj pot file missing header

### DIFF
--- a/workspace-grid@hernejj/files/workspace-grid@hernejj/po/workspace-grid@hernejj.pot
+++ b/workspace-grid@hernejj/files/workspace-grid@hernejj/po/workspace-grid@hernejj.pot
@@ -1,6 +1,17 @@
 #
 msgid ""
 msgstr ""
+"Project-Id-Version: workspace-grid@hernejj\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2017-04-20 16:17+0800\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 #. workspace-grid@hernejj->metadata.json->description
 msgid "2D workspace grid and switcher for Cinnamon"


### PR DESCRIPTION
GitHub Copilot summary:

> This pull request adds metadata headers to the translation template file for the workspace grid applet. These headers provide important information for translators and help standardize the translation process.
> 
> Translation infrastructure improvements:
> 
> * Added standard PO file headers to `workspace-grid@hernejj/po/workspace-grid@hernejj.pot`, including project version, bug report URL, creation date, and encoding information.