### PR TITLE
bluetooth-battery@zamszowy: don't indicate error when no updates

### DIFF
--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/applet.js
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/applet.js
@@ -381,14 +381,16 @@ UpdatesNotifier.prototype = {
         // accept updates changes only when originating from this applet
         this.checkingInProgress = true;
         Util.spawn_async(['/usr/bin/bash', this.applet_path + '/updates.sh', "check", refreshMode], (stdout) => {
+            this.lastRefreshTime = GLib.get_monotonic_time();
+
             if (stdout !== '') {
                 this.checkingInProgress = false;
                 global.logError(`${UUID}: pkcon get-updates failed`);
                 this.hasError = true;
                 this._update();
+                return;
             }
 
-            this.lastRefreshTime = GLib.get_monotonic_time();
             if (this.showFirmware) {
                 let fwCount = 0;
                 for (let line of stdout.trim().split("\n")) {

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
@@ -2,5 +2,5 @@
     "uuid": "updates-notifier@zamszowy",
     "name": "Updates notifier",
     "description": "Shows icons for pending update packages",
-    "version": "2.3.0"
+    "version": "2.3.1"
 }

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/updates.sh
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/updates.sh
@@ -13,7 +13,9 @@ check)
         pkcon refresh &>/dev/null
     fi
 
-    if ! out=$(pkcon get-updates 2>&1); then
+    out=$(pkcon get-updates 2>&1)
+    exit_code=$?
+    if [[ $exit_code -ne 0 ]] && [[ $exit_code -ne 5 ]]; then
         echo ERROR
         echo "$out" > "$DIR/error"
         exit 0


### PR DESCRIPTION
When there are no updates pending, pkcon exits with code '5' - we should not treat is as an error.