### PR TITLE
Betterlock : use the user-defined symbolic icon size

### DIFF
--- a/betterlock/files/betterlock/applet.js
+++ b/betterlock/files/betterlock/applet.js
@@ -81,16 +81,6 @@ MyApplet.prototype = {
             style_class: "system-status-icon"
         });
 
-        this._updateIconsSize = function() {
-            let size = this.getPanelIconSize(St.IconType.SYMBOLIC);
-            this.caps_on.icon_size = size;
-            this.caps_off.icon_size = size;
-            this.num_on.icon_size = size;
-            this.num_off.icon_size = size;
-            this.scr_on.icon_size = size;
-            this.scr_off.icon_size = size;
-        };
-
         this.binScr.child = this.scr_off;
         this.binNum.child = this.num_off;
         this.binCaps.child = this.caps_off;
@@ -173,6 +163,17 @@ MyApplet.prototype = {
         if (this.showOSDNotifications) {
             Main.osdWindowManager.show(-1, Gio.Icon.new_for_string(iconName), text, null);
         }
+    },
+
+
+    _updateIconsSize: function() {
+        let size = this.getPanelIconSize(St.IconType.SYMBOLIC);
+        this.caps_on.icon_size = size;
+        this.caps_off.icon_size = size;
+        this.num_on.icon_size = size;
+        this.num_off.icon_size = size;
+        this.scr_on.icon_size = size;
+        this.scr_off.icon_size = size;
     },
 
     _updateIconVisibility: function() {


### PR DESCRIPTION
Hello !

This PR makes the BetterLock applet use the user-selected symbolic panel icon size, rather than a hard-coded value, so that the size of the applet is consistent with the other applets.

Tested on Linux Mint 22.2 (Cinnamon 6.4.8) : Applet loads and works fine at the correct size, and change size like the other applets when changing the symbolic icon size of the panel, and logs show no issue whatsoever.