### PR TITLE
Avoids paint() errors for several applets

### DIFF
--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v3.8.4~20251031
+  * Avoids paint() errors.
+
 ### v3.8.3~20251023
   * Fixes error opening menu.
   * Fixes [#7907](https://github.com/linuxmint/cinnamon-spices-applets/issues/7907).

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/applet.js
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/applet.js
@@ -1475,7 +1475,7 @@ class WebRadioReceiverAndRecorder extends TextIconApplet {
           this.percentage = value;
           if (this.context_menu_item_slider != null) {
             this.context_menu_item_slider.slider._value = value / 100;
-            this.context_menu_item_slider.slider._slider.queue_repaint();
+            try { this.context_menu_item_slider.slider._slider.queue_repaint() } catch(e) {};
             this.context_menu_item_slider.slider.emit('value-changed', value / 100);
           }
           if (value >= vol_end) {
@@ -1592,7 +1592,7 @@ class WebRadioReceiverAndRecorder extends TextIconApplet {
       let value = this.percentage / 100;
       if (this.context_menu_item_slider != null) {
         this.context_menu_item_slider.slider._value = value;
-        this.context_menu_item_slider.slider._slider.queue_repaint();
+        try { this.context_menu_item_slider.slider._slider.queue_repaint() } catch(e) {};
         this.context_menu_item_slider.slider.emit('value-changed', value);
       }
     });
@@ -1603,7 +1603,7 @@ class WebRadioReceiverAndRecorder extends TextIconApplet {
       let value = this.percentage / 100;
       if (this.context_menu_item_slider != null) {
         this.context_menu_item_slider.slider._value = value;
-        this.context_menu_item_slider.slider._slider.queue_repaint();
+        try { this.context_menu_item_slider.slider._slider.queue_repaint() } catch(e) {};
         this.context_menu_item_slider.slider.emit('value-changed', value);
       }
     });
@@ -1620,7 +1620,7 @@ class WebRadioReceiverAndRecorder extends TextIconApplet {
         else value = (this.old_percentage) ? this.old_percentage / 100 : volume_at_startup / 100;
 
         this.context_menu_item_slider.slider._value = value;
-        this.context_menu_item_slider.slider._slider.queue_repaint();
+        try { this.context_menu_item_slider.slider._slider.queue_repaint() } catch(e) {};
         this.context_menu_item_slider.slider.emit('value-changed', value);
       }
     });
@@ -4042,7 +4042,7 @@ class WebRadioReceiverAndRecorder extends TextIconApplet {
       let value = volume_at_startup / 100;
       if (this.context_menu_item_slider != null) {
         this.context_menu_item_slider.slider._value = value;
-        this.context_menu_item_slider.slider._slider.queue_repaint();
+        try { this.context_menu_item_slider.slider._slider.queue_repaint() } catch(e) {};
         this.context_menu_item_slider.slider.emit('value-changed', value);
       }
     }

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "The Ultimate Internet Radio Receiver & Recorder for Cinnamon",
   "max-instances": 1,
-  "version": "3.8.3",
+  "version": "3.8.4",
   "uuid": "Radio3.0@claudiux",
   "name": "Radio3.0",
   "author": "claudiux",

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/radiodb/server-list.json
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/radiodb/server-list.json
@@ -3,12 +3,9 @@
         "server": "https://api.radiodb.fr"
     },
     {
-        "server": "https://fi1.api.radio-browser.info"
-    },
-    {
-        "server": "https://de1.api.radio-browser.info"
-    },
-    {
         "server": "https://de2.api.radio-browser.info"
+    },
+    {
+        "server": "https://fi1.api.radio-browser.info"
     }
 ]

--- a/sound150@claudiux/files/sound150@claudiux/6.4/lib/volumeSlider.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/lib/volumeSlider.js
@@ -222,7 +222,7 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
         }
 
         if (this._slider)
-            this._slider.queue_repaint();
+            try { this._slider.queue_repaint() } catch(e) {};
         if (this.tooltip)
             this.tooltip.show();
         this.emit("value-changed", this._value);
@@ -242,7 +242,7 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             } else {
                 this._value = Math.min(1, this._value + delta / this.applet._volumeMax * this.applet._volumeNorm);
             }
-            this._slider.queue_repaint();
+            try { this._slider.queue_repaint() } catch(e) {};
             this.emit("value-changed", this._value);
             return true;
         }

--- a/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v13.5.2~20251031
+  * Avoids 'paint' errors.
+
 ### v13.5.1~20251031
   * Avoids 'destroy' errors.
 

--- a/sound150@claudiux/files/sound150@claudiux/metadata.json
+++ b/sound150@claudiux/files/sound150@claudiux/metadata.json
@@ -5,7 +5,7 @@
   "max-instances": "1",
   "description": "Enhanced sound applet",
   "hide-configuration": false,
-  "version": "13.5.1",
+  "version": "13.5.2",
   "cinnamon-version": [
     "2.8",
     "3.0",

--- a/xsession@claudiux/files/xsession@claudiux/CHANGELOG.md
+++ b/xsession@claudiux/files/xsession@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v5.1.1~20251031
+  * Avoids paint() errors.
+
 ### v5.1.0~20251003
 Developers often have to repeat the same action several times (reloading a Spice or opening its settings).
 

--- a/xsession@claudiux/files/xsession@claudiux/applet.js
+++ b/xsession@claudiux/files/xsession@claudiux/applet.js
@@ -94,7 +94,7 @@ class LGSsliderItem extends PopupMenu.PopupSliderMenuItem {
             this._value = Math.min(1, this._value + SLIDER_SCROLL_STEP);
         }
 
-        this._slider.queue_repaint();
+        try{ this._slider.queue_repaint() } catch(e) {};
         this.emit('value-changed', this._value);
     }
 }

--- a/xsession@claudiux/files/xsession@claudiux/metadata.json
+++ b/xsession@claudiux/files/xsession@claudiux/metadata.json
@@ -3,7 +3,7 @@
   "name": "Xsession",
   "max-instances": "1",
   "hide-configuration": false,
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Restart, access source code and configure your Spices (Applets, Desklets, Extensions). View the contents of your .xsession-errors file in real time. Restart Cinnamon.",
   "author": "claudiux"
 }


### PR DESCRIPTION
Concerned applets:

- `Radio3.0@claudiux`
- `sound150@claudiux`
- `xsession@claudiux`