### PR TITLE
mem-monitor-text@datanom.net: fix system monitor not opening

### DIFF
--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/applet.js
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/applet.js
@@ -96,8 +96,15 @@ _update:
 _runSysMon:
     function() {
         let _appSys = Cinnamon.AppSystem.get_default();
-        let _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
-        _gsmApp.activate();
+        let _gsmApp = _appSys.lookup_app('org.gnome.SystemMonitor.desktop');
+        if(_gsmApp) {
+            _gsmApp.activate();
+            return
+        }
+        _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
+        if(_gsmApp) {
+            _gsmApp.activate();
+        }
     },
 };
 


### PR DESCRIPTION
The gnome system monitor can no longer be accessed by the id `'gnome-system-monitor.desktop'`. The new id is `'org.gnome.SystemMonitor.desktop'`.
Currently the code just logs an error to `.xsession-errors`:
```
(cinnamon:3529): Gjs-CRITICAL **: 19:28:44.249: JS ERROR: TypeError: _gsmApp is null
_runSysMon@/home/hduelme/.local/share/cinnamon/applets/mem-monitor-text@datanom.net/applet.js:102:9
on_applet_clicked@/home/hduelme/.local/share/cinnamon/applets/mem-monitor-text@datanom.net/applet.js:63:14
_onButtonPressEvent@/usr/share/cinnamon/js/ui/applet.js:283:18
```

I kept the old it as a fallback for older systems.