### PR TITLE
batterymonitor@pdcurtis: add support for multiple alert levels in battery monitor

### DIFF
--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/5.4/applet.js
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/5.4/applet.js
@@ -16,13 +16,13 @@ const UUID = "batterymonitor@pdcurtis";
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 
 function _(str) {
-    return Gettext.dgettext(UUID, str);
+	return Gettext.dgettext(UUID, str);
 }
 
 function titleCase(str) {
-    return str.replace(/\w\S*/g, function (txt) {
-        return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-    });
+	return str.replace(/\w\S*/g, function (txt) {
+		return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+	});
 }
 
 const UPowerInterface = `<node>
@@ -35,652 +35,1013 @@ const UPowerInterface = `<node>
 const UPowerProxy = Gio.DBusProxy.makeProxyWrapper(UPowerInterface);
 
 function MyApplet(metadata, orientation, panelHeight, instance_id) {
-    this._init(metadata, orientation, panelHeight, instance_id);
+	this._init(metadata, orientation, panelHeight, instance_id);
 }
 
 MyApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
-
-    _init: function (metadata, orientation, panelHeight, instance_id) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panelHeight, instance_id);
-        this.instance_id = instance_id;
-        this.metadata = metadata;
-        this.orientation = orientation;
-        this.setupUI();
-    },
-
-    setupIconPaths: function () {
-        this.battery100 = this.metadata.path + `/icons/${this.iconTheme}/battery-100.png`;
-        this.battery080 = this.metadata.path + `/icons/${this.iconTheme}/battery-080.png`;
-        this.battery060 = this.metadata.path + `/icons/${this.iconTheme}/battery-060.png`;
-        this.battery040 = this.metadata.path + `/icons/${this.iconTheme}/battery-040.png`;
-        this.batteryCaution = this.metadata.path + `/icons/${this.iconTheme}/battery-caution.png`;
-        this.batteryLow = this.metadata.path + `/icons/${this.iconTheme}/battery-low.png`;
-        this.batteryCharging100 = this.metadata.path + `/icons/${this.iconTheme}/battery-charging.png`;
-        this.batteryCharging080 = this.metadata.path + `/icons/${this.iconTheme}/battery-charging-080.png`;
-        this.batteryCharging060 = this.metadata.path + `/icons/${this.iconTheme}/battery-charging-060.png`;
-        this.batteryCharging040 = this.metadata.path + `/icons/${this.iconTheme}/battery-charging-040.png`;
-        this.batteryChargingCaution = this.metadata.path + `/icons/${this.iconTheme}/battery-charging-caution.png`;
-        this.batteryChargingLow = this.metadata.path + `/icons/${this.iconTheme}/battery-charging-low.png`;
-    },
-
-    setupUI: function () {
-        try {
-            // Picks up UUID from metadata for Settings
-            this.settings = new Settings.AppletSettings(this, UUID, this.instance_id);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN, // Setting type
-                "refreshInterval-spinner", // The setting key
-                "refreshInterval", // The property to manage (this.refreshInterval)
-                this.on_settings_changed, // Callback when value changes
-                null); // Optional callback data
-
-            this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
-                "alertPercentage",
-                "alertPercentage",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "recharged_alert",
-                "recharged_alert",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "recharged_alert_percentage",
-                "recharged_alert_percentage",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "displayType",
-                "displayType",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "iconTheme",
-                "iconTheme",
-                this.on_settings_changed,
-                null)
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "time_remaining_display",
-                "time_remaining_display",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "time_remaining_toolbar",
-                "time_remaining_toolbar",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "time_remaining_tooltip",
-                "time_remaining_tooltip",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "useBatteryLowSound",
-                "useBatteryLowSound",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "chooseBatteryLowSound",
-                "chooseBatteryLowSound",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "batteryLowSound",
-                "batteryLowSound1",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "batteryShutdownSound",
-                "batteryShutdownSound1",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "notifyBatteryLowSound",
-                "notifyBatteryLowSound",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "customBatteryPath",
-                "customBatteryPath",
-                this.on_settings_changed,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "normal_background_color",
-                "normal_background_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "normal_border_color",
-                "normal_border_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "normal_font_size",
-                "normal_font_size",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "discharging_background_color",
-                "discharging_background_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "discharging_border_color",
-                "discharging_border_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "discharging_font_size",
-                "discharging_font_size",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "alert_background_color",
-                "alert_background_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "alert_border_color",
-                "alert_border_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "alert_font_size",
-                "alert_font_size",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "alert_discharging_background_color",
-                "alert_discharging_background_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "alert_discharging_border_color",
-                "alert_discharging_border_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "alert_discharging_font_size",
-                "alert_discharging_font_size",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "limit_exceeded_background_color",
-                "limit_exceeded_background_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "limit_exceeded_border_color",
-                "limit_exceeded_border_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "limit_exceeded_font_size",
-                "limit_exceeded_font_size",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "limit_exceeded2_background_color",
-                "limit_exceeded2_background_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "limit_exceeded2_border_color",
-                "limit_exceeded2_border_color",
-                this.setupUI,
-                null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                "limit_exceeded2_font_size",
-                "limit_exceeded2_font_size",
-                this.setupUI,
-                null);
-
-            // Define a subprocess launcher
-            this.launcher = new Gio.SubprocessLauncher({
-                flags: (Gio.SubprocessFlags.STDIN_PIPE |
-                    Gio.SubprocessFlags.STDOUT_PIPE |
-                    Gio.Subprocess.STDERR_PIPE)
-            });
-
-            // Make metadata values available within applet for context menu.
-            this.appletPath = this.metadata.path;
-            this.changelog = this.metadata.path + "/../CHANGELOG.md";
-            this.helpfile = this.metadata.path + "/../README.md";
-            this.setupIconPaths();
-
-            // Determine best default battery path if possible
-            let batteryBasePath = "/sys/class/power_supply";
-            let batteryCapacityFile, batteryStatusFile;
-
-            this.BUS_NAME = "org.freedesktop.UPower";
-            for (let i = 0; i < 10; i++) {
-                this.batteryObjectDir = "BAT" + i.toString();
-                this.batteryPath = batteryBasePath + '/' + this.batteryObjectDir;
-                batteryCapacityFile = Gio.File.new_for_path(this.batteryPath + '/capacity');
-                batteryStatusFile = Gio.File.new_for_path(this.batteryPath + '/status');
-                if (batteryCapacityFile.query_exists(null) && batteryStatusFile.query_exists(null))
-                    break;
-            }
-
-            // Set initial value
-            this.set_applet_icon_path(this.batteryCharging100);
-
-            this.set_applet_label(_("--%"));
-            this.set_applet_tooltip(_("Waiting"));
-
-            if (this.recharged_alert)
-                this.showRechargedAlert = false; // flag for flashing recharged alert
-            this.flashFlag = true; // flag for flashing background
-            this.flashFlag2 = true; // flag for second flashing background
-            this.lastBatteryPercentage = 50; // Initialise lastBatteryPercentage
-            this.batteryStateOld = "invalid";
-            this.alertFlag = false; // Flag says alert has been tripped to avoid repeat notifications
-
-            this.on_orientation_changed(this.orientation); // Initialise for panel orientation
-
-            this.applet_running = true; // Allow applet to be fully stopped when removed from panel
-
-            // Set text editor
-            this.textEd = '/usr/bin/open';
-
-            // Check that all Dependencies Met by presence of sox and zenity
-            if (GLib.find_program_in_path("sox") && GLib.find_program_in_path("zenity")) {
-                this.dependenciesMet = true;
-            } else {
-                let icon = new St.Icon({
-                    icon_name: 'error',
-                    icon_type: St.IconType.FULLCOLOR,
-                    icon_size: 36
-                });
-                Main.criticalNotify(_("Some dependencies not installed."), _("Both 'sox' and 'zenity' are required for this applet to have all of its functionality including notifications and audible alerts.\n\nPlease view the README for help on installing them.\n"), icon);
-                this.dependenciesMet = false;
-            }
-
-            if (!this.chooseBatteryLowSound) {
-                // paths to default sound files
-                this.batteryLowSound = "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga";
-                this.batteryShutdownSound = "/usr/share/sounds/freedesktop/stereo/complete.oga";
-            } else {
-                if (this.notifyBatteryLowSound && this.useBatteryLowSound)
-                    Main.warningNotify(_("Battery Monitor Applet"), _("A user-defined sound file has been specified for Low Battery.\n\nPlease ensure the volume is set sensibly in public places,\nespecially if a long or loud file is specified.\n"));
-                this.batteryLowSound = this.batteryLowSound1;
-                this.batteryShutdownSound = this.batteryShutdownSound1;
-            }
-
-            // Set up left click menu
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, this.orientation);
-            this.menuManager.addMenu(this.menu);
-
-            // Build Context (Right Click) Menu
-            this.buildContextMenu();
-            this.makeMenu();
-
-            // Finally setup to start the update loop for the applet display running
-            this.on_settings_changed();
-
-        } catch (e) {
-            global.logError(e);
-        }
-    },
-
-    on_orientation_changed: function (orientation) {
-        this.orientation = orientation;
-        if (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT) {
-            // vertical
-            this.isHorizontal = false;
-        } else {
-            // horizontal
-            this.isHorizontal = true;
-        }
-    },
-
-    // Function called when settings are changed
-    on_settings_changed: function () {
-        this.slider.setValue((this.alertPercentage - 10) / 30);
-        if (this.recharged_alert)
-            this.showRechargedAlert = false;
-        if (!this.chooseBatteryLowSound) {
-            // paths to default sound files
-            this.batteryLowSound = "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga";
-            this.batteryShutdownSound = "/usr/share/sounds/freedesktop/stereo/complete.oga";
-        } else {
-            this.batteryLowSound = this.batteryLowSound1;
-            this.batteryShutdownSound = this.batteryShutdownSound1
-        }
-        this.setupIconPaths();
-        this.updateLoop();
-    },
-
-    on_slider_changed: function (slider, value) {
-        this.alertPercentage = Math.round((value * 30) + 10); // This is our BIDIRECTIONAL setting - by updating our configuration file will also be updated
-        this.updateUI();
-    },
-
-    // Build the Right Click Context Menu
-    buildContextMenu: function () {
-        try {
-            this._applet_context_menu.removeAll();
-
-            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-            let menuitem2 = new PopupMenu.PopupMenuItem(_("Open Power Statistics"));
-            menuitem2.connect('activate', Lang.bind(this, function (event) {
-                this.launcher.spawnv(['/usr/bin/gnome-power-statistics']);
-            }));
-            this._applet_context_menu.addMenuItem(menuitem2);
-
-            this.menuitem3 = new PopupMenu.PopupMenuItem(_("Open System Monitor"));
-            this.menuitem3.connect('activate', Lang.bind(this, function (event) {
-                this.launcher.spawnv(['/usr/bin/gnome-system-monitor']);
-            }));
-            this._applet_context_menu.addMenuItem(this.menuitem3);
-
-            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-            // Set up submenu for Housekeeping and System Items
-            this.subMenu1 = new PopupMenu.PopupSubMenuMenuItem(_("Housekeeping and System Submenu"));
-            this._applet_context_menu.addMenuItem(this.subMenu1);
-
-            this.subMenuItem1 = new PopupMenu.PopupMenuItem(_("View the Changelog"));
-            this.subMenuItem1.connect('activate', Lang.bind(this, function (event) {
-                this.launcher.spawnv([this.textEd, this.changelog]);
-            }));
-            this.subMenu1.menu.addMenuItem(this.subMenuItem1); // Note this has subMenu1.menu not subMenu1._applet_context_menu as one might expect
-
-            this.subMenuItem2 = new PopupMenu.PopupMenuItem(_("Open the README"));
-            this.subMenuItem2.connect('activate', Lang.bind(this, function (event) {
-                this.launcher.spawnv([this.textEd, this.helpfile]);
-            }));
-            this.subMenu1.menu.addMenuItem(this.subMenuItem2);
-
-        } catch (e) {
-            global.logError(e);
-        }
-    },
-
-    // Build left click menu
-    makeMenu: function () {
-        try {
-            this.menu.removeAll();
-
-            this.menuitemInfo1 = new PopupMenu.PopupMenuItem("     " + _("Waiting for battery information"), {
-                reactive: false
-            });
-            this.menu.addMenuItem(this.menuitemInfo1);
-
-            this.sliderLabel = new PopupMenu.PopupMenuItem(_('Alert/Suspend:'), {
-                reactive: false
-            });
-            this.slider = new PopupMenu.PopupSliderMenuItem(0);
-            this.slider.connect("value-changed", Lang.bind(this, this.on_slider_changed));
-            this.menu.addMenuItem(this.sliderLabel);
-            this.menu.addMenuItem(this.slider);
-        } catch (e) {
-            global.logError(e);
-        }
-    },
-
-    // Handler for when the applet is clicked.
-    on_applet_clicked: function (event) {
-        this.updateLoop();
-        this.menu.toggle();
-    },
-
-    // Refresh values from battery
-    refreshBattery: function () {
-        try {
-            // Try to get the battery capacity as an int
-            let capacityPath = this.batteryPath + '/capacity';
-            let capacityValue = GLib.file_get_contents(capacityPath)[1];
-            let capacityValueString = ByteArray.toString(capacityValue);
-            this.batteryPercentage = parseInt(capacityValueString);
-
-            // Try to get the battery state as a lowercase string
-            let statePath = this.batteryPath + '/status';
-            let stateValue = GLib.file_get_contents(statePath)[1];
-            let stateValueString = ByteArray.toString(stateValue);
-            this.batteryState = stateValueString.toLowerCase().trim();
-        } catch (err) {
-            global.logError(err);
-        }
-    },
-
-    // This updates the numerical display in the applet and in the tooltip
-    updateUI: function () {
-        try {
-            // Update path to battery and verify customBatteryPath
-            // contains the correct files before using it
-            let customPath = this.customBatteryPath.substring(this.customBatteryPath.lastIndexOf('//') + 1);
-            if (GLib.file_test(customPath, GLib.FileTest.EXISTS)
-                && GLib.file_test(customPath, GLib.FileTest.IS_DIR)) {
-                if (GLib.file_test(customPath + '/capacity', GLib.FileTest.EXISTS)
-                    && GLib.file_test(customPath + '/status', GLib.FileTest.EXISTS)) {
-                    this.batteryPath = customPath;
-                }
-            }
-
-            // Read the battery status
-            this.refreshBattery();
-
-            // Read the battery time properties if we need to display anywhere
-            if (this.time_remaining_display || this.time_remaining_toolbar || this.time_remaining_tooltip) {
-                this.BUS_PATH = `/org/freedesktop/UPower/devices/battery_${this.batteryObjectDir}`;
-
-                try {
-                    this._upowerProxy = new UPowerProxy(Gio.DBus.system, this.BUS_NAME, this.BUS_PATH);
-                    this._timeToFull = this._upowerProxy.TimeToFull;
-                    this._timeToEmpty = this._upowerProxy.TimeToEmpty;
-                } catch { };
-            }
-
-            // now check we have a genuine number otherwise use last value
-            if (!(this.batteryPercentage > 0 && this.batteryPercentage <= 100))
-                this.batteryPercentage = this.lastBatteryPercentage;
-            if (this.batteryState.length > 3) {
-                this.batteryStateOld = this.batteryState;
-            } else {
-                this.batteryState = this.batteryStateOld;
-            }
-
-            // Define CSS styles for the applet appearance
-            this._base_style = " margin: 2px, 1px, 0px, 1px; border-radius: 4px, 4px, 1px, 1px;";
-            this._normal = `border: 1px; background-color: ${this.normal_background_color}; border-color: ${this.normal_border_color}; font-size: ${this.normal_font_size}%;${this._base_style}`;
-            this._discharging = `border: 2px; background-color: ${this.discharging_background_color}; border-color: ${this.discharging_border_color}; font-size: ${this.discharging_font_size}%;${this._base_style}`;
-            this._alert = `border: 2px; background-color: ${this.alert_background_color}; border-color: ${this.alert_border_color}; font-size: ${this.alert_font_size}%;${this._base_style}`;
-            this._alert_discharging = `border: 2px; background-color: ${this.alert_discharging_background_color}; border-color: ${this.alert_discharging_border_color}; font-size: ${this.alert_discharging_font_size}%;${this._base_style}`;
-            this._limit_exceeded = `border: 1px; background-color: ${this.limit_exceeded_background_color}; border-color: ${this.limit_exceeded_border_color}; font-size: ${this.limit_exceeded_font_size}%;${this._base_style}`;
-            this._limit_exceeded2 = `border: 1px; background-color: ${this.limit_exceeded2_background_color}; border-color: ${this.limit_exceeded2_border_color}; font-size: ${this.limit_exceeded2_font_size}%;${this._base_style}`;
-
-            this.batteryMessage = " ";
-            let is_discharging = this.batteryState.indexOf("discharg") > -1;
-
-            if (Math.floor(this.batteryPercentage) >= Math.floor(this.alertPercentage)) {
-                this.actor.style = this._normal;
-                if (is_discharging)
-                    this.actor.style = this._discharging;
-                this.alertFlag = false;
-            }
-
-            if (Math.floor(this.batteryPercentage) < Math.floor(this.alertPercentage)) {
-                if (this.flashFlag) {
-                    this.actor.style = this._alert;
-                    this.flashFlag = false;
-                } else {
-                    if (is_discharging) {
-                        this.actor.style = this._alert_discharging;
-                        this.flashFlag = true; // Corrected placement
-                    }
-                }
-
-                if (is_discharging) {
-                    this.batteryMessage = _("Battery Low - turn off or connect to power supply") + " ";
-                    if (!this.alertFlag) {
-                        this.alertFlag = true; // Reset above when out of warning range
-                        // Audible alert - type set earlier
-                        if (this.useBatteryLowSound)
-                            this.launcher.spawnv(['/usr/bin/play', this.batteryLowSound]);
-                        new ModalDialog.NotifyDialog(_("The battery level has fallen to your alert level.\n\nEither connect to a power source or save or close down\nyour work and suspend or shutdown the machine.\n")).open();
-                    }
-                }
-            }
-
-            if (Math.floor(this.batteryPercentage) < Math.floor(this.alertPercentage) / 1.5) {
-                if (this.flashFlag2) {
-                    this.actor.style = this._limit_exceeded2;
-                    this.flashFlag2 = false;
-                } else {
-                    this.actor.style = this._limit_exceeded;
-                    this.flashFlag2 = true;
-                }
-
-                if (is_discharging) {
-                    this.batteryMessage = _("Battery Critical - will suspend unless connected to power supply") + " ";
-                    if (this.batteryPercentage < this.lastBatteryPercentage) {
-                        // Audible alert moved from suspendScript in v32_1.0.0
-                        if (this.useBatteryLowSound)
-                            this.launcher.spawnv(['/usr/bin/play', this.batteryShutdownSound]);
-                        this.launcher.spawnv(['/usr/bin/bash', `${this.appletPath}/suspendScript.sh`]);
-                    }
-                }
-            }
-
-            this.lastBatteryPercentage = this.batteryPercentage;
-            /*
+	__proto__: Applet.TextIconApplet.prototype,
+
+	_init: function (metadata, orientation, panelHeight, instance_id) {
+		Applet.TextIconApplet.prototype._init.call(
+			this,
+			orientation,
+			panelHeight,
+			instance_id
+		);
+		this.instance_id = instance_id;
+		this.metadata = metadata;
+		this.orientation = orientation;
+		this.setupUI();
+	},
+
+	setupIconPaths: function () {
+		this.battery100 =
+			this.metadata.path + `/icons/${this.iconTheme}/battery-100.png`;
+		this.battery080 =
+			this.metadata.path + `/icons/${this.iconTheme}/battery-080.png`;
+		this.battery060 =
+			this.metadata.path + `/icons/${this.iconTheme}/battery-060.png`;
+		this.battery040 =
+			this.metadata.path + `/icons/${this.iconTheme}/battery-040.png`;
+		this.batteryCaution =
+			this.metadata.path + `/icons/${this.iconTheme}/battery-caution.png`;
+		this.batteryLow =
+			this.metadata.path + `/icons/${this.iconTheme}/battery-low.png`;
+		this.batteryCharging100 =
+			this.metadata.path +
+			`/icons/${this.iconTheme}/battery-charging.png`;
+		this.batteryCharging080 =
+			this.metadata.path +
+			`/icons/${this.iconTheme}/battery-charging-080.png`;
+		this.batteryCharging060 =
+			this.metadata.path +
+			`/icons/${this.iconTheme}/battery-charging-060.png`;
+		this.batteryCharging040 =
+			this.metadata.path +
+			`/icons/${this.iconTheme}/battery-charging-040.png`;
+		this.batteryChargingCaution =
+			this.metadata.path +
+			`/icons/${this.iconTheme}/battery-charging-caution.png`;
+		this.batteryChargingLow =
+			this.metadata.path +
+			`/icons/${this.iconTheme}/battery-charging-low.png`;
+	},
+
+	setupUI: function () {
+		try {
+			// Picks up UUID from metadata for Settings
+			this.settings = new Settings.AppletSettings(
+				this,
+				UUID,
+				this.instance_id
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN, // Setting type
+				"refreshInterval-spinner", // The setting key
+				"refreshInterval", // The property to manage (this.refreshInterval)
+				this.on_settings_changed, // Callback when value changes
+				null
+			); // Optional callback data
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.BIDIRECTIONAL,
+				"alertPercentage",
+				"alertPercentage",
+				this.on_settings_changed,
+				null
+			);
+			/* new setting: allow comma-separated list of alert levels */
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"alertPercentages",
+				"alertPercentagesString",
+				this.on_settings_changed,
+				null
+			);
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"recharged_alert",
+				"recharged_alert",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"recharged_alert_percentage",
+				"recharged_alert_percentage",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"displayType",
+				"displayType",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"iconTheme",
+				"iconTheme",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"time_remaining_display",
+				"time_remaining_display",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"time_remaining_toolbar",
+				"time_remaining_toolbar",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"time_remaining_tooltip",
+				"time_remaining_tooltip",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"useBatteryLowSound",
+				"useBatteryLowSound",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"chooseBatteryLowSound",
+				"chooseBatteryLowSound",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"batteryLowSound",
+				"batteryLowSound1",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"batteryShutdownSound",
+				"batteryShutdownSound1",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"notifyBatteryLowSound",
+				"notifyBatteryLowSound",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"customBatteryPath",
+				"customBatteryPath",
+				this.on_settings_changed,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"normal_background_color",
+				"normal_background_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"normal_border_color",
+				"normal_border_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"normal_font_size",
+				"normal_font_size",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"discharging_background_color",
+				"discharging_background_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"discharging_border_color",
+				"discharging_border_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"discharging_font_size",
+				"discharging_font_size",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"alert_background_color",
+				"alert_background_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"alert_border_color",
+				"alert_border_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"alert_font_size",
+				"alert_font_size",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"alert_discharging_background_color",
+				"alert_discharging_background_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"alert_discharging_border_color",
+				"alert_discharging_border_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"alert_discharging_font_size",
+				"alert_discharging_font_size",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"limit_exceeded_background_color",
+				"limit_exceeded_background_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"limit_exceeded_border_color",
+				"limit_exceeded_border_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"limit_exceeded_font_size",
+				"limit_exceeded_font_size",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"limit_exceeded2_background_color",
+				"limit_exceeded2_background_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"limit_exceeded2_border_color",
+				"limit_exceeded2_border_color",
+				this.setupUI,
+				null
+			);
+
+			this.settings.bindProperty(
+				Settings.BindingDirection.IN,
+				"limit_exceeded2_font_size",
+				"limit_exceeded2_font_size",
+				this.setupUI,
+				null
+			);
+
+			// Define a subprocess launcher
+			this.launcher = new Gio.SubprocessLauncher({
+				flags:
+					Gio.SubprocessFlags.STDIN_PIPE |
+					Gio.SubprocessFlags.STDOUT_PIPE |
+					Gio.Subprocess.STDERR_PIPE,
+			});
+
+			// Make metadata values available within applet for context menu.
+			this.appletPath = this.metadata.path;
+			this.changelog = this.metadata.path + "/../CHANGELOG.md";
+			this.helpfile = this.metadata.path + "/../README.md";
+			this.setupIconPaths();
+
+			// Determine best default battery path if possible
+			let batteryBasePath = "/sys/class/power_supply";
+			let batteryCapacityFile, batteryStatusFile;
+
+			this.BUS_NAME = "org.freedesktop.UPower";
+			for (let i = 0; i < 10; i++) {
+				this.batteryObjectDir = "BAT" + i.toString();
+				this.batteryPath =
+					batteryBasePath + "/" + this.batteryObjectDir;
+				batteryCapacityFile = Gio.File.new_for_path(
+					this.batteryPath + "/capacity"
+				);
+				batteryStatusFile = Gio.File.new_for_path(
+					this.batteryPath + "/status"
+				);
+				if (
+					batteryCapacityFile.query_exists(null) &&
+					batteryStatusFile.query_exists(null)
+				)
+					break;
+			}
+
+			// Set initial value
+			this.set_applet_icon_path(this.batteryCharging100);
+
+			this.set_applet_label(_("--%"));
+			this.set_applet_tooltip(_("Waiting"));
+
+			if (this.recharged_alert) this.showRechargedAlert = false; // flag for flashing recharged alert
+			this.flashFlag = true; // flag for flashing background
+			this.flashFlag2 = true; // flag for second flashing background
+			this.lastBatteryPercentage = 50; // Initialise lastBatteryPercentage
+			this.batteryStateOld = "invalid";
+			// track thresholds parsed from comma-separated string
+			this.alertPercentagesString =
+				this.alertPercentagesString || String(this.alertPercentage);
+			this.alertThresholds = [];
+			this.parseAlertPercentages();
+
+			this.on_orientation_changed(this.orientation); // Initialise for panel orientation
+
+			this.applet_running = true; // Allow applet to be fully stopped when removed from panel
+
+			// Set text editor
+			this.textEd = "/usr/bin/open";
+
+			// Check that all Dependencies Met by presence of sox and zenity
+			if (
+				GLib.find_program_in_path("sox") &&
+				GLib.find_program_in_path("zenity")
+			) {
+				this.dependenciesMet = true;
+			} else {
+				let icon = new St.Icon({
+					icon_name: "error",
+					icon_type: St.IconType.FULLCOLOR,
+					icon_size: 36,
+				});
+				Main.criticalNotify(
+					_("Some dependencies not installed."),
+					_(
+						"Both 'sox' and 'zenity' are required for this applet to have all of its functionality including notifications and audible alerts.\n\nPlease view the README for help on installing them.\n"
+					),
+					icon
+				);
+				this.dependenciesMet = false;
+			}
+
+			if (!this.chooseBatteryLowSound) {
+				// paths to default sound files
+				this.batteryLowSound =
+					"/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga";
+				this.batteryShutdownSound =
+					"/usr/share/sounds/freedesktop/stereo/complete.oga";
+			} else {
+				if (this.notifyBatteryLowSound && this.useBatteryLowSound)
+					Main.warningNotify(
+						_("Battery Monitor Applet"),
+						_(
+							"A user-defined sound file has been specified for Low Battery.\n\nPlease ensure the volume is set sensibly in public places,\nespecially if a long or loud file is specified.\n"
+						)
+					);
+				this.batteryLowSound = this.batteryLowSound1;
+				this.batteryShutdownSound = this.batteryShutdownSound1;
+			}
+
+			// Set up left click menu
+			this.menuManager = new PopupMenu.PopupMenuManager(this);
+			this.menu = new Applet.AppletPopupMenu(this, this.orientation);
+			this.menuManager.addMenu(this.menu);
+
+			// Build Context (Right Click) Menu
+			this.buildContextMenu();
+			this.makeMenu();
+
+			// Finally setup to start the update loop for the applet display running
+			this.on_settings_changed();
+
+			// ensure thresholds are initialised from string once settings loaded
+			this.parseAlertPercentages();
+		} catch (e) {
+			global.logError(e);
+		}
+	},
+
+	// parse a comma-separated list of alert percentages into a sorted numeric array
+	parseAlertPercentages: function () {
+		if (
+			!this.alertPercentagesString ||
+			this.alertPercentagesString.trim() === ""
+		) {
+			this.alertPercentagesString = String(this.alertPercentage);
+		}
+		let parts = this.alertPercentagesString
+			.split(",")
+			.map((p) => parseInt(p.trim(), 10));
+		// keep only valid numbers between 0 and 100
+		parts = parts.filter((n) => !isNaN(n) && n >= 0 && n <= 100);
+		// sort descending and deduplicate
+		parts.sort((a, b) => b - a);
+		parts = [...new Set(parts)];
+		if (parts.length === 0) {
+			parts = [this.alertPercentage];
+		}
+		this.alertThresholds = parts;
+		// primary alert percentage is the first element
+		this.alertPercentage = this.alertThresholds[0];
+	},
+
+	on_orientation_changed: function (orientation) {
+		this.orientation = orientation;
+		if (
+			this.orientation == St.Side.LEFT ||
+			this.orientation == St.Side.RIGHT
+		) {
+			// vertical
+			this.isHorizontal = false;
+		} else {
+			// horizontal
+			this.isHorizontal = true;
+		}
+	},
+
+	// Function called when settings are changed
+	on_settings_changed: function () {
+		// parse comma separated percentages every time settings change
+		this.parseAlertPercentages();
+
+		this.slider.setValue((this.alertPercentage - 10) / 30);
+		if (this.recharged_alert) this.showRechargedAlert = false;
+		if (!this.chooseBatteryLowSound) {
+			// paths to default sound files
+			this.batteryLowSound =
+				"/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga";
+			this.batteryShutdownSound =
+				"/usr/share/sounds/freedesktop/stereo/complete.oga";
+		} else {
+			this.batteryLowSound = this.batteryLowSound1;
+			this.batteryShutdownSound = this.batteryShutdownSound1;
+		}
+		this.setupIconPaths();
+		this.updateLoop();
+	},
+
+	on_slider_changed: function (slider, value) {
+		// only update the first (primary) threshold when slider is moved
+		let newVal = Math.round(value * 30 + 10);
+		this.alertPercentage = newVal;
+		if (this.alertThresholds && this.alertThresholds.length > 0) {
+			this.alertThresholds[0] = newVal;
+		} else {
+			this.alertThresholds = [newVal];
+		}
+		// reflect change back into the settings string so that it is saved
+		this.alertPercentagesString = this.alertThresholds.join(",");
+		this.parseAlertPercentages();
+		this.updateUI();
+	},
+
+	// Build the Right Click Context Menu
+	buildContextMenu: function () {
+		try {
+			this._applet_context_menu.removeAll();
+
+			this._applet_context_menu.addMenuItem(
+				new PopupMenu.PopupSeparatorMenuItem()
+			);
+
+			let menuitem2 = new PopupMenu.PopupMenuItem(
+				_("Open Power Statistics")
+			);
+			menuitem2.connect(
+				"activate",
+				Lang.bind(this, function (event) {
+					this.launcher.spawnv(["/usr/bin/gnome-power-statistics"]);
+				})
+			);
+			this._applet_context_menu.addMenuItem(menuitem2);
+
+			this.menuitem3 = new PopupMenu.PopupMenuItem(
+				_("Open System Monitor")
+			);
+			this.menuitem3.connect(
+				"activate",
+				Lang.bind(this, function (event) {
+					this.launcher.spawnv(["/usr/bin/gnome-system-monitor"]);
+				})
+			);
+			this._applet_context_menu.addMenuItem(this.menuitem3);
+
+			this._applet_context_menu.addMenuItem(
+				new PopupMenu.PopupSeparatorMenuItem()
+			);
+
+			// Set up submenu for Housekeeping and System Items
+			this.subMenu1 = new PopupMenu.PopupSubMenuMenuItem(
+				_("Housekeeping and System Submenu")
+			);
+			this._applet_context_menu.addMenuItem(this.subMenu1);
+
+			this.subMenuItem1 = new PopupMenu.PopupMenuItem(
+				_("View the Changelog")
+			);
+			this.subMenuItem1.connect(
+				"activate",
+				Lang.bind(this, function (event) {
+					this.launcher.spawnv([this.textEd, this.changelog]);
+				})
+			);
+			this.subMenu1.menu.addMenuItem(this.subMenuItem1); // Note this has subMenu1.menu not subMenu1._applet_context_menu as one might expect
+
+			this.subMenuItem2 = new PopupMenu.PopupMenuItem(
+				_("Open the README")
+			);
+			this.subMenuItem2.connect(
+				"activate",
+				Lang.bind(this, function (event) {
+					this.launcher.spawnv([this.textEd, this.helpfile]);
+				})
+			);
+			this.subMenu1.menu.addMenuItem(this.subMenuItem2);
+		} catch (e) {
+			global.logError(e);
+		}
+	},
+
+	// Build left click menu
+	makeMenu: function () {
+		try {
+			this.menu.removeAll();
+
+			this.menuitemInfo1 = new PopupMenu.PopupMenuItem(
+				"     " + _("Waiting for battery information"),
+				{
+					reactive: false,
+				}
+			);
+			this.menu.addMenuItem(this.menuitemInfo1);
+
+			this.sliderLabel = new PopupMenu.PopupMenuItem(
+				_("Alert/Suspend:"),
+				{
+					reactive: false,
+				}
+			);
+			this.slider = new PopupMenu.PopupSliderMenuItem(0);
+			this.slider.connect(
+				"value-changed",
+				Lang.bind(this, this.on_slider_changed)
+			);
+			this.menu.addMenuItem(this.sliderLabel);
+			this.menu.addMenuItem(this.slider);
+		} catch (e) {
+			global.logError(e);
+		}
+	},
+
+	// Handler for when the applet is clicked.
+	on_applet_clicked: function (event) {
+		this.updateLoop();
+		this.menu.toggle();
+	},
+
+	// Refresh values from battery
+	refreshBattery: function () {
+		try {
+			// Try to get the battery capacity as an int
+			let capacityPath = this.batteryPath + "/capacity";
+			let capacityValue = GLib.file_get_contents(capacityPath)[1];
+			let capacityValueString = ByteArray.toString(capacityValue);
+			this.batteryPercentage = parseInt(capacityValueString);
+
+			// Try to get the battery state as a lowercase string
+			let statePath = this.batteryPath + "/status";
+			let stateValue = GLib.file_get_contents(statePath)[1];
+			let stateValueString = ByteArray.toString(stateValue);
+			this.batteryState = stateValueString.toLowerCase().trim();
+		} catch (err) {
+			global.logError(err);
+		}
+	},
+
+	// This updates the numerical display in the applet and in the tooltip
+	updateUI: function () {
+		try {
+			// Update path to battery and verify customBatteryPath
+			// contains the correct files before using it
+			let customPath = this.customBatteryPath.substring(
+				this.customBatteryPath.lastIndexOf("//") + 1
+			);
+			if (
+				GLib.file_test(customPath, GLib.FileTest.EXISTS) &&
+				GLib.file_test(customPath, GLib.FileTest.IS_DIR)
+			) {
+				if (
+					GLib.file_test(
+						customPath + "/capacity",
+						GLib.FileTest.EXISTS
+					) &&
+					GLib.file_test(customPath + "/status", GLib.FileTest.EXISTS)
+				) {
+					this.batteryPath = customPath;
+				}
+			}
+
+			// Read the battery status
+			this.refreshBattery();
+
+			// Read the battery time properties if we need to display anywhere
+			if (
+				this.time_remaining_display ||
+				this.time_remaining_toolbar ||
+				this.time_remaining_tooltip
+			) {
+				this.BUS_PATH = `/org/freedesktop/UPower/devices/battery_${this.batteryObjectDir}`;
+
+				try {
+					this._upowerProxy = new UPowerProxy(
+						Gio.DBus.system,
+						this.BUS_NAME,
+						this.BUS_PATH
+					);
+					this._timeToFull = this._upowerProxy.TimeToFull;
+					this._timeToEmpty = this._upowerProxy.TimeToEmpty;
+				} catch {}
+			}
+
+			// now check we have a genuine number otherwise use last value
+			if (!(this.batteryPercentage > 0 && this.batteryPercentage <= 100))
+				this.batteryPercentage = this.lastBatteryPercentage;
+			if (this.batteryState.length > 3) {
+				this.batteryStateOld = this.batteryState;
+			} else {
+				this.batteryState = this.batteryStateOld;
+			}
+
+			// Define CSS styles for the applet appearance
+			this._base_style =
+				" margin: 2px, 1px, 0px, 1px; border-radius: 4px, 4px, 1px, 1px;";
+			this._normal = `border: 1px; background-color: ${this.normal_background_color}; border-color: ${this.normal_border_color}; font-size: ${this.normal_font_size}%;${this._base_style}`;
+			this._discharging = `border: 2px; background-color: ${this.discharging_background_color}; border-color: ${this.discharging_border_color}; font-size: ${this.discharging_font_size}%;${this._base_style}`;
+			this._alert = `border: 2px; background-color: ${this.alert_background_color}; border-color: ${this.alert_border_color}; font-size: ${this.alert_font_size}%;${this._base_style}`;
+			this._alert_discharging = `border: 2px; background-color: ${this.alert_discharging_background_color}; border-color: ${this.alert_discharging_border_color}; font-size: ${this.alert_discharging_font_size}%;${this._base_style}`;
+			this._limit_exceeded = `border: 1px; background-color: ${this.limit_exceeded_background_color}; border-color: ${this.limit_exceeded_border_color}; font-size: ${this.limit_exceeded_font_size}%;${this._base_style}`;
+			this._limit_exceeded2 = `border: 1px; background-color: ${this.limit_exceeded2_background_color}; border-color: ${this.limit_exceeded2_border_color}; font-size: ${this.limit_exceeded2_font_size}%;${this._base_style}`;
+
+			this.batteryMessage = " ";
+			let is_discharging = this.batteryState.indexOf("discharg") > -1;
+
+			// compute primary threshold (first element) and allow extra popups
+			let primary = this.alertThresholds.length
+				? this.alertThresholds[0]
+				: this.alertPercentage;
+			let criticalThreshold = primary / 1.5; // keep original critical calculation
+
+			if (Math.floor(this.batteryPercentage) >= Math.floor(primary)) {
+				this.actor.style = this._normal;
+				if (is_discharging) this.actor.style = this._discharging;
+			}
+
+			if (Math.floor(this.batteryPercentage) < Math.floor(primary)) {
+				if (this.flashFlag) {
+					this.actor.style = this._alert;
+					this.flashFlag = false;
+				} else {
+					if (is_discharging) {
+						this.actor.style = this._alert_discharging;
+						this.flashFlag = true; // Corrected placement
+					}
+				}
+				if (is_discharging) {
+					this.batteryMessage =
+						_("Battery Low - turn off or connect to power supply") +
+						" ";
+				}
+			}
+
+			if (Math.floor(this.batteryPercentage) < criticalThreshold) {
+				if (this.flashFlag2) {
+					this.actor.style = this._limit_exceeded2;
+					this.flashFlag2 = false;
+				} else {
+					this.actor.style = this._limit_exceeded;
+					this.flashFlag2 = true;
+				}
+
+				if (is_discharging) {
+					this.batteryMessage =
+						_(
+							"Battery Critical - will suspend unless connected to power supply"
+						) + " ";
+					if (this.batteryPercentage < this.lastBatteryPercentage) {
+						// Audible alert moved from suspendScript in v32_1.0.0
+						if (this.useBatteryLowSound)
+							this.launcher.spawnv([
+								"/usr/bin/play",
+								this.batteryShutdownSound,
+							]);
+						this.launcher.spawnv([
+							"/usr/bin/bash",
+							`${this.appletPath}/suspendScript.sh`,
+						]);
+					}
+				}
+			}
+
+			// pop-up notifications for each threshold crossing
+			if (is_discharging) {
+				for (let i = 0; i < this.alertThresholds.length; i++) {
+					let thresh = this.alertThresholds[i];
+					if (
+						this.batteryPercentage < thresh &&
+						this.lastBatteryPercentage >= thresh
+					) {
+						// play sound and show dialog for this specific threshold
+						if (this.useBatteryLowSound)
+							this.launcher.spawnv([
+								"/usr/bin/play",
+								this.batteryLowSound,
+							]);
+						new ModalDialog.NotifyDialog(
+							_("The battery level has fallen to") +
+								` ${thresh}%.\n\n` +
+								_(
+									"Either connect to a power source or save or close down\nyour work and suspend or shutdown the machine.\n"
+								)
+						).open();
+					}
+				}
+			}
+
+			this.lastBatteryPercentage = this.batteryPercentage;
+			/*
             If less than 4%, then shutdown completely immediately.
             May be implemented in future version
             */
-            // set Tooltip
+			// set Tooltip
 
-            this.time_string = (this.time_remaining_display || this.time_remaining_tooltip || this.time_remaining_toolbar) && this.batteryPercentage != 100 ?
-                (is_discharging ?
-                    (this._timeToEmpty != 0 ? "\n" + _("Time to Empty:") + " (" + this.timeToString(this._timeToEmpty) + ")" : "") :
-                    (this._timeToFull != 0 ? "\n" + _("Time to Full:") + " (" + this.timeToString(this._timeToFull) + ")" : "")) :
-                "";
-            this.time_tooltip = this.time_remaining_tooltip ? this.time_string : "";
-            this.set_applet_tooltip(_("Current Charge:") + " " + this.batteryPercentage + "% (" + titleCase(this.batteryState) + `)${this.time_tooltip}\n` + _("Alert:") + " " + Math.floor(this.alertPercentage) + "%\n" + _("Suspend:") + " " + Math.floor(this.alertPercentage / 1.5) + "%");
-            // Now select icon to display
-            if (this.batteryPercentage == 100) {
-                this.batteryIcon = is_discharging ? this.battery100 : this.batteryCharging100;
-            } else if (this.batteryPercentage >= 80) {
-                this.batteryIcon = is_discharging ? this.battery080 : this.batteryCharging080;
-            } else if (this.batteryPercentage >= 60) {
-                this.batteryIcon = is_discharging ? this.battery060 : this.batteryCharging060;
-            } else if (this.batteryPercentage >= Math.floor(this.alertPercentage)) {
-                this.batteryIcon = is_discharging ? this.battery040 : this.batteryCharging040;
-            } else if (this.batteryPercentage >= Math.floor(this.alertPercentage / 1.5)) {
-                this.batteryIcon = is_discharging ? this.batteryCaution : this.batteryChargingCaution;
-            } else {
-                this.batteryIcon = is_discharging ? this.batteryLow : this.batteryChargingLow;
-            }
+			this.time_string =
+				(this.time_remaining_display ||
+					this.time_remaining_tooltip ||
+					this.time_remaining_toolbar) &&
+				this.batteryPercentage != 100
+					? is_discharging
+						? this._timeToEmpty != 0
+							? "\n" +
+								_("Time to Empty:") +
+								" (" +
+								this.timeToString(this._timeToEmpty) +
+								")"
+							: ""
+						: this._timeToFull != 0
+							? "\n" +
+								_("Time to Full:") +
+								" (" +
+								this.timeToString(this._timeToFull) +
+								")"
+							: ""
+					: "";
+			this.time_tooltip = this.time_remaining_tooltip
+				? this.time_string
+				: "";
+			let alertsText = this.alertThresholds.join("%, ") + "%";
+			this.set_applet_tooltip(
+				_("Current Charge:") +
+					" " +
+					this.batteryPercentage +
+					"% (" +
+					titleCase(this.batteryState) +
+					`)${this.time_tooltip}\n` +
+					_("Alerts at:") +
+					" " +
+					alertsText +
+					"\n" +
+					_("Suspend:") +
+					" " +
+					Math.floor(primary / 1.5) +
+					"%"
+			);
+			// Now select icon to display
+			if (this.batteryPercentage == 100) {
+				this.batteryIcon = is_discharging
+					? this.battery100
+					: this.batteryCharging100;
+			} else if (this.batteryPercentage >= 80) {
+				this.batteryIcon = is_discharging
+					? this.battery080
+					: this.batteryCharging080;
+			} else if (this.batteryPercentage >= 60) {
+				this.batteryIcon = is_discharging
+					? this.battery060
+					: this.batteryCharging060;
+			} else if (
+				this.batteryPercentage >= Math.floor(this.alertPercentage)
+			) {
+				this.batteryIcon = is_discharging
+					? this.battery040
+					: this.batteryCharging040;
+			} else if (
+				this.batteryPercentage >= Math.floor(this.alertPercentage / 1.5)
+			) {
+				this.batteryIcon = is_discharging
+					? this.batteryCaution
+					: this.batteryChargingCaution;
+			} else {
+				this.batteryIcon = is_discharging
+					? this.batteryLow
+					: this.batteryChargingLow;
+			}
 
-            // Choose what to display based on Display Type from settings dropdown
-            if (this.displayType == "classicPlus" || this.displayType == "compactPlus" || this.displayType == "icon") {
-                this.set_applet_icon_path(this.batteryIcon);
-            } else {
-                this.hide_applet_icon();
-            }
-            if (!(this.displayType == "classic" || this.displayType == "classicPlus") || !this.isHorizontal)
-                this.batteryMessage = "";
+			// Choose what to display based on Display Type from settings dropdown
+			if (
+				this.displayType == "classicPlus" ||
+				this.displayType == "compactPlus" ||
+				this.displayType == "icon"
+			) {
+				this.set_applet_icon_path(this.batteryIcon);
+			} else {
+				this.hide_applet_icon();
+			}
+			if (
+				!(
+					this.displayType == "classic" ||
+					this.displayType == "classicPlus"
+				) ||
+				!this.isHorizontal
+			)
+				this.batteryMessage = "";
 
-            this.time_display = this.time_remaining_display && this.batteryPercentage != 100 ?
-                (is_discharging ?
-                    (this._timeToEmpty != 0 ? ` (${this.timeToString(this._timeToEmpty)})` : "") :
-                    (this._timeToFull != 0 ? ` (${this.timeToString(this._timeToFull)})` : "")) :
-                "";
-            if (this.batteryPercentage == 100 && !this.isHorizontal) {
-                this.set_applet_label(this.batteryMessage + this.batteryPercentage + `${this.time_display}`);
-            } else {
-                this.set_applet_label(this.batteryMessage + this.batteryPercentage + `%${this.time_display}`);
-            }
+			this.time_display =
+				this.time_remaining_display && this.batteryPercentage != 100
+					? is_discharging
+						? this._timeToEmpty != 0
+							? ` (${this.timeToString(this._timeToEmpty)})`
+							: ""
+						: this._timeToFull != 0
+							? ` (${this.timeToString(this._timeToFull)})`
+							: ""
+					: "";
+			if (this.batteryPercentage == 100 && !this.isHorizontal) {
+				this.set_applet_label(
+					this.batteryMessage +
+						this.batteryPercentage +
+						`${this.time_display}`
+				);
+			} else {
+				this.set_applet_label(
+					this.batteryMessage +
+						this.batteryPercentage +
+						`%${this.time_display}`
+				);
+			}
 
-            if (this.displayType == "icon") {
-                this.set_applet_label("");
-                if (!this.isHorizontal)
-                    this.hide_applet_label(true);
-            } else {
-                if (!this.isHorizontal)
-                    this.hide_applet_label(false);
-            }
+			if (this.displayType == "icon") {
+				this.set_applet_label("");
+				if (!this.isHorizontal) this.hide_applet_label(true);
+			} else {
+				if (!this.isHorizontal) this.hide_applet_label(false);
+			}
 
-            // Set left click menu item 'label' for slider
-            this.time_label = this.time_remaining_toolbar ? this.time_string : "";
-            this.menuitemInfo1.label.text = _("Current Charge:") + " " + this.batteryPercentage + "% " + "(" + titleCase(this.batteryState) + `)${this.time_label}\n` + _("Alert at:") + " " + Math.floor(this.alertPercentage) + "%\n" + _("Suspend at:") + " " + Math.floor(this.alertPercentage / 1.5) + "%";
+			// Set left click menu item 'label' for slider
+			this.time_label = this.time_remaining_toolbar
+				? this.time_string
+				: "";
+			// alertsText was computed earlier for the tooltip, so we can reuse it here
+			this.menuitemInfo1.label.text =
+				_("Current Charge:") +
+				" " +
+				this.batteryPercentage +
+				"% " +
+				"(" +
+				titleCase(this.batteryState) +
+				`)${this.time_label}\n` +
+				_("Alerts at:") +
+				" " +
+				alertsText +
+				"\n" +
+				_("Suspend at:") +
+				" " +
+				Math.floor(primary / 1.5) +
+				"%";
 
-            // Check if a recharged alert needs to be shown, flip the switch under the right conditions otherwise
-            if (!is_discharging && this.recharged_alert) {
-                if (this.showRechargedAlert && this.recharged_alert_percentage <= this.batteryPercentage) {
-                    this.showRechargedAlert = false;
-                    new ModalDialog.NotifyDialog(_("The battery level has been recharged to") + ` ${this.batteryPercentage}%.`).open();
-                } else if (!this.showRechargedAlert && this.recharged_alert_percentage > this.batteryPercentage) {
-                    this.showRechargedAlert = true;
-                }
-            }
-        } catch (e) {
-            global.logError(e);
-        }
-    },
+			// Check if a recharged alert needs to be shown, flip the switch under the right conditions otherwise
+			if (!is_discharging && this.recharged_alert) {
+				if (
+					this.showRechargedAlert &&
+					this.recharged_alert_percentage <= this.batteryPercentage
+				) {
+					this.showRechargedAlert = false;
+					new ModalDialog.NotifyDialog(
+						_("The battery level has been recharged to") +
+							` ${this.batteryPercentage}%.`
+					).open();
+				} else if (
+					!this.showRechargedAlert &&
+					this.recharged_alert_percentage > this.batteryPercentage
+				) {
+					this.showRechargedAlert = true;
+				}
+			}
+		} catch (e) {
+			global.logError(e);
+		}
+	},
 
-    // This is the loop run at refreshInterval rate to call updateUI() to update the display in the applet and tooltip
-    updateLoop: function () {
-        // Also inhibit when applet after has been removed from panel
-        if (this.applet_running == true) {
-            this.updateUI();
-            this.timeout = Mainloop.timeout_add_seconds(this.refreshInterval, Lang.bind(this, this.updateLoop));
-        }
-    },
+	// This is the loop run at refreshInterval rate to call updateUI() to update the display in the applet and tooltip
+	updateLoop: function () {
+		// Also inhibit when applet after has been removed from panel
+		if (this.applet_running == true) {
+			this.updateUI();
+			this.timeout = Mainloop.timeout_add_seconds(
+				this.refreshInterval,
+				Lang.bind(this, this.updateLoop)
+			);
+		}
+	},
 
-    // This takes an int value of seconds and returns a string formatted with hours and minutes
-    timeToString: function (time_in_seconds) {
-        let totalTime = Math.round(time_in_seconds / 60);
-        let minutes = Math.floor(totalTime % 60);
-        let minutesToString = String(minutes).padStart(2, '0');
-        let hours = Math.floor(totalTime / 60);
-        return `${hours}:${minutesToString}`;
-    },
+	// This takes an int value of seconds and returns a string formatted with hours and minutes
+	timeToString: function (time_in_seconds) {
+		let totalTime = Math.round(time_in_seconds / 60);
+		let minutes = Math.floor(totalTime % 60);
+		let minutesToString = String(minutes).padStart(2, "0");
+		let hours = Math.floor(totalTime / 60);
+		return `${hours}:${minutesToString}`;
+	},
 
-    // This finalizes the settings when the applet is removed from the panel
-    on_applet_removed_from_panel: function () {
-        // inhibit the update timer when applet removed from panel
-        this.applet_running = false;
-        Mainloop.source_remove(this.timeout);
-        this.settings.finalize();
-    }
+	// This finalizes the settings when the applet is removed from the panel
+	on_applet_removed_from_panel: function () {
+		// inhibit the update timer when applet removed from panel
+		this.applet_running = false;
+		Mainloop.source_remove(this.timeout);
+		this.settings.finalize();
+	},
 };
 
 function main(metadata, orientation, panelHeight, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panelHeight, instance_id);
-    return myApplet;
+	let myApplet = new MyApplet(
+		metadata,
+		orientation,
+		panelHeight,
+		instance_id
+	);
+	return myApplet;
 }

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/5.4/settings-schema.json
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/5.4/settings-schema.json
@@ -1,371 +1,368 @@
 {
-    "layout": {
-        "type": "layout",
-        "pages": [
-            "General",
-            "Style"
-        ],
-        "General": {
-            "type": "page",
-            "title": "General",
-            "sections": [
-                "general",
-                "display_mode",
-                "low_alert",
-                "advanced"
-            ]
-        },
-        "Style": {
-            "type": "page",
-            "title": "Style",
-            "sections": [
-                "bam_normal",
-                "bam_discharging",
-                "bam_alert",
-                "bam_alert_discharging",
-                "bam_limit_exceeded",
-                "bam_limit_exceeded2"
-            ]
-        },
-        "general": {
-            "type": "section",
-            "title": "General Settings",
-            "keys": [
-                "refreshInterval-spinner",
-                "alertPercentage",
-                "recharged_alert",
-                "recharged_alert_percentage"
-            ]
-        },
-        "display_mode": {
-            "type": "section",
-            "title": "Display Options",
-            "keys": [
-                "displayType",
-                "iconTheme",
-                "time_remaining_display",
-                "time_remaining_toolbar",
-                "time_remaining_tooltip"
-            ]
-        },
-        "low_alert": {
-            "type": "section",
-            "title": "Battery Low Alert Settings",
-            "keys": [
-                "useBatteryLowSound",
-                "chooseBatteryLowSound",
-                "batteryLowSound",
-                "batteryShutdownSound",
-                "notifyBatteryLowSound"
-            ]
-        },
-        "advanced": {
-            "type": "section",
-            "title": "Advanced",
-            "keys": [
-                "customBatteryPath"
-            ]
-        },
-        "bam_normal": {
-            "type": "section",
-            "title": "Normal",
-            "keys": [
-                "normal_background_color",
-                "normal_border_color",
-                "normal_font_size"
-            ]
-        },
-        "bam_discharging": {
-            "type": "section",
-            "title": "Discharging",
-            "keys": [
-                "discharging_background_color",
-                "discharging_border_color",
-                "discharging_font_size"
-            ]
-        },
-        "bam_alert": {
-            "type": "section",
-            "title": "Alert",
-            "keys": [
-                "alert_background_color",
-                "alert_border_color",
-                "alert_font_size"
-            ]
-        },
-        "bam_alert_discharging": {
-            "type": "section",
-            "title": "Alert Discharging",
-            "keys": [
-                "alert_discharging_background_color",
-                "alert_discharging_border_color",
-                "alert_discharging_font_size"
-            ]
-        },
-        "bam_limit_exceeded": {
-            "type": "section",
-            "title": "Limit Exceeded",
-            "keys": [
-                "limit_exceeded_background_color",
-                "limit_exceeded_border_color",
-                "limit_exceeded_font_size"
-            ]
-        },
-        "bam_limit_exceeded2": {
-            "type": "section",
-            "title": "Limit Exceeded - Critical",
-            "keys": [
-                "limit_exceeded2_background_color",
-                "limit_exceeded2_border_color",
-                "limit_exceeded2_font_size"
-            ]
-        }
-    },
-    "refreshInterval-spinner": {
-        "type": "spinbutton",
-        "default": 2,
-        "min": 1,
-        "max": 300,
-        "step": 1,
-        "units": "seconds",
-        "description": "Refresh Interval for Display",
-        "tooltip": "Increase or decrease this spinner value to change the refresh interval - use a slow refresh if you have a slow machine. This also governs the flash speed."
-    },
-    "alertPercentage": {
-        "type": "spinbutton",
-        "default": 25,
-        "min": 10,
-        "max": 40,
-        "step": 5,
-        "units": "%",
-        "description": "Percentage Battery Charge at which Alert Displayed",
-        "tooltip": "Percentage of Battery Charge at which Orange Warning Background is displayed - It is also shown and can be adjusted in the Applet left click menu"
-    },
-    "recharged_alert": {
-        "type": "checkbox",
-        "default": false,
-        "description": "Visible Alert when Recharging",
-        "tooltip": "Provide visible alert when battery is recharged to a certain threshold"
-    },
-    "recharged_alert_percentage": {
-        "type": "spinbutton",
-        "default": 80,
-        "min": 45,
-        "max": 100,
-        "step": 5,
-        "units": "%",
-        "description": "Percentage threshold for visible recharged alert",
-        "dependency": "recharged_alert"
-    },
-    "displayType": {
-        "type": "combobox",
-        "default": "classic",
-        "options": {
-            "Classic": "classic",
-            "Classic Plus": "classicPlus",
-            "Compact": "compact",
-            "Compact Plus": "compactPlus",
-            "Icon Only": "icon"
-        },
-        "description": "Toolbar Display Type",
-        "tooltip": "The following display options are available (including Compact, Compact Plus, and Icon Only for vertical panels):\n  Classic: Battery percentage with extended messages for horizontal panel\n  Classic Plus: Classic with the addition of a battery icon\n  Compact: Battery percentage without extended messages\n  Compact Plus: Compact with the addition of a battery icon\n  Icon Only: The battery icon on a colored background indicating the current status"
-    },
-    "iconTheme": {
-        "type": "combobox",
-        "default": "classic",
-        "options": {
-            "Classic": "classic",
-            "Yaru Light": "yaru-light",
-            "Yaru Dark": "yaru-dark"
-        },
-        "description": "Icon Theme",
-        "tooltip": "Icon Theme"
-    },
-    "time_remaining_display": {
-        "type": "checkbox",
-        "default": false,
-        "description": "Append estimated time remaining to chosen display type",
-        "tooltip": "This will append an estimate to the above option for time remaining based on the amount of remaining battery power"
-    },
-    "time_remaining_toolbar": {
-        "type": "checkbox",
-        "default": false,
-        "description": "Append estimated time remaining to toolbar menu",
-        "tooltip": "This will append an estimate to the toolbar menu for time remaining based on the amount of remaining battery power"
-    },
-    "time_remaining_tooltip": {
-        "type": "checkbox",
-        "default": false,
-        "description": "Append estimated time remaining to tooltip",
-        "tooltip": "This will append an estimate to the tooltip for time remaining based on the amount of remaining battery power"
-    },
-    "useBatteryLowSound": {
-        "type": "checkbox",
-        "default": false,
-        "description": "Provide audible alerts when Battery Low and at Shutdown Level",
-        "tooltip": "Must have `sox` installed. Limited number of sound file types supported (.oga and .wav)"
-    },
-    "chooseBatteryLowSound": {
-        "type": "checkbox",
-        "default": false,
-        "description": "Allow choice of audible alert file when Battery Low and at Shutdown Level",
-        "tooltip": "Must have `sox` installed. Limited number of sound file types supported in versions < 4.2"
-    },
-    "batteryLowSound": {
-        "type": "soundfilechooser",
-        "default": "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga",
-        "dependency": "chooseBatteryLowSound",
-        "description": "Choose sound file to use when Battery is Low",
-        "tooltip": "Please ensure the volume is set sensibly in public places, especially if a long or loud file is specified",
-        "event-sounds": false
-    },
-    "batteryShutdownSound": {
-        "type": "soundfilechooser",
-        "default": "/usr/share/sounds/freedesktop/stereo/complete.oga",
-        "dependency": "chooseBatteryLowSound",
-        "description": "Sound file to use when Battery is at Shutdown Level",
-        "tooltip": "Please ensure the volume is set sensibly in public places - do not specify a long or loud file at Shutdown",
-        "event-sounds": false
-    },
-    "notifyBatteryLowSound": {
-        "type": "checkbox",
-        "default": true,
-        "dependency": "chooseBatteryLowSound",
-        "description": "Provide notification when user specified sound file is in use (Recommended)",
-        "tooltip": "To remind that the volume may need to be set sensibly in public places"
-    },
-    "customBatteryPath": {
-        "default": "",
-        "type": "filechooser",
-        "description": "Path to battery capacity directory (device path)",
-        "tooltip": "Choose your own power_supply object e.g. for monitoring your secondary battery.\n\nDefault:\n/sys/class/power_supply/BAT0",
-        "allow-none": true,
-        "select-dir": true
-    },
-    "normal_background_color": {
-        "type": "colorchooser",
-        "description": "Background Color",
-        "default": "rgba(0, 255, 0, 0.3)",
-        "tooltip": "RGB or RGBA"
-    },
-    "normal_border_color": {
-        "type": "colorchooser",
-        "description": "Border Color",
-        "default": "rgba(0, 255, 0, 0.5)",
-        "tooltip": "RGB or RGBA"
-    },
-    "normal_font_size": {
-        "type": "spinbutton",
-        "default": 95,
-        "min": 0,
-        "max": 200,
-        "step": 5,
-        "units": "%",
-        "description": "Font Size"
-    },
-    "discharging_background_color": {
-        "type": "colorchooser",
-        "description": "Background Color",
-        "default": "rgba(0, 255, 0, 0.3)",
-        "tooltip": "RGB or RGBA"
-    },
-    "discharging_border_color": {
-        "type": "colorchooser",
-        "description": "Border Color",
-        "default": "rgba(255, 0, 0, 1)",
-        "tooltip": "RGB or RGBA"
-    },
-    "discharging_font_size": {
-        "type": "spinbutton",
-        "default": 95,
-        "min": 0,
-        "max": 200,
-        "step": 5,
-        "units": "%",
-        "description": "Font Size"
-    },
-    "alert_background_color": {
-        "type": "colorchooser",
-        "description": "Background Color",
-        "default": "rgba(255, 165, 0, 1)",
-        "tooltip": "RGB or RGBA"
-    },
-    "alert_border_color": {
-        "type": "colorchooser",
-        "description": "Border Color",
-        "default": "rgba(255, 165, 0, 1)",
-        "tooltip": "RGB or RGBA"
-    },
-    "alert_font_size": {
-        "type": "spinbutton",
-        "default": 95,
-        "min": 0,
-        "max": 200,
-        "step": 5,
-        "units": "%",
-        "description": "Font Size"
-    },
-    "alert_discharging_background_color": {
-        "type": "colorchooser",
-        "description": "Background Color",
-        "default": "rgba(255, 255, 255, 1)",
-        "tooltip": "RGB or RGBA"
-    },
-    "alert_discharging_border_color": {
-        "type": "colorchooser",
-        "description": "Border Color",
-        "default": "rgba(255, 0, 0, 1)",
-        "tooltip": "RGB or RGBA"
-    },
-    "alert_discharging_font_size": {
-        "type": "spinbutton",
-        "default": 95,
-        "min": 0,
-        "max": 200,
-        "step": 5,
-        "units": "%",
-        "description": "Font Size"
-    },
-    "limit_exceeded_background_color": {
-        "type": "colorchooser",
-        "description": "Background Color",
-        "default": "rgba(255, 0, 0, 1)",
-        "tooltip": "RGB or RGBA"
-    },
-    "limit_exceeded_border_color": {
-        "type": "colorchooser",
-        "description": "Border Color",
-        "default": "rgba(255, 0, 0, 0)",
-        "tooltip": "RGB or RGBA"
-    },
-    "limit_exceeded_font_size": {
-        "type": "spinbutton",
-        "default": 95,
-        "min": 0,
-        "max": 200,
-        "step": 5,
-        "units": "%",
-        "description": "Font Size"
-    },
-    "limit_exceeded2_background_color": {
-        "type": "colorchooser",
-        "description": "Background Color",
-        "default": "rgba(255, 255, 255, 1)",
-        "tooltip": "RGB or RGBA"
-    },
-    "limit_exceeded2_border_color": {
-        "type": "colorchooser",
-        "description": "Border Color",
-        "default": "rgba(255, 255, 255, 0)",
-        "tooltip": "RGB or RGBA"
-    },
-    "limit_exceeded2_font_size": {
-        "type": "spinbutton",
-        "default": 95,
-        "min": 0,
-        "max": 200,
-        "step": 5,
-        "units": "%",
-        "description": "Font Size"
-    }
+	"layout": {
+		"type": "layout",
+		"pages": ["General", "Style"],
+		"General": {
+			"type": "page",
+			"title": "General",
+			"sections": ["general", "display_mode", "low_alert", "advanced"]
+		},
+		"Style": {
+			"type": "page",
+			"title": "Style",
+			"sections": [
+				"bam_normal",
+				"bam_discharging",
+				"bam_alert",
+				"bam_alert_discharging",
+				"bam_limit_exceeded",
+				"bam_limit_exceeded2"
+			]
+		},
+		"general": {
+			"type": "section",
+			"title": "General Settings",
+			"keys": [
+				"refreshInterval-spinner",
+				"alertPercentage",
+				"alertPercentages",
+				"recharged_alert",
+				"recharged_alert_percentage"
+			]
+		},
+		"display_mode": {
+			"type": "section",
+			"title": "Display Options",
+			"keys": [
+				"displayType",
+				"iconTheme",
+				"time_remaining_display",
+				"time_remaining_toolbar",
+				"time_remaining_tooltip"
+			]
+		},
+		"low_alert": {
+			"type": "section",
+			"title": "Battery Low Alert Settings",
+			"keys": [
+				"useBatteryLowSound",
+				"chooseBatteryLowSound",
+				"batteryLowSound",
+				"batteryShutdownSound",
+				"notifyBatteryLowSound"
+			]
+		},
+		"advanced": {
+			"type": "section",
+			"title": "Advanced",
+			"keys": ["customBatteryPath"]
+		},
+		"bam_normal": {
+			"type": "section",
+			"title": "Normal",
+			"keys": [
+				"normal_background_color",
+				"normal_border_color",
+				"normal_font_size"
+			]
+		},
+		"bam_discharging": {
+			"type": "section",
+			"title": "Discharging",
+			"keys": [
+				"discharging_background_color",
+				"discharging_border_color",
+				"discharging_font_size"
+			]
+		},
+		"bam_alert": {
+			"type": "section",
+			"title": "Alert",
+			"keys": [
+				"alert_background_color",
+				"alert_border_color",
+				"alert_font_size"
+			]
+		},
+		"bam_alert_discharging": {
+			"type": "section",
+			"title": "Alert Discharging",
+			"keys": [
+				"alert_discharging_background_color",
+				"alert_discharging_border_color",
+				"alert_discharging_font_size"
+			]
+		},
+		"bam_limit_exceeded": {
+			"type": "section",
+			"title": "Limit Exceeded",
+			"keys": [
+				"limit_exceeded_background_color",
+				"limit_exceeded_border_color",
+				"limit_exceeded_font_size"
+			]
+		},
+		"bam_limit_exceeded2": {
+			"type": "section",
+			"title": "Limit Exceeded - Critical",
+			"keys": [
+				"limit_exceeded2_background_color",
+				"limit_exceeded2_border_color",
+				"limit_exceeded2_font_size"
+			]
+		}
+	},
+	"refreshInterval-spinner": {
+		"type": "spinbutton",
+		"default": 2,
+		"min": 1,
+		"max": 300,
+		"step": 1,
+		"units": "seconds",
+		"description": "Refresh Interval for Display",
+		"tooltip": "Increase or decrease this spinner value to change the refresh interval - use a slow refresh if you have a slow machine. This also governs the flash speed."
+	},
+	"alertPercentage": {
+		"type": "spinbutton",
+		"default": 25,
+		"min": 10,
+		"max": 40,
+		"step": 5,
+		"units": "%",
+		"description": "Percentage Battery Charge at which Alert Displayed (first threshold)",
+		"tooltip": "This value is used by the slider and is the primary alert level. Additional levels can be specified below."
+	},
+	"alertPercentages": {
+		"type": "text",
+		"default": "25",
+		"description": "Comma-separated list of percentages for alert popups",
+		"tooltip": "Enter one or more battery percentages (e.g. 20,5) at which the applet will show notifications when the level falls below them. The first value is used for the normal warning colour and the slider."
+	},
+	"recharged_alert": {
+		"type": "checkbox",
+		"default": false,
+		"description": "Visible Alert when Recharging",
+		"tooltip": "Provide visible alert when battery is recharged to a certain threshold"
+	},
+	"recharged_alert_percentage": {
+		"type": "spinbutton",
+		"default": 80,
+		"min": 45,
+		"max": 100,
+		"step": 5,
+		"units": "%",
+		"description": "Percentage threshold for visible recharged alert",
+		"dependency": "recharged_alert"
+	},
+	"displayType": {
+		"type": "combobox",
+		"default": "classic",
+		"options": {
+			"Classic": "classic",
+			"Classic Plus": "classicPlus",
+			"Compact": "compact",
+			"Compact Plus": "compactPlus",
+			"Icon Only": "icon"
+		},
+		"description": "Toolbar Display Type",
+		"tooltip": "The following display options are available (including Compact, Compact Plus, and Icon Only for vertical panels):\n  Classic: Battery percentage with extended messages for horizontal panel\n  Classic Plus: Classic with the addition of a battery icon\n  Compact: Battery percentage without extended messages\n  Compact Plus: Compact with the addition of a battery icon\n  Icon Only: The battery icon on a colored background indicating the current status"
+	},
+	"iconTheme": {
+		"type": "combobox",
+		"default": "classic",
+		"options": {
+			"Classic": "classic",
+			"Yaru Light": "yaru-light",
+			"Yaru Dark": "yaru-dark"
+		},
+		"description": "Icon Theme",
+		"tooltip": "Icon Theme"
+	},
+	"time_remaining_display": {
+		"type": "checkbox",
+		"default": false,
+		"description": "Append estimated time remaining to chosen display type",
+		"tooltip": "This will append an estimate to the above option for time remaining based on the amount of remaining battery power"
+	},
+	"time_remaining_toolbar": {
+		"type": "checkbox",
+		"default": false,
+		"description": "Append estimated time remaining to toolbar menu",
+		"tooltip": "This will append an estimate to the toolbar menu for time remaining based on the amount of remaining battery power"
+	},
+	"time_remaining_tooltip": {
+		"type": "checkbox",
+		"default": false,
+		"description": "Append estimated time remaining to tooltip",
+		"tooltip": "This will append an estimate to the tooltip for time remaining based on the amount of remaining battery power"
+	},
+	"useBatteryLowSound": {
+		"type": "checkbox",
+		"default": false,
+		"description": "Provide audible alerts when Battery Low and at Shutdown Level",
+		"tooltip": "Must have `sox` installed. Limited number of sound file types supported (.oga and .wav)"
+	},
+	"chooseBatteryLowSound": {
+		"type": "checkbox",
+		"default": false,
+		"description": "Allow choice of audible alert file when Battery Low and at Shutdown Level",
+		"tooltip": "Must have `sox` installed. Limited number of sound file types supported in versions < 4.2"
+	},
+	"batteryLowSound": {
+		"type": "soundfilechooser",
+		"default": "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga",
+		"dependency": "chooseBatteryLowSound",
+		"description": "Choose sound file to use when Battery is Low",
+		"tooltip": "Please ensure the volume is set sensibly in public places, especially if a long or loud file is specified",
+		"event-sounds": false
+	},
+	"batteryShutdownSound": {
+		"type": "soundfilechooser",
+		"default": "/usr/share/sounds/freedesktop/stereo/complete.oga",
+		"dependency": "chooseBatteryLowSound",
+		"description": "Sound file to use when Battery is at Shutdown Level",
+		"tooltip": "Please ensure the volume is set sensibly in public places - do not specify a long or loud file at Shutdown",
+		"event-sounds": false
+	},
+	"notifyBatteryLowSound": {
+		"type": "checkbox",
+		"default": true,
+		"dependency": "chooseBatteryLowSound",
+		"description": "Provide notification when user specified sound file is in use (Recommended)",
+		"tooltip": "To remind that the volume may need to be set sensibly in public places"
+	},
+	"customBatteryPath": {
+		"default": "",
+		"type": "filechooser",
+		"description": "Path to battery capacity directory (device path)",
+		"tooltip": "Choose your own power_supply object e.g. for monitoring your secondary battery.\n\nDefault:\n/sys/class/power_supply/BAT0",
+		"allow-none": true,
+		"select-dir": true
+	},
+	"normal_background_color": {
+		"type": "colorchooser",
+		"description": "Background Color",
+		"default": "rgba(0, 255, 0, 0.3)",
+		"tooltip": "RGB or RGBA"
+	},
+	"normal_border_color": {
+		"type": "colorchooser",
+		"description": "Border Color",
+		"default": "rgba(0, 255, 0, 0.5)",
+		"tooltip": "RGB or RGBA"
+	},
+	"normal_font_size": {
+		"type": "spinbutton",
+		"default": 95,
+		"min": 0,
+		"max": 200,
+		"step": 5,
+		"units": "%",
+		"description": "Font Size"
+	},
+	"discharging_background_color": {
+		"type": "colorchooser",
+		"description": "Background Color",
+		"default": "rgba(0, 255, 0, 0.3)",
+		"tooltip": "RGB or RGBA"
+	},
+	"discharging_border_color": {
+		"type": "colorchooser",
+		"description": "Border Color",
+		"default": "rgba(255, 0, 0, 1)",
+		"tooltip": "RGB or RGBA"
+	},
+	"discharging_font_size": {
+		"type": "spinbutton",
+		"default": 95,
+		"min": 0,
+		"max": 200,
+		"step": 5,
+		"units": "%",
+		"description": "Font Size"
+	},
+	"alert_background_color": {
+		"type": "colorchooser",
+		"description": "Background Color",
+		"default": "rgba(255, 165, 0, 1)",
+		"tooltip": "RGB or RGBA"
+	},
+	"alert_border_color": {
+		"type": "colorchooser",
+		"description": "Border Color",
+		"default": "rgba(255, 165, 0, 1)",
+		"tooltip": "RGB or RGBA"
+	},
+	"alert_font_size": {
+		"type": "spinbutton",
+		"default": 95,
+		"min": 0,
+		"max": 200,
+		"step": 5,
+		"units": "%",
+		"description": "Font Size"
+	},
+	"alert_discharging_background_color": {
+		"type": "colorchooser",
+		"description": "Background Color",
+		"default": "rgba(255, 255, 255, 1)",
+		"tooltip": "RGB or RGBA"
+	},
+	"alert_discharging_border_color": {
+		"type": "colorchooser",
+		"description": "Border Color",
+		"default": "rgba(255, 0, 0, 1)",
+		"tooltip": "RGB or RGBA"
+	},
+	"alert_discharging_font_size": {
+		"type": "spinbutton",
+		"default": 95,
+		"min": 0,
+		"max": 200,
+		"step": 5,
+		"units": "%",
+		"description": "Font Size"
+	},
+	"limit_exceeded_background_color": {
+		"type": "colorchooser",
+		"description": "Background Color",
+		"default": "rgba(255, 0, 0, 1)",
+		"tooltip": "RGB or RGBA"
+	},
+	"limit_exceeded_border_color": {
+		"type": "colorchooser",
+		"description": "Border Color",
+		"default": "rgba(255, 0, 0, 0)",
+		"tooltip": "RGB or RGBA"
+	},
+	"limit_exceeded_font_size": {
+		"type": "spinbutton",
+		"default": 95,
+		"min": 0,
+		"max": 200,
+		"step": 5,
+		"units": "%",
+		"description": "Font Size"
+	},
+	"limit_exceeded2_background_color": {
+		"type": "colorchooser",
+		"description": "Background Color",
+		"default": "rgba(255, 255, 255, 1)",
+		"tooltip": "RGB or RGBA"
+	},
+	"limit_exceeded2_border_color": {
+		"type": "colorchooser",
+		"description": "Border Color",
+		"default": "rgba(255, 255, 255, 0)",
+		"tooltip": "RGB or RGBA"
+	},
+	"limit_exceeded2_font_size": {
+		"type": "spinbutton",
+		"default": 95,
+		"min": 0,
+		"max": 200,
+		"step": 5,
+		"units": "%",
+		"description": "Font Size"
+	}
 }

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
@@ -1,270 +1,278 @@
+### 2.2.1
+
+- Added support for multiple alert levels – users can now supply a
+  comma-separated list of battery percentages. Pop‑ups (and optional
+  sounds) are shown each time the level drops below any configured value.
+  The first percentage in the list remains tied to the existing warning
+  colour, the slider control and the old critical calculation.
+
 ### 2.2.0
 
-* Added a label for the applet menu slider
-* Added automatic updating of the applet menu when the slider is adjusted
-* Fixed a rounding bug between the slider and configuration option
-* Fixed a potential display bug when the charging level reached 100%
-* Updated strings
-* Cleaned up metadata and CHANGELOG files
-* Closes #5500
+- Added a label for the applet menu slider
+- Added automatic updating of the applet menu when the slider is adjusted
+- Fixed a rounding bug between the slider and configuration option
+- Fixed a potential display bug when the charging level reached 100%
+- Updated strings
+- Cleaned up metadata and CHANGELOG files
+- Closes #5500
 
 ### 2.1.0
 
-* Modified system calls to use full paths
-* Modified the suspend script to support translatable strings
-* Added support for Zenity 4.x+
+- Modified system calls to use full paths
+- Modified the suspend script to support translatable strings
+- Added support for Zenity 4.x+
 
 ### 2.0.0
 
-* Style options are now managed via the GUI configuration dialog, deprecating
-stylesheet.css
-* Added an optional alert when recharging
-* Added additional options for estimated time to appear in various displays
-* Updated batterymonitor.pot and translation files
-* Added support for Cinnamon 5.8
+- Style options are now managed via the GUI configuration dialog, deprecating
+  stylesheet.css
+- Added an optional alert when recharging
+- Added additional options for estimated time to appear in various displays
+- Updated batterymonitor.pot and translation files
+- Added support for Cinnamon 5.8
 
 ### 1.5.1
 
-* Improved the logic for determining the default kernel path (some systems
-default to BAT1 instead of BAT0)
-  * Fixes "-- Waiting" permanent message and removes the need for manual
-configuration in the single battery condition to address it
+- Improved the logic for determining the default kernel path (some systems
+  default to BAT1 instead of BAT0)
+    - Fixes "-- Waiting" permanent message and removes the need for manual
+      configuration in the single battery condition to address it
 
 ### 1.5.0
 
-* Switched from `upower` to the power status module provided by the kernel at
-/sys/class/power_supply/BAT0 (`upower` updates on a two minute interval while
-the kernel module updates live and the applet supports smaller increments,
-increasing the overall accuracy of the applet.)
-* Added a setting for manual configuration of the system battery path
-* Consolidated changelogs into CHANGELOG.md
-* Formatted .json files to standard JSON schema
-* Cleaned up unneeded legacy files and organized into a consistent versioned
-structure
-* Code comments improved and other comments removed
-* Updated batterymonitor.pot and translation files
-* Renamed ua.po to uk.po (Ukrainian)
-* Fixed file modes
-* Cleaned up whitespace, semicolons, and formatting
-* Cinnamon versions up to 5.6
+- Switched from `upower` to the power status module provided by the kernel at
+  /sys/class/power_supply/BAT0 (`upower` updates on a two minute interval while
+  the kernel module updates live and the applet supports smaller increments,
+  increasing the overall accuracy of the applet.)
+- Added a setting for manual configuration of the system battery path
+- Consolidated changelogs into CHANGELOG.md
+- Formatted .json files to standard JSON schema
+- Cleaned up unneeded legacy files and organized into a consistent versioned
+  structure
+- Code comments improved and other comments removed
+- Updated batterymonitor.pot and translation files
+- Renamed ua.po to uk.po (Ukrainian)
+- Fixed file modes
+- Cleaned up whitespace, semicolons, and formatting
+- Cinnamon versions up to 5.6
 
 ### 1.4.1
 
-* Updates README.md to stress audio file must be .oga mime type
-audio/x-vorbis+ogg
-  * the mime type is crucial to it being recognized by the soundfilechooser
-widget
-* Cinnamon versions up to 5.2
+- Updates README.md to stress audio file must be .oga mime type
+  audio/x-vorbis+ogg
+    - the mime type is crucial to it being recognized by the soundfilechooser
+      widget
+- Cinnamon versions up to 5.2
 
 ### 1.4.0
 
-* Removes dependency on 'batteryscript.sh'.
-  * This script used to write two files on every update, maybe wearing out the
-hard disk.
-  * Now it uses asynchronous calls to execute the `upower` command directly and
-captures its output.
-* Checks for dependency on `upower`
-* Increases maximum refresh interval to 5 min (300 s).
-* Simplification of the logic to select the icon to display.
-* Removes (outdated) 3.2/changelog.txt.
-* Added a button to the configuration box to delete the old temporary files.
-* Updated Cinnamon version to 4.4.
+- Removes dependency on 'batteryscript.sh'.
+    - This script used to write two files on every update, maybe wearing out the
+      hard disk.
+    - Now it uses asynchronous calls to execute the `upower` command directly and
+      captures its output.
+- Checks for dependency on `upower`
+- Increases maximum refresh interval to 5 min (300 s).
+- Simplification of the logic to select the icon to display.
+- Removes (outdated) 3.2/changelog.txt.
+- Added a button to the configuration box to delete the old temporary files.
+- Updated Cinnamon version to 4.4.
 
 ### 1.3.9
 
-* Adds events-sounds property to soundfilechooser widget to allow any sound
-file to be selected under Cinnamon 4.2
-* Adds additional option to inhibit applet notifications when user selected
-audible alert is in use
-  * Closes feature request #2511
+- Adds events-sounds property to soundfilechooser widget to allow any sound
+  file to be selected under Cinnamon 4.2
+- Adds additional option to inhibit applet notifications when user selected
+  audible alert is in use
+    - Closes feature request #2511
 
 ### 1.3.8
 
-* Change location of temporary files to home folder to avoid permissions
-problem when switching users
-* Fixes #2502
+- Change location of temporary files to home folder to avoid permissions
+  problem when switching users
+- Fixes #2502
 
 ### 1.3.7.1
 
-* Change to cinnamon-version in metadata.json to add use under Cinnamon 4.2
+- Change to cinnamon-version in metadata.json to add use under Cinnamon 4.2
 
 ### 1.3.7
 
-* Change to allow Multiversion 3.2
-* Change to allow selection of audible alert file in Applet Settings for 3.2
-and higher.
-  * Puts up warning about high volumes and times in public spaces.
+- Change to allow Multiversion 3.2
+- Change to allow selection of audible alert file in Applet Settings for 3.2
+  and higher.
+    - Puts up warning about high volumes and times in public spaces.
 
 ### 1.3.6
 
-* Translation File update only
+- Translation File update only
 
 ### 1.3.5
 
-* Update stylesheet to better match Cinnamon 4.0 System Styles - less rounded.
-* Add an initial mechanism to provide persistence for user edits of the
-stylesheet.
+- Update stylesheet to better match Cinnamon 4.0 System Styles - less rounded.
+- Add an initial mechanism to provide persistence for user edits of the
+  stylesheet.
 
 ### 1.3.4
 
-* Use ModalDialog.NotifyDialog or main.criticalNotify in place of internal code
-for Alerts
-* Provide option of users sound file called batterymonitorwarning.mp3 in home
-folder
-  * Checks for presence and uses if found otherwise uses default
-  * Puts up warning about high volumes and times in public spaces.
+- Use ModalDialog.NotifyDialog or main.criticalNotify in place of internal code
+  for Alerts
+- Provide option of users sound file called batterymonitorwarning.mp3 in home
+  folder
+    - Checks for presence and uses if found otherwise uses default
+    - Puts up warning about high volumes and times in public spaces.
 
 ### 1.3.3
 
-* Use xdg-open in place of gedit or xed to allow use on more distros
+- Use xdg-open in place of gedit or xed to allow use on more distros
 
 ### 1.3.2.2
 
-* Remove instance of deprecated code giving a harmless warning in
-.xsession-errors.
+- Remove instance of deprecated code giving a harmless warning in
+  .xsession-errors.
 
 ### 1.3.2.1
 
-* Revert change on handling empty battery
+- Revert change on handling empty battery
 
 ### 1.3.2
 
-* Added checks that sox and zenity are installed and warn that full
-functionality is not available without them.
-* Improve handling of completely empty batteries.
-* Update README.md, CHANGELOG.md and metadata.json
-* Update batterymonitor.pot so translations can be updated.
+- Added checks that sox and zenity are installed and warn that full
+  functionality is not available without them.
+- Improve handling of completely empty batteries.
+- Update README.md, CHANGELOG.md and metadata.json
+- Update batterymonitor.pot so translations can be updated.
 
 ### 1.3.1
 
-* Bug Fix for use with early versions of Cinnamon
-* Inhibited use of hide_applet_label() to Cinnamon version 3.2 or higher in
-vertical panels.
-* Corrected Icon Only display mode
+- Bug Fix for use with early versions of Cinnamon
+- Inhibited use of hide_applet_label() to Cinnamon version 3.2 or higher in
+  vertical panels.
+- Corrected Icon Only display mode
 
 ### 1.3.0
 
 Major update - now includes support for Vertical Panels, Battery icons and 5
 Display Modes
 
-* Renamed batterytempscript to batteryscript - cosmetic
-* Change to improved form of l10n support function
-* Code added to allow display on vertical panels and added
-on_orientation_changed function with call to initialise.
-* Options of display of icon and shortening message text with prime aim of
-support of vertical panels
-* Display Modes added to Configuration as Dropdown with 5 types (modes) and
-implemented. Includes a Classic mode which is the same as version 1.2.3 of
-applet.
-* Removed some redundant code still present from earlier versions which
-affected vertical display
-* Code comments improved and some commented out code removed.
-* Update README.md, CHANGELOG.md and metadata.json
-* Recreate batterymonitor.pot to allow translation support to be updated.
+- Renamed batterytempscript to batteryscript - cosmetic
+- Change to improved form of l10n support function
+- Code added to allow display on vertical panels and added
+  on_orientation_changed function with call to initialise.
+- Options of display of icon and shortening message text with prime aim of
+  support of vertical panels
+- Display Modes added to Configuration as Dropdown with 5 types (modes) and
+  implemented. Includes a Classic mode which is the same as version 1.2.3 of
+  applet.
+- Removed some redundant code still present from earlier versions which
+  affected vertical display
+- Code comments improved and some commented out code removed.
+- Update README.md, CHANGELOG.md and metadata.json
+- Recreate batterymonitor.pot to allow translation support to be updated.
 
 ### 1.2.3
 
-* Added CHANGELOG.md to applet folder with symbolic link to it in UUID so it
-shows on latest Cinnamon spices web site.
-* CHANGELOG.md is a simplified and reformatted version of changelog.txt which
-currently remains in applet folder.
-* Changed 'view changelog' in context menu to use CHANGELOG.md
-* Changed to use a symbolic link for README.md
+- Added CHANGELOG.md to applet folder with symbolic link to it in UUID so it
+  shows on latest Cinnamon spices web site.
+- CHANGELOG.md is a simplified and reformatted version of changelog.txt which
+  currently remains in applet folder.
+- Changed 'view changelog' in context menu to use CHANGELOG.md
+- Changed to use a symbolic link for README.md
 
 ### 1.2.2
 
-* Changes to text strings to remove spaces from start and end of strings for
-translation
-* Some extra strings marked for translation
-* Updated batterymonitor.pot
-* Version numbering harmonised with other Cinnamon applets and added to
-metadata.json so it shows in 'About...'
-* icon.png copied back into applet folder so it shows in 'About...'
-* Version information updated in applet.js, changelog.txt and README.md
+- Changes to text strings to remove spaces from start and end of strings for
+  translation
+- Some extra strings marked for translation
+- Updated batterymonitor.pot
+- Version numbering harmonised with other Cinnamon applets and added to
+  metadata.json so it shows in 'About...'
+- icon.png copied back into applet folder so it shows in 'About...'
+- Version information updated in applet.js, changelog.txt and README.md
 
 ### 1.2.1
 
-* First major update following transition to cinnamon-spices-applets repository
-under Cinnamon 3.2
-* Added fixed audible warning at alert stage (requested)
-* Added 'discharging' indication via border colour (requested)
-* Move audible alert from suspendScript to applet
-* Added translation support to applet.js and identified strings
-* Added `po` folder to applet
-* Created batterymonitor.pot using cinnamon-json-makepot --js
-po/batterymonitor.pot
-* Updated documentation and tidied comments in applet
+- First major update following transition to cinnamon-spices-applets repository
+  under Cinnamon 3.2
+- Added fixed audible warning at alert stage (requested)
+- Added 'discharging' indication via border colour (requested)
+- Move audible alert from suspendScript to applet
+- Added translation support to applet.js and identified strings
+- Added `po` folder to applet
+- Created batterymonitor.pot using cinnamon-json-makepot --js
+  po/batterymonitor.pot
+- Updated documentation and tidied comments in applet
 
 ### 1.2.0
 
-* Initial transition to new cinnamon-spices-applets repository from
-github.com/pdcurtis/cinnamon-applets
-* Changed help file from help.txt to README.md, updated and put copy in UUID.
+- Initial transition to new cinnamon-spices-applets repository from
+  github.com/pdcurtis/cinnamon-applets
+- Changed help file from help.txt to README.md, updated and put copy in UUID.
 
 ### 1.1.9
 
-* Released 17-09-2016
-* Added ability to edit stylesheet.css to context menu.
-* Added warnings about editing to stylesheet.css
+- Released 17-09-2016
+- Added ability to edit stylesheet.css to context menu.
+- Added warnings about editing to stylesheet.css
 
 ### 1.1.8
 
-* Released 01-08-2016
-* Corrected icon.png in applet folder which is used by Add Applets
+- Released 01-08-2016
+- Corrected icon.png in applet folder which is used by Add Applets
 
 ### 1.1.7
 
-* No code change, just re-packaging and re-uploading to fix 1.1.5 deployment
+- No code change, just re-packaging and re-uploading to fix 1.1.5 deployment
 
 ### 1.1.6
 
-* No code change, just re-packaging and re-uploading to fix 1.1.5 deployment
+- No code change, just re-packaging and re-uploading to fix 1.1.5 deployment
 
 ### 1.1.5
 
-* Initial Release 16-07-2016
-* Minor text changes to improve consistency.
+- Initial Release 16-07-2016
+- Minor text changes to improve consistency.
 
 ### 1.1.4
 
-* Old call removed from batterytempscript.sh which was filling error log
-* Error checks on status to ensure valid
-* Spelling corrections
-* Help File extended
+- Old call removed from batterytempscript.sh which was filling error log
+- Error checks on status to ensure valid
+- Spelling corrections
+- Help File extended
 
 ### 1.1.3
 
-* Added Modal Dialog tripped once at Alert Level and reset by going back above
-alert level
-* Shutdown (Suspend) now at 2/3 of Alert Level
-* Suspend level added to tooltip and left click menu
-* TEST CODE REMOVED
+- Added Modal Dialog tripped once at Alert Level and reset by going back above
+  alert level
+- Shutdown (Suspend) now at 2/3 of Alert Level
+- Suspend level added to tooltip and left click menu
+- TEST CODE REMOVED
 
 ### 1.1.2
 
-* Some changes in how test are applied to make it easier to take them out
-* Extra flag added for flashing
-* Range changed to 10 -> 40 for Alert Percentage
-* Tests look good and suspendscript works
-* TEST CODE STILL IN PLACE
-* Should I add a forced shutdown if level drops to say 5% because taken out of
-suspend with level dropped too far or suspend cancelled too many times?
+- Some changes in how test are applied to make it easier to take them out
+- Extra flag added for flashing
+- Range changed to 10 -> 40 for Alert Percentage
+- Tests look good and suspendscript works
+- TEST CODE STILL IN PLACE
+- Should I add a forced shutdown if level drops to say 5% because taken out of
+  suspend with level dropped too far or suspend cancelled too many times?
 
 ### 1.0.1
 
-* Code added to ensure valid readings of batteryPercentage
-* Code added to 'flash' messages  and extend width with messages but only when
-discharging.
-* Code added to call Suspend script but only when percentage has fallen (i.e.
-it will be called every 1% fall so it is re-enabled after returning from suspend)
-* Suspendscript active
-* TEST CODE STILL IN PLACE so levels incorrect
+- Code added to ensure valid readings of batteryPercentage
+- Code added to 'flash' messages and extend width with messages but only when
+  discharging.
+- Code added to call Suspend script but only when percentage has fallen (i.e.
+  it will be called every 1% fall so it is re-enabled after returning from suspend)
+- Suspendscript active
+- TEST CODE STILL IN PLACE so levels incorrect
 
 ### 1.0.0
 
-* Developed using code from NUMA, Bumblebee and Timer Applets
-* Includes changes to work with Mint 18 and Cinnamon 3.0 (gedit -> xed)
-* Tested with Cinnamon 3.0 in Mint 18 and Cinnamon 2.4 in Mint 17.1
-* TEST CODE IN PLACE namely batteryPercentage divided by 4 to allow testing
-* Test Version without call to suspendScript
-* Beautified
+- Developed using code from NUMA, Bumblebee and Timer Applets
+- Includes changes to work with Mint 18 and Cinnamon 3.0 (gedit -> xed)
+- Tested with Cinnamon 3.0 in Mint 18 and Cinnamon 2.4 in Mint 17.1
+- TEST CODE IN PLACE namely batteryPercentage divided by 4 to allow testing
+- Test Version without call to suspendScript
+- Beautified


### PR DESCRIPTION
- Introduced a new configuration option to allow users to specify a comma-separated list of battery percentages for alerts.
- The first percentage in the list is linked to the existing warning color and slider control.
- Updated settings schema to include the new alertPercentages field.
- Enhanced the CHANGELOG to reflect the new feature and its implications.

https://github.com/linuxmint/cinnamon-spices-applets/issues/8240