### PR TITLE
sessionManager@scollins: Add the possibility to choose which entry are shown in Session manager 

### DIFF
--- a/sessionManager@scollins/files/sessionManager@scollins/applet.js
+++ b/sessionManager@scollins/files/sessionManager@scollins/applet.js
@@ -215,6 +215,17 @@ class MyApplet extends Applet.TextIconApplet {
         this.settings.bindProperty(Settings.BindingDirection.IN, "panelText", "panelText", this.setPanelText);
         this.settings.bindProperty(Settings.BindingDirection.IN, "iconSize", "iconSize", this.buildMenu);
         this.settings.bindProperty(Settings.BindingDirection.IN, "symbolicMenuIcons", "symbolicMenuIcons", this.buildMenu);
+        
+        // Bind menu option settings
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showLockScreen", "showLockScreen", this.buildMenu);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showSwitchUser", "showSwitchUser", this.buildMenu);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showGuestSession", "showGuestSession", this.buildMenu);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showLogOff", "showLogOff", this.buildMenu);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showSuspend", "showSuspend", this.buildMenu);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showSleep", "showSleep", this.buildMenu);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showHibernate", "showHibernate", this.buildMenu);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showRestart", "showRestart", this.buildMenu);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showShutDown", "showShutDown", this.buildMenu);
     }
 
     buildMenu() {
@@ -225,48 +236,68 @@ class MyApplet extends Applet.TextIconApplet {
             use_symbolic_icons = this.symbolicMenuIcons;
 
             //lock
-            let lock = new CommandItem("lock", _("Lock Screen"));
-            this.menu.addMenuItem(lock);
+            if (this.showLockScreen) {
+                let lock = new CommandItem("lock", _("Lock Screen"));
+                this.menu.addMenuItem(lock);
+            }
 
             //switch user
-            let uSwitch = new CommandItem("uSwitch", _("Switch User"));
-            this.menu.addMenuItem(uSwitch);
+            if (this.showSwitchUser) {
+                let uSwitch = new CommandItem("uSwitch", _("Switch User"));
+                this.menu.addMenuItem(uSwitch);
+            }
 
             //guest
-            if ( display_manager == "lightdm" ) {
+            if (this.showGuestSession && display_manager == "lightdm") {
                 let guest = new CommandItem("guest", _("Guest Session"));
                 this.menu.addMenuItem(guest);
             }
 
             //log off
-            let logOff = new CommandItem("logOff", _("Log Off"));
-            this.menu.addMenuItem(logOff);
+            if (this.showLogOff) {
+                let logOff = new CommandItem("logOff", _("Log Off"));
+                this.menu.addMenuItem(logOff);
+            }
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            // Add separator if any of the above items are shown
+            if (this.showLockScreen || this.showSwitchUser || (this.showGuestSession && display_manager == "lightdm") || this.showLogOff) {
+                this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
 
             //suspend
-            let suspend = new CommandItem("suspend", _("Suspend"));
-            this.menu.addMenuItem(suspend);
+            if (this.showSuspend) {
+                let suspend = new CommandItem("suspend", _("Suspend"));
+                this.menu.addMenuItem(suspend);
+            }
 
             //sleep
-            if ( has_systemd ) {
+            if (this.showSleep && has_systemd) {
                 let sleep = new CommandItem("sleep", _("Sleep"));
                 this.menu.addMenuItem(sleep);
             }
 
             //hibernate
-            let hibernate = new CommandItem("hibernate", _("Hibernate"));
-            this.menu.addMenuItem(hibernate);
+            if (this.showHibernate) {
+                let hibernate = new CommandItem("hibernate", _("Hibernate"));
+                this.menu.addMenuItem(hibernate);
+            }
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            // Add separator if any power management items are shown
+            if (this.showSuspend || (this.showSleep && has_systemd) || this.showHibernate) {
+                this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
 
             //restart
-            let restart = new CommandItem("restart", _("Restart"));
-            this.menu.addMenuItem(restart);
+            if (this.showRestart) {
+                let restart = new CommandItem("restart", _("Restart"));
+                this.menu.addMenuItem(restart);
+            }
 
             //shut down
-            let shutDown = new CommandItem("shutDown", _("Shut Down"));
-            this.menu.addMenuItem(shutDown);
+            if (this.showShutDown) {
+                let shutDown = new CommandItem("shutDown", _("Shut Down"));
+                this.menu.addMenuItem(shutDown);
+            }
         } catch(e) {
             global.logError(e);
         }

--- a/sessionManager@scollins/files/sessionManager@scollins/po/bg.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/bg.po
@@ -1,97 +1,73 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-19 21:02+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2017-11-19 21:11+0200\n"
+"Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: bg\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Сесия"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Заключване на екрана"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Смяна на потребител"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Сесия като гост "
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Отписване"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Режим на готовност"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Приспиване"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Хиберниране"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Рестарт"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Изключване"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Иконка в панела"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Мениджър на сесии"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Размер на иконка"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "пкс"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Символни иконки в менюто"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Текст в панела"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Общи настройки"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Доставя лесен достъп до изключване, рестарт и др."
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Автор: Стивън Колинс"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -106,6 +82,75 @@ msgstr ""
 "конфигурации. Ако вашата конкретна конфигурация не се поддържа, изпратете "
 "искане за функция в github и аз ще я добавя в първия удобен момент."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Мениджър на сесии"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Автор: Стивън Колинс"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Общи настройки"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Иконка в панела"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Текст в панела"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "пкс"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Размер на иконка"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Символни иконки в менюто"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Заключване на екрана"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Смяна на потребител"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Сесия като гост "
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Хиберниране"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Изключване"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/ca.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/ca.po
@@ -1,14 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2024-07-09 23:59+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,80 +19,55 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Sessió"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Blocar la pantalla"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Canviar usuari"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Sessió de convidat"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Tancar la sessió"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Suspendre"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Adormir"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Hivernar"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Apagar"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Icona del tauler"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Gestor de Sessions"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Mida de la icona"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Icones simbòliques al menú"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Text del tauler"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Configuració general"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Facilita accessos ràpids per a l'apagada, reinici, suspensió, etc"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Autor - Stephen Collins"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -107,6 +83,75 @@ msgstr ""
 "obriu una sol·licitud de funcionalitat a github i l'afegiré quan em vingui "
 "bé."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Gestor de Sessions"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Autor - Stephen Collins"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Configuració general"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Icona del tauler"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Text del tauler"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Mida de la icona"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Icones simbòliques al menú"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Blocar la pantalla"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Canviar usuari"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Sessió de convidat"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Hivernar"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Apagar"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/da.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/da.po
@@ -1,97 +1,73 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-01 15:07+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2017-10-01 18:48+0200\n"
+"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: da\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Session"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Lås skærmen"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Skift bruger"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Gæstesession"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Log af"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Sæt i hviletilstand"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Sæt i slumretilstand"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Sæt i dvaletilstand"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Genstart"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Sluk"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Panelikon"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Sessionshåndtering"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Ikonstørrelse"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Symbolske ikoner i menuen"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Paneltekst"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Generelle indstillinger"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Nem adgang til at slukke, genstarte osv."
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - forfatter"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -106,6 +82,75 @@ msgstr ""
 "ikke understøttes, så indsend et ønske om nye funktioner på github, og jeg "
 "vil tilføje det så snart som muligt."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Sessionshåndtering"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - forfatter"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Generelle indstillinger"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Panelikon"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Paneltekst"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Ikonstørrelse"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Symbolske ikoner i menuen"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Lås skærmen"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Skift bruger"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Gæstesession"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Sæt i dvaletilstand"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Sluk"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/de.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/de.po
@@ -1,97 +1,73 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:48+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2017-02-14 12:48+0100\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Sitzung"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Bildschirm sperren"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Benutzer wechseln"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Gastsitzung"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Abmelden"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Bereitschaft"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Schlafzustand"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Ruhezustand"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Neu starten"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Herunterfahren"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Leistensymbol"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Sitzungsmanager"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Symbolgröße"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Symbolische Icons im Menü"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Leistentext"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Allgemeine Einstellungen"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Bietet einfachen Zugriff zum Herunterfahren, Neustarten, usw."
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Autor"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -108,6 +84,75 @@ msgstr ""
 "Feature-Anfrage auf GitHub, und ich werde es so schnell wie mir möglich "
 "hinzufügen."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Sitzungsmanager"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Autor"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Allgemeine Einstellungen"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Leistensymbol"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Leistentext"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Symbolgröße"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Symbolische Icons im Menü"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Bildschirm sperren"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Benutzer wechseln"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Gastsitzung"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Ruhezustand"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Herunterfahren"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/es.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/es.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2021-12-21 15:38-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,80 +19,55 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Sesión"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Bloquear pantalla"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Cambiar de usuario"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Sesión de invitado"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Cerrar sesión"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Suspender"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Hibernar"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Apagar"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Icono del panel"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Administrador de la Sesión"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Tamaño de icono"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Utilizar iconos simbólicos en el menú"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Texto del panel"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Configuración general"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Proporciona un fácil acceso para apagar, reiniciar, etc"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Autor"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -107,6 +83,75 @@ msgstr ""
 "particular no está soportada, por favor envíe una solicitud de "
 "característica en github, y la añadiré a la mayor brevedad posible."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Administrador de la Sesión"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Autor"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Configuración general"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Icono del panel"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Texto del panel"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Tamaño de icono"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Utilizar iconos simbólicos en el menú"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Bloquear pantalla"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Cambiar de usuario"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Sesión de invitado"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Hibernar"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Apagar"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/eu.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/eu.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2023-08-28 16:28+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,80 +19,55 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Saioa"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Blokeatu pantaila"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Erabiltzailea aldatu"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Gonbidatuen saioa"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Amaitu saioa"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Eseki"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Lo egin"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Hibernatu"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Berrabiarazi"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Itzali"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Panelaren ikonoa"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Saioen kudeatzailea"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Ikonoaren tamaina"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Ikono sinbolikoak menuan"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Paneleko testua"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Ezarpen orokorrak"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Itzali, berrabiarazteko, etab. sarbide erraza eskaintzen du"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Egilea"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -106,6 +82,75 @@ msgstr ""
 "onartzen ditu. Zure konfigurazio zehatza onartzen ez bada, bidali eginbide-"
 "eskaera github-en, eta lehenbailehen gehituko dut."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Saioen kudeatzailea"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Egilea"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Ezarpen orokorrak"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Panelaren ikonoa"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Paneleko testua"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Ikonoaren tamaina"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Ikono sinbolikoak menuan"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Blokeatu pantaila"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Erabiltzailea aldatu"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Gonbidatuen saioa"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Hibernatu"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Itzali"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/fi.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/fi.po
@@ -1,97 +1,73 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2022-11-28 20:38+0200\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Istunto"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Lukitusnäyttö"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Vaihda käyttäjä"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Vierailu istunto"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Kirjaudu ulos"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Keskeytä"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Lepotila"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Horrostila"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Käynnistä"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Sammuta"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Paneelin kuvake"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Session Manager"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Kuvakkeen koko"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Symboliset kuvakkeet valikossa"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Paneelin teksti"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Yleiset asetukset"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Tarjoaa helpon tavan tietokoneen sammuttamiseen, käynnistykseen jne"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Tekijä - Stephen Collins"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -106,6 +82,75 @@ msgstr ""
 "kokoonpanoja. Jos tiettyä määritystäsi ei tueta, lähetä ominaisuuden pyyntö "
 "github:ssa, niin lisään sen mahdollisimman pian."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Session Manager"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Tekijä - Stephen Collins"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Yleiset asetukset"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Paneelin kuvake"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Paneelin teksti"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Kuvakkeen koko"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Symboliset kuvakkeet valikossa"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Lukitusnäyttö"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Vaihda käyttäjä"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Vierailu istunto"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Horrostila"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Sammuta"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/fr.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/fr.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2020-01-20 02:45+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -18,80 +19,55 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Session"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Verrouiller l'écran"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Changer d'utilisateur"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Session Invité"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Fermer la session"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Suspendre toute activité"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Mettre en sommeil"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Mettre en hibernation"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Redémarrer"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Arrêter"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Icône sur le panneau"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Session Manager (Gestionnaire de session)"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Taille de l'icône"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Icônes symboliques dans le menu"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Texte sur le panneau"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Paramètres généraux"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Accès rapide aux fonctions Arrêter, Redémarrer, etc"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Auteur"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -108,6 +84,75 @@ msgstr ""
 "veuillez soumettre une demande de fonctionnalité sur Github, et je "
 "l'ajouterai dans les meilleurs délais."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Session Manager (Gestionnaire de session)"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Auteur"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Paramètres généraux"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Icône sur le panneau"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Texte sur le panneau"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Taille de l'icône"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Icônes symboliques dans le menu"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Verrouiller l'écran"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Changer d'utilisateur"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Session Invité"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Mettre en hibernation"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Arrêter"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/hr.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/hr.po
@@ -1,98 +1,74 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Session Manager 1.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-25 11:30+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2017-02-25 11:38+0100\n"
+"Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: gogo <trebelnik2@gmail.com>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Sesija"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Zaključaj zaslon"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Zamijeni korisnika"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Prijava gosta"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Odjava"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Suspendiraj"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Spavaj"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Hiberniraj"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Ponovno pokreni"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Isključi"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Ikona panela"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Upravitelj sesije"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Veličina ikone"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "pikseli"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Simboličke ikone u izborniku"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Tekst panela"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Opće postavke"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Omogućuje jednostavan pristup isključivanju, ponovnom pokretanju, itd."
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Autor"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -107,6 +83,75 @@ msgstr ""
 "softverskih podešavanja. Ako vaša određena postavka nije podržana, prijavite "
 "zahtjev za začajku na githubu i ja ću ga čim prije razmotriti."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Upravitelj sesije"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Autor"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Opće postavke"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Ikona panela"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Tekst panela"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "pikseli"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Veličina ikone"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Simboličke ikone u izborniku"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Zaključaj zaslon"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Zamijeni korisnika"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Prijava gosta"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Hiberniraj"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Isključi"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/hu.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/hu.po
@@ -1,111 +1,156 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2021-04-03 20:32+0200\n"
+"Last-Translator: Bosák Balázs <bossbob88@gmail.com>\n"
+"Language-Team: \n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hu\n"
-"Last-Translator: Bosák Balázs <bossbob88@gmail.com>\n"
-"Language-Team: \n"
 "X-Generator: Poedit 2.4.2\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Munkamenet"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Zárolási képernyő"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Felhasználóváltás"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Vendég munkamenet"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Kijelentkezés"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Felfüggesztés"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Alvó mód"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Hibernálás"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Újraindítás"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Leállítás"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Panelikon"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Munkamenet kezelő"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Ikonméret"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Szimbolikus ikonok a menüben"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Panel szöveg"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Általános beállítások"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Könnyű elérést biztosít a leállításhoz, újraindításhoz, stb"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - szerző"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
-"such as shut down, restart, log off, switch user, etc. It has been tested "
-"in Arch, Fedora and Linux Mint, and supports a wide variety of software "
+"such as shut down, restart, log off, switch user, etc. It has been tested in "
+"Arch, Fedora and Linux Mint, and supports a wide variety of software "
 "configurations. If your particular configuration is not supported, please "
 "submit a feature request on github, and I will add it at my earliest "
 "convenience."
 msgstr ""
-"A Session Manager egy olyan kisalkalmazás, amely könnyű hozzáférést "
-"biztosít a munkamenet-vezérlőkhöz, például leállításhoz, újraindításhoz, "
+"A Session Manager egy olyan kisalkalmazás, amely könnyű hozzáférést biztosít "
+"a munkamenet-vezérlőkhöz, például leállításhoz, újraindításhoz, "
 "kijelentkezéshez, felhasználóváltáshoz stb. Az Archban, a Fedoraban és a "
-"Linux Mintben tesztelték, és sokféle szoftverkonfigurációt támogat. Ha az "
-"Ön konfigurációja nem támogatott, kérjük, küldjön egy funkciókérést a "
-"github-on, és én azt a lehető leghamarabb hozzáadom."
+"Linux Mintben tesztelték, és sokféle szoftverkonfigurációt támogat. Ha az Ön "
+"konfigurációja nem támogatott, kérjük, küldjön egy funkciókérést a github-"
+"on, és én azt a lehető leghamarabb hozzáadom."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Munkamenet kezelő"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - szerző"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Általános beállítások"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Panelikon"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Panel szöveg"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Ikonméret"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Szimbolikus ikonok a menüben"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Zárolási képernyő"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Felhasználóváltás"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Vendég munkamenet"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Hibernálás"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Leállítás"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/it.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/it.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2022-06-03 19:11+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -17,80 +18,55 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Sessione"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Blocca Schermo"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Cambia utente"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Sessione Ospite"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Disconnetti"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Sospendi"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Sospendi"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Iberna"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Riavvia"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Arresta"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Icona Pannello"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Gestore Sessione"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Dimensione Icona"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Icone simboliche nel menù"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Testo Pannello"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Impostazioni Generali"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Fornisce un facile accesso per l'arresto, il riavvio, ecc"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Autore"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -106,6 +82,75 @@ msgstr ""
 "supportata, invia una richiesta di funzionalità su github e la aggiungerò al "
 "più presto."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Gestore Sessione"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Autore"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Impostazioni Generali"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Icona Pannello"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Testo Pannello"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Dimensione Icona"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Icone simboliche nel menù"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Blocca Schermo"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Cambia utente"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Sessione Ospite"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Iberna"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Arresta"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/nl.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/nl.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2024-04-21 18:18+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,80 +17,55 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Sessie"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Scherm vergrendelen"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Gebruiker wisselen"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Gastsessie"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Afmelden"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Sluimerstand"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Slaapstand"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Slaapstand naar schijf"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Herstarten"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Afsluiten"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Paneelpictogram"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Sessiebeheerder"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Pictogramgrootte"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Symbolische pictogrammen in menu"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Paneeltekst"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Algemene instellingen"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Biedt eenvoudige toegang tot afsluiten, herstarten, enz."
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Auteur"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -105,6 +81,75 @@ msgstr ""
 "niet wordt ondersteund, dien dan alstublieft een functieverzoek in op "
 "GitHub, en ik zal het zo snel mogelijk toevoegen."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Sessiebeheerder"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Auteur"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Algemene instellingen"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Paneelpictogram"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Paneeltekst"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Pictogramgrootte"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Symbolische pictogrammen in menu"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Scherm vergrendelen"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Gebruiker wisselen"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Gastsessie"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Slaapstand naar schijf"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Afsluiten"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/pt_BR.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/pt_BR.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Vinícius Queiroz <viniciusqueiroz.voq@gmail.com>, 2018.
@@ -6,92 +6,68 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-20 23:29-0300\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2021-09-30 17:28-0300\n"
+"Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Last-Translator: Marcelo Aof\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: pt_BR\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Sessão"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Bloquear tela"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Trocar usuário"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Sessão de convidado"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Sair"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Dormir"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Hibernar"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Desligar"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Ícone no painel"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Gerenciador de sessão"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Tamanho do ícone"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Ícones monocromáticos no menu"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Texto no painel"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Configurações gerais"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Fornece acesso fácil para desligar, reiniciar, etc"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Autor"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -107,6 +83,75 @@ msgstr ""
 "erros, entre em contato por meio do GitHub. Eu considerarei o seu pedido "
 "assim que possível."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Gerenciador de sessão"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Autor"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Configurações gerais"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Ícone no painel"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Texto no painel"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Tamanho do ícone"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Ícones monocromáticos no menu"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Bloquear tela"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Trocar usuário"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Sessão de convidado"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Hibernar"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Desligar"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/ru.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/ru.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2023-07-25 11:07+0300\n"
 "Last-Translator: Rinaldus <forreg@rinaldus.ru>\n"
 "Language-Team: \n"
@@ -17,80 +18,55 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.2\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Сессия"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Заблокировать экран"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Сменить пользователя"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Гостевая сессия"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Завершить сеанс"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Ждущий режим"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Режим сна"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Спящий режим"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Перезагрузить"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Выключить компьютер"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Иконка на панели"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Менеджер сессий"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Размер иконки"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Символические иконки в меню"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Текст на панели"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Общие настройки"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Обеспечивает быстрый доступ к выключению, перезагрузке и т.д"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Автор"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -106,6 +82,75 @@ msgstr ""
 "конфигурация не поддерживается, пожалуйста сделайте запрос на Github, и я "
 "добавлю ее при первой же возможности."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Менеджер сессий"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Автор"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Общие настройки"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Иконка на панели"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Текст на панели"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Размер иконки"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Символические иконки в меню"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Заблокировать экран"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Сменить пользователя"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Гостевая сессия"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Спящий режим"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Выключить компьютер"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/sessionManager@scollins.pot
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/sessionManager@scollins.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: sessionManager@scollins 1.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-07 13:08-0400\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,39 +21,39 @@ msgstr ""
 msgid "Session"
 msgstr ""
 
-#. applet.js:228
+#. applet.js:240
 msgid "Lock Screen"
 msgstr ""
 
-#. applet.js:232
+#. applet.js:246
 msgid "Switch User"
 msgstr ""
 
-#. applet.js:237
+#. applet.js:252
 msgid "Guest Session"
 msgstr ""
 
-#. applet.js:242
+#. applet.js:258
 msgid "Log Off"
 msgstr ""
 
-#. applet.js:248
+#. applet.js:269
 msgid "Suspend"
 msgstr ""
 
-#. applet.js:253
+#. applet.js:275
 msgid "Sleep"
 msgstr ""
 
-#. applet.js:258
+#. applet.js:281
 msgid "Hibernate"
 msgstr ""
 
-#. applet.js:264
+#. applet.js:292
 msgid "Restart"
 msgstr ""
 
-#. applet.js:268
+#. applet.js:298
 msgid "Shut Down"
 msgstr ""
 
@@ -101,4 +101,44 @@ msgstr ""
 
 #. settings-schema.json->symbolicMenuIcons->description
 msgid "Symbolic icons in menu"
+msgstr ""
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+msgid "Show Lock Screen option"
+msgstr ""
+
+#. settings-schema.json->showSwitchUser->description
+msgid "Show Switch User option"
+msgstr ""
+
+#. settings-schema.json->showGuestSession->description
+msgid "Show Guest Session option"
+msgstr ""
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+msgid "Show Hibernate option"
+msgstr ""
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+msgid "Show Shut Down option"
 msgstr ""

--- a/sessionManager@scollins/files/sessionManager@scollins/po/sv.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/sv.po
@@ -6,92 +6,68 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sessionManager@scollins\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-11 20:44+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2017-05-11 21:10+0200\n"
+"Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: sv\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Session"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Lås skärmen"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Växla användare"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Gästsession"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Logga ut"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Vänteläge"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Strömsparläge"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Viloläge"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Starta om"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Stäng av"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Panelikon"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Sessionshanterare"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Ikonstorlek"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Symboliska ikoner i menyn"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Paneltext"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Allmänna inställningar"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Tillhandahåller enkel åtkomst till Stäng av och Starta om etc."
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Author"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -107,6 +83,75 @@ msgstr ""
 "stöds, kan du posta en funktionsbegäran så lägger jag till den så snart som "
 "möjligt."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Sessionshanterare"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Author"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Allmänna inställningar"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Panelikon"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Paneltext"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Ikonstorlek"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Symboliska ikoner i menyn"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Lås skärmen"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Växla användare"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Gästsession"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Viloläge"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Stäng av"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/tr.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/tr.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Gökhan GÖKKAYA <gokhanlnx@gmail.com>.
@@ -6,92 +6,68 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2018-11-06 17:06+0300\n"
+"Last-Translator: Gökhan GÖKKAYA <gokhanlnx@gmail.com>\n"
 "Language-Team: Linux Mint Türkiye <gokhanlnx@gmail.com>\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
-"Last-Translator: Gökhan GÖKKAYA <gokhanlnx@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: tr\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Oturum"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Ekran Kilidi"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Kullanıcı Değiştir"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Misafir Oturumu"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Oturum Kapat"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Askı"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Uyku"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Derin Uyku"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Yeniden Başlat"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Kapat"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Panel Simgesi"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Oturum Yöneticisi"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Simge Boyutu"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "piksel"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Menüde sembolik simge kullan"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Panel Metni"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Genel Ayarlar"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Kapatma, yeniden başlatma vb. için kolay erişim sunar"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Yazar"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -107,6 +83,75 @@ msgstr ""
 "desteklenmiyorsa, lütfen Github'da bir özellik isteği gönderebilirsiniz ve "
 "böylece bunu en kısa zamanda ekleyebilirim."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Oturum Yöneticisi"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Yazar"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Genel Ayarlar"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Panel Simgesi"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Panel Metni"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "piksel"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Simge Boyutu"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Menüde sembolik simge kullan"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Ekran Kilidi"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Kullanıcı Değiştir"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Misafir Oturumu"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Derin Uyku"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Kapat"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/uk.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/uk.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-13 23:47+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2023-08-22 21:20+0300\n"
 "Last-Translator: DmytroVoytko <Dmytro.Voytko@gmail.com>\n"
 "Language-Team: \n"
@@ -17,80 +18,55 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.2\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "Сесія"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "Заблокувати екран"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "Змінити користувача"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "Гостьова сесія"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "Завершити сеанс"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "Режим очікування"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "Режим сну"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "Сплячий режим"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "Перезавантажити"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "Вимкнути комп'ютер"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "Значок панелі"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "Менеджер сесій"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "Розмір значка"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "Символічні іконки в меню"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "Текст на панелі"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "Загальні налаштування"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "Забезпечує швидкий доступ до вимкнення, перезавантаження тощо"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Автор"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -99,13 +75,82 @@ msgid ""
 "submit a feature request on github, and I will add it at my earliest "
 "convenience."
 msgstr ""
-"Менеджер сесій - це аплет, який забезпечує швидкий доступ до "
-"управління сесіями, такому як вимикання, перезавантаження, завершення сеансу, "
-"зміни користувача тощо. Він був перевірений у Arch, Fedora і Linux Mint та "
-"підтримує широкий вибір конфігурацій. Якщо ваша конкретна конфигурація "
-"не підтримується, будь ласка, зробіть запит на Github, і я додам її "
-"за першої ж можливості."
+"Менеджер сесій - це аплет, який забезпечує швидкий доступ до управління "
+"сесіями, такому як вимикання, перезавантаження, завершення сеансу, зміни "
+"користувача тощо. Він був перевірений у Arch, Fedora і Linux Mint та "
+"підтримує широкий вибір конфігурацій. Якщо ваша конкретна конфигурація не "
+"підтримується, будь ласка, зробіть запит на Github, і я додам її за першої ж "
+"можливості."
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "Менеджер сесій"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Автор"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "Загальні налаштування"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "Значок панелі"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "Текст на панелі"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "Розмір значка"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "Символічні іконки в меню"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "Заблокувати екран"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "Змінити користувача"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "Гостьова сесія"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "Сплячий режим"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "Вимкнути комп'ютер"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/zh_CN.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/zh_CN.po
@@ -1,97 +1,73 @@
-# SOME DESCRIPTIVE TITLE.
+# SESSION MANAGER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# collinss, 2016
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-11 18:29+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2017-03-11 18:47+0800\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"Language: zh_CN\n"
 
-#: applet.js:159
+#. applet.js:154
 msgid "Session"
 msgstr "会话"
 
-#: applet.js:226
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "锁定屏幕"
 
-#: applet.js:230
+#. applet.js:246
 msgid "Switch User"
 msgstr "切换用户"
 
-#: applet.js:235
+#. applet.js:252
 msgid "Guest Session"
 msgstr "访客会话"
 
-#: applet.js:240
+#. applet.js:258
 msgid "Log Off"
 msgstr "注销"
 
-#: applet.js:246
+#. applet.js:269
 msgid "Suspend"
 msgstr "挂起"
 
-#: applet.js:251
+#. applet.js:275
 msgid "Sleep"
 msgstr "睡眠"
 
-#: applet.js:256
+#. applet.js:281
 msgid "Hibernate"
 msgstr "休眠"
 
-#: applet.js:262
+#. applet.js:292
 msgid "Restart"
 msgstr "重启"
 
-#: applet.js:266
+#. applet.js:298
 msgid "Shut Down"
 msgstr "关机"
 
-#. sessionManager@scollins->settings-schema.json->panelIcon->description
-msgid "Panel Icon"
-msgstr "面板图标"
+#. metadata.json->name
+msgid "Session Manager"
+msgstr "会话管理器"
 
-#. sessionManager@scollins->settings-schema.json->iconSize->description
-msgid "Icon Size"
-msgstr "图标大小"
-
-#. sessionManager@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. sessionManager@scollins->settings-
-#. schema.json->symbolicMenuIcons->description
-msgid "Symbolic icons in menu"
-msgstr "菜单中的符号图标"
-
-#. sessionManager@scollins->settings-schema.json->panelText->description
-msgid "Panel Text"
-msgstr "面板文本"
-
-#. sessionManager@scollins->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "常规设置"
-
-#. sessionManager@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides easy access to shut down, restart, etc"
 msgstr "提供对关机、重启等的轻松访问"
 
-#. sessionManager@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - 作者"
-
-#. sessionManager@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Session Manager is an applet that provides easy access to session controls "
 "such as shut down, restart, log off, switch user, etc. It has been tested in "
@@ -100,10 +76,79 @@ msgid ""
 "submit a feature request on github, and I will add it at my earliest "
 "convenience."
 msgstr ""
-"会话管理器是一个提供对诸如关机、重启、注销、切换用户等会话控制进行轻松访问的小程"
-"序。它已经在Arch，Fedora和Linux Mint中测试，并支持各种软件配置。如果不支持您"
-"的特定配置，请在github上提交功能请求，我会在我方便的时候尽早添加。"
+"会话管理器是一个提供对诸如关机、重启、注销、切换用户等会话控制进行轻松访问的"
+"小程序。它已经在Arch，Fedora和Linux Mint中测试，并支持各种软件配置。如果不支"
+"持您的特定配置，请在github上提交功能请求，我会在我方便的时候尽早添加。"
 
-#. sessionManager@scollins->metadata.json->name
-msgid "Session Manager"
-msgstr "会话管理器"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - 作者"
+
+#. settings-schema.json->general->description
+msgid "General Settings"
+msgstr "常规设置"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel Icon"
+msgstr "面板图标"
+
+#. settings-schema.json->panelText->description
+msgid "Panel Text"
+msgstr "面板文本"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Icon Size"
+msgstr "图标大小"
+
+#. settings-schema.json->symbolicMenuIcons->description
+msgid "Symbolic icons in menu"
+msgstr "菜单中的符号图标"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "锁定屏幕"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "切换用户"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "访客会话"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "休眠"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "关机"

--- a/sessionManager@scollins/files/sessionManager@scollins/po/zh_TW.po
+++ b/sessionManager@scollins/files/sessionManager@scollins/po/zh_TW.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: sessionManager@scollins 1.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-07 13:08-0400\n"
+"POT-Creation-Date: 2025-09-27 10:12+0200\n"
 "PO-Revision-Date: 2025-09-23 01:42+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -20,39 +20,39 @@ msgstr ""
 msgid "Session"
 msgstr "工作階段"
 
-#. applet.js:228
+#. applet.js:240
 msgid "Lock Screen"
 msgstr "鎖定螢幕"
 
-#. applet.js:232
+#. applet.js:246
 msgid "Switch User"
 msgstr "切換使用者"
 
-#. applet.js:237
+#. applet.js:252
 msgid "Guest Session"
 msgstr "訪客工作階段"
 
-#. applet.js:242
+#. applet.js:258
 msgid "Log Off"
 msgstr "登出"
 
-#. applet.js:248
+#. applet.js:269
 msgid "Suspend"
 msgstr "暫停"
 
-#. applet.js:253
+#. applet.js:275
 msgid "Sleep"
 msgstr "睡眠"
 
-#. applet.js:258
+#. applet.js:281
 msgid "Hibernate"
 msgstr "休眠"
 
-#. applet.js:264
+#. applet.js:292
 msgid "Restart"
 msgstr "重新啟動"
 
-#. applet.js:268
+#. applet.js:298
 msgid "Shut Down"
 msgstr "關機"
 
@@ -105,3 +105,48 @@ msgstr "圖示大小"
 #. settings-schema.json->symbolicMenuIcons->description
 msgid "Symbolic icons in menu"
 msgstr "選單中使用符號圖示"
+
+#. settings-schema.json->menuOptions->description
+msgid "Menu Options"
+msgstr ""
+
+#. settings-schema.json->showLockScreen->description
+#, fuzzy
+msgid "Show Lock Screen option"
+msgstr "鎖定螢幕"
+
+#. settings-schema.json->showSwitchUser->description
+#, fuzzy
+msgid "Show Switch User option"
+msgstr "切換使用者"
+
+#. settings-schema.json->showGuestSession->description
+#, fuzzy
+msgid "Show Guest Session option"
+msgstr "訪客工作階段"
+
+#. settings-schema.json->showLogOff->description
+msgid "Show Log Off option"
+msgstr ""
+
+#. settings-schema.json->showSuspend->description
+msgid "Show Suspend option"
+msgstr ""
+
+#. settings-schema.json->showSleep->description
+msgid "Show Sleep option"
+msgstr ""
+
+#. settings-schema.json->showHibernate->description
+#, fuzzy
+msgid "Show Hibernate option"
+msgstr "休眠"
+
+#. settings-schema.json->showRestart->description
+msgid "Show Restart option"
+msgstr ""
+
+#. settings-schema.json->showShutDown->description
+#, fuzzy
+msgid "Show Shut Down option"
+msgstr "關機"

--- a/sessionManager@scollins/files/sessionManager@scollins/settings-schema.json
+++ b/sessionManager@scollins/files/sessionManager@scollins/settings-schema.json
@@ -30,5 +30,64 @@
         "type": "checkbox",
         "description": "Symbolic icons in menu",
         "default": true
+    },
+    
+    "menuOptions": {
+        "type": "header",
+        "description": "Menu Options"
+    },
+    
+    "showLockScreen": {
+        "type": "checkbox",
+        "description": "Show Lock Screen option",
+        "default": true
+    },
+    
+    "showSwitchUser": {
+        "type": "checkbox",
+        "description": "Show Switch User option",
+        "default": true
+    },
+    
+    "showGuestSession": {
+        "type": "checkbox",
+        "description": "Show Guest Session option",
+        "default": true
+    },
+    
+    "showLogOff": {
+        "type": "checkbox",
+        "description": "Show Log Off option",
+        "default": true
+    },
+    
+    "showSuspend": {
+        "type": "checkbox",
+        "description": "Show Suspend option",
+        "default": true
+    },
+    
+    "showSleep": {
+        "type": "checkbox",
+        "description": "Show Sleep option",
+        "default": true
+    },
+    
+    "showHibernate": {
+        "type": "checkbox",
+        "description": "Show Hibernate option",
+        "default": true
+    },
+    
+    "showRestart": {
+        "type": "checkbox",
+        "description": "Show Restart option",
+        "default": true
+    },
+    
+    "showShutDown": {
+        "type": "checkbox",
+        "description": "Show Shut Down option",
+        "default": true
     }
 }


### PR DESCRIPTION
This PR add the capability to select which entries are shown by the applet.

Useful in case of restricted/kiosk environments, to provide a controlled experience.

@collinss 