### PR TITLE
weather@mockturtl: Fix touchpad hourly forecast scroll behaviour

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -18897,7 +18897,7 @@ class UIHourlyForecasts {
             const adjustment = hScroll.get_adjustment();
             const direction = event.get_scroll_direction();
             const newVal = adjustment.get_value() +
-                (direction === ScrollDirection.UP ? -adjustment.step_increment : adjustment.step_increment);
+                ((direction === ScrollDirection.UP) ? -adjustment.step_increment : (direction === ScrollDirection.DOWN) ? adjustment.step_increment : 0);
             if (global.settings.get_boolean("desktop-effects-on-menus"))
                 addTween(adjustment, { value: newVal, time: 0.25 });
             else

--- a/weather@mockturtl/src/3_8/ui_elements/uiHourlyForecasts.ts
+++ b/weather@mockturtl/src/3_8/ui_elements/uiHourlyForecasts.ts
@@ -71,7 +71,7 @@ export class UIHourlyForecasts {
 			const adjustment = hScroll.get_adjustment();
 			const direction = event.get_scroll_direction();
 			const newVal = adjustment.get_value() +
-				(direction === ScrollDirection.UP ? -adjustment.step_increment : adjustment.step_increment);
+				((direction === ScrollDirection.UP) ? -adjustment.step_increment : (direction === ScrollDirection.DOWN) ? adjustment.step_increment : 0);
 
 			if (global.settings.get_boolean("desktop-effects-on-menus"))
 				addTween(adjustment, { value: newVal, time: 0.25});


### PR DESCRIPTION
Fix scroll on hourly forecast by only handling up/down scroll direction, horizontal scroll is being handled automatically.

Fixes #6484 , fixes #6706