### PR TITLE
Radio3.0@claudiux - v3.7.0: Added Blacklist management

### DIFF
--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v3.7.0~20250910
+  * Added Blacklist management.
+
 ### v3.6.2~20250908
   * Better memory management.
 

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "The Ultimate Internet Radio Receiver & Recorder for Cinnamon",
   "max-instances": 1,
-  "version": "3.6.2",
+  "version": "3.7.0",
   "uuid": "Radio3.0@claudiux",
   "name": "Radio3.0",
   "author": "claudiux",

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/Radio3.0@claudiux.pot
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/Radio3.0@claudiux.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Radio3.0@claudiux 3.6.2\n"
+"Project-Id-Version: Radio3.0@claudiux 3.7.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -195,388 +195,393 @@ msgstr ""
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr ""
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr ""
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr ""
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr ""
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr ""
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr ""
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr ""
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr ""
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr ""
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr ""
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr ""
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr ""
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr ""
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr ""
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr ""
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr ""
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr ""
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr ""
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr ""
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr ""
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr ""
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr ""
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr ""
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr ""
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr ""
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr ""
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr ""
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr ""
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr ""
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr ""
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr ""
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr ""
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr ""
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr ""
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr ""
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr ""
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr ""
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr ""
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr ""
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr ""
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr ""
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr ""
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr ""
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr ""
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr ""
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr ""
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr ""
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr ""
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr ""
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr ""
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr ""
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr ""
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
 msgstr ""
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr ""
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr ""
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr ""
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr ""
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr ""
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr ""
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr ""
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr ""
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr ""
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr ""
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr ""
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr ""
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr ""
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr ""
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr ""
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr ""
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr ""
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr ""
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr ""
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr ""
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr ""
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr ""
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
 msgstr ""
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr ""
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr ""
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr ""
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr ""
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr ""
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr ""
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr ""
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr ""
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr ""
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr ""
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr ""
@@ -783,6 +788,10 @@ msgstr ""
 
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
+msgstr ""
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
 msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
@@ -1043,6 +1052,10 @@ msgstr ""
 msgid "Update my station list with the Radio Database data"
 msgstr ""
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr ""
@@ -1082,6 +1095,10 @@ msgstr ""
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr ""
+
+#. settings-schema.json->import-blacklist-button->description
+msgid "Blacklist selected items from this list"
 msgstr ""
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/ca.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/ca.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2024-09-14 03:06+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -239,394 +239,399 @@ msgstr ""
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Sense definir)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Iniciar"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Aturar"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Volum: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Clic del mig: Aturar gravació"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Clic del mig: Encès/Apagat"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Clic: Seleccioneu una altra emissora"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Roda del ratolí: canvi de volum"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Clic per a seleccionar una emissora"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr ""
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Configurar..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Buscar noves emissores..."
 
-#. applet.js:2643
+#. applet.js:2648
 #, fuzzy
 msgid "Load a sample station list"
 msgstr "Actualitzar aquesta llista d'emissores"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Configuració de So"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Veure a Youtube"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Intentar descarregar-ho de Youtube (no és segur)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Emissores escoltades recentment:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Visiteu el lloc web d'aquesta emissora"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Categories"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Emissores de Ràdio"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Totes les categories"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Les meves emissores"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Descarregant..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Atura la descàrrega"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Descàrrega completa"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Obre la carpeta de les gravacions"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Sembla que hi ha hagut un error mentre es gravava!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Si us plau, reviseu aquesta gravació."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Gravar des d'ara"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Aturar la gravació actual"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Reproduint %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Ràdio Apagada"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "No s'ha pogut gravar res!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Espai insuficient"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "S'ha arribat al límit que heu establert."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Si us plau tanqueu la sessió i inicieu-la de nou"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "per acabar l'actualització de yt-dlp"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "No hi ha res a guardar."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Llista d'emissores de ràdio guardades"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Això substituirà totes les emissores de ràdio actuals."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Segur que voleu continuar?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Actualització en procés"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Pot ser que tardi una mica... si us plau, espereu."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "S'ha completat l'actualització amb èxit"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "ERROR: URL de vídeo de Youtube invàlida!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "No s'ha pogut extreure cap pista de so"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Potser és una llista de reproducció?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Tancar"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr ""
 
-#. applet.js:4778
+#. applet.js:4837
 #, fuzzy
 msgid "Radio3.0 applet"
 msgstr "Radio3.0"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr ""
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr ""
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
 msgstr ""
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Quant a..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Manual..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Recarrega aquesta miniaplicació"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Programar una gravació desatesa..."
 
-#. applet.js:4977
+#. applet.js:5036
 #, fuzzy
 msgid "Configure the Alarm Clock..."
 msgstr "Configurar..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Extreure pista d'àudio d'un vídeo de Youtube..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(auto)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(manual)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Para de gravar"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Inicia la gravació"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Cancel·la descàrregues de Youtube"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Pulse Effects"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Easy Effects"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Ràdio engegada a l'inici"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Mostrar el logo de l'emissora"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr ""
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr ""
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr ""
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "No facis comprovacions de dependències"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Mostra el nivell de volum al costat de la icona"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr ""
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr ""
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
 msgstr ""
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Tanca sense aturar la gravació"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Comença la gravació des de %s:%s fins a %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Gravació completada"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Això importarà un fitxer nou contenint emissores de ràdio."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Voleu continuar?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "No hi ha cap ràdio nova a la vostra llista."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Una nova ràdio a la vostra llista."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s ràdios noves a la vostra llista."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 "No hi ha noves emissores per afegir al menú de la miniaplicació Radio3.0"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr ""
 "Una nova emissora de ràdio s'ha afegit al menú de la miniaplicació Radio3.0"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr ""
 "%s noves emissores de ràdio s'han afegir al menú de la miniaplicació Radio3.0"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -839,6 +844,10 @@ msgstr "Guardar i restaurar"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Actualitzar aquesta llista d'emissores"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1106,6 +1115,10 @@ msgstr "Obre la carpeta contenidora d'aquestes llistes"
 msgid "Update my station list with the Radio Database data"
 msgstr "Actualitza la meva llista d'emissores amb la base de dades de ràdios"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr ""
@@ -1145,6 +1158,11 @@ msgstr "Importa les emissores seleccionades a la meva llista"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Elimina les emissores seleccionades d'aquesta llista"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Elimina les emissores seleccionades d'aquesta llista"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/de.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2025-05-05 15:59+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -240,227 +240,232 @@ msgstr "Sa."
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Undefiniert)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Start"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Stop"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Lautstärke: %s%"
 
 # Better use "Mittelklick"?
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Klick mit mittlerer Maustaste: Aufnahme stoppen"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Klick mit mittlerer Maustaste: EIN/AUS"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Klicken: Anderen Sender auswählen"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Scrollrad: Lautstärke ändern"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Klicken, um einen Sender auszuwählen"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr "Aufwecken"
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Konfigurieren..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Nach neuen Sendern suchen..."
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr "Eine Beispiel-Senderliste laden"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Toneinstellungen"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Auf YT ansehen"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Versuchen, es von YT herunterzuladen (unsicher)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Kürzlich gespielte Sender:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Besuchen Sie die Homepage dieses Senders"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Kategorien"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Radiosender"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Alle Kategorien"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Meine Radiosender"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Herunterladen..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Herunterladen stoppen"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Download abgeschlossen"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Öffnen Sie den Aufnahmen-Ordner"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Während der Aufnahme scheint ein Fehler aufgetreten zu sein!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Bitte überprüfen Sie diese Aufnahme."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Jetzt aufnehmen"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Aktuelle Aufnahme stoppen"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Spielt %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Radio AUS"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Kann nichts aufnehmen!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Unzureichender Speicherplatz"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Das von Ihnen gesetzte Limit wurde erreicht."
 
 # Please check. But comma should be okay here since there is a 2nd part.
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Bitte loggen Sie sich aus und dann wieder ein"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "um das yt-dlp-Update abzuschließen"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Nichts zu speichern."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Liste der gespeicherten Radiosender"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Dies wird alle aktuellen Radiosender ersetzen."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Sind Sie sicher, dass Sie fortfahren möchten?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Update läuft"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Es kann eine Weile dauern ... Bitte warten."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Update erfolgreich abgeschlossen"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "FEHLER: Ungültige YT-Video-URL!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Kann keinen einzelnen Soundtrack extrahieren"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Vielleicht ist es eine Playlist?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Schließen"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr "Radio3.0 Applet"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr "Die OSD150-Erweiterung aktivieren"
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 "Um ein horizontales OSD zu erhalten, müssen Sie die OSD150-Erweiterung "
 "aktivieren."
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr "Die OSD150-Erweiterung herunterladen"
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
@@ -470,99 +475,99 @@ msgstr ""
 "Klicken Sie auf Download, suchen Sie nach OSD150 und wählen Sie die ⬇-"
 "Schaltfläche aus."
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Entfernen '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Über..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Handbuch..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Dieses Applet neu laden"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Hintergrundaufnahme planen..."
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr "Wecker konfigurieren..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Soundtrack aus YouTube-Video extrahieren..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(auto)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(manuell)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Aufnahme stoppen"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Aufnahme starten"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Downloads von YT abbrechen"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Pulse-Effekte"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Einfache Effekte"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Radio beim Start einschalten"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Senderlogo anzeigen"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "Einstellungen für das Albumcover-Desklet"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr "Weck mich auf!"
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "Albumcover auf dem Desktop anzeigen"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Nicht nach Abhängigkeiten prüfen"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Lautstärkepegel neben dem Symbol anzeigen"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr "Sie benötigen das 'Album Art 3.0' Desklet"
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
@@ -570,15 +575,15 @@ msgstr ""
 "Sie können es installieren, indem Sie auf die erste Schaltfläche klicken und "
 "dann nach Album suchen."
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr "Desklets"
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr "Sie müssen das 'Album Art 3.0' Desklet aktivieren"
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
@@ -586,56 +591,56 @@ msgstr ""
 "Sie können es aktivieren, indem Sie auf die erste Schaltfläche klicken, dann "
 "nach Album suchen und es schließlich mit der Schaltfläche [+] hinzufügen."
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Schließen ohne Aufnahme zu stoppen"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Aufnahme startet von %s:%s bis %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Aufnahme abgeschlossen"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Dies wird eine neue Datei mit Radiosendern importieren."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Möchten Sie fortfahren?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Kein neuer Sender in Ihrer Liste."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Ein weiterer Sender in Ihrer Liste."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s weitere Sender in Ihrer Liste."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 "Es gibt keine neuen Sender, die dem Radio3.0-Applet-Menü hinzugefügt werden "
 "können"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Ein neuer Sender wurde dem Radio3.0-Applet-Menü hinzugefügt"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s neue Sender wurden dem Radio3.0-Applet-Menü hinzugefügt"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -846,6 +851,10 @@ msgstr "Speichern und Wiederherstellen"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Diese Senderliste aktualisieren"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1114,6 +1123,10 @@ msgstr "Den Ordner mit diesen Listen öffnen"
 msgid "Update my station list with the Radio Database data"
 msgstr "Meine Senderliste mit den Daten der Radiodatenbank aktualisieren"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "Importieren Sie Ihre Sender von Radio++"
@@ -1153,6 +1166,11 @@ msgstr "Die ausgewählten Sender in meine eigene Liste importieren"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Ausgewählte Elemente aus dieser Liste entfernen"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Ausgewählte Elemente aus dieser Liste entfernen"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/es.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2025-06-29 10:05-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -236,224 +236,229 @@ msgstr "Sáb."
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Sin definir)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Iniciar"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Pausar"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Volumen: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Clic del medio: Detener la grabación"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Clic del medio: ON/OFF"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Haga clic en: Seleccione otra estación"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Rueda del ratón: cambio de volumen"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Haga clic para seleccionar una estación"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr "Despertador"
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Configurar..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Buscar nuevas estaciones..."
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr "Cargar una lista de estaciones de muestra"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Ajustes de sonido"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Ver en YT"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Intente descargarlo desde YT (no es seguro)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Estaciones reproducidas recientemente:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Visitar la página web de esta estación"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Categorías"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Estaciones de radio"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Todas las categorías"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Mis estaciones de radio"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Detener la descarga"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Descarga completa"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Abrir la carpeta de grabaciones"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "¡Parece que se ha producido un error durante la grabación!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Por favor revise esta grabación."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Grabar desde ahora"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Detener la grabación actual"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Reproduciendo %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Radio Apagada"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "¡No se puede grabar nada!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Espacio insuficiente"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Se ha alcanzado el límite establecido."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Cierre la sesión y vuelva a iniciarla"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "para finalizar la actualización de yt-dlp"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "No hay nada que guardar."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Lista de estaciones de radio guardadas"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Esto sustituirá a todas las emisoras de radio actuales."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "¿Está seguro de que quiere continuar?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Actualización en progreso"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Puede tomar un tiempo... Por favor, espere."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Actualización completada con éxito"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "ERROR: ¡La URL del video de YT no es válida!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "No se puede extraer una sola pista de sonido"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "¿Acaso es una lista de reproducción?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Cerrar"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr "Cancelar"
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr "Applet Radio3.0"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr "Activar la extensión OSD150"
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 "Para obtener un OSD horizontal, es necesario activar la extensión OSD150."
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr "Descargar la extensión OSD150"
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
@@ -462,114 +467,114 @@ msgstr ""
 "Haga clic en el botón Descargar y, a continuación, busque OSD150 y "
 "seleccione el botón ⬇."
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Quitar '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Acerca de..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Manual..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Recargar este applet"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Programar una grabación en segundo plano..."
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr "Configurar el reloj despertador..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Extraer pista de sonido de un vídeo de YouTube..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(automático)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(manual)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Detener la grabación"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Iniciar grabación"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Cancelar las descargas de YT"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Pulse Effects"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Easy Effects"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Radio encendida al inicio"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Mostrar logotipo de la estación"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "Configuracion del desklet de la carátula del álbum"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr "¡Despiértame!"
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "Mostrar la carátula del álbum en el escritorio"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "No comprobar las dependencias"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Mostrar el nivel de volumen cerca del icono"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr "Necesitas el desklet Album Art 3.0"
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr ""
 "Puedes instalarlo haciendo clic en el primer botón y luego buscando Álbum."
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr "Desklets"
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr "Necesitas activar el desklet 'Album Art 3.0'"
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
@@ -577,54 +582,54 @@ msgstr ""
 "Puedes activarlo haciendo clic en el primer botón, luego buscando Álbum y "
 "agregándolo con el botón [+]."
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Close without stopping recording"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Comenzar la grabación desde %s:%s hasta %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Grabación completada"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Esto importará un nuevo archivo que contiene estaciones de radio."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "¿Quiere continuar?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "No hay radios nuevas en su lista."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Una radio más en su lista."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s radios más en su lista."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr "No hay nuevas estaciones para agregar al menú del applet de Radio3.0"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Se ha añadido una nueva estación al menú del applet de Radio3.0"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "Se agregaron %s nuevas estaciones al menú del applet de Radio3.0"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -834,6 +839,10 @@ msgstr "Guardar y restaurar"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Actualizar la lista de estaciones"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1100,6 +1109,10 @@ msgid "Update my station list with the Radio Database data"
 msgstr ""
 "Actualizar mi lista de emisoras con los datos de la base de datos de radio"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "Importe sus emisoras de Radio++"
@@ -1139,6 +1152,11 @@ msgstr "Importar las estaciones seleccionadas a mi propia lista"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Eliminar elementos seleccionados de esta lista"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Eliminar elementos seleccionados de esta lista"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/fi.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2025-04-04 13:34+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -228,223 +228,228 @@ msgstr "la"
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(ei valintaa)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Aloita"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Pysäytä"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Voimakkuus: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Keskipainike: Lopeta tallennus"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Keskipainike: ON/OFF"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Painallus: Valitse toinen asema"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Rulla: voimakkuus muuttuu"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Valitse asema painamalla"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr "Herätys"
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Asetukset..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Hae asemia..."
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr "Lataa näyteasemalista"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Laitteet"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Katso YT"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Yritä ladata YT:n kautta (turvaton)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Viimeiksi toistetut asemat:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Vieraile aseman kotisivulla"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Kategoriat"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Radioasemat"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Kaikki kategoriat"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Minun asemat"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Ladataan..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Pysäytä lataaminen"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Lataaminen valmis"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Avaa tallennuskansio"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Virhe tapahtui tallennuksen aikana!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Tarkista tämä tallennus."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Nauhoita tästä"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Lopeta nykyinen tallennus"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Nyt soi %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Radio POIS"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Ei voi tallentaa mitään!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Levytilaa ei ole riittävästi"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Asetamasi raja on saavutettu."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Kirjaudu ulos ja sitten sisään"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "yt-dlp päivityksen viimeistelemiseksi"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Ei mitään tallennettavaa."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Lista tallennetuista radioasemista"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Tämä korvaa kaikki nykyiset radioasemat."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Haluatko varmasti jatkaa?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Päivitys käynnissä"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Tämä voi kestää hetken... Odota."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Päivitys suoritettu onnistuneesti"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "VIRHE: Virheellinen YT videon URL-osoite!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Yksittäistä ääniraitaa ei voi purkaa"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Ehkä tämä on soittolista?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Sulje"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr "Peru"
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr "Radio3.0"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr "Ota OSD150 extension käyttöön"
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr "Vaakaruudun saamiseksi sinun on otettava OSD150-laajennus käyttöön."
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr "Lataa OSD150 extension"
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
@@ -452,99 +457,99 @@ msgstr ""
 "Vaakaruudun saamiseksi sinun on ladattava OSD150-laajennus.\n"
 "Paina Lataa-painiketta, etsi sitten hakusana OSD150 ja valitse ⬇-painike."
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Poista \"%s\""
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Tietoja..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Manuaali..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Lataa sovelma uudelleen"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Ajasta tallennus taustalla..."
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr "Määritä herätyskello..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Poimi ääniraita YouTube videosta..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(auto)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(manuaalinen)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Lopeta tallennus"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Aloita tallennus"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Peruuta Youtube lataukset"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Pulse Effects"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Easy Effects"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Radio ON (kirjautuessa)"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Näytä aseman logo"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "Album Art kasikuvien asetukset"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr "Herätä minut!"
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "Näytä albumin kansi työpöydällä"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Riippuvuuksia ei tarkisteta"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Näytä voimakkuus kuvakkeessa"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr "Sinä tarvitset \"Album Art 3.0\" sovelman työpydälle"
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
@@ -552,15 +557,15 @@ msgstr ""
 "Voit asentaa sen painamalla ensimmäistä painiketta ja sitten hakemalla Album "
 "hakusanalla."
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr "Sovelmia työpöydälle"
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr "Sinun on otettava käyttöön Album Art 3.0 työpöytäsovelma"
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
@@ -568,54 +573,54 @@ msgstr ""
 "Voit ottaa sen käyttöön painamalla ensimmäistä painiketta, hakemalla Album "
 "hakusanalla ja lisäämällä sen painikkeella [+]."
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Sulje lopettamatta tallennusta"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Tallennus alkaa %s:%s - %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Tallennus valmis"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Tämä tuo uuden tiedoston, joka sisältää radioasemia."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Haluatko jatkaa?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Ei uutta radiota listallasi."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Yksi radio lisää listallasi."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s radiota lisää sinun listalla."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr "Radio3.0 sovelman valikkoon ei ole lisättävää uutta asemaa"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Radio3.0 sovelman valikkoon on lisätty uusi asema"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s uutta asemaa on lisätty Radio3.0 sovelman valikkoon"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -825,6 +830,10 @@ msgstr "Tallenna ja palauta"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Päivitä tämä asemalista"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1084,6 +1093,10 @@ msgstr "Avaa kansio, joka sisältää nämä radiolistat"
 msgid "Update my station list with the Radio Database data"
 msgstr "Päivitä minun asemat radiotietokannan tiedoilla"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "Tuo sinun Radio++ asemat"
@@ -1123,6 +1136,11 @@ msgstr "Tuo valitut asemat minun listalle"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Poista valitut kohteet tästä listasta"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Poista valitut kohteet tästä listasta"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/fr.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/fr.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: Radio3.0@claudiux\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
-"PO-Revision-Date: 2025-06-29 15:52+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
+"PO-Revision-Date: 2025-09-10 19:47+0200\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -236,223 +236,228 @@ msgstr "Sam."
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Indéfini)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr "(Indésirables (Blacklist))"
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Marche"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Arrêt"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Volume : %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Clic-molette : Arrêter l'enregistrement"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Clic-molette : Marche/Arrêt"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Clic : Choisir une autre station"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Roule-molette : Modifier le volume"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Cliquer pour choisir une autre station"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr "Réveil"
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Configurer..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Rechercher de nouvelles stations..."
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr "Charger un exemple de liste de stations"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Paramètres du son"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Voir sur YT"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Essayer de télécharger depuis YT (peu sûr)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Stations récemment écoutées :"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Visiter le site web de cette station"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Catégories"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Stations de radio"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Toutes catégories"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Mes stations de radio"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Téléchargement..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Arrêter ce téléchargement"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Enregistrement terminé"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Ouvrir le dossier des enregistrements"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Une erreur semble survenue pendant l'enregistrement !"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Veuillez vérifier cet enregistrement."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Enregistrer à partir de maintenant"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Arrêter l'enregistrement actuel"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "À l'écoute de %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Radio éteinte"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Impossible d'enregistrer !"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Espace insuffisant"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "La limite que vous avez fixée a été atteinte."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Veuillez vous déconnecter et vous reconnecter"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "pour finaliser la mise à jour de yt-dlp"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Rien à sauvegarder."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Liste des stations sauvegardées"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Cela va remplacer toutes vos stations actuelles."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Êtes-vous sûr(e) de vouloir continuer ?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Mise à jour en cours"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Cela peut prendre du temps... Merci de patienter."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Mise à jour effectuée avec succès"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "ERREUR : URL de la vidéo YT invalide !"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Impossible d'extraire une seule bande son"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "S'agit-il d'une playlist ?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Fermer"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr "Annuler"
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr "Radio3.0"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr "Activer l'extension OSD150"
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr "Pour obtenir un OSD horizontal, vous devez activer l'extension OSD150."
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr "Télécharger l'extension OSD150"
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
@@ -461,99 +466,99 @@ msgstr ""
 "Cliquez sur le bouton Télécharger puis recherchez OSD150 et sélectionnez le "
 "bouton ⬇."
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Supprimer '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "À propos..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Manuel..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Recharger cette applet"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Planifier un enregistrement en arrière-plan..."
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr "Configurer le Réveil..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Extraire la bande son d'une vidéo YouTube..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(auto)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(manuel)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Arrêter l'enregistrement"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Démarrer l'enregistrement"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Abandon des téléchargements depuis YT"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Pulse Effects"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Easy Effects"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Allumer la radio au démarrage"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Afficher le logo de la station"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "Paramètres de la Pochette d'album"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr "Réveillez-moi !"
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "Afficher la pochette d'album sur le Bureau"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Ne pas vérifier les dépendances"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Afficher le niveau de volume près de l'icône"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr "Vous avez besoin du desklet Album Art 3.0"
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
@@ -561,15 +566,15 @@ msgstr ""
 "Vous pouvez l'installer en cliquant sur le premier bouton et en recherchant "
 "Album."
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr "Desklets"
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr "Vous devez activer le desklet Album Art 3.0"
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
@@ -577,55 +582,55 @@ msgstr ""
 "Vous pouvez l'activer en cliquant sur le premier bouton, puis en recherchant "
 "Album et en l'ajoutant à l'aide du bouton [+]."
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Fermer sans arrêter l'enregistrement"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Démarrage de l'enregistrement de %s:%s à %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Enregistrement terminé"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Cela va importer un nouveau fichier contenant des stations de radio."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Voulez-vous continuer ?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Aucune nouvelle radio dans votre liste."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Une radio de plus dans votre liste."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s radios de plus dans votre liste."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 "Il n'y a aucune nouvelle station à ajouter au menu de l'applet Radio3.0"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Une nouvelle station a été ajoutée au menu de l'applet Radio3.0"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s  nouvelles stations ont été ajoutées au menu de l'applet Radio3.0"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbit/s"
@@ -836,6 +841,10 @@ msgstr "Sauvegarde et Restauration"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Mettre à jour cette liste de stations"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr "Indésirables (blacklist)"
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1101,6 +1110,10 @@ msgstr "Ouvrir le dossier contenant ces listes"
 msgid "Update my station list with the Radio Database data"
 msgstr "Mettre à jour ma liste de stations à l'aide de la base de données"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr "URL indésirable (blacklistée)"
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "Importez vos stations depuis Radio++"
@@ -1141,6 +1154,10 @@ msgstr "Importer dans ma liste les stations sélectionnées"
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
 msgstr "Supprimer de cette liste les stations sélectionnées"
+
+#. settings-schema.json->import-blacklist-button->description
+msgid "Blacklist selected items from this list"
+msgstr "Blacklister (rendre indésirables) les stations sélectionnées"
 
 #. settings-schema.json->import-select-all->description
 #. settings-schema.json->search-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/hr.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/hr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2023-01-12 15:17+0100\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: \n"
@@ -234,393 +234,398 @@ msgstr ""
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Neodređeno)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Pokreni"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Zaustavi"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Glasnoća zvuka: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Srednji-klik: Zaustavi snimanje"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Srednji-klik: ISKLJ/UKLJ"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Klik: Odaberi drugu stanicu"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Pomicanje kotačića miša: promjena glasnoće zvuka"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Klikni za odabir druge stanice"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr ""
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Prilagodi..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Pretraži novu stanicu..."
 
-#. applet.js:2643
+#. applet.js:2648
 #, fuzzy
 msgid "Load a sample station list"
 msgstr "Nadopuna ovog popisa stanica"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Postavke zvuka"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Gledaj na YT"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Probaj preuzeti s YT (nesigurno)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Nedavno slušane stanice:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Posjeti naslovnicu ove stanice"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr ""
 
-#. applet.js:2880
+#. applet.js:2896
 #, fuzzy
 msgid "Radio Stations"
 msgstr "Moje radio stanice"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr ""
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Moje radio stanice"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Preuzimanje..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Zaustavi preuzimanje"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Preuzimanje je završeno"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Otvori mape snimanja"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Dogodila se greška tijekom snimanja!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Provjerite ovu snimku."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Snimaj od sada"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Zaustavi trenutno snimanje"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Reprodukcija %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Radio ISKLJUČEN"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Nemoguće je bilo što snimiti!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Nedovoljno prostora"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Ograničenje koje ste postavili je dosegnuto."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr ""
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr ""
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Nema ništa za spremanje."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Popis spremljenih radio stanica"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Ovo će zamijeniti sve trenutne radio stanice."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Želite li sigurno nastaviti?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Nadopuna u tijeku"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Može potrajati... Pričekajte."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Nadopuna je završena uspješno"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "GREŠKA: Nevaljali URL YT video snimke!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Nemoguće izdvajanje jednog zvučnog zapisa"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Možda je popis izvođenja?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Zatvori"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr ""
 
-#. applet.js:4778
+#. applet.js:4837
 #, fuzzy
 msgid "Radio3.0 applet"
 msgstr "Radio3.0"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr ""
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr ""
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
 msgstr ""
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Ukloni '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "O programu..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Ručno..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Ponovno učitaj ovaj aplet"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Zakaži pozadinsko snimanje..."
 
-#. applet.js:4977
+#. applet.js:5036
 #, fuzzy
 msgid "Configure the Alarm Clock..."
 msgstr "Prilagodi..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Izdvoji zvučni zapis iz YouTube videa..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(automatski)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(ručno)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Zaustavi snimanje"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Pokreni snimanje"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Prekini preuzimanje s YT"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Pulse Effects"
 
-#. applet.js:5039
+#. applet.js:5098
 #, fuzzy
 msgid "Easy Effects"
 msgstr "Pulse Effects"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Uključi radio pri pokretanju"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr ""
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr ""
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr ""
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr ""
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Ne provjeravaj zavisnosti"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr ""
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr ""
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr ""
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
 msgstr ""
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Zatvori bez zaustavljanja snimanja"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Pokretanje snimanja od %s:%s do %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Snimanje završilo"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Ovo će uvesti novu datoteku koja sadrži radio stanice."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Želite li nastaviti?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Nema novih radio stanicu u vašem popisu."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Još jedna radio stanica u vašem popisu."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "Još %s radio stanica u vašem popisu."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr "Nema novih stanica za dodavanje u izbornik Radio3.0 apleta"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Dodana je nova stanica u izbornik Radio3.0 apleta"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s novih stanica je dodano u izbornik Radio3.0 apleta"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -829,6 +834,10 @@ msgstr "Spremanje i obnova"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Nadopuna ovog popisa stanica"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1093,6 +1102,10 @@ msgstr "Otvorite mapu koja sadrži te popise"
 msgid "Update my station list with the Radio Database data"
 msgstr "Nadopuni moj popis stanica pomoću podataka Radio baze podataka"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr ""
@@ -1132,6 +1145,11 @@ msgstr "Uvezi odabrane stanice u moj vlastiti popis"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Ukloni odabrane stavke iz ovog popisa"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Ukloni odabrane stavke iz ovog popisa"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/hu.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2025-08-08 08:32+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -234,224 +234,229 @@ msgstr "Szo."
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Nincs megadva)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Indulás"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Leállítás"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Hangerő: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Középső kattintás: Felvétel leállítása"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Középső kattintás: BE/KI"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Kattintás: Válasszon másik állomást"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Görgő: hangerő változtatás"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Kattintson egy állomás kiválasztásához"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr "Ébresztő"
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Beállítások…"
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Új állomások keresése..."
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr "Mintaállomás-lista betöltése"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Hangbeállítások"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Tekintse meg a YouTube-on"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Próbálja meg letölteni a YouTube-ról (nem biztonságos)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Legutóbb játszott állomások:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Látogassa meg az állomás kezdőlapját"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Kategóriák"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Rádióállomások"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Összes kategória"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Saját rádióállomások"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Letöltés…"
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Letöltés leállítása"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Letöltés befejeződött"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Nyissa meg a felvételek mappát"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Úgy tűnik, hiba történt a rögzítés közben!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Kérjük, ellenőrizze ezt a rekordot."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Felvétel mostantól"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Az aktuális rögzítés leállítása"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Lejátszás: %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Rádió Ki"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Semmit nem lehet rögzíteni!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Elégtelen hely"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Elérte a beállított korlátot."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Kérjük, jelentkezzen ki, majd jelentkezzen be"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "a yt-dlp frissítés véglegesítéséhez"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Nincs mit menteni."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "A mentett rádióállomások listája"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Ez felváltja az összes jelenlegi rádióállomást."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Biztos benne, hogy folytatni kívánja?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Frissítés folyamatban"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Eltarthat egy ideig... Kérem, várjon."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "A frissítés sikeresen befejeződött"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "HIBA: Érvénytelen a YouTube-videó URL-címe"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Nem szerezhető meg kizárólag a hangsáv"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Talán ez egy lejátszási lista?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Bezárás"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr "Mégse"
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr "Radio3.0 kisalkalmazás"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr "OSD150 bővítmény engedélyezése"
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 "A vízszintes OSD megjelenítéséhez engedélyeznie kell az OSD150 bővítményt."
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr "OSD150 bővítmény letöltése"
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
@@ -460,113 +465,113 @@ msgstr ""
 "Kattintson a Letöltés gombra, majd keresse meg az OSD150 bővítményt, és "
 "válassza a ⬇ gombot."
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eltávolítás: „%s”"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Névjegy…"
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Kézi…"
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Kisalkalmazás újratöltése"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Háttérrekord ütemezése..."
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr "Az ébresztőóra beállítása..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Hangsáv kinyerése a YouTube videóból…"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(auto)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(kézi)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Felvétel leállítása"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Felvétel elindítása"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Letöltések megszakítása a YOUTUBE webhelyről"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Pulse Effects"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Easy Effects"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Rádió BE indításkor"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Az állomás logójának megjelenítése"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "Albumborító kisalkalmazás beállítások"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr "Ébressz fel!"
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "Albumborító megjelenítése az asztalon"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Ne ellenőrizze a függőségeket"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Hangerőszint megjelenítése az ikon közelében"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr "Szüksége van az „Albumborító 3.0” asztalkalmazásra"
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr "Telepítheti az első gombra kattintva, majd az Album keresésével."
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr "Asztalkalmazások"
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr "Be kell kapcsolnia az „Albumborító 3.0” asztalkalmazást"
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
@@ -574,56 +579,56 @@ msgstr ""
 "Az első gombra kattintva aktiválhatja, majd keressen egy Albumot, és a [+] "
 "gombbal hozzáadhatja."
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Zárja be a felvétel leállítása nélkül"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Felvétel indítása %s:%s és %s:%s között"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Felvétel kész"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Ezzel egy új fájlt importál, amely rádióállomásokat tartalmaz."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Szeretné folytatni?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Nincs új rádió a listán."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Még egy rádió a listán."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s további rádió a listán."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 "Nincsenek új állomások, amelyeket hozzáadhatna a Radio3.0 kisalkalmazás "
 "menühöz"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Új állomás került a Radio3.0 kisalkalmazás menüjébe"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s új állomás került a Radio3.0 kisalkalmazás menüjébe"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -838,6 +843,10 @@ msgstr "Mentés és visszaállítás"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Frissítse ezt az állomáslistát"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1097,6 +1106,10 @@ msgstr "Nyissa meg az ezeket a listákat tartalmazó mappát"
 msgid "Update my station list with the Radio Database data"
 msgstr "Frissítse az állomáslistámat a Radio Database adataival"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "Importáld az állomásaidat a Radio++-ból"
@@ -1136,6 +1149,11 @@ msgstr "Importálja a kiválasztott állomásokat a saját listámba"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "A kiválasztott elemek eltávolítása a listáról"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "A kiválasztott elemek eltávolítása a listáról"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/is.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/is.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Radio3.0@claudiux 2.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2025-04-01 10:28+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic\n"
@@ -236,225 +236,230 @@ msgstr "Lau."
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Óskilgreint)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Byrja"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Stöðva"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Hljóðstyrkur: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Miðjusmellur: Stöðva upptöku"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Miðjusmellur: KVEIKT/SLÖKKT"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Smella: velja aðra stöð"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Skrunhjól: breyting hljóðstyrks"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Smelltu til að velja stöð"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr "Vekja"
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Grunnstilla..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Leita að nýjum útvarpsstöðvum..."
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr "Hlaða inn sýnishorni stöðvalista"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Hljóðstillingar"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Skoða á YouTube"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Prófa að sækja þetta frá YouTube (óöruggt)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Nýlega spilaðar útvarpsstöðvar:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Fara á heimasíðu útvarpsstöðvarinnar"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Flokkar"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Útvarpsstöðvar"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Allir flokkar"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Útvarpsstöðvarnar mínar"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Sæki..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Hætta að sækja"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Niðurhali lokið"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Opna upptökumöppuna"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Villa virðist hafa komið upp við upptöku!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Athugaðu þessa upptöku."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Taka upp héðan"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Stöðva fyrirliggjandi upptöku"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Spila %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Útvarp AF"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Mistókst að taka neitt upp!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Ekki nóg diskpláss"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Takmörkum sem þú settir hefur verið náð."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Skráðu þig út og svo inn aftur"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "til að ljúka uppfærslu á yt-dlp"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Ekkert til að vista."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Listi yfir vistaðar útvarpsstöðvar"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Þetta mun skipta út öllum fyrirliggjandi útvarpsstöðvum."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Ertu viss um að þú viljir halda áfram?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Uppfærsla í gangi"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Þetta getur tekið dálítinn tíma, sýndu smá þolinmæði."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Tókst að ljúka uppfærslunni"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "Villa: Ógild slóð á YouTube-myndskeið!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Mistókst að ná í stakt hljóðspor"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Er þetta kannski spilunarlisti?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Loka"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr "Hætta við"
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr "Radio3.0 smáforritið"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr "Virkjaðu OSD150 forritsaukann"
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 "Til að fá fram láréttan OSD-stjórntexta, þarftu að virkja OSD150 "
 "forritsaukann."
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr "Sækja OSD150 forritsaukann"
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
@@ -464,99 +469,99 @@ msgstr ""
 "Smelltu á niðurhalshnappinn og leitaðu síðan að OSD150 og veldu svo ⬇ "
 "hnappinn."
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Fjarlægja '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Um hugbúnaðinn..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Handvirkt..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Endurhlaða þessu smáforriti"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Áætla upptöku í bakgrunni..."
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr "Grunnstilla vekjaraklukkuna..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Ná í hljóðspor úr YouTube-myndskeiði..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(sjálfvirkt)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(handvirkt)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Stöðva upptöku"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Hefja upptöku"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Hætta við niðurhal frá YT"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Púls-áhrif"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Slökunar-áhrif"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Kveikt á útvarpi í ræsingu"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Birta táknmerki stöðvar"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "Stillingar skjágræju fyrir umslagsmyndir"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr "Vekja mig!"
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "Sýna umslagsmyndir á skjáborði"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Ekki skoða kerfiskröfur"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Birta hljóðstyrk nálægt táknmynd"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr "Þú þarft 'Album Art 3.0' skjágræjuna"
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
@@ -564,15 +569,15 @@ msgstr ""
 "Þú getur virkjað það með því að smella á fyrsta hnappinn og leita síðan að "
 "albúmi."
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr "Skjágræjur (desklets)"
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr "Þú þarft að virkja 'Album Art 3.0' skjágræjuna"
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
@@ -580,57 +585,57 @@ msgstr ""
 "Þú getur virkjað það með því að smella á fyrsta hnappinn, leita síðan að "
 "albúmi og bæta því við með [+] hnappnum."
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Loka án þess að stöðva upptöku"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Hefja upptöku frá %s:%s til %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Upptöku lokið"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Þetta mun flytja inn nýja skrá sem inniheldur útvarpsstöðvar."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Viltu halda áfram?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Engin ný útvarpsstöð á listanum þínum."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Ein ný útvarpsstöð á listanum þínum."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s nýjar útvarpsstöðvar á listanum þínum."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 "Það eru engar nýjar útvarpsstöðvar til að bæta á valmynd Radio3.0 "
 "smáforritsins"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Nýrri útvarpsstöð hefur verið bætt á valmynd Radio3.0 smáforritsins"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr ""
 "%s nýjum útvarpsstöðvum hefur verið bætt á valmynd Radio3.0 smáforritsins"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kb/sek"
@@ -841,6 +846,10 @@ msgstr "Vista og endurheimta"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Uppfæra þennan stöðvalista"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1104,6 +1113,10 @@ msgstr "Opna möppuna sem inniheldur þessa lista"
 msgid "Update my station list with the Radio Database data"
 msgstr "Uppfæra útvarpsstöðvalistann minn með gögnum frá Radio Database"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "Flyttu stöðvarnar þínar inn úr Radio++"
@@ -1143,6 +1156,11 @@ msgstr "Flytja valdar stöðvar inn í minn eigin lista"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Fjarlægja valin atriði af þessum lista"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Fjarlægja valin atriði af þessum lista"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/it.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2025-08-27 18:00+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -236,224 +236,229 @@ msgstr "Sab."
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Sconosciuto)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Avvia"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Ferma"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Volume: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Clic-Centrale: Arresta Registrazione"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Clic-Centrale: ON/OFF"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Clic: Seleziona un'altra stazione"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Rotella di scorrimento: cambio volume"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Clicca per selezionare una stazione"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr "Svegliati"
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Configura..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Cerca nuove stazioni..."
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr "Carica un elenco di stazioni di esempio"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Impostazioni del Suono"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Guarda su YT"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Prova a scaricare da YouTube (non sicuro)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Stazioni Ascoltate Recentemente:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Visita l'home page di questa stazione"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Categorie"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Stazioni Radio"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Tutte le categorie"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Le Mie Stazioni Radio"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Scaricando..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Interrompi scaricamento"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Scaricamento completato"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Apri la cartella delle registrazioni"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "C'è stato un errore durante la registrazione!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Controlla questo record."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Registra da adesso"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Arresta Registrazione Corrente"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Riproducendo %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Radio OFF"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Impossibile registrare qualcosa!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Spazio insufficiente"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Il limite che hai impostato è stato raggiunto."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Effettua la discussione e accedi nuovamente"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "per finalizzare l'aggiornamento di yt-dlp"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Niente da salvare."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Elenco di stazione radio memorizzate"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Questo rimpiazzerà l'attuale elenco di stazioni radio."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Vuoi procedere davvero?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Aggiornamento in corso"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Potrebbe richiedere un po' ... Attendi."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Aggiornamento effettuato con successo"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "ERRORE: URL video YT non valido!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Impossibile estrarre una singola traccia audio"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Forse è una playlist?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Chiudi"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr "Annulla"
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr "Radio3.0 applet"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr "Abilita l'estensione OSD150"
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 "Per ottenere un OSD orizzontale, è necessario abilitare l'estensione OSD150."
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr "Scarica l'estensione OSD150"
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
@@ -462,113 +467,113 @@ msgstr ""
 "OSD150.\n"
 "Clicca sul pulsante Download, quindi cerca OSD150 e seleziona il pulsante ⬇."
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Rimuovi '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Informazioni su..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Manuale..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Ricarica questa applet"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Pianifica una registrazione in background..."
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr "Configura la Sveglia..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Estrai traccia audio da un video YouTube..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(auto)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(manuale)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Interrompi Registrazione"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Avvia Registrazione"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Annulla download da YT"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Effetti Pulse"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Effetti semplici"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Radio ON all'avvio"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Mostra Logo Stazione"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "Impostazioni desklet copertina album"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr "Svegliami!"
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "Mostra la copertina dell'album sul desktop"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Non controllare le dipendenze"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Visualizza il livello del volume vicino all'icona"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr "Hai bisogno del desklet 'Album Art 3.0'"
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr "Puoi installarlo cliccando sul primo pulsante e poi cercando Album."
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr "Desklet"
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr "Devi attivare il desklet 'Album Art 3.0'"
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
@@ -576,54 +581,54 @@ msgstr ""
 "Puoi attivarlo cliccando sul primo pulsante, quindi cercando Album e "
 "aggiungendolo con il pulsante [+]."
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Chiudi senza interrompere la registrazione"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Avvio registrazione da %s:%s fino a %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Registrazione completata"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Questo importerà un nuovo file contenente le stazioni radio."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Vuoi procedere?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Nessuna nuova radio nel tuo elenco."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Una radio in più nel tuo elenco."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s radio in più nel tuo elenco."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr "Non ci sono nuove stazioni da aggiungere al menù dell'applet Radio3.0"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Una nuova stazione è stata aggiunta al menù dell'applet Radio3.0"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s nuove stazioni sono state aggiunte al menù dell'applet Radio3.0"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -834,6 +839,10 @@ msgstr "Salva e Ripristina"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Aggiorna questo elenco stazioni"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1100,6 +1109,10 @@ msgstr "Apri la cartella contenente questi elenchi"
 msgid "Update my station list with the Radio Database data"
 msgstr "Aggiorna l'elenco delle mie stazioni con i dati del Database Radio"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "Importa le tue stazioni da Radio++"
@@ -1139,6 +1152,11 @@ msgstr "Importa le stazioni selezionate nel mio elenco"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Rimuovi gli elementi selezionati da questo elenco"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Rimuovi gli elementi selezionati da questo elenco"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/nl.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2025-08-26 08:30+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -230,224 +230,229 @@ msgstr "Za."
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Ongedefinieerd)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Start"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Stop"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Volume: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Middenklik: Stop opname"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Middenklik: AAN/UIT"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Klik: Selecteer een ander station"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Scrollwiel: volumewijziging"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Klik om een station te selecteren"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr "Word wakker"
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Configureren..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Zoeken naar nieuwe stations..."
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr "Een voorbeeldzenderlijst laden"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Geluidsinstellingen"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Bekijken op YT"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Probeer het te downloaden van YT (onveilig)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Onlangs afgespeelde stations:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Bezoek de homepagina van dit station"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Categorieën"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Radio Stations"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Alle Categorieën"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Mijn Radiostations"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Downloaden..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Stop met downloaden"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Download voltooid"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Open de opnamefolder"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Er lijkt een fout te zijn opgetreden tijdens het opnemen!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Controleer deze opname alstublieft."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Neem op vanaf nu"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Stop huidige opname"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Afspelen %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Radio UIT"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Kan niets opnemen!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Onvoldoende ruimte"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Het door jou ingestelde limiet is bereikt."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Log uit en log weer in"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "om de yt-dlp-update te voltooien"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Niets om op te slaan."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Lijst met opgeslagen radiostations"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Dit zal alle huidige radiostations vervangen."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Weet je zeker dat je door wilt gaan?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Update bezig"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Het kan even duren ... Even geduld a.u.b."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Update succesvol voltooid"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "FOUT: Ongeldige YT-video-URL!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Kan geen enkel geluidsspoor extraheren"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Misschien is het een afspeellijst?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Sluiten"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr "Annuleren"
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr "Radio3.0-applet"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr "OSD150-extensie inschakelen"
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 "Om een horizontale OSD te verkrijgen, moet je de OSD150-extensie inschakelen."
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr "OSD150-extensie downloaden"
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
@@ -456,99 +461,99 @@ msgstr ""
 "downloaden.\n"
 "Klik op de Download-knop, zoek naar OSD150 en selecteer de ⬇-knop."
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Verwijder '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Over..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Handleiding..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Herlaad deze applet"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Plan een achtergrondopname..."
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr "Configureer de wekker..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Soundtrack extraheren uit YouTube-video..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(automatisch)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(handmatig)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Stop opname"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Start opname"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Downloads van YT annuleren"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Pulse-effecten"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Easy Effects"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Radio AAN bij opstarten"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Toon stationlogo"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "Instellingen voor Albumhoes-desklet"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr "Maak me wakker!"
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "Albumhoes op het bureaublad weergeven"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Controleer niet op afhankelijkheden"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Toon volumeniveau in de buurt van het pictogram"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr "Je hebt de 'Album Art 3.0'-desklet nodig"
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
@@ -556,15 +561,15 @@ msgstr ""
 "Je kunt deze installeren door op de eerste knop te klikken en vervolgens te "
 "zoeken naar Album."
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr "Desklets"
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr "Je moet de 'Album Art 3.0'-desklet activeren"
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
@@ -572,56 +577,56 @@ msgstr ""
 "Je kunt deze activeren door op de eerste knop te klikken, te zoeken naar "
 "Album en het toe te voegen met de knop [+]."
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Sluiten zonder opname te stoppen"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Opname starten vanaf %s:%s tot %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Opname voltooid"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Dit zal een nieuw bestand importeren dat radiozenders bevat."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Wil je doorgaan?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Geen nieuwe radio in je lijst."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Nog één radio in je lijst."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "Nog %s radio's in je lijst."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 "Er zijn geen nieuwe stations om toe te voegen aan het menu van de Radio3.0-"
 "applet"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Een nieuw station is toegevoegd aan het menu van de Radio3.0-applet"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s nieuwe stations zijn toegevoegd aan het menu van de Radio3.0-applet"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -833,6 +838,10 @@ msgstr "Opslaan en Herstellen"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Werk deze lijst met stations bij"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1096,6 +1105,10 @@ msgstr "Open de map die deze lijsten bevat"
 msgid "Update my station list with the Radio Database data"
 msgstr "Werk mijn lijst met stations bij met de gegevens van de radiodatabase"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "Importeer je zenders uit Radio++"
@@ -1135,6 +1148,11 @@ msgstr "Importeer de geselecteerde stations naar mijn eigen lijst"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Verwijder geselecteerde items uit deze lijst"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Verwijder geselecteerde items uit deze lijst"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/ru.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2023-03-26 11:24+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -238,394 +238,399 @@ msgstr ""
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Не выбрано)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Запустить"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Остановить"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Громкость: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Щелчок средней кнопкой - остановить запись"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Щелчок средней кнопкой - ВКЛ/ВЫКЛ"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Щелчок левой кнопкой - выбрать другую радиостанцию"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Колесо прокрутки - изменение громкости"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Щелкните, чтобы выбрать радиостанцию"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr ""
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Настройка..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Поиск новых радиостанций..."
 
-#. applet.js:2643
+#. applet.js:2648
 #, fuzzy
 msgid "Load a sample station list"
 msgstr "Обновление списка радиостанций"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Настройки звука"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Смотреть на YouTube"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Попытаться скачать с YouTube (небезопасно)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Недавно воспроизведенные радиостанции:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Посетить домашнюю страницу радиостанции"
 
-#. applet.js:2877
+#. applet.js:2893
 #, fuzzy
 msgid "Categories"
 msgstr "Мои категории"
 
-#. applet.js:2880
+#. applet.js:2896
 #, fuzzy
 msgid "Radio Stations"
 msgstr "Мои радиостанции"
 
-#. applet.js:2891
+#. applet.js:2907
 #, fuzzy
 msgid "All Categories"
 msgstr "Мои категории"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Мои радиостанции"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Загрузка..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Остановить загрузку"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Загрузка завершена"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Открыть папку записей"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "При осуществлении записи вероятно возникла ошибка!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Пожалуйста, проверьте эту запись."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Записать с текущего момента"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Остановить текущую запись"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Воспроизведение %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Радио ВЫКЛ"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Невозможно что-либо записать!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Недостаточно места"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Достигнут установленный вами лимит."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Пожалуйста, завершите сеанс пользователя и снова войдите"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "для завершения обновления yt-dlp"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Нечего сохранять."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Список сохраненных радиостанций"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Это перезапишет все текущие радиостанции."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Вы уверены, что хотите продолжить?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Идет обновление"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Это может занять некоторое время... Пожалуйста, подождите."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Обновление успешно завершено"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "ОШИБКА: Неверный адрес YouTube-видео!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Невозможно извлечь звуковую дорожку"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Возможно, это список воспроизведения?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Закрыть"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr ""
 
-#. applet.js:4778
+#. applet.js:4837
 #, fuzzy
 msgid "Radio3.0 applet"
 msgstr "Перезагрузить апплет"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr ""
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr ""
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
 msgstr ""
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Удалить '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "О..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Описание..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Перезагрузить апплет"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Запланировать фоновую запись..."
 
-#. applet.js:4977
+#. applet.js:5036
 #, fuzzy
 msgid "Configure the Alarm Clock..."
 msgstr "Настройка..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Извлечь звуковую дорожку из YouTube-видео..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(авто)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(вручную)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Остановить запись"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Начать запись"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Отменить загрузки из YouTube"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr ""
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr ""
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Радио ВКЛ при загрузке"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr ""
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr ""
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr ""
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr ""
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Не проверять зависимости"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr ""
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr ""
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr ""
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
 msgstr ""
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Закрыть, не останавливая запись"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Начинается запись от %s:%s до %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Запись завершена"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Это осуществит импорт нового файла, содержащего радиостанции."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Вы хотите продолжить?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "В вашем списке нет новых радиостанций."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Еще одна радиостанция в вашем списке."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "Еще %s радиостанции(ий) в вашем списке."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr "Нет новых радиостанций для добавления в меню апплета Radio3.0"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Новая радиостанция была добавлена в меню апплета Radio3.0"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s новые(ых) радиостанции(ий) были добавлены в меню апплета Radio3.0"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s кбит/с"
@@ -836,6 +841,10 @@ msgstr "Сохранение и восстановление"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Обновление списка радиостанций"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1101,6 +1110,10 @@ msgstr "Открыть папку, содержащую эти списки"
 msgid "Update my station list with the Radio Database data"
 msgstr "Обновить мой список радиостанций в соответствии с базой данных"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr ""
@@ -1140,6 +1153,11 @@ msgstr "Импортировать выбранные радиостанции �
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Удалить выбранные позиции из этого списка"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Удалить выбранные позиции из этого списка"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/sv.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/sv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2024-02-01 15:30+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -229,395 +229,400 @@ msgstr ""
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Odefinierad)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Start"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Stopp"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Volym: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Mushjulsklick: Stoppa inspelning"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Mushjulsklick: PÅ/AV"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Klick: Välj en annan station"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Rullningshjul: Volymändring"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Klicka för att välja en station"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr ""
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Konfigurera..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Sök efter nya stationer..."
 
-#. applet.js:2643
+#. applet.js:2648
 #, fuzzy
 msgid "Load a sample station list"
 msgstr "Uppdatera stationslistan"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Ljudinställningar"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "Titta på YT"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "Försök ladda ner det från YT (osäkert)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Nyligen spelade stationer:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Besök hemsidan för denna station"
 
-#. applet.js:2877
+#. applet.js:2893
 #, fuzzy
 msgid "Categories"
 msgstr "Mina kategorier"
 
-#. applet.js:2880
+#. applet.js:2896
 #, fuzzy
 msgid "Radio Stations"
 msgstr "Mina radiostationer"
 
-#. applet.js:2891
+#. applet.js:2907
 #, fuzzy
 msgid "All Categories"
 msgstr "Mina kategorier"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Mina radiostationer"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "Laddar ner..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "Stoppa nerladdning"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "Nerladdning slutförd"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Öppna inspelningsmappen"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Ett fel verkar ha inträffat under inspelning!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Kontrollera denna inspelning."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Spela in från nu"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Stoppa aktuell inspelning"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "Spelar upp %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Radio AV"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Kan inte spela in någonting!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Otillräckligt utrymme"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Gränsen du anger har nåtts."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Logga ut och in igen"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "för att slutföra uppdateringen av yt-dlp"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Inget att spara."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Lista över sparade radiostationer"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Detta kommer att ersätta alla aktuella radiostationer."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Vill du verkligen fortsätta?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Uppdatering pågår"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Det kan ta en stund... vänta!"
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Uppdatering slutförd"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "FEL: Ogiltig YT video-URL!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Kan inte extrahera ett enskilt ljudspår"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Det kanske är en spelningslista?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Stäng"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr ""
 
-#. applet.js:4778
+#. applet.js:4837
 #, fuzzy
 msgid "Radio3.0 applet"
 msgstr "Radio3.0"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr ""
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr ""
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
 msgstr ""
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Ta bort \"%s\""
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Om..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Manual..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Uppdatera detta panelprogram"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Schemalägg bakgrundsinspelning..."
 
-#. applet.js:4977
+#. applet.js:5036
 #, fuzzy
 msgid "Configure the Alarm Clock..."
 msgstr "Konfigurera..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Extrahera ljudspår från YouTube-video..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(auto)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(manuell)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Stoppa inspelning"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Starta inspelning"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "Avbryt nerladdningar från YT"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Pulse Effects"
 
-#. applet.js:5039
+#. applet.js:5098
 #, fuzzy
 msgid "Easy Effects"
 msgstr "Pulse Effects"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Radio PÅ vid uppstart"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "Visa stationslogo"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr ""
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr ""
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr ""
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Kontrollera inte beroenden"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Visa volymnivå nära ikonen"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr ""
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr ""
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
 msgstr ""
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Stäng utan stoppa inspelning"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Startar inspelning från %s:%s till %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Inspelning slutförd"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Detta importerar en ny fil innehållande radistationer."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Vill du fortsätta?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Ingen ny radiostation i din lista."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "En radiostation till i din lista."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s radiostationer till i din lista."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr "Det finns inga nya stationer att lägga till i panelmenyn för Radio3.0"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "En ny station har lagts till i panelmenyn för Radio3.0"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s nya stationer har lagts till i panelmenyn för Radio3.0"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -827,6 +832,10 @@ msgstr "Spara och återställ"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Uppdatera stationslistan"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1092,6 +1101,10 @@ msgstr "Öppna mappen som innehåller dessa listor"
 msgid "Update my station list with the Radio Database data"
 msgstr "Uppdatera min stationslista med Radio Database-data"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr ""
@@ -1131,6 +1144,11 @@ msgstr "Importera de markerade stationerna till min egen lista"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Ta bort markerade objekt från denna lista"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Ta bort markerade objekt från denna lista"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/tr.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Radio3.0 v1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2025-01-13 12:14+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
@@ -232,391 +232,396 @@ msgstr ""
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "(Tanımsız)"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "Başlat"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "Durdur"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "Ses düzeyi: %s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "Orta Tıklama: Kaydı Durdur"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "Orta tıklama: AÇIK/KAPALI"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "Tıklayın: Başka bir istasyon seçin"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "Kaydırma tekerleği: ses değişikliği"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "Bir istasyon seçmek için tıklayın"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr ""
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "Yapılandır..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "Yeni istasyonlar arayın..."
 
-#. applet.js:2643
+#. applet.js:2648
 #, fuzzy
 msgid "Load a sample station list"
 msgstr "Bu istasyon listesini güncelle"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "Ses Ayarları"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "YT'de izle"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "YT'den indirmeyi deneyin (güvenli değil)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "Son Oynatılan İstasyonlar:"
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "Bu istasyonun ana sayfasını ziyaret edin"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "Kategoriler"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "Radyo İstasyonları"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "Tüm Kategoriler"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "Radyo İstasyonlarım"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "İndiriliyor..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "İndirmeyi durdur"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "İndirme tamamlandı"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "Kayıtlar klasörünü aç"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "Kayıt sırasında bir hata oluşmuş gibi görünüyor!"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "Lütfen bu kaydı kontrol edin."
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "Şu andan itibaren kaydet"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "Geçerli Kaydı Durdur"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "%s%s oynatılıyor"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "Radyo KAPALI"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "Hiçbir şey kaydedilemiyor!"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "Yetersiz alan"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "Belirlediğiniz sınıra ulaşıldı."
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "Lütfen Oturumu Kapatın ve Yeniden Oturum Açın"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "yt-dlp güncellemesini sonlandırmak için"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "Kaydedilecek bir şey yok."
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "Kayıtlı radyo istasyonlarının listesi"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "Bu, mevcut tüm radyo istasyonlarının yerini alacaktır."
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "Devam etmek istediğine emin misin?"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "Güncelleme devam ediyor"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "Biraz zaman alabilir... Lütfen bekleyin."
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "Güncelleme başarıyla tamamlandı"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "HATA: Geçersiz YT video URL'si!"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "Tek bir film müziği çıkarılamıyor"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "Belki bir çalma listesidir?"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "Kapat"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr ""
 
-#. applet.js:4778
+#. applet.js:4837
 #, fuzzy
 msgid "Radio3.0 applet"
 msgstr "Radio3.0"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr ""
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr ""
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr ""
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
 msgstr ""
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "'%s'ı kaldır"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "Hakkında..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "Klavuz..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "Bu uygulamayı yeniden yükle"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "Bir arka plan kaydı planlayın..."
 
-#. applet.js:4977
+#. applet.js:5036
 #, fuzzy
 msgid "Configure the Alarm Clock..."
 msgstr "Yapılandır..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Film müziğini YouTube videosundan çıkarın..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "(otomatik)"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "(elle)"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "Kaydı Durdur"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "Kayda Başla"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "YOUTUBE'dan indirmeleri iptal et"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "Nabız Efektleri"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "Kolay Efektler"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "Başlangıçta radyo AÇIK"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "İstasyon Logosunu Göster"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "Albüm Kapağı masaüstü ayarları"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr ""
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "Masaüstünde Albüm Kapağını Göster"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "Bağımlılıkları kontrol etme"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "Simgenin yanında ses seviyesini göster"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr ""
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr ""
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr ""
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
 msgstr ""
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "Kaydı durdurmadan kapatın"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "%s:%s'den %s:%s'ye kayıt başlatılıyor"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "Kayıt tamamlandı"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "Bu, radyo istasyonlarını içeren yeni bir dosyayı içe aktaracaktır."
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "Devam etmek istiyor musun?"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "Listenizde yeni radyo yok."
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "Listenize bir radyo daha eklendi."
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "Listenizde %s tane daha radyo var."
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr "Radio3.0 uygulama menüsüne eklenecek yeni istasyon yok"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Radio3.0 uygulama menüsüne yeni bir istasyon eklendi"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "Radio3.0 uygulama menüsüne %s yeni istasyon eklendi"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -826,6 +831,10 @@ msgstr "Kaydet ve Geri Yükle"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "Bu istasyon listesini güncelle"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1090,6 +1099,10 @@ msgstr "Bu listeleri içeren klasörü açın"
 msgid "Update my station list with the Radio Database data"
 msgstr "İstasyon listemi Radyo Veritabanı verileriyle güncelle"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "İstasyonlarınızı Radio++'dan içe aktarın"
@@ -1129,6 +1142,11 @@ msgstr "Seçilen istasyonları kendi listeme aktar"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "Seçili öğeleri bu listeden kaldır"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "Seçili öğeleri bu listeden kaldır"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/zh_TW.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/zh_TW.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Radio3.0@claudiux 3.5.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-09-08 21:08+0200\n"
+"POT-Creation-Date: 2025-09-10 19:42+0200\n"
 "PO-Revision-Date: 2025-08-07 01:21+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -200,223 +200,228 @@ msgstr "週六"
 #. settings-schema.json->search-order->options
 #. settings-schema.json->alarm-clock-working-days-radio->options
 #. settings-schema.json->alarm-clock-workoff-days-radio->options
-#. applet.js:585 applet.js:601 applet.js:5447 applet.js:5463
+#. applet.js:585 applet.js:603 applet.js:5506 applet.js:5522
 msgid "(Undefined)"
 msgstr "（未定義）"
 
-#. applet.js:2257
+#. settings-schema.json->category-to-move->options
+#. applet.js:586 applet.js:5523
+msgid "(Blacklist)"
+msgstr ""
+
+#. applet.js:2259
 msgid "Start"
 msgstr "開始"
 
-#. applet.js:2265 applet.js:2994
+#. applet.js:2267 applet.js:3010
 msgid "Stop"
 msgstr "停止"
 
-#. applet.js:2536
+#. applet.js:2541
 msgid "Volume: %s%"
 msgstr "音量：%s%"
 
-#. applet.js:2541
+#. applet.js:2546
 msgid "Middle-Click: Stop Recording"
 msgstr "滑鼠中鍵：停止錄音"
 
-#. applet.js:2543
+#. applet.js:2548
 msgid "Middle-click: ON/OFF"
 msgstr "滑鼠中鍵：開啟/關閉"
 
-#. applet.js:2545
+#. applet.js:2550
 msgid "Click: Select another station"
 msgstr "點選：選擇其他電台"
 
-#. applet.js:2546
+#. applet.js:2551
 msgid "Scroll wheel: volume change"
 msgstr "滾輪：調整音量"
 
-#. applet.js:2549
+#. applet.js:2554
 msgid "Click to select a station"
 msgstr "點選以選擇電台"
 
-#. applet.js:2555
+#. applet.js:2560
 msgid "Wake Up"
 msgstr "喚醒"
 
-#. applet.js:2633 applet.js:3012 applet.js:4959
+#. applet.js:2638 applet.js:3028 applet.js:5018
 msgid "Configure..."
 msgstr "設定..."
 
-#. applet.js:2637 applet.js:3004
+#. applet.js:2642 applet.js:3020
 msgid "Search for new stations..."
 msgstr "搜尋新電台..."
 
-#. applet.js:2643
+#. applet.js:2648
 msgid "Load a sample station list"
 msgstr "載入範例電台清單"
 
-#. applet.js:2690 applet.js:3016 applet.js:5029
+#. applet.js:2695 applet.js:3032 applet.js:5088
 msgid "Sound Settings"
 msgstr "音效設定"
 
-#. applet.js:2761
+#. applet.js:2766
 msgid "Watch on YT"
 msgstr "在 YT 上觀看"
 
-#. applet.js:2768
+#. applet.js:2773
 msgid "Try to download it from YT (unsafe)"
 msgstr "嘗試從 YT 下載 (不安全)"
 
-#. applet.js:2788
+#. applet.js:2793
 msgid "Recently Played Stations:"
 msgstr "最近播放的電台："
 
-#. applet.js:2829
+#. applet.js:2844
 msgid "Visit the home page of this station"
 msgstr "造訪此電台的首頁"
 
-#. applet.js:2877
+#. applet.js:2893
 msgid "Categories"
 msgstr "分類"
 
-#. applet.js:2880
+#. applet.js:2896
 msgid "Radio Stations"
 msgstr "廣播電台"
 
-#. applet.js:2891
+#. applet.js:2907
 msgid "All Categories"
 msgstr "所有分類"
 
-#. applet.js:2936
+#. applet.js:2952
 msgid "My Radio Stations"
 msgstr "我的電台"
 
-#. applet.js:3136
+#. applet.js:3152
 msgid "Downloading..."
 msgstr "下載中..."
 
-#. applet.js:3138
+#. applet.js:3154
 msgid "Stop downloading"
 msgstr "停止下載"
 
-#. applet.js:3244
+#. applet.js:3260
 msgid "Download complete"
 msgstr "下載完成"
 
 #. settings-schema.json->button-open-rec-folder->description
 #. settings-schema.json->recordings-open-folder->description
-#. applet.js:3246 applet.js:3255 applet.js:4679 applet.js:4688 applet.js:4697
-#. applet.js:4992
+#. applet.js:3262 applet.js:3271 applet.js:4738 applet.js:4747 applet.js:4756
+#. applet.js:5051
 msgid "Open the recordings folder"
 msgstr "開啟錄音資料夾"
 
-#. applet.js:3253 applet.js:4676 applet.js:4686 applet.js:4695
+#. applet.js:3269 applet.js:4735 applet.js:4745 applet.js:4754
 msgid "An error seems to have occurred during recording!"
 msgstr "錄音時似乎發生錯誤！"
 
-#. applet.js:3254 applet.js:4678 applet.js:4687 applet.js:4696
+#. applet.js:3270 applet.js:4737 applet.js:4746 applet.js:4755
 msgid "Please check this record."
 msgstr "請檢查此錄音。"
 
-#. applet.js:3361 applet.js:3395
+#. applet.js:3377 applet.js:3411
 msgid "Record from now"
 msgstr "立即錄音"
 
-#. applet.js:3379 applet.js:5349
+#. applet.js:3395 applet.js:5408
 msgid "Stop Current Recording"
 msgstr "停止目前錄音"
 
-#. applet.js:3527
+#. applet.js:3543
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "正在播放 %s%s"
 
-#. applet.js:3581
+#. applet.js:3597
 msgid "Radio OFF"
 msgstr "收音機關閉"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "Unable to record anything!"
 msgstr "無法錄音！"
 
-#. applet.js:3709 applet.js:5009 applet.js:5168
+#. applet.js:3725 applet.js:5068 applet.js:5227
 msgid "Insufficient space"
 msgstr "空間不足"
 
-#. applet.js:3709
+#. applet.js:3725
 msgid "The limit you set has been reached."
 msgstr "已達您設定的上限。"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "Please Log Out then Log In"
 msgstr "請先登出再登入"
 
-#. applet.js:4110
+#. applet.js:4126
 msgid "to finalize yt-dlp update"
 msgstr "以完成 yt-dlp 的更新"
 
-#. applet.js:4245
+#. applet.js:4261
 msgid "Nothing to save."
 msgstr "沒有可儲存的內容。"
 
-#. applet.js:4258
+#. applet.js:4274
 msgid "List of saved radio stations"
 msgstr "已儲存的電台清單"
 
-#. applet.js:4276
+#. applet.js:4292
 msgid "This will replace all current radio stations."
 msgstr "這將取代目前所有的電台。"
 
-#. applet.js:4277
+#. applet.js:4293
 msgid "Are you sure you want to continue?"
 msgstr "確定要繼續嗎？"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "Update in progress"
 msgstr "正在更新"
 
-#. applet.js:4341
+#. applet.js:4357
 msgid "It may take a while ... Please wait."
 msgstr "可能需要一些時間... 請稍候。"
 
-#. applet.js:4433
+#. applet.js:4449
 msgid "Update completed successfully"
 msgstr "更新已成功完成"
 
-#. applet.js:4561 applet.js:4617
+#. applet.js:4620 applet.js:4676
 msgid "ERROR: Invalid YT video URL!"
 msgstr "錯誤：無效的 YT 影片網址！"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Unable to extract a single soundtrack"
 msgstr "無法擷取單一音軌"
 
-#. applet.js:4586
+#. applet.js:4645
 msgid "Maybe it's a playlist?"
 msgstr "這可能是個播放清單？"
 
-#. applet.js:4619
+#. applet.js:4678
 msgid "Close"
 msgstr "關閉"
 
-#. applet.js:4777 applet.js:5236 applet.js:5254
+#. applet.js:4836 applet.js:5295 applet.js:5313
 msgid "Cancel"
 msgstr "取消"
 
-#. applet.js:4778
+#. applet.js:4837
 msgid "Radio3.0 applet"
 msgstr "Radio3.0 小程式"
 
-#. applet.js:4781
+#. applet.js:4840
 msgid "Enable the OSD150 extension"
 msgstr "啟用 OSD150 擴充功能"
 
-#. applet.js:4782
+#. applet.js:4841
 msgid "To obtain an horizontal OSD, you need to enable the OSD150 extension."
 msgstr "如需橫向 OSD，請啟用 OSD150 擴充功能。"
 
-#. applet.js:4799
+#. applet.js:4858
 msgid "Download the OSD150 extension"
 msgstr "下載 OSD150 擴充功能"
 
-#. applet.js:4800
+#. applet.js:4859
 msgid ""
 "To obtain an horizontal OSD, you need to download the OSD150 extension.\n"
 "Click on the Download button then search for OSD150 and select the ⬇ button."
@@ -424,166 +429,166 @@ msgstr ""
 "如需橫向 OSD，請下載 OSD150 擴充功能。\n"
 "點選「下載」按鈕後搜尋 OSD150 並選擇「⬇」按鈕。"
 
-#. applet.js:4931
+#. applet.js:4990
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "移除 '%s'"
 
-#. applet.js:4939
+#. applet.js:4998
 msgid "About..."
 msgstr "關於..."
 
-#. applet.js:4946
+#. applet.js:5005
 msgid "Manual..."
 msgstr "使用手冊..."
 
-#. applet.js:4953
+#. applet.js:5012
 msgid "Reload this applet"
 msgstr "重新載入這個小程式"
 
-#. applet.js:4970
+#. applet.js:5029
 msgid "Schedule a background record..."
 msgstr "排程背景錄製..."
 
-#. applet.js:4977
+#. applet.js:5036
 msgid "Configure the Alarm Clock..."
 msgstr "設定鬧鐘..."
 
-#. applet.js:4984
+#. applet.js:5043
 msgid "Extract soundtrack from YouTube video..."
 msgstr "從 YouTube 影片擷取音軌..."
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(auto)"
 msgstr "（自動）"
 
-#. applet.js:5006 applet.js:5165
+#. applet.js:5065 applet.js:5224
 msgid "(manual)"
 msgstr "（手動）"
 
-#. applet.js:5009 applet.js:5168 applet.js:5396
+#. applet.js:5068 applet.js:5227 applet.js:5455
 msgid "Stop Recording"
 msgstr "停止錄音"
 
-#. applet.js:5009 applet.js:5168
+#. applet.js:5068 applet.js:5227
 msgid "Start Recording"
 msgstr "開始錄音"
 
-#. applet.js:5025
+#. applet.js:5084
 msgid "Cancel downloads from YT"
 msgstr "取消從 YT 下載"
 
-#. applet.js:5034
+#. applet.js:5093
 msgid "Pulse Effects"
 msgstr "PulseEffects"
 
-#. applet.js:5039
+#. applet.js:5098
 msgid "Easy Effects"
 msgstr "EasyEffects"
 
-#. applet.js:5044
+#. applet.js:5103
 msgid "Radio ON at startup"
 msgstr "啟動時開啟廣播"
 
-#. applet.js:5053
+#. applet.js:5112
 msgid "Display Station Logo"
 msgstr "顯示電台標誌"
 
-#. applet.js:5063
+#. applet.js:5122
 msgid "Album Art desklet settings"
 msgstr "專輯封面桌面小程式設定"
 
 #. settings-schema.json->alarm-clock-wake-me-up->description
-#. applet.js:5068
+#. applet.js:5127
 msgid "Wake me up!"
 msgstr "叫我起床！"
 
-#. applet.js:5077
+#. applet.js:5136
 msgid "Show Album Art on desktop"
 msgstr "在桌面顯示專輯封面"
 
 #. settings-schema.json->dont-check-dependencies->description
-#. applet.js:5086
+#. applet.js:5145
 msgid "Do not check about dependencies"
 msgstr "不檢查相依性"
 
 #. settings-schema.json->show-volume-level-near-icon->description
-#. applet.js:5096
+#. applet.js:5155
 msgid "Display volume level near icon"
 msgstr "在圖示旁顯示音量大小"
 
-#. applet.js:5233
+#. applet.js:5292
 msgid "You need the 'Album Art 3.0' desklet"
 msgstr "您需要「Album Art 3.0」桌面小程式"
 
-#. applet.js:5234
+#. applet.js:5293
 msgid ""
 "You can install it by clicking on the first button and then searching for "
 "Album."
 msgstr "您可以點選第一個按鈕，然後搜尋 Album 來安裝。"
 
-#. applet.js:5235 applet.js:5253
+#. applet.js:5294 applet.js:5312
 msgid "Desklets"
 msgstr "桌面小程式"
 
-#. applet.js:5251
+#. applet.js:5310
 msgid "You need to activate the 'Album Art 3.0' desklet"
 msgstr "您需要啟用「Album Art 3.0」桌面小程式"
 
-#. applet.js:5252
+#. applet.js:5311
 msgid ""
 "You can activate it by clicking on the first button, then searching for "
 "Album and adding it with button [+]."
 msgstr "您可以點選第一個按鈕來啟用它，然後搜尋 Album 並使用 [+] 按鈕新增。"
 
-#. applet.js:5397
+#. applet.js:5456
 msgid "Close without stopping recording"
 msgstr "關閉但不停止錄音"
 
-#. applet.js:5611
+#. applet.js:5671
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "開始錄音：從 %s:%s 到 %s:%s"
 
-#. applet.js:5623
+#. applet.js:5683
 msgid "Recording completed"
 msgstr "錄製完成"
 
-#. applet.js:5748
+#. applet.js:5808
 msgid "This will import a new file containing radio stations."
 msgstr "這將匯入一個包含廣播電台的新檔案。"
 
-#. applet.js:5749
+#. applet.js:5809
 msgid "Do you want to continue?"
 msgstr "要繼續嗎？"
 
-#. applet.js:5821
+#. applet.js:5886
 msgid "No new radio in your list."
 msgstr "清單中沒有新的廣播電台。"
 
-#. applet.js:5823
+#. applet.js:5888
 msgid "One more radio in your list."
 msgstr "清單中增加了一個廣播電台。"
 
-#. applet.js:5825
+#. applet.js:5890
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "清單中增加了 %s 個廣播電台。"
 
-#. applet.js:6032
+#. applet.js:6149
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr "沒有新的電台可新增至 Radio3.0 小程式選單"
 
-#. applet.js:6034
+#. applet.js:6151
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "已新增一個電台至 Radio3.0 小程式選單"
 
-#. applet.js:6036
+#. applet.js:6153
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "已新增 %s 個電台至 Radio3.0 小程式選單"
 
-#. applet.js:6261
+#. applet.js:6378
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbps"
@@ -791,6 +796,10 @@ msgstr "儲存與還原"
 #. settings-schema.json->sectionStationsUpdate->title
 msgid "Update this station list"
 msgstr "更新此電台清單"
+
+#. settings-schema.json->sectionBlacklist->title
+msgid "Unwanted (blacklist)"
+msgstr ""
 
 #. settings-schema.json->sectionImportRadiopp->title
 msgid "Only for Radio++ users"
@@ -1052,6 +1061,10 @@ msgstr "開啟包含這些清單的資料夾"
 msgid "Update my station list with the Radio Database data"
 msgstr "使用廣播電台資料庫的資料更新電台清單"
 
+#. settings-schema.json->blacklist->columns->title
+msgid "Blacklisted URL"
+msgstr ""
+
 #. settings-schema.json->import-radiopp-button->description
 msgid "Import your stations from Radio++"
 msgstr "從 Radio++ 匯入電台"
@@ -1091,6 +1104,11 @@ msgstr "將所選取的電台匯入清單"
 #. settings-schema.json->import-remove-from-list-button->description
 #. settings-schema.json->search-remove-from-list-button->description
 msgid "Remove selected items from this list"
+msgstr "從此清單移除所選項目"
+
+#. settings-schema.json->import-blacklist-button->description
+#, fuzzy
+msgid "Blacklist selected items from this list"
 msgstr "從此清單移除所選項目"
 
 #. settings-schema.json->import-select-all->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/settings-schema.json
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/settings-schema.json
@@ -20,7 +20,8 @@
         "sectionStationsList",
         "sectionStationsMove",
         "sectionStationsSaveRestore",
-        "sectionStationsUpdate"
+        "sectionStationsUpdate",
+        "sectionBlacklist"
       ]
     },
     "pageImport": {
@@ -149,6 +150,13 @@
         "scale-update"
       ]
     },
+    "sectionBlacklist": {
+      "type": "section",
+      "title": "Unwanted (blacklist)",
+      "keys": [
+        "blacklist"
+      ]
+    },
     "sectionImportRadiopp": {
       "type": "section",
       "dependency": "radiopp-is-here",
@@ -181,6 +189,7 @@
         "import-list-play-button",
         "import-list-button",
         "import-remove-from-list-button",
+        "import-blacklist-button",
         "import-select-all",
         "import-unselect-all"
       ]
@@ -624,7 +633,8 @@
     "description": "Category to which to move the selected stations:",
     "default": "",
     "options": {
-      "(Undefined)": ""
+      "(Undefined)": "",
+      "(Blacklist)": "R30BLACKLIST"
     }
   },
   "button-moving": {
@@ -684,6 +694,19 @@
     "default": 0,
     "description": "%",
     "dependency": "show-scale-update"
+  },
+  "blacklist": {
+    "type": "list",
+    "columns": [
+      {
+        "id": "url",
+        "title": "Blacklisted URL",
+        "type": "string",
+        "expand-width": true,
+        "default": ""
+      }
+    ],
+    "default": []
   },
   "show-scale-update": {
     "type": "generic",
@@ -782,6 +805,11 @@
     "type": "button",
     "description": "Remove selected items from this list",
     "callback": "on_button_import_remove_clicked"
+  },
+  "import-blacklist-button": {
+    "type": "button",
+    "description": "Blacklist selected items from this list",
+    "callback": "on_button_import_blacklist_clicked"
   },
   "import-select-all": {
     "type": "button",
@@ -1937,12 +1965,6 @@
   "last-category": {
     "type": "generic",
     "default": ""
-  },
-  "storedRadios": {
-    "type": "generic",
-    "default": [
-
-    ]
   },
   "recentRadios": {
     "type": "generic",


### PR DESCRIPTION
The Blacklist is at the bottom of the Radios tab of this applet settings.

You can blacklist stations moving them to the virtual _(Blacklist)_ category.

You also can blacklist stations from the Import tab of this applet settings.