### PR TITLE
download-and-upload-speed@cardsurf: add options for hide icon, fixed units and inactive text style

### DIFF
--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
@@ -106,6 +106,7 @@ DownloadAndUploadSpeed.prototype = {
         this.data_limit_command = "";
         this.data_limit = 0;
         this.gui_text_css = "";
+        this.gui_inactive_text_css = "";
         this.gui_show_icons = true;
         this.gui_received_icon_filename = "";
         this.gui_symbolic_icon = false;
@@ -207,6 +208,7 @@ DownloadAndUploadSpeed.prototype = {
                         [Settings.BindingDirection.IN, "show_hover", this.on_show_hover_changed],
                         [Settings.BindingDirection.IN, "gui_data_limit_type", this.on_gui_data_limit_type_changed],
                         [Settings.BindingDirection.IN, "gui_text_css", this.on_gui_css_changed],
+                        [Settings.BindingDirection.IN, "gui_inactive_text_css", null],
                         [Settings.BindingDirection.IN, "gui_show_icons", this.on_gui_icon_visible_changed],
                         [Settings.BindingDirection.IN, "gui_received_icon_filename", this.on_gui_icon_changed],
                         [Settings.BindingDirection.IN, "gui_sent_icon_filename", this.on_gui_icon_changed],
@@ -758,11 +760,13 @@ DownloadAndUploadSpeed.prototype = {
                 bytes_sent_total += info.bytes_sent_total;
             }
 
-            let received = this.get_bytes_received_iteration_string(bytes_received_iteration);
-            let sent = this.get_bytes_sent_iteration_string(bytes_sent_iteration);
+            let [received, is_received] = this.get_bytes_received_iteration_string(bytes_received_iteration);
+            let [sent, is_sent] = this.get_bytes_sent_iteration_string(bytes_sent_iteration);
             let received_total = this.convert_to_two_decimals_string(bytes_received_total);
             let sent_total = this.convert_to_two_decimals_string(bytes_sent_total);
 
+            this.gui_speed.set_received_text_style(is_received ? this.gui_text_css : this.gui_inactive_text_css);
+            this.gui_speed.set_sent_text_style(is_sent ? this.gui_text_css : this.gui_inactive_text_css);
             this.gui_speed.set_received_text(received);
             this.gui_speed.set_sent_text(sent);
             this.update_gui_data_limit(bytes_received_total, bytes_sent_total);
@@ -785,8 +789,7 @@ DownloadAndUploadSpeed.prototype = {
     get_bytes_received_iteration_string: function (bytes) {
         let received = this.replace_with_zero(bytes, this.minimum_bytes_received_to_display);
         received = this.scale(received);
-        received = this.convert_to_readable_string(received);
-        return received;
+        return this.convert_to_readable_string(received);
     },
 
     replace_with_zero: function (bytes, minimum) {
@@ -804,7 +807,7 @@ DownloadAndUploadSpeed.prototype = {
         }
 
         let output = number.toString() + unit;
-        return output;
+        return [output, parseFloat(number) !== 0];
     },
 
     convert_to_readable_unit: function (bytes) {
@@ -860,8 +863,7 @@ DownloadAndUploadSpeed.prototype = {
     get_bytes_sent_iteration_string: function (bytes) {
         let sent = this.replace_with_zero(bytes, this.minimum_bytes_sent_to_display);
         sent = this.scale(sent);
-        sent = this.convert_to_readable_string(sent);
-        return sent;
+        return this.convert_to_readable_string(sent);
     },
 
     convert_to_two_decimals_string: function (bytes) {

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
@@ -100,6 +100,7 @@ DownloadAndUploadSpeed.prototype = {
         this.data_limit_command = "";
         this.data_limit = 0;
         this.gui_text_css = "";
+        this.gui_show_icons = true;
         this.gui_received_icon_filename = "";
         this.gui_symbolic_icon = false;
         this.gui_sent_icon_filename = "";
@@ -199,6 +200,7 @@ DownloadAndUploadSpeed.prototype = {
                         [Settings.BindingDirection.IN, "show_hover", this.on_show_hover_changed],
                         [Settings.BindingDirection.IN, "gui_data_limit_type", this.on_gui_data_limit_type_changed],
                         [Settings.BindingDirection.IN, "gui_text_css", this.on_gui_css_changed],
+                        [Settings.BindingDirection.IN, "gui_show_icons", this.on_gui_icon_visible_changed],
                         [Settings.BindingDirection.IN, "gui_received_icon_filename", this.on_gui_icon_changed],
                         [Settings.BindingDirection.IN, "gui_sent_icon_filename", this.on_gui_icon_changed],
                         [Settings.BindingDirection.IN, "gui_symbolic_icon", this.on_gui_icon_style_change],
@@ -308,6 +310,10 @@ DownloadAndUploadSpeed.prototype = {
         else {
             this.hover_popup.disable();
         }
+    },
+
+    on_gui_icon_visible_changed: function () {
+        this.gui_speed.set_icons_visible(this.gui_show_icons);
     },
 
     on_gui_icon_changed: function () {
@@ -698,6 +704,7 @@ DownloadAndUploadSpeed.prototype = {
         this.actor.add(this.gui_speed.actor,
                       { x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE, y_fill: false });
         this.on_gui_icon_changed();
+        this.on_gui_icon_visible_changed();
         this.on_gui_css_changed();
     },
 

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletConstants.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletConstants.js
@@ -4,6 +4,15 @@ var DisplayMode = {
     DATA: 1
 }
 
+var Unit = {
+    AUTO: 0,
+    B: 1,
+    KB: 2,
+    MB: 3,
+    GB: 4,
+    TB: 5
+}
+
 var UnitType = {
     BYTES: 0,
     BITS: 1
@@ -46,4 +55,10 @@ var BytesStartTime = {
     CUSTOM_DATE : -2
 }
 
+const SIZE_DEC = [1, 1e3, 1e6, 1e9, 1e12];
+const SIZE_BIN = [1, 1024, 1024**2, 1024**3, 1024**4];
+const BYTE_UNITS_DEC = ["  B", " kB", " MB", " GB", " TB"];
+const BYTE_UNITS_BIN = ["   B", " kiB", " MiB", " GiB", " TiB"];
+const BIT_UNITS_DEC  = ["  b", " kb", " Mb", " Gb", " Tb"];
+const BIT_UNITS_BIN  = ["   b", " kib", " Mib", " Gib", " Tib"];
 

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
@@ -197,12 +197,18 @@ GuiSpeed.prototype = {
     },
 
     set_text_style: function(css_style) {
-        css_style = this.add_font_size(css_style);
-        for(let iconlabel of [this.iconlabel_received, this.iconlabel_sent]){
-            iconlabel.set_label_style(css_style);
-        }
+        this.set_received_text_style(css_style);
+        this.set_sent_text_style(css_style);
 
-        this._resize_gui_elements_to_match_text(css_style);
+        this._resize_gui_elements_to_match_text(this.add_font_size(css_style));
+    },
+
+    set_received_text_style: function(css_style) {
+        this.iconlabel_received.set_label_style(this.add_font_size(css_style));
+    },
+
+    set_sent_text_style: function(css_style) {
+        this.iconlabel_sent.set_label_style(this.add_font_size(css_style));
     },
 
     add_font_size: function(css_style) {

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
@@ -52,6 +52,15 @@ IconLabel.prototype = {
         this.actor.add(this.label);
     },
 
+    set_icon_visible: function (visible) {
+        if (visible) {
+            this.icon.show();
+        }
+        else {
+            this.icon.hide();
+        }
+    },
+
     set_gicon: function(file_icon) {
         this.icon.set_gicon(file_icon);
     },
@@ -148,6 +157,11 @@ GuiSpeed.prototype = {
     _init_actor_upload_first: function(){
         this.actor.add(this.iconlabel_sent.actor);
         this.actor.add(this.iconlabel_received.actor);
+    },
+
+    set_icons_visible: function (visible) {
+        this.iconlabel_received.set_icon_visible(visible);
+        this.iconlabel_sent.set_icon_visible(visible);
     },
 
     set_reveived_icon: function(icon_path) {

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/metadata.json
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/metadata.json
@@ -1,6 +1,6 @@
 {
     "description": "Shows usage of a network interface",
-    "version": "1.6.9",
+    "version": "1.7.0",
     "uuid": "download-and-upload-speed@cardsurf",
     "name": "Download and upload speed",
     "author": "cardsurf"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/bg.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/bg.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2017-11-20 22:44+0200\n"
 "Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
@@ -19,168 +19,85 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. applet.js:438
+#. applet.js:468
 #, fuzzy
 msgid "Network interfaces"
 msgstr "Мрежов интерфейс"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Общи данни начало"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Стартиране на аплета"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Днес"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Вчера"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "Отпреди 3 дни"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "Отпреди 5 дни"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "Отпреди 7 дни"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "Отпреди 10 дни"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "Отпреди 14 дни"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "Отпреди 30 дни"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Потребителска дата"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Гпи"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Компактен"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Голям"
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-#, fuzzy
-msgid " GB"
-msgstr "Гпи"
-
-#. applet.js:816
-#, fuzzy
-msgid " MB"
-msgstr "МБ"
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-msgid " Tb"
-msgstr ""
-
-#. applet.js:848
-#, fuzzy
-msgid " Gb"
-msgstr "Гпи"
-
-#. applet.js:851
-msgid " Mb"
-msgstr ""
-
-#. applet.js:854
-msgid " kb"
-msgstr ""
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Общо сваляне:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Общо качване:"
 
@@ -212,9 +129,42 @@ msgstr "Количество на прехвърлени данни"
 msgid "Values shown in the panel"
 msgstr "Стойности показвани в панела"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Единица"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Авто"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -302,10 +252,6 @@ msgid "Decimal places"
 msgstr "Място на десетицата"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Авто"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0"
 
@@ -334,6 +280,20 @@ msgstr "CSS на текста"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "CSS стила, прилаган за текста в панела"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/ca.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/ca.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2024-10-01 03:04+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -19,164 +19,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Interfícies de xarxa"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Inici del recompte de dades"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Des de l'inici de la miniaplicació"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Avui"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Ahir"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "Fa 3 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "Fa 5 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "Fa 7 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "Fa 10 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "Fa 14 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "Fa 30 dies"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Data personalitzada"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Interfície"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Compacta"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Gran"
 
-#. applet.js:796
-msgid " TiB"
-msgstr " TiB"
-
-#. applet.js:799
-msgid " GiB"
-msgstr " GiB"
-
-#. applet.js:802
-msgid " MiB"
-msgstr " MiB"
-
-#. applet.js:805
-msgid " kiB"
-msgstr " kiB"
-
-#. applet.js:807
-msgid "   B"
-msgstr "   B"
-
-#. applet.js:810
-msgid " TB"
-msgstr " TB"
-
-#. applet.js:813
-msgid " GB"
-msgstr " GB"
-
-#. applet.js:816
-msgid " MB"
-msgstr " MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr " kB"
-
-#. applet.js:821
-msgid "  B"
-msgstr "  B"
-
-#. applet.js:831
-msgid " Tib"
-msgstr " Tib"
-
-#. applet.js:834
-msgid " Gib"
-msgstr " Gib"
-
-#. applet.js:837
-msgid " Mib"
-msgstr " Mib"
-
-#. applet.js:840
-msgid " kib"
-msgstr " kib"
-
-#. applet.js:842
-msgid "   b"
-msgstr "   b"
-
-#. applet.js:845
-msgid " Tb"
-msgstr " Tb"
-
-#. applet.js:848
-msgid " Gb"
-msgstr " Gb"
-
-#. applet.js:851
-msgid " Mb"
-msgstr " Mb"
-
-#. applet.js:854
-msgid " kb"
-msgstr " kb"
-
-#. applet.js:856
-msgid "  b"
-msgstr "  b"
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Baixada total:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Pujada total:"
 
@@ -208,9 +128,42 @@ msgstr "Quantitat de dades transferides"
 msgid "Values shown in the panel"
 msgstr "Valors mostrats al tauler"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Unitat"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Auto"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -300,10 +253,6 @@ msgid "Decimal places"
 msgstr "Número de decimals"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Auto"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -331,6 +280,20 @@ msgstr "CSS del text"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Estil CSS pel text del tauler"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/da.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2022-10-26 18:50+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -19,170 +19,84 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Netværksgrænseflader"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Total datastart"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Opstart af panelprogrammet"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "I dag"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "I går"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 dage siden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Tilpasset dato"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Grafisk brugergrænseflade"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Kompakt"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Stor"
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-#, fuzzy
-msgid " GB"
-msgstr "Grafisk brugergrænseflade"
-
-#. applet.js:816
-#, fuzzy
-msgid " MB"
-msgstr "MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-#, fuzzy
-msgid " Tb"
-msgstr "b"
-
-#. applet.js:848
-#, fuzzy
-msgid " Gb"
-msgstr "b"
-
-#. applet.js:851
-#, fuzzy
-msgid " Mb"
-msgstr "b"
-
-#. applet.js:854
-#, fuzzy
-msgid " kb"
-msgstr "b"
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Total download:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Total upload:"
 
@@ -214,9 +128,42 @@ msgstr "Mængden af data overført"
 msgid "Values shown in the panel"
 msgstr "Værdier vist i panelet"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Enhed"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Automatisk"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -304,10 +251,6 @@ msgid "Decimal places"
 msgstr "Decimaler"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Automatisk"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -334,6 +277,20 @@ msgstr "Tekst-CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "CSS-stil anvendt på teksten i panelet"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/de.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2021-02-27 00:14+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,170 +19,84 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Netzwerkschnittstellen"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Start der Gesamtdaten"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Start des Applets"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Heute"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Gestern"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "vor 3 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "vor 5 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "vor 7 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "vor 10 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "vor 14 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "vor 30 Tagen"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Benutzerdefiniertes Datum"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Darstellung in der Leiste"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Kompakt"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Groß"
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-#, fuzzy
-msgid " GB"
-msgstr "Darstellung in der Leiste"
-
-#. applet.js:816
-#, fuzzy
-msgid " MB"
-msgstr "MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-#, fuzzy
-msgid " Tb"
-msgstr "b"
-
-#. applet.js:848
-#, fuzzy
-msgid " Gb"
-msgstr "b"
-
-#. applet.js:851
-#, fuzzy
-msgid " Mb"
-msgstr "b"
-
-#. applet.js:854
-#, fuzzy
-msgid " kb"
-msgstr "b"
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Gesamt-Download:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Gesamt-Upload:"
 
@@ -214,9 +128,42 @@ msgstr "Übertragene Datenmenge"
 msgid "Values shown in the panel"
 msgstr "Werte, die in der Leiste angezeigt werden"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Einheit"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Automatisch"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -306,10 +253,6 @@ msgid "Decimal places"
 msgstr "Nachkommastellen"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Automatisch"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -337,6 +280,20 @@ msgstr "Text CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Ein CSS-Stil, der auf den Text in der Leiste angewendet wird"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/download-and-upload-speed@cardsurf.pot
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/download-and-upload-speed@cardsurf.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: download-and-upload-speed@cardsurf 1.6.7\n"
+"Project-Id-Version: download-and-upload-speed@cardsurf 1.6.9\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,164 +17,84 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr ""
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr ""
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr ""
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr ""
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr ""
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr ""
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-msgid " GB"
-msgstr ""
-
-#. applet.js:816
-msgid " MB"
-msgstr ""
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-msgid " Tb"
-msgstr ""
-
-#. applet.js:848
-msgid " Gb"
-msgstr ""
-
-#. applet.js:851
-msgid " Mb"
-msgstr ""
-
-#. applet.js:854
-msgid " kb"
-msgstr ""
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr ""
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr ""
 
@@ -206,8 +126,41 @@ msgstr ""
 msgid "Values shown in the panel"
 msgstr ""
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
+msgstr ""
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
 msgstr ""
 
 #. settings-schema.json->unit_type->options
@@ -293,10 +246,6 @@ msgid "Decimal places"
 msgstr ""
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr ""
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr ""
 
@@ -322,6 +271,20 @@ msgstr ""
 
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
 msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/es.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2024-09-28 11:14-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,164 +19,84 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Interfaces de red"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Cantidad total de datos"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Desde el lanzamiento del applet"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Desde hoy"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Desde ayer"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "Hace 3 días"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "Hace 5 días"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "Hace 7 días"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "Hace 10 días"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "Hace 14 días"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "Hace 30 días"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Fecha personalizada"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Estilo"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Compacto"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Grande"
 
-#. applet.js:796
-msgid " TiB"
-msgstr "TiB"
-
-#. applet.js:799
-msgid " GiB"
-msgstr " GiB"
-
-#. applet.js:802
-msgid " MiB"
-msgstr " MiB"
-
-#. applet.js:805
-msgid " kiB"
-msgstr " kiB"
-
-#. applet.js:807
-msgid "   B"
-msgstr "   B"
-
-#. applet.js:810
-msgid " TB"
-msgstr " TB"
-
-#. applet.js:813
-msgid " GB"
-msgstr " GB"
-
-#. applet.js:816
-msgid " MB"
-msgstr " MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr " kB"
-
-#. applet.js:821
-msgid "  B"
-msgstr "  B"
-
-#. applet.js:831
-msgid " Tib"
-msgstr " Tib"
-
-#. applet.js:834
-msgid " Gib"
-msgstr " Gib"
-
-#. applet.js:837
-msgid " Mib"
-msgstr " Mib"
-
-#. applet.js:840
-msgid " kib"
-msgstr " kib"
-
-#. applet.js:842
-msgid "   b"
-msgstr "   b"
-
-#. applet.js:845
-msgid " Tb"
-msgstr " Tb"
-
-#. applet.js:848
-msgid " Gb"
-msgstr " Gb"
-
-#. applet.js:851
-msgid " Mb"
-msgstr " Mb"
-
-#. applet.js:854
-msgid " kb"
-msgstr " kb"
-
-#. applet.js:856
-msgid "  b"
-msgstr "  b"
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Descarga total:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Subida total:"
 
@@ -208,9 +128,42 @@ msgstr "Cantidad de datos transferidos"
 msgid "Values shown in the panel"
 msgstr "Valores mostrados en el panel"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Unidad"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Automático"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -301,10 +254,6 @@ msgid "Decimal places"
 msgstr "Cifras decimales"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Automático"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -332,6 +281,20 @@ msgstr "CSS del texto"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Un estilo CSS aplicado al texto en el panel"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/fi.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2024-11-13 18:26+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -19,164 +19,84 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Verkkoliitäntä"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Datan määrä alkaen"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Sovelman avaamisesta"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Tänään"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Eilen"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 päivää sitten"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Mukautettu päivämäärä"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Pääte"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Tiivis"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Suuri"
 
-#. applet.js:796
-msgid " TiB"
-msgstr " TiB"
-
-#. applet.js:799
-msgid " GiB"
-msgstr " GiB"
-
-#. applet.js:802
-msgid " MiB"
-msgstr " MiB"
-
-#. applet.js:805
-msgid " kiB"
-msgstr " kiB"
-
-#. applet.js:807
-msgid "   B"
-msgstr "   B"
-
-#. applet.js:810
-msgid " TB"
-msgstr " TB"
-
-#. applet.js:813
-msgid " GB"
-msgstr " GB"
-
-#. applet.js:816
-msgid " MB"
-msgstr " MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr " kB"
-
-#. applet.js:821
-msgid "  B"
-msgstr "  B"
-
-#. applet.js:831
-msgid " Tib"
-msgstr " Tib"
-
-#. applet.js:834
-msgid " Gib"
-msgstr " Gib"
-
-#. applet.js:837
-msgid " Mib"
-msgstr " Mib"
-
-#. applet.js:840
-msgid " kib"
-msgstr " kib"
-
-#. applet.js:842
-msgid "   b"
-msgstr "   b"
-
-#. applet.js:845
-msgid " Tb"
-msgstr " Tb"
-
-#. applet.js:848
-msgid " Gb"
-msgstr " Gb"
-
-#. applet.js:851
-msgid " Mb"
-msgstr " Mb"
-
-#. applet.js:854
-msgid " kb"
-msgstr " kb"
-
-#. applet.js:856
-msgid "  b"
-msgstr "  b"
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Lataus yhteensä:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Lähetys yhteensä:"
 
@@ -208,9 +128,42 @@ msgstr "Siirretyn datan määrä"
 msgid "Values shown in the panel"
 msgstr "Arvot näytetään paneelissa"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Yksikkö"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Auto"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -299,10 +252,6 @@ msgid "Decimal places"
 msgstr "Desimaalipilkku"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Auto"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -329,6 +278,20 @@ msgstr "Teksti CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Paneelin tekstiin käytetty CSS-tyyli"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/fr.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2025-02-12 03:07+0100\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -19,164 +19,84 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Interfaces réseau"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Quantités totales depuis..."
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "le lancement de l'applet"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "aujourd'hui"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "depuis hier"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 derniers jours"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 derniers jours"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 derniers jours"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 derniers jours"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 derniers jours"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 derniers jours"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "la date personnalisée"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Affichage"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Compact"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Étendu"
 
-#. applet.js:796
-msgid " TiB"
-msgstr " Tio"
-
-#. applet.js:799
-msgid " GiB"
-msgstr " Gio"
-
-#. applet.js:802
-msgid " MiB"
-msgstr " Mio"
-
-#. applet.js:805
-msgid " kiB"
-msgstr " kio"
-
-#. applet.js:807
-msgid "   B"
-msgstr "   o"
-
-#. applet.js:810
-msgid " TB"
-msgstr " To"
-
-#. applet.js:813
-msgid " GB"
-msgstr " Go"
-
-#. applet.js:816
-msgid " MB"
-msgstr " Mo"
-
-#. applet.js:819
-msgid " kB"
-msgstr " ko"
-
-#. applet.js:821
-msgid "  B"
-msgstr "  o"
-
-#. applet.js:831
-msgid " Tib"
-msgstr " Tib"
-
-#. applet.js:834
-msgid " Gib"
-msgstr " Gib"
-
-#. applet.js:837
-msgid " Mib"
-msgstr " Mib"
-
-#. applet.js:840
-msgid " kib"
-msgstr " kib"
-
-#. applet.js:842
-msgid "   b"
-msgstr "   b"
-
-#. applet.js:845
-msgid " Tb"
-msgstr " Tb"
-
-#. applet.js:848
-msgid " Gb"
-msgstr " Gb"
-
-#. applet.js:851
-msgid " Mb"
-msgstr " Mb"
-
-#. applet.js:854
-msgid " kb"
-msgstr " kb"
-
-#. applet.js:856
-msgid "  b"
-msgstr "  b"
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Total reçu :"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Total envoyé :"
 
@@ -208,9 +128,42 @@ msgstr "Quantité de données transférées"
 msgid "Values shown in the panel"
 msgstr "Valeurs affichées dans le panneau"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Unité"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Auto"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -299,10 +252,6 @@ msgid "Decimal places"
 msgstr "Nombre de décimales"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Auto"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -331,6 +280,20 @@ msgstr "Style CSS du texte"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Saisir le style CSS appliqué au texte du panneau"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/hr.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/hr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2017-04-29 14:01+0100\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian\n"
@@ -20,168 +20,85 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#. applet.js:438
+#. applet.js:468
 #, fuzzy
 msgid "Network interfaces"
 msgstr "Mrežno sučelje"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Pokreni s ukupno podataka"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "od pokretanja apleta"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "od danas"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "od jučer"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "od prije 3 dana"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "od prije 5 dana"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "od prije 7 dana"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "od prije 10 dana"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "od prije 14 dana"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "od prije 30 dana"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Prilagođeni datum"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Grafičko sučelje"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Kompaktno"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Veliko"
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-#, fuzzy
-msgid " GB"
-msgstr "Grafičko sučelje"
-
-#. applet.js:816
-#, fuzzy
-msgid " MB"
-msgstr "MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-msgid " Tb"
-msgstr ""
-
-#. applet.js:848
-#, fuzzy
-msgid " Gb"
-msgstr "Grafičko sučelje"
-
-#. applet.js:851
-msgid " Mb"
-msgstr ""
-
-#. applet.js:854
-msgid " kb"
-msgstr ""
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Ukupno preuzeto:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Ukupno poslano:"
 
@@ -213,9 +130,42 @@ msgstr "Količinu prenesenih podataka"
 msgid "Values shown in the panel"
 msgstr "Vrijednosti prikazane u panelu"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Mjerna jedinica"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Automatski"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -303,10 +253,6 @@ msgid "Decimal places"
 msgstr "Decimalna mjesta"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Automatski"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0"
 
@@ -333,6 +279,21 @@ msgstr "CSS tekst"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "CSS izgled primijenjen na tekst u panelu"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+#, fuzzy
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/hu.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2024-10-02 17:08+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -18,164 +18,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Hálózati csatolók"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Összesített adatmennyiség indításkor"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Kisalkalmazás indítása"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Ma"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Tegnap"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "Három nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "Öt nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "Hét nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "Tíz nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "Tízennégy nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "Harminc nappal ezelőtt"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Egyéni dátum"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "GUI"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Kompakt"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Nagy"
 
-#. applet.js:796
-msgid " TiB"
-msgstr " TiB"
-
-#. applet.js:799
-msgid " GiB"
-msgstr " GiB"
-
-#. applet.js:802
-msgid " MiB"
-msgstr " MiB"
-
-#. applet.js:805
-msgid " kiB"
-msgstr " kiB"
-
-#. applet.js:807
-msgid "   B"
-msgstr "   B"
-
-#. applet.js:810
-msgid " TB"
-msgstr " TB"
-
-#. applet.js:813
-msgid " GB"
-msgstr " GB"
-
-#. applet.js:816
-msgid " MB"
-msgstr " MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr " kB"
-
-#. applet.js:821
-msgid "  B"
-msgstr "  B"
-
-#. applet.js:831
-msgid " Tib"
-msgstr " Tib"
-
-#. applet.js:834
-msgid " Gib"
-msgstr " Gib"
-
-#. applet.js:837
-msgid " Mib"
-msgstr " Mib"
-
-#. applet.js:840
-msgid " kib"
-msgstr " kib"
-
-#. applet.js:842
-msgid "   b"
-msgstr "   b"
-
-#. applet.js:845
-msgid " Tb"
-msgstr " Tb"
-
-#. applet.js:848
-msgid " Gb"
-msgstr " Gb"
-
-#. applet.js:851
-msgid " Mb"
-msgstr " Mb"
-
-#. applet.js:854
-msgid " kb"
-msgstr " kb"
-
-#. applet.js:856
-msgid "  b"
-msgstr "  b"
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Összes letöltés:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Összes feltöltés:"
 
@@ -207,9 +127,42 @@ msgstr "Átvitt adatok mennyisége"
 msgid "Values shown in the panel"
 msgstr "Panelen megjelenített értékek"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Egység"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Auto"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -298,10 +251,6 @@ msgid "Decimal places"
 msgstr "Tizedesjegyek száma"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Auto"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -328,6 +277,20 @@ msgstr "Szöveg CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "A panel szövegére alkalmazott CSS-stílus"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/it.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2025-01-03 15:10+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,164 +19,84 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Interfacce di rete"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Dati totali dall'avvio"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Avvio dell'applet"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Oggi"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Ieri"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 giorni fa"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Data personalizzata"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Interfaccia Grafica"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Compatto"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Grande"
 
-#. applet.js:796
-msgid " TiB"
-msgstr " TiB"
-
-#. applet.js:799
-msgid " GiB"
-msgstr " GiB"
-
-#. applet.js:802
-msgid " MiB"
-msgstr " MiB"
-
-#. applet.js:805
-msgid " kiB"
-msgstr " kiB"
-
-#. applet.js:807
-msgid "   B"
-msgstr "   B"
-
-#. applet.js:810
-msgid " TB"
-msgstr " TB"
-
-#. applet.js:813
-msgid " GB"
-msgstr " GB"
-
-#. applet.js:816
-msgid " MB"
-msgstr " MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr " kB"
-
-#. applet.js:821
-msgid "  B"
-msgstr "  B"
-
-#. applet.js:831
-msgid " Tib"
-msgstr " Tib"
-
-#. applet.js:834
-msgid " Gib"
-msgstr " Gib"
-
-#. applet.js:837
-msgid " Mib"
-msgstr " Mib"
-
-#. applet.js:840
-msgid " kib"
-msgstr " kib"
-
-#. applet.js:842
-msgid "   b"
-msgstr "   b"
-
-#. applet.js:845
-msgid " Tb"
-msgstr " Tb"
-
-#. applet.js:848
-msgid " Gb"
-msgstr " Gb"
-
-#. applet.js:851
-msgid " Mb"
-msgstr " Mb"
-
-#. applet.js:854
-msgid " kb"
-msgstr " kb"
-
-#. applet.js:856
-msgid "  b"
-msgstr "  b"
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Totale download:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Totale upload:"
 
@@ -208,9 +128,42 @@ msgstr "Quantità di dati trasferiti"
 msgid "Values shown in the panel"
 msgstr "Valori mostrati nel pannello"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Unità"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Auto"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -301,10 +254,6 @@ msgid "Decimal places"
 msgstr "Posizioni decimali"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Auto"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -332,6 +281,20 @@ msgstr "Testo CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Uno stile CSS applicato al testo nel pannello"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/nl.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2024-11-28 17:28+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -17,164 +17,84 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Netwerkinterfaces"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Totale gegevens start"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Start van applet"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Vandaag"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Gisteren"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 dagen geleden"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Aangepaste datum"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Grafische gebruikersinterface"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Compact"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Groot"
 
-#. applet.js:796
-msgid " TiB"
-msgstr " TiB"
-
-#. applet.js:799
-msgid " GiB"
-msgstr " GiB"
-
-#. applet.js:802
-msgid " MiB"
-msgstr " MiB"
-
-#. applet.js:805
-msgid " kiB"
-msgstr " kiB"
-
-#. applet.js:807
-msgid "   B"
-msgstr "   B"
-
-#. applet.js:810
-msgid " TB"
-msgstr " TB"
-
-#. applet.js:813
-msgid " GB"
-msgstr " GB"
-
-#. applet.js:816
-msgid " MB"
-msgstr " MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr " kB"
-
-#. applet.js:821
-msgid "  B"
-msgstr "  B"
-
-#. applet.js:831
-msgid " Tib"
-msgstr " Tib"
-
-#. applet.js:834
-msgid " Gib"
-msgstr " Gib"
-
-#. applet.js:837
-msgid " Mib"
-msgstr " Mib"
-
-#. applet.js:840
-msgid " kib"
-msgstr " kib"
-
-#. applet.js:842
-msgid "   b"
-msgstr "   b"
-
-#. applet.js:845
-msgid " Tb"
-msgstr " Tb"
-
-#. applet.js:848
-msgid " Gb"
-msgstr " Gb"
-
-#. applet.js:851
-msgid " Mb"
-msgstr " Mb"
-
-#. applet.js:854
-msgid " kb"
-msgstr " kb"
-
-#. applet.js:856
-msgid "  b"
-msgstr "  b"
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Totaal gedownload:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Totaal geüpload:"
 
@@ -206,9 +126,42 @@ msgstr "Hoeveelheid overgedragen gegevens"
 msgid "Values shown in the panel"
 msgstr "Waarden weergegeven in het paneel"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Eenheid"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Auto"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -299,10 +252,6 @@ msgid "Decimal places"
 msgstr "Decimalen"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Auto"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0"
 
@@ -329,6 +278,20 @@ msgstr "Tekst CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Een CSS-stijl toegepast op de tekst in het paneel"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/pl.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/pl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2018-04-06 22:12+0200\n"
 "Last-Translator: xearonet\n"
 "Language-Team: \n"
@@ -20,168 +20,85 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#. applet.js:438
+#. applet.js:468
 #, fuzzy
 msgid "Network interfaces"
 msgstr "Interfejs sieciowy"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Początek zliczania danych"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Od uruchomienia"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Dzisiaj"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Wczoraj"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 dni temu"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 dni temu"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 dni temu"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 dni temu"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 dni temu"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 dni temu"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Niestandardowa data"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Rozmiar"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Kompaktowy"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Duży"
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-#, fuzzy
-msgid " GB"
-msgstr "Rozmiar"
-
-#. applet.js:816
-#, fuzzy
-msgid " MB"
-msgstr "MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-msgid " Tb"
-msgstr ""
-
-#. applet.js:848
-#, fuzzy
-msgid " Gb"
-msgstr "Rozmiar"
-
-#. applet.js:851
-msgid " Mb"
-msgstr ""
-
-#. applet.js:854
-msgid " kb"
-msgstr ""
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Pobrano:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Wysłano:"
 
@@ -213,9 +130,42 @@ msgstr "Ilość przesłanych danych"
 msgid "Values shown in the panel"
 msgstr "Wartości wyświetlane w panelu"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Jednostki"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Automatycznie"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -303,10 +253,6 @@ msgid "Decimal places"
 msgstr "Miejsca dziesiętne"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Automatycznie"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -333,6 +279,20 @@ msgstr "Styl CSS tekstu w panelu"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Styl CSS zastosowany do tekstu w panelu"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/pt.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.6.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2024-06-25 02:39-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,167 +18,84 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Interfaces de rede"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Início do total dos dados"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Ao lançar do applet"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Hoje"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Ontem"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 dias antes"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Data personalizada"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Interface"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Compacto"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Largo"
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-#, fuzzy
-msgid " GB"
-msgstr "Interface"
-
-#. applet.js:816
-#, fuzzy
-msgid " MB"
-msgstr "MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-msgid " Tb"
-msgstr ""
-
-#. applet.js:848
-#, fuzzy
-msgid " Gb"
-msgstr "Interface"
-
-#. applet.js:851
-msgid " Mb"
-msgstr ""
-
-#. applet.js:854
-msgid " kb"
-msgstr ""
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Download total:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Upload total:"
 
@@ -210,9 +127,42 @@ msgstr "Quantidade de dados transferridos"
 msgid "Values shown in the panel"
 msgstr "Valores mostrados no painel"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Unidades"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Automático"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -303,10 +253,6 @@ msgid "Decimal places"
 msgstr "Casas decimais"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Automático"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr ""
 
@@ -334,6 +280,20 @@ msgstr "Texto CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Um estilo de CSS aplicado ao texto no painel"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/sv.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/sv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2017-04-29 14:01+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -19,168 +19,85 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. applet.js:438
+#. applet.js:468
 #, fuzzy
 msgid "Network interfaces"
 msgstr "Nätverksgränssnitt"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Total datamängd börjar"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Programstart"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "I dag"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "I går"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 dagar sedan"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 dagar sedan"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 dagar sedan"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 dagar sedan"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 dagar sedan"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 dagar sedan"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Anpassat datum"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "GUI"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Kompakt"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Stor"
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-#, fuzzy
-msgid " GB"
-msgstr "GUI"
-
-#. applet.js:816
-#, fuzzy
-msgid " MB"
-msgstr "MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-msgid " Tb"
-msgstr ""
-
-#. applet.js:848
-#, fuzzy
-msgid " Gb"
-msgstr "GUI"
-
-#. applet.js:851
-msgid " Mb"
-msgstr ""
-
-#. applet.js:854
-msgid " kb"
-msgstr ""
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Totalt nerladdat:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Totalt uppladdat:"
 
@@ -212,9 +129,42 @@ msgstr "Mängden överförd data"
 msgid "Values shown in the panel"
 msgstr "Värden visas i panelen"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Enhet"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Auto"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -302,10 +252,6 @@ msgid "Decimal places"
 msgstr "Decimaler"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Auto"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0"
 
@@ -332,6 +278,20 @@ msgstr "CSS-stil för paneltext"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "CSS-stil som tillämpas på text i panelen"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/tr.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 1.6.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2020-06-16 14:18+0300\n"
 "Last-Translator: serkan önder <serkanonder@outlook.com>\n"
 "Language-Team: \n"
@@ -19,170 +19,84 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "Ağ arayüzleri"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "Toplam veri başlangıcı"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "Uygulamanın başlangıcı"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "Bugün"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "Dün"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 gün önce"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "Özel tarih"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "Arayüz"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "Sıkışık"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "Büyük"
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-#, fuzzy
-msgid " GB"
-msgstr "Arayüz"
-
-#. applet.js:816
-#, fuzzy
-msgid " MB"
-msgstr "MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-#, fuzzy
-msgid " Tb"
-msgstr "b"
-
-#. applet.js:848
-#, fuzzy
-msgid " Gb"
-msgstr "b"
-
-#. applet.js:851
-#, fuzzy
-msgid " Mb"
-msgstr "b"
-
-#. applet.js:854
-#, fuzzy
-msgid " kb"
-msgstr "b"
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "Toplam indirme:"
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "Toplam yükleme:"
 
@@ -214,9 +128,42 @@ msgstr "Aktarılan veri miktarı"
 msgid "Values shown in the panel"
 msgstr "Panelde gösterilen değerler"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "Birim"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "Otomatik"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -307,10 +254,6 @@ msgid "Decimal places"
 msgstr "Ondalık"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "Otomatik"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -337,6 +280,20 @@ msgstr "Metin CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "Paneldeki metne uygulanan bir CSS stili"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/zh_CN.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/zh_CN.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2023-06-01 17:30+0800\n"
 "Last-Translator: Slinet6056 <slinet6056@gmail.com>\n"
 "Language-Team: \n"
@@ -19,170 +19,84 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.3.1\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "网络接口"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "总数据开始"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "启动小程序"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "今天"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "昨天"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "自定义日期"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "图形用户界面"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "小"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "大"
 
-#. applet.js:796
-msgid " TiB"
-msgstr ""
-
-#. applet.js:799
-msgid " GiB"
-msgstr ""
-
-#. applet.js:802
-msgid " MiB"
-msgstr ""
-
-#. applet.js:805
-msgid " kiB"
-msgstr ""
-
-#. applet.js:807
-msgid "   B"
-msgstr ""
-
-#. applet.js:810
-msgid " TB"
-msgstr ""
-
-#. applet.js:813
-#, fuzzy
-msgid " GB"
-msgstr "图形用户界面"
-
-#. applet.js:816
-#, fuzzy
-msgid " MB"
-msgstr "MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr ""
-
-#. applet.js:821
-msgid "  B"
-msgstr ""
-
-#. applet.js:831
-msgid " Tib"
-msgstr ""
-
-#. applet.js:834
-msgid " Gib"
-msgstr ""
-
-#. applet.js:837
-msgid " Mib"
-msgstr ""
-
-#. applet.js:840
-msgid " kib"
-msgstr ""
-
-#. applet.js:842
-msgid "   b"
-msgstr ""
-
-#. applet.js:845
-#, fuzzy
-msgid " Tb"
-msgstr "b"
-
-#. applet.js:848
-#, fuzzy
-msgid " Gb"
-msgstr "b"
-
-#. applet.js:851
-#, fuzzy
-msgid " Mb"
-msgstr "b"
-
-#. applet.js:854
-#, fuzzy
-msgid " kb"
-msgstr "b"
-
-#. applet.js:856
-msgid "  b"
-msgstr ""
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "总下载："
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "总上传："
 
@@ -214,9 +128,42 @@ msgstr "传输的数据量"
 msgid "Values shown in the panel"
 msgstr "显示在面板中的值"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "单位"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "自动"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -235,9 +182,8 @@ msgid "Decimal or binary"
 msgstr ""
 
 #. settings-schema.json->is_binary->options
-#, fuzzy
 msgid "Decimal"
-msgstr "小数位"
+msgstr ""
 
 #. settings-schema.json->is_binary->options
 msgid "Binary"
@@ -302,10 +248,6 @@ msgid "Decimal places"
 msgstr "小数位"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "自动"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -332,6 +274,20 @@ msgstr "文本 CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "应用到面板中文本的 CSS 样式"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/zh_TW.po
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/po/zh_TW.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: download-and-upload-speed@cardsurf 1.6.7\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-27 21:38+0200\n"
+"POT-Creation-Date: 2025-09-30 13:31+0200\n"
 "PO-Revision-Date: 2025-08-26 01:33+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -16,164 +16,84 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. applet.js:438
+#. applet.js:468
 msgid "Network interfaces"
 msgstr "網路介面"
 
-#. applet.js:507
+#. applet.js:537
 msgid "Total data start"
 msgstr "總資料量計算起點"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:514
+#. applet.js:544
 msgid "Launch of applet"
 msgstr "小程式啟動時"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:515
+#. applet.js:545
 msgid "Today"
 msgstr "今天"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:516
+#. applet.js:546
 msgid "Yesterday"
 msgstr "昨天"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:517
+#. applet.js:547
 msgid "3 days ago"
 msgstr "3 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:518
+#. applet.js:548
 msgid "5 days ago"
 msgstr "5 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:519
+#. applet.js:549
 msgid "7 days ago"
 msgstr "7 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:520
+#. applet.js:550
 msgid "10 days ago"
 msgstr "10 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:521
+#. applet.js:551
 msgid "14 days ago"
 msgstr "14 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:522
+#. applet.js:552
 msgid "30 days ago"
 msgstr "30 天前"
 
 #. settings-schema.json->bytes_start_time->options
-#. applet.js:523
+#. applet.js:553
 msgid "Custom date"
 msgstr "自訂日期"
 
 #. settings-schema.json->gui_start->description
-#. applet.js:560
+#. applet.js:590
 msgid "Gui"
 msgstr "圖形介面"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Compact"
 msgstr "精簡"
 
 #. settings-schema.json->gui_speed_type->options
-#. applet.js:560
+#. applet.js:590
 msgid "Large"
 msgstr "大型"
 
-#. applet.js:796
-msgid " TiB"
-msgstr " TiB"
-
-#. applet.js:799
-msgid " GiB"
-msgstr " GiB"
-
-#. applet.js:802
-msgid " MiB"
-msgstr " MiB"
-
-#. applet.js:805
-msgid " kiB"
-msgstr " kiB"
-
-#. applet.js:807
-msgid "   B"
-msgstr "   B"
-
-#. applet.js:810
-msgid " TB"
-msgstr " TB"
-
-#. applet.js:813
-msgid " GB"
-msgstr " GB"
-
-#. applet.js:816
-msgid " MB"
-msgstr " MB"
-
-#. applet.js:819
-msgid " kB"
-msgstr " kB"
-
-#. applet.js:821
-msgid "  B"
-msgstr "  B"
-
-#. applet.js:831
-msgid " Tib"
-msgstr " Tib"
-
-#. applet.js:834
-msgid " Gib"
-msgstr " Gib"
-
-#. applet.js:837
-msgid " Mib"
-msgstr " Mib"
-
-#. applet.js:840
-msgid " kib"
-msgstr " kib"
-
-#. applet.js:842
-msgid "   b"
-msgstr "   b"
-
-#. applet.js:845
-msgid " Tb"
-msgstr " Tb"
-
-#. applet.js:848
-msgid " Gb"
-msgstr " Gb"
-
-#. applet.js:851
-msgid " Mb"
-msgstr " Mb"
-
-#. applet.js:854
-msgid " kb"
-msgstr " kb"
-
-#. applet.js:856
-msgid "  b"
-msgstr "  b"
-
-#. appletGui.js:480
+#. appletGui.js:510
 msgid "Total download:"
 msgstr "總下載："
 
-#. appletGui.js:481
+#. appletGui.js:511
 msgid "Total upload:"
 msgstr "總上傳："
 
@@ -205,9 +125,42 @@ msgstr "傳輸資料量"
 msgid "Values shown in the panel"
 msgstr "面板上顯示的數值"
 
-#. settings-schema.json->unit_type->description
+#. settings-schema.json->unit->description
 msgid "Unit"
 msgstr "單位"
+
+#. settings-schema.json->unit->options
+#. settings-schema.json->decimal_places->options
+msgid "Auto"
+msgstr "自動"
+
+#. settings-schema.json->unit->options
+msgid "Bytes/Bits"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "KB/Kb/KiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "MB/Mb/MiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "GB/Gb/GiB"
+msgstr ""
+
+#. settings-schema.json->unit->options
+msgid "TB/Tb/TiB"
+msgstr ""
+
+#. settings-schema.json->unit->tooltip
+msgid "Use fixed unit for displaying, or automatically choose the best unit"
+msgstr ""
+
+#. settings-schema.json->unit_type->description
+msgid "Unit type"
+msgstr ""
 
 #. settings-schema.json->unit_type->options
 msgid "Bytes"
@@ -263,8 +216,7 @@ msgstr "每隔多久更新可用介面"
 msgid ""
 "How often to update list of available network interfaces. 0 means list of "
 "available network interfaces is not updated periodically."
-msgstr ""
-"多久更新一次可用網路介面清單。0 代表不定期更新可用網路介面清單。"
+msgstr "多久更新一次可用網路介面清單。0 代表不定期更新可用網路介面清單。"
 
 #. settings-schema.json->gui_speed_type->description
 msgid "Type"
@@ -295,10 +247,6 @@ msgid "Decimal places"
 msgstr "小數位數"
 
 #. settings-schema.json->decimal_places->options
-msgid "Auto"
-msgstr "自動"
-
-#. settings-schema.json->decimal_places->options
 msgid "0 "
 msgstr "0 "
 
@@ -325,6 +273,20 @@ msgstr "文字 CSS"
 #. settings-schema.json->gui_text_css->tooltip
 msgid "A CSS style applied to the text in the panel"
 msgstr "套用至面板文字的 CSS 樣式"
+
+#. settings-schema.json->gui_inactive_text_css->description
+msgid "Inactive text CSS"
+msgstr ""
+
+#. settings-schema.json->gui_inactive_text_css->tooltip
+msgid ""
+"A CSS style applied to the text in the panel when there is no network "
+"activity"
+msgstr ""
+
+#. settings-schema.json->gui_show_icons->description
+msgid "Show icons"
+msgstr ""
 
 #. settings-schema.json->gui_received_icon_filename->description
 msgid "Download icon"
@@ -431,8 +393,7 @@ msgstr "每隔多久儲存一次"
 msgid ""
 "How often to save total amount of data downloaded and uploaded to the file. "
 "0 means no saving to the file."
-msgstr ""
-"將總下載與上傳資料量儲存至檔案的頻率。0 代表不儲存至檔案。"
+msgstr "將總下載與上傳資料量儲存至檔案的頻率。0 代表不儲存至檔案。"
 
 #. settings-schema.json->data_limit_start->description
 msgid "Data limits"
@@ -478,8 +439,7 @@ msgstr "超過資料上限時執行指令"
 msgid ""
 "Invoke a command when amount of data downloaded and uploaded exceeded the "
 "limit"
-msgstr ""
-"當下載與上傳資料量總和超過上限時，執行一個指令。"
+msgstr "當下載與上傳資料量總和超過上限時，執行一個指令。"
 
 #. settings-schema.json->data_limit_command->description
 msgid "Command"
@@ -501,8 +461,7 @@ msgstr "左鍵點選時列出目前網際網路連線"
 msgid ""
 "Open a terminal with a list of current connections on a left mouse click. "
 "The next click closes the terminal."
-msgstr ""
-"左鍵點選時開啟終端機並列出目前連線，再次點選則關閉終端機。"
+msgstr "左鍵點選時開啟終端機並列出目前連線，再次點選則關閉終端機。"
 
 #. settings-schema.json->list_connections_command->description
 msgid "Command "

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/settings-schema.json
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/settings-schema.json
@@ -107,22 +107,30 @@
         "tooltip": "A CSS style applied to the text in the panel",
         "expand-width": true
     },
+    "gui_show_icons" : {
+        "type" : "switch",
+        "default" : true,
+        "description": "Show icons"
+    },
     "gui_received_icon_filename" : {
         "type" : "filechooser",
         "default" : "~/.local/share/cinnamon/applets/download-and-upload-speed@cardsurf/icons/arrow_down_blue.svg",
         "description" : "Download icon",
-        "tooltip": "An icon displayed next to download speed in the panel.\nTo display a symbolic icon make sure its name ends with '-symbolic.svg'."
+        "tooltip": "An icon displayed next to download speed in the panel.\nTo display a symbolic icon make sure its name ends with '-symbolic.svg'.",
+        "dependency": "gui_show_icons"
     },
     "gui_sent_icon_filename" : {
         "type" : "filechooser",
         "default" : "~/.local/share/cinnamon/applets/download-and-upload-speed@cardsurf/icons/arrow_up_red.svg",
         "description" : "Upload icon",
-        "tooltip": "An icon displayed next to upload speed in the panel.\nTo display a symbolic icon make sure its name ends with '-symbolic.svg'."
+        "tooltip": "An icon displayed next to upload speed in the panel.\nTo display a symbolic icon make sure its name ends with '-symbolic.svg'.",
+        "dependency": "gui_show_icons"
     },
     "gui_symbolic_icon" : {
         "type" : "switch",
         "default" : false,
-        "description": "Show a default set of symbolic icons"
+        "description": "Show a default set of symbolic icons",
+        "dependency": "gui_show_icons"
     },
     "hover_popup_text_css": {
         "type": "entry",

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/settings-schema.json
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/settings-schema.json
@@ -17,10 +17,24 @@
         },
         "tooltip" : "Values shown in the panel"
     },
-    "unit_type" : {
+    "unit" : {
         "type": "combobox",
         "default" : 0,
         "description" : "Unit",
+        "options" : {
+            "Auto" : 0,
+            "Bytes/Bits" : 1,
+            "KB/Kb/KiB" : 2,
+            "MB/Mb/MiB" : 3,
+            "GB/Gb/GiB" : 4,
+            "TB/Tb/TiB" : 5
+        },
+        "tooltip" : "Use fixed unit for displaying, or automatically choose the best unit"
+    },
+    "unit_type" : {
+        "type": "combobox",
+        "default" : 0,
+        "description" : "Unit type",
         "options" : {
             "Bytes" : 0,
             "Bits" : 1

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/settings-schema.json
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/settings-schema.json
@@ -121,6 +121,13 @@
         "tooltip": "A CSS style applied to the text in the panel",
         "expand-width": true
     },
+    "gui_inactive_text_css": {
+        "type": "entry",
+        "default": "color: grey; font-weight: normal; font-size: 15px; text-align: right; font-family: monospace;",
+        "description": "Inactive text CSS",
+        "tooltip": "A CSS style applied to the text in the panel when there is no network activity",
+        "expand-width": true
+    },
     "gui_show_icons" : {
         "type" : "switch",
         "default" : true,


### PR DESCRIPTION
This PR adds features that I found useful and I think would be nice additions to this applet:
- option to hide icons
- option to use fixed units (e.g. always MB) instead of auto choosing the unit
- option to display no traffic text ("0.00") in a different style, which would make it easier to notice when the traffic is active 

<img width="107" height="40" alt="screenshot" src="https://github.com/user-attachments/assets/55df6cc1-c2aa-4d79-9b86-3d87c945e079" />
</br></br>

cc: @cardsurf @claudiux 

@claudiux I hope it's okay to add you here, since I saw that lately only you were making changes to this applet.