### PR TITLE
[windowlist@cobinja.de] Fix update process when removing a window

### DIFF
--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/6.4/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/6.4/applet.js
@@ -992,11 +992,7 @@ class CobiAppButton {
         this._workspace.menuManager.removeMenu(this.menu);
       }
     }
-    this._updateTooltip();
-    this._updateNumber();
-    this._updateLabelVisibility();
-    this._updateVisibility();
-    this._updateProgress();
+    this.updateView();
   }
   
   _updateCurrentWindow() {
@@ -1287,6 +1283,8 @@ class CobiAppButton {
     this._updateVisibility();
     this._updateTooltip();
     this.updateIcon();
+    this._updateLabelVisibility();
+    this._updateProgress();
   }
   
   destroy() {


### PR DESCRIPTION
This completes update process when removing a window. E.g. when moving a window to a different monitor, the app button still reported having a focussed window, although that focus window was no longer managed by this instance.