### PR TITLE
xsession v5.1.0: Adds "Repeat last action" option in menu

### DIFF
--- a/xsession@claudiux/files/xsession@claudiux/CHANGELOG.md
+++ b/xsession@claudiux/files/xsession@claudiux/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v5.1.0~20251003
+Developers often have to repeat the same action several times (reloading a Spice or opening its settings).
+
+A “Repeat last action” option is now available in the menu when an action has been performed. This option disappears after one hour.
+
+If you cannot remember what the action was, simply do not use this option.
+
+
 ### v5.0.0~20250417
   * Ctrl+MiddleClick opens only latest messages.
   * Can set from menu the number of latest messages.

--- a/xsession@claudiux/files/xsession@claudiux/metadata.json
+++ b/xsession@claudiux/files/xsession@claudiux/metadata.json
@@ -3,7 +3,7 @@
   "name": "Xsession",
   "max-instances": "1",
   "hide-configuration": false,
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Restart, access source code and configure your Spices (Applets, Desklets, Extensions). View the contents of your .xsession-errors file in real time. Restart Cinnamon.",
   "author": "claudiux"
 }

--- a/xsession@claudiux/files/xsession@claudiux/po/ca.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/ca.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: 2025-09-28 17:10+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -47,84 +47,88 @@ msgstr "Extensions"
 msgid "RELOAD ALL"
 msgstr "RECARREGAR TOT"
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "Clic del mig:\n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr "Mostrar .xsession-errors"
 
-#. applet.js:242
+#. applet.js:249
 msgid "Ctrl + Middle-click: \n"
 msgstr "Ctrl + Clic del mig: \n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr "Mostra els darrers missatges"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr "%s darrers missatges"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr "mín: 10. màx: 250."
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "Reiniciar Cinnamon"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- Recarregar Espècies ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "Recarregar la miniaplicació:"
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "Recarregar la miniaplicació d'escriptori:"
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "Recarregar l'extensió:"
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr "Recarrega el tema actual"
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr "--- Opcions per ---"
 
-#. applet.js:470
+#. applet.js:486
 msgid "Applet:"
 msgstr "Miniaplicació:"
 
-#. applet.js:479
+#. applet.js:495
 msgid "Desklet:"
 msgstr "Miniaplicació d'escriptori:"
 
-#. applet.js:488
+#. applet.js:504
 msgid "Extension:"
 msgstr "Extensió:"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- Veure el codi ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "Veure el codi de la miniaplicació:"
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "Veure el codi de la miniaplicació d'escriptori:"
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "Veure el codi de l'extensió:"
 

--- a/xsession@claudiux/files/xsession@claudiux/po/da.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: 2023-12-28 08:51+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -47,88 +47,92 @@ msgstr "Udvidelser"
 msgid "RELOAD ALL"
 msgstr ""
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "Midterklik: \n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr "Vis .xsession-errors"
 
-#. applet.js:242
+#. applet.js:249
 #, fuzzy
 msgid "Ctrl + Middle-click: \n"
 msgstr "Midterklik: \n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr ""
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "Genstart Cinnamon"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- Genindlæs Spices ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "Genindlæs panelprogram:"
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "Genindlæs skrivebordsprogram:"
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "Genindlæs udvidelse:"
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr ""
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr ""
 
-#. applet.js:470
+#. applet.js:486
 #, fuzzy
 msgid "Applet:"
 msgstr "Panelprogram"
 
-#. applet.js:479
+#. applet.js:495
 #, fuzzy
 msgid "Desklet:"
 msgstr "Skrivebordsprogram"
 
-#. applet.js:488
+#. applet.js:504
 #, fuzzy
 msgid "Extension:"
 msgstr "Udvidelse"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- Vis kode ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "Vis koden for panelprogrammet:"
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "Vis koden for skrivebordsprogrammet:"
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "Vis koden for udvidelsen:"
 

--- a/xsession@claudiux/files/xsession@claudiux/po/de.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: xsession@claudiux 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -46,85 +46,89 @@ msgstr "Erweiterungen"
 msgid "RELOAD ALL"
 msgstr ""
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "Mittlerer Maus Klick:\n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr ".xsession-errors anzeigen"
 
-#. applet.js:242
+#. applet.js:249
 #, fuzzy
 msgid "Ctrl + Middle-click: \n"
 msgstr "Mittlerer Maus Klick:\n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr ""
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "Cinnamon neustarten"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- Spices neuladen ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "Applet Neuladen:"
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "Desklet Neuladen:"
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "Extension Neuladen:"
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr ""
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr "--- Einstellungen für --_"
 
-#. applet.js:470
+#. applet.js:486
 msgid "Applet:"
 msgstr "Applet:"
 
-#. applet.js:479
+#. applet.js:495
 msgid "Desklet:"
 msgstr "Desklet:"
 
-#. applet.js:488
+#. applet.js:504
 msgid "Extension:"
 msgstr "Erweiterung:"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- Code anzeigen ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "Zeige Applet Code für:"
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "Zeige Desklet code für:"
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "Zeige Erweiterungs Code für:"
 

--- a/xsession@claudiux/files/xsession@claudiux/po/es.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: 2025-04-17 10:43-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -46,84 +46,88 @@ msgstr "Extensiones"
 msgid "RELOAD ALL"
 msgstr "RECARGAR TODO"
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "Click medio: \n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr "Mostrar .xsession-errors"
 
-#. applet.js:242
+#. applet.js:249
 msgid "Ctrl + Middle-click: \n"
 msgstr "Ctrl + Click medio: \n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr "Mostrar los últimos mensajes"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr "%s últimos mensajes"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr "mín: 10. máx: 250."
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "Reiniciar Cinnamon"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- Recargar Especias ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "Recargar Applet:"
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "Recargar Desklet:"
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "Recargar Extensión:"
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr "Recargar el tema actual"
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr "--- Ajustes para ---"
 
-#. applet.js:470
+#. applet.js:486
 msgid "Applet:"
 msgstr "Applet:"
 
-#. applet.js:479
+#. applet.js:495
 msgid "Desklet:"
 msgstr "Desklet:"
 
-#. applet.js:488
+#. applet.js:504
 msgid "Extension:"
 msgstr "Extensión:"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- Ver Código ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "Ver código del Applet para:"
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "Ver código del Desklet para:"
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "Ver código de la Extensión para:"
 

--- a/xsession@claudiux/files/xsession@claudiux/po/fr.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/fr.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
-"PO-Revision-Date: 2025-04-17 13:59+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
+"PO-Revision-Date: 2025-10-03 18:31+0200\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -47,84 +47,88 @@ msgstr "Extensions"
 msgid "RELOAD ALL"
 msgstr "TOUT RELANCER"
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "Clic-molette : \n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr "Afficher .xsession-errors"
 
-#. applet.js:242
+#. applet.js:249
 msgid "Ctrl + Middle-click: \n"
 msgstr "Ctrl + Clic-molette : \n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr "Afficher les derniers messages"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr "%s derniers messages"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr "min: 10. max: 250."
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "Redémarrer Cinnamon"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr "Répéter la dernière action"
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- Relancer des Spices ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "Relancer cette Applet :"
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "Relancer cette Desklet :"
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "Relancer cette Extension :"
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr "Relancer le thème actuel"
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr "--- Paramètres ---"
 
-#. applet.js:470
+#. applet.js:486
 msgid "Applet:"
 msgstr "Applet :"
 
-#. applet.js:479
+#. applet.js:495
 msgid "Desklet:"
 msgstr "Desklet :"
 
-#. applet.js:488
+#. applet.js:504
 msgid "Extension:"
 msgstr "Extension :"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- Code Source ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "Consulter le code de l'Applet :"
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "Consulter le code de la Desklet :"
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "Consulter le code de l'Extension :"
 

--- a/xsession@claudiux/files/xsession@claudiux/po/hu.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: 2025-08-09 18:50+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -46,84 +46,88 @@ msgstr "Bővítmények"
 msgid "RELOAD ALL"
 msgstr "ÖSSZES ÚJRATÖLTÉSE"
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "Kattintás a középső egérgombbal: \n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr "Az „.xsession-errors” fájl megjelenítése"
 
-#. applet.js:242
+#. applet.js:249
 msgid "Ctrl + Middle-click: \n"
 msgstr "Ctrl + középső kattintás: \n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr "Show latest messages"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr "%s legújabb üzenetek"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr "min: 10. max: 250."
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "Cinnamon környezet újraindítása"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- Spices kiegészítők újratöltése ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "Kisalkalmazás újratöltése:"
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "Asztalkalmazás újratöltése:"
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "Bővítmény újratöltése:"
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr "Az aktuális téma újratöltése"
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr "--- Beállítások ehhez: ---"
 
-#. applet.js:470
+#. applet.js:486
 msgid "Applet:"
 msgstr "Kisalkalmazás:"
 
-#. applet.js:479
+#. applet.js:495
 msgid "Desklet:"
 msgstr "Asztalkalmazás:"
 
-#. applet.js:488
+#. applet.js:504
 msgid "Extension:"
 msgstr "Bővítmény:"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- Kód megjelenítése ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "Kisalkalmazás forráskód megjelenítése:"
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "Asztalkalmazás forráskód megjelenítése:"
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "Bővítmény forráskód megjelenítése:"
 

--- a/xsession@claudiux/files/xsession@claudiux/po/it.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: 2025-08-27 19:26+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -47,84 +47,88 @@ msgstr "Estensioni"
 msgid "RELOAD ALL"
 msgstr "RICARICA TUTTO"
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "Clic-centrale: \n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr "Mostra .xsession-errors"
 
-#. applet.js:242
+#. applet.js:249
 msgid "Ctrl + Middle-click: \n"
 msgstr "Ctrl + Clic-centrale: \n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr "Mostra ultimi messaggi"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr "%s ultimi messaggi"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr "min: 10. max: 250."
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "Riavvia Cinnamon"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- Ricarica Spice ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "Ricarica Applet:"
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "Ricarica Desklet:"
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "Ricarica Estensione:"
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr "Ricarica Tema Corrente"
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr "--- Impostazioni di ---"
 
-#. applet.js:470
+#. applet.js:486
 msgid "Applet:"
 msgstr "Applet:"
 
-#. applet.js:479
+#. applet.js:495
 msgid "Desklet:"
 msgstr "Desklet:"
 
-#. applet.js:488
+#. applet.js:504
 msgid "Extension:"
 msgstr "Estensione:"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- Mostra Codice ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "Mostra Codice Applet di:"
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "Mostra Codice Desklet di:"
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "Mostra Codice Estensione di:"
 

--- a/xsession@claudiux/files/xsession@claudiux/po/nl.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: 2025-05-13 14:53+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -45,84 +45,88 @@ msgstr "Extensies"
 msgid "RELOAD ALL"
 msgstr "ALLES HERLADEN"
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "Middelklik: \n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr "Toon .xsession-errors"
 
-#. applet.js:242
+#. applet.js:249
 msgid "Ctrl + Middle-click: \n"
 msgstr "Ctrl + Middelklik: \n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr "Toon laatste berichten"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr "%s laatste berichten"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr "min: 10, max: 250."
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "Herstart Cinnamon"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- Herlaad Spices ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "Herlaad Applet:"
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "Herlaad Desklet:"
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "Herlaad Extensie:"
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr "Herlaad huidig thema"
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr "--- Instellingen voor ---"
 
-#. applet.js:470
+#. applet.js:486
 msgid "Applet:"
 msgstr "Applet:"
 
-#. applet.js:479
+#. applet.js:495
 msgid "Desklet:"
 msgstr "Desklet:"
 
-#. applet.js:488
+#. applet.js:504
 msgid "Extension:"
 msgstr "Extensie:"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- Bekijk Code ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "Bekijk Applet-code voor:"
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "Bekijk Desklet-code voor:"
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "Bekijk Extensie-code voor:"
 

--- a/xsession@claudiux/files/xsession@claudiux/po/tr.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: 2023-01-31 11:51+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
@@ -47,87 +47,91 @@ msgstr "Eklentiler"
 msgid "RELOAD ALL"
 msgstr ""
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr ""
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr ".xoturumu-hatalarını göster"
 
-#. applet.js:242
+#. applet.js:249
 msgid "Ctrl + Middle-click: \n"
 msgstr ""
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr ""
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "Cinnamon'u Yeniden Başlat"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- Uygulamacıkları Yeniden Yükle ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "Uygulamayı Yeniden Yükle:"
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "Masaüstü Uygulamacığını Yeniden Yükle:"
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "Uzantıyı Yeniden Yükle:"
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr ""
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr ""
 
-#. applet.js:470
+#. applet.js:486
 #, fuzzy
 msgid "Applet:"
 msgstr "Uygulamacık"
 
-#. applet.js:479
+#. applet.js:495
 #, fuzzy
 msgid "Desklet:"
 msgstr "Masaüstü Uygulamacığı"
 
-#. applet.js:488
+#. applet.js:504
 #, fuzzy
 msgid "Extension:"
 msgstr "Eklenti"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- Kodu Görüntüle ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "Uygulamacık Kodunu Görüntüle:"
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "Masaüstü Uygulamacığı Kodunu Görüntüle:"
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "Eklenti Kodunu Görüntüle:"
 

--- a/xsession@claudiux/files/xsession@claudiux/po/xsession@claudiux.pot
+++ b/xsession@claudiux/files/xsession@claudiux/po/xsession@claudiux.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: xsession@claudiux 5.0.0\n"
+"Project-Id-Version: xsession@claudiux 5.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -45,84 +45,88 @@ msgstr ""
 msgid "RELOAD ALL"
 msgstr ""
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr ""
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr ""
 
-#. applet.js:242
+#. applet.js:249
 msgid "Ctrl + Middle-click: \n"
 msgstr ""
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr ""
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr ""
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr ""
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr ""
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr ""
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr ""
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr ""
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr ""
 
-#. applet.js:470
+#. applet.js:486
 msgid "Applet:"
 msgstr ""
 
-#. applet.js:479
+#. applet.js:495
 msgid "Desklet:"
 msgstr ""
 
-#. applet.js:488
+#. applet.js:504
 msgid "Extension:"
 msgstr ""
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr ""
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr ""
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr ""
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr ""
 

--- a/xsession@claudiux/files/xsession@claudiux/po/zh_CN.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/zh_CN.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: 2023-05-31 19:41+0800\n"
 "Last-Translator: Slinet6056 <slinet6056@gmail.com>\n"
 "Language-Team: \n"
@@ -47,88 +47,92 @@ msgstr "扩展"
 msgid "RELOAD ALL"
 msgstr ""
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "中键点击：\n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr "显示 .xsession-errors"
 
-#. applet.js:242
+#. applet.js:249
 #, fuzzy
 msgid "Ctrl + Middle-click: \n"
 msgstr "中键点击：\n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr ""
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr ""
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "重新启动 Cinnamon"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- 重新加载 Spices ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "重新加载小程序："
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "重新加载桌面小工具："
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "重新加载扩展："
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr ""
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr ""
 
-#. applet.js:470
+#. applet.js:486
 #, fuzzy
 msgid "Applet:"
 msgstr "小程序"
 
-#. applet.js:479
+#. applet.js:495
 #, fuzzy
 msgid "Desklet:"
 msgstr "桌面小工具"
 
-#. applet.js:488
+#. applet.js:504
 #, fuzzy
 msgid "Extension:"
 msgstr "扩展"
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- 查看代码 ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "查看小程序的代码："
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "查看桌面小工具的代码："
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "查看扩展的代码："
 

--- a/xsession@claudiux/files/xsession@claudiux/po/zh_TW.po
+++ b/xsession@claudiux/files/xsession@claudiux/po/zh_TW.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: xsession@claudiux 5.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-17 13:58+0200\n"
+"POT-Creation-Date: 2025-10-03 18:30+0200\n"
 "PO-Revision-Date: 2025-09-11 00:10+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -44,84 +44,88 @@ msgstr "擴充功能"
 msgid "RELOAD ALL"
 msgstr "全部重新載入"
 
-#. applet.js:241
+#. applet.js:248
 msgid "Middle-click: \n"
 msgstr "滑鼠中鍵點選：\n"
 
-#. applet.js:241 applet.js:317
+#. applet.js:248 applet.js:327
 msgid "Show .xsession-errors"
 msgstr "顯示 .xsession-errors"
 
-#. applet.js:242
+#. applet.js:249
 msgid "Ctrl + Middle-click: \n"
 msgstr "Ctrl + 滑鼠中鍵點選：\n"
 
-#. applet.js:242 applet.js:331
+#. applet.js:249 applet.js:341
 msgid "Show latest messages"
 msgstr "顯示最新訊息"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 #, javascript-format
 msgid "%s latest messages"
 msgstr "%s 則最新訊息"
 
-#. applet.js:295 applet.js:537
+#. applet.js:311 applet.js:553
 msgid "min: 10. max: 250."
 msgstr "最小值：10，最大值：250。"
 
-#. applet.js:348
+#. applet.js:358
 msgid "Restart Cinnamon"
 msgstr "重新啟動 Cinnamon"
 
-#. applet.js:364
+#. applet.js:376
+msgid "Repeat last action"
+msgstr ""
+
+#. applet.js:380
 msgid "--- Reload Spices ---"
 msgstr "--- 重新載入 Spices ---"
 
-#. applet.js:370
+#. applet.js:386
 msgid "Reload Applet:"
 msgstr "重新載入面板小程式："
 
-#. applet.js:397
+#. applet.js:413
 msgid "Reload Desklet:"
 msgstr "重新載入桌面小工具："
 
-#. applet.js:424
+#. applet.js:440
 msgid "Reload Extension:"
 msgstr "重新載入擴充功能："
 
-#. applet.js:450
+#. applet.js:466
 msgid "Reload Current Theme"
 msgstr "重新載入目前佈景主題"
 
-#. applet.js:464
+#. applet.js:480
 msgid "--- Settings for ---"
 msgstr "--- 設定選項 ---"
 
-#. applet.js:470
+#. applet.js:486
 msgid "Applet:"
 msgstr "面板小程式："
 
-#. applet.js:479
+#. applet.js:495
 msgid "Desklet:"
 msgstr "桌面小工具："
 
-#. applet.js:488
+#. applet.js:504
 msgid "Extension:"
 msgstr "擴充功能："
 
-#. applet.js:497
+#. applet.js:513
 msgid "--- View Code ---"
 msgstr "--- 檢視程式碼 ---"
 
-#. applet.js:503
+#. applet.js:519
 msgid "View Applet Code for:"
 msgstr "檢視面板小程式原始碼："
 
-#. applet.js:512
+#. applet.js:528
 msgid "View Desklet Code for:"
 msgstr "檢視桌面小工具原始碼："
 
-#. applet.js:521
+#. applet.js:537
 msgid "View Extension Code for:"
 msgstr "檢視擴充功能原始碼："
 


### PR DESCRIPTION
Developers often have to repeat the same action several times (reloading a Spice or opening its settings).

A “Repeat last action” option is now available in the menu when an action has been performed. This option disappears after one hour.

If you cannot remember what the action was, simply do not use this option.

