### PR TITLE
sysmon@rohan: prevent showing "..." if taskbar is full

### DIFF
--- a/sysmon@rohan/files/sysmon@rohan/applet.js
+++ b/sysmon@rohan/files/sysmon@rohan/applet.js
@@ -58,6 +58,10 @@ MyApplet.prototype = {
 
       this.cpuLabel = new St.Label();
       this.memLabel = new St.Label();
+      
+      // Prevent ellipsizing (showing "...") when space is limited
+      this.cpuLabel.clutter_text.ellipsize = imports.gi.Pango.EllipsizeMode.NONE;
+      this.memLabel.clutter_text.ellipsize = imports.gi.Pango.EllipsizeMode.NONE;
 
       let iconBasePath = HOME_DIR + "/.local/share/cinnamon/applets/sysmon@rohan/icons";
 


### PR DESCRIPTION
This pull requests prevents the percentage being replaced by '...' if the taskbar is full.
Thank you @222rohan for creating this applet!