### PR TITLE
power-profiles@rcalixte: Fix menu items duplication during icon style change

### DIFF
--- a/power-profiles@rcalixte/files/power-profiles@rcalixte/5.4/applet.js
+++ b/power-profiles@rcalixte/files/power-profiles@rcalixte/5.4/applet.js
@@ -262,7 +262,7 @@ PowerProfilesApplet.prototype = {
 
   _onIconStyleChanged() {
     this._setIconMap();
-    this._updateApplet();
+    this._update();
   },
 
   _setIconMap() {


### PR DESCRIPTION
Steps to reproduce:
- Open applet settings
- Change applet icon style, during each style change it repeatedly adds the same menu items again to the menu without removing them prior to that.

cc @rcalixte

This was reported by a user while in this applet's page in the cinnamon-spices webpage:
https://cinnamon-spices.linuxmint.com/applets/view/369