### PR TITLE
Quick Alarm v1.4.2

### DIFF
--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/applet.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/applet.js
@@ -9,14 +9,17 @@ const GLib = imports.gi.GLib;
 const AppletManager = imports.ui.appletManager;
 const Clutter = imports.gi.Clutter;
 const Gio = imports.gi.Gio;
+const Gtk = imports.gi.Gtk;
 const Gettext = imports.gettext;
 
 let APPLET_PATH = null;
 let AlarmService = null;
 let Time = null;
 let TimeAgo = null;
+let AlarmText = null;
 let EntryKeys = null;
 let Hotkeys = null;
+let Icon = null;
 
 function _spawnWithExitCallback(argv, onExit) {
   const pid = Util.spawn(argv);
@@ -107,11 +110,34 @@ QuickAlarmApplet.prototype = {
   _updatePanelIconSize() {
     try {
       if (!this._applet_icon) return;
-      const base = this.getPanelIconSize(St.IconType.SYMBOLIC);
+      const type = this._iconIsSymbolic ? St.IconType.SYMBOLIC : St.IconType.FULLCOLOR;
+      const base = this.getPanelIconSize(type);
       this._applet_icon.set_icon_size(Math.round(base * 1.3));
     } catch (e) {
       // ignore
     }
+  },
+
+  _updateIcon() {
+    const resolved = Icon.resolveIcon(this._useCustomIcon, this._customIcon, {
+      isAbsolutePath: (p) => GLib.path_is_absolute(p),
+      themeLookupIcon: (n) => Gtk.IconTheme.get_default().lookup_icon(n, 16, 0),
+    });
+    try {
+      const methods = {
+        symbolic_name: "set_applet_icon_symbolic_name",
+        name: "set_applet_icon_name",
+        symbolic_path: "set_applet_icon_symbolic_path",
+        path: "set_applet_icon_path",
+      };
+      this[methods[resolved.method]](resolved.value);
+      this._iconIsSymbolic = resolved.method.indexOf("symbolic") !== -1;
+    } catch (e) {
+      global.logWarning("quick-alarm: could not load icon: " + e);
+      this.set_applet_icon_symbolic_name("alarm-symbolic");
+      this._iconIsSymbolic = true;
+    }
+    this._updatePanelIconSize();
   },
 
   _applyPanelIconStyle() {
@@ -209,26 +235,33 @@ QuickAlarmApplet.prototype = {
     this._soundMode = "chime";
     this._ringSeconds = 10;
     this._fullscreenNotification = true;
+    this._showCountdown = false;
     this._openShortcut = "";
     this._openHotkeyName = `${metadata.uuid}-open-${instanceId}`;
     this._activeSoundTimers = new Set();
     this._activeAudioPids = new Set();
     this._blinkTimerId = 0;
     this._ringEndTimerId = 0;
+    this._countdownTimerId = 0;
     this._isRinging = false;
     this._ringToken = 0;
     this._panelState = "idle";
     this._fullscreenOverlay = null;
+    this._useCustomIcon = false;
+    this._customIcon = "alarm-symbolic";
+    this._iconIsSymbolic = true;
 
     this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
     this.settings.bind("soundMode", "_soundMode");
     this.settings.bind("ringSeconds", "_ringSeconds");
     this.settings.bind("fullscreenNotification", "_fullscreenNotification");
+    this.settings.bind("showCountdown", "_showCountdown", () => this._render());
     this.settings.bind("openShortcut", "_openShortcut", () => this._registerOpenHotkey());
+    this.settings.bind("useCustomIcon", "_useCustomIcon", () => this._updateIcon());
+    this.settings.bind("customIcon", "_customIcon", () => this._updateIcon());
 
     this.setAllowedLayout(Applet.AllowedLayout.BOTH);
-    this.set_applet_icon_symbolic_name("alarm-symbolic");
-    this._updatePanelIconSize();
+    this._updateIcon();
     this.set_applet_label("");
     this.set_applet_tooltip(this._("Quick Alarm"));
     this._applyPanelIconStyle();
@@ -242,8 +275,8 @@ QuickAlarmApplet.prototype = {
     this.menuManager.addMenu(this.menu);
     this.menu.actor.add_style_class_name("qa-menu");
 
-    this._interfaceSettings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.interface" });
-    this._interfaceSettings.connect("changed::gtk-theme", () => this._applyThemeClass());
+    this._cinnamonThemeSettings = new Gio.Settings({ schema_id: "org.cinnamon.theme" });
+    this._cinnamonThemeSettings.connect("changed::name", () => this._applyThemeClass());
     this._applyThemeClass();
 
     const gearIcon = new St.Icon({
@@ -368,7 +401,7 @@ QuickAlarmApplet.prototype = {
   },
 
   _applyThemeClass() {
-    const theme = this._interfaceSettings.get_string("gtk-theme") || "";
+    const theme = this._cinnamonThemeSettings.get_string("name") || "";
     const isDark = /dark/i.test(theme);
     if (!this.menu || !this.menu.actor) return;
     this.menu.actor.remove_style_class_name("qa-theme-light");
@@ -401,6 +434,8 @@ QuickAlarmApplet.prototype = {
     }
     if (this._ringEndTimerId) GLib.source_remove(this._ringEndTimerId);
     this._ringEndTimerId = 0;
+    if (this._countdownTimerId) GLib.source_remove(this._countdownTimerId);
+    this._countdownTimerId = 0;
     this._stopBlinking();
     this.settings.finalize();
   },
@@ -414,7 +449,7 @@ QuickAlarmApplet.prototype = {
         return;
       }
 
-      const label = parsed.label || `Alarm ${Time.formatTime(parsed.due, parsed.showSeconds)}`;
+      const label = AlarmText.getStoredLabel(parsed.label);
       this._service.add(parsed.due, label, parsed.showSeconds);
       this._setEntryText("");
       this._errorLabel.text = "";
@@ -438,7 +473,7 @@ QuickAlarmApplet.prototype = {
       this._showFullscreenOverlay(alarm);
     } else {
       const title = this._("Alarm");
-      const body = alarm.label || `Alarm ${Time.formatTime(alarm.due, alarm.showSeconds)}`;
+      const body = AlarmText.getAlarmNotificationBody(alarm);
 
       const notification = new MessageTray.Notification(this._notificationSource, title, body);
       notification.setTransient(false);
@@ -656,6 +691,43 @@ QuickAlarmApplet.prototype = {
     }
   },
 
+  _stopCountdown() {
+    if (this._countdownTimerId) {
+      GLib.source_remove(this._countdownTimerId);
+      this._countdownTimerId = 0;
+    }
+    this.set_applet_label("");
+  },
+
+  _updateCountdownLabel(alarm) {
+    try {
+      const text = Time.formatCountdown(alarm.due, Date.now());
+      this.set_applet_label(text || "");
+    } catch (e) {
+      // ignore
+    }
+  },
+
+  _startCountdown(alarm) {
+    this._stopCountdown();
+    this._updateCountdownLabel(alarm);
+    this._countdownTimerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
+      if (!this._showCountdown) {
+        this._countdownTimerId = 0;
+        this.set_applet_label("");
+        return GLib.SOURCE_REMOVE;
+      }
+      const alarms = this._service ? this._service.list() : [];
+      if (alarms.length === 0) {
+        this._countdownTimerId = 0;
+        this.set_applet_label("");
+        return GLib.SOURCE_REMOVE;
+      }
+      this._updateCountdownLabel(alarms[0]);
+      return GLib.SOURCE_CONTINUE;
+    });
+  },
+
   _render() {
     this._listSection.removeAll();
     const alarms = this._service.list();
@@ -663,14 +735,18 @@ QuickAlarmApplet.prototype = {
     if (alarms.length === 0) {
       const emptyItem = new PopupMenu.PopupMenuItem(this._("No alarms queued"), { reactive: false });
       this._listSection.addMenuItem(emptyItem);
-      this.set_applet_label("");
+      this._stopCountdown();
       this.set_applet_tooltip(this._("Quick Alarm"));
       this._refreshPanelState();
       return;
     }
 
     const next = alarms[0];
-    this.set_applet_label("");
+    if (this._showCountdown) {
+      this._startCountdown(next);
+    } else {
+      this._stopCountdown();
+    }
     this.set_applet_tooltip(`${Time.formatTime(next.due, next.showSeconds)} ${next.label || ""}`.trim());
     this._refreshPanelState();
 
@@ -716,7 +792,9 @@ function main(metadata, orientation, panelHeight, instanceId) {
   AlarmService = imports.services.alarmService.AlarmService;
   Time = imports.lib.time;
   TimeAgo = imports.lib.timeAgo;
+  AlarmText = imports.lib.alarmText;
   EntryKeys = imports.lib.entryKeys;
   Hotkeys = imports.lib.hotkeys;
+  Icon = imports.lib.icon;
   return new QuickAlarmApplet(metadata, orientation, panelHeight, instanceId);
 }

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/alarmText.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/alarmText.js
@@ -1,0 +1,13 @@
+const Time = imports.lib.time;
+
+function getStoredLabel(label) {
+  return label ? String(label).trim() : "";
+}
+
+function getAlarmNotificationBody(alarm) {
+  const label = getStoredLabel(alarm && alarm.label);
+  return label || Time.formatTime(alarm.due, alarm.showSeconds);
+}
+
+var getStoredLabel = getStoredLabel;
+var getAlarmNotificationBody = getAlarmNotificationBody;

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/icon.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/icon.js
@@ -1,0 +1,30 @@
+/**
+ * Resolves an icon setting value into an action the applet should take.
+ *
+ * @param {boolean} useCustom - Whether the custom icon toggle is on
+ * @param {string} value - The icon setting value (file path or theme icon name)
+ * @param {object} env - Environment functions for file/theme checks:
+ *   @param {function} env.isAbsolutePath - (path) => boolean
+ *   @param {function} env.themeLookupIcon - (name) => object|null
+ * @returns {{ method: string, value: string }}
+ *   method is one of: "symbolic_name", "name", "symbolic_path", "path"
+ */
+function resolveIcon(useCustom, value, env) {
+  var DEFAULT = { method: "symbolic_name", value: "alarm-symbolic" };
+
+  if (!useCustom || !value || value === "") return DEFAULT;
+
+  var isSymbolic = value.indexOf("-symbolic") !== -1;
+
+  if (env.isAbsolutePath(value)) {
+    return { method: isSymbolic ? "symbolic_path" : "path", value: value };
+  }
+
+  if (env.themeLookupIcon(value)) {
+    return { method: isSymbolic ? "symbolic_name" : "name", value: value };
+  }
+
+  return DEFAULT;
+}
+
+var resolveIcon = resolveIcon;

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/time.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/time.js
@@ -21,10 +21,16 @@ function _splitLabel(raw) {
   return { spec: m[1].trim(), label: m[2].trim() };
 }
 
-function _normalizeSpec(raw) {
+function _lightNormalizeSpec(raw) {
   return raw
     .replace(/^[\s,;:.!?]+/, "")
     .replace(/^(set|add|new)\s+/i, "")
+    .replace(/^(at|for)\s+/i, "")
+    .trim();
+}
+
+function _normalizeSpec(raw) {
+  return _lightNormalizeSpec(raw)
     .replace(/^(an?\s+)?(alarm|reminder|timer)\s+/i, "")
     .replace(/^(at|for)\s+/i, "")
     .trim();
@@ -58,10 +64,15 @@ function _parseAbsoluteTime(part) {
 }
 
 function _parseRelative(spec) {
-  const s = spec.trim().toLowerCase();
+  const orig = spec.trim();
+  const s = orig.toLowerCase();
   let rest = s;
+  let restOrig = orig;
   const m = s.match(/^(in|after)\s+(.+)$/);
-  if (m) rest = m[2].trim();
+  if (m) {
+    rest = m[2].trim();
+    restOrig = orig.slice(orig.length - rest.length);
+  }
 
   // Important: order longest -> shortest so "seconds" doesn't match just "s".
   const re = /^(\d+)\s*(hours?|hrs?|hr|h|minutes?|mins?|min|m|seconds?|secs?|sec|s)\s*/;
@@ -84,12 +95,13 @@ function _parseRelative(spec) {
       totalMs += value * 1000;
     }
     rest = rest.slice(r[0].length);
+    restOrig = restOrig.slice(r[0].length);
   }
 
   if (!matchedAny) return null;
   if (totalMs <= 0) return null;
 
-  return { delayMs: totalMs, label: rest.trim(), showSeconds };
+  return { delayMs: totalMs, label: restOrig.trim(), showSeconds };
 }
 
 function parseAlarmSpec(input, now = new Date(), t = null) {
@@ -123,7 +135,31 @@ function parseAlarmSpec(input, now = new Date(), t = null) {
     spec = _normalizeSpec(dayMatch[2]);
   }
 
-  const rel = _parseRelative(spec);
+  function _tryRelativeWithLabelFirst(s) {
+    let r = _parseRelative(s);
+    if (r) return r;
+    // Support label-first relative input: "TEA 10 seconds", "Meeting in 5m"
+    const words = s.split(/\s+/);
+    for (let i = 1; i < words.length; i++) {
+      const candidate = words.slice(i).join(" ");
+      const tryRel = _parseRelative(candidate);
+      if (tryRel) {
+        const prefix = words.slice(0, i).join(" ");
+        const combined = [prefix, tryRel.label].filter(Boolean).join(" ");
+        return { delayMs: tryRel.delayMs, label: combined, showSeconds: tryRel.showSeconds };
+      }
+    }
+    return null;
+  }
+
+  // Try light-normalized spec first (keeps "alarm"/"reminder"/"timer" intact)
+  // so label-first inputs like "Alarm in 10s" preserve the full label.
+  // Fall back to fully normalized spec for command-style inputs like "add alarm 10m".
+  const lightSpec = dayHint ? spec : _lightNormalizeSpec(split.spec);
+  let rel = _tryRelativeWithLabelFirst(lightSpec);
+  if (!rel && lightSpec !== spec) {
+    rel = _tryRelativeWithLabelFirst(spec);
+  }
   if (rel) {
     return {
       ok: true,
@@ -187,7 +223,29 @@ function parseAlarmSpec(input, now = new Date(), t = null) {
   return { ok: true, due, label, showSeconds: false };
 }
 
+/**
+ * Formats the time remaining until a future date as a compact string for panel display.
+ * @param {Date} dueDate - The target date
+ * @param {number} nowMs - Current time in milliseconds (Date.now())
+ * @returns {string} Compact countdown string, e.g. "42s", "5m", "1m 30s", "1h 5m". Empty string if past.
+ */
+function formatCountdown(dueDate, nowMs) {
+  const diffMs = dueDate.getTime() - nowMs;
+  if (diffMs <= 0) return "";
+
+  const totalSec = Math.ceil(diffMs / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+
+  if (h > 0) return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  if (m >= 2) return `${m}m`;
+  if (m === 1) return s > 0 ? `1m ${s}s` : "1m";
+  return `${s}s`;
+}
+
 var formatTime = formatTime;
 var formatTimeHHMM = formatTimeHHMM;
 var formatTimeHHMMSS = formatTimeHHMMSS;
+var formatCountdown = formatCountdown;
 var parseAlarmSpec = parseAlarmSpec;

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/metadata.json
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/metadata.json
@@ -2,6 +2,6 @@
   "uuid": "quick-alarm@andreas-glaser",
   "name": "Quick Alarm",
   "description": "Queue alarms quickly.",
-  "version": 7,
+  "version": 12,
   "max-instances": 1
 }

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/settings-schema.json
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/settings-schema.json
@@ -1,4 +1,26 @@
 {
+  "sectionPanel": {
+    "type": "section",
+    "description": "Panel"
+  },
+  "showCountdown": {
+    "type": "switch",
+    "default": false,
+    "description": "Show remaining time beside icon"
+  },
+  "useCustomIcon": {
+    "type": "switch",
+    "default": false,
+    "description": "Use a custom icon"
+  },
+  "customIcon": {
+    "type": "iconfilechooser",
+    "default": "alarm-symbolic",
+    "description": "Panel icon",
+    "default_icon": "alarm-symbolic",
+    "tooltip": "Select an icon file or type a theme icon name",
+    "dependency": "useCustomIcon"
+  },
   "sectionNotification": {
     "type": "section",
     "description": "Notification"


### PR DESCRIPTION
## Changes in v1.4.2


### Added
- Hungarian translation (hu.po), sourced from Cinnamon Spices.

### Fixed
- Label-first input starting with "Alarm", "Reminder", or "Timer" no longer strips those words from the label (e.g. `Alarm in 10s` now keeps "Alarm" as the label). Reported by [@sphh](https://github.com/sphh) in [linuxmint/cinnamon-spices-applets#8471](https://github.com/linuxmint/cinnamon-spices-applets/issues/8471).

---
Automated update from tag `v1.4.2` in https://github.com/andreas-glaser/quick-alarm-cinnamon