### PR TITLE
[windowlist@cobinja.de] Fix for windows changing the monitor

### DIFF
--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/6.4/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/6.4/applet.js
@@ -2169,7 +2169,7 @@ class CobiWindowList extends Applet.Applet {
     this._signalManager.connect(global.screen, "workspace-removed", this._onWorkspaceRemoved, this);
     this._signalManager.connect(global.screen, "window-added", this._windowAdded, this);
     this._signalManager.connect(global.screen, "window-removed", this._windowRemoved, this);
-    this._signalManager.connect(global.screen, "window-monitor-changed", this.windowMonitorChanged, this);
+    this._signalManager.connect(global.screen.get_display(), "window-monitor-changed", this.windowMonitorChanged, this);
     this._signalManager.connect(Main.layoutManager, "monitors-changed", this._updateMonitor, this);
   }
   


### PR DESCRIPTION
This fixes a problem with how a monitor change for windows was handled. The previous method couldn't work, because CinnamonScreen::window-monitor-change doesn't always name the new monitor, but also the old one, without the listener being able to distinguish between those cases.