### PR TITLE
`ddcci-monitor-control@andr35`: Allow 0% brightess/contrast

### DIFF
--- a/ddcci-monitor-control@andr35/files/ddcci-monitor-control@andr35/applet.js
+++ b/ddcci-monitor-control@andr35/files/ddcci-monitor-control@andr35/applet.js
@@ -199,7 +199,7 @@ MyApplet.prototype = {
         }
 
         // Ensure is value
-        if (value > 100 || value <= 0) {
+        if (value > 100 || value < 0) {
             return;
         }
 
@@ -249,7 +249,7 @@ MyApplet.prototype = {
         }
 
         // Ensure is value
-        if (value > 100 || value <= 0) {
+        if (value > 100 || value < 0) {
             return;
         }
 


### PR DESCRIPTION
Let's the user set brightness/contrast to 0%, previously 1% was the minimum and setting it to 0% would have no effect. 