### PR TITLE
sound150 v13.7.4: Avoids deleting the cover art after modifying the volume or the workspace

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/applet.js
@@ -118,7 +118,7 @@ function run_playerctld() {
 function kill_playerctld() {
     //~ Util.spawnCommandLineAsync("/usr/bin/env bash -C '" + PATH2SCRIPTS + "/kill_playerctld.sh'");
     Util.spawnCommandLine("/usr/bin/env bash -C '" + PATH2SCRIPTS + "/kill_playerctld.sh'");
-    del_song_arts(); //added
+    //~ del_song_arts(); //added
 }
 
 const superRND = (2**31-1)**2;

--- a/sound150@claudiux/files/sound150@claudiux/6.4/lib/s150PopupMenu.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/lib/s150PopupMenu.js
@@ -987,6 +987,7 @@ class Player extends PopupMenu.PopupMenuSection {
                 if (this.cover && !this._applet.dontShowAnyImageInMenu) {
                     this.coverBox.add_actor(this.cover);
                     //~ this.coverBox.set_reactive = true;
+                    //~ this.coverBox.connect("click-event", (event) => Util.spawnCommandLineAsync("xdg-open "+this._cover_path));
                     //~ this.coverBox.connect("button-press-event", (event) => Util.spawnCommandLineAsync("xdg-open "+this._cover_path));
                     try {
                         this.coverBox.set_child_below_sibling(this.cover, this.trackInfo);

--- a/sound150@claudiux/files/sound150@claudiux/6.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/6.4/settings-schema.json
@@ -380,7 +380,7 @@
   },
   "showalbumDelay": {
     "type": "scale",
-    "default": 5,
+    "default": 0,
     "min": 0,
     "max":10,
     "step": 1,

--- a/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v13.7.4~20251201
+  * Avoids deleting the cover art after modifying the volume or the workspace.
+  * Fixes [#8020](https://github.com/linuxmint/cinnamon-spices-applets/issues/8020)
+
 ### v13.7.3~20251126
   * Avoids treating apostrophes as quotes (artist and title).
 

--- a/sound150@claudiux/files/sound150@claudiux/metadata.json
+++ b/sound150@claudiux/files/sound150@claudiux/metadata.json
@@ -5,7 +5,7 @@
   "max-instances": "1",
   "description": "Enhanced sound applet",
   "hide-configuration": false,
-  "version": "13.7.3",
+  "version": "13.7.4",
   "cinnamon-version": [
     "2.8",
     "3.0",


### PR DESCRIPTION
Fixes #8020.