### PR TITLE
cpu-monitor-text@gnemonix: fix system monitor not opening

### DIFF
--- a/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
+++ b/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
@@ -104,8 +104,15 @@ MyApplet.prototype = {
 
 	_runSysMon: function() {
 		let _appSys = Cinnamon.AppSystem.get_default();
-		let _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
-		_gsmApp.activate();
+        let _gsmApp = _appSys.lookup_app('org.gnome.SystemMonitor.desktop');
+        if(_gsmApp) {
+            _gsmApp.activate();
+            return
+        }
+        _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
+        if(_gsmApp) {
+            _gsmApp.activate();
+        }
 	},
 };
 


### PR DESCRIPTION
The gnome system monitor can no longer be accessed by the id `'gnome-system-monitor.desktop'`. The new id is `'org.gnome.SystemMonitor.desktop'`.
Currently the code just logs an error to `.xsession-errors`:
```
(cinnamon:3529): Gjs-CRITICAL **: 22:35:35.649: JS ERROR: TypeError: _gsmApp is null
_runSysMon@/home/hduelme/.local/share/cinnamon/applets/cpu-monitor-text@gnemonix/applet.js:110:3
on_applet_clicked@/home/hduelme/.local/share/cinnamon/applets/cpu-monitor-text@gnemonix/applet.js:62:8
_onButtonPressEvent@/usr/share/cinnamon/js/ui/applet.js:283:18
```

I kept the old it as a fallback for older systems.