### PR TITLE
[updates-notifier@zamszowy] add support for pkgcli/pkgctl

### DIFF
--- a/updates-notifier@zamszowy/README.md
+++ b/updates-notifier@zamszowy/README.md
@@ -1,7 +1,7 @@
 # updates notifier
 
 This applet monitors and refreshes (via configurable timeout) available updates
-using pkcon tool and PackageKitGlib package.  
+using pkgcli/pkgctl/pkcon tool and PackageKitGlib package.  
 It also allows refreshing updates, viewing available ones and installing them
 through the popup menu.  
 When viewing updates, all entries are clickable and will open the update
@@ -24,7 +24,7 @@ are waiting for the upgrades.
 
 ## Dependencies
 
-- `pkcon`, `PackageKitGlib`,
+- `pkgcli/pkgctl/pkcon` form `PackageKit` package, `PackageKitGlib`,
 - optional `fwupdmgr` and `jq` for showing available firmware updates
 
 ## Icons

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/applet.js
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/applet.js
@@ -385,7 +385,7 @@ UpdatesNotifier.prototype = {
 
             if (stdout !== '') {
                 this.checkingInProgress = false;
-                global.logError(`${UUID}: pkcon get-updates failed`);
+                global.logError(`${UUID}: getting list of updates failed`);
                 this.hasError = true;
                 this._update();
                 return;

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/info-window.js
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/info-window.js
@@ -46,13 +46,22 @@ function capitalize(str) {
     return str.charAt(0).toLocaleUpperCase() + str.slice(1);
 }
 
-function getPkconDetails(pkgid, callback) {
+function getPkgDetails(pkgid, callback) {
+    let pkg_cmd = [];
+    if (GLib.find_program_in_path("pkgcli")) {
+        pkg_cmd = ["pkgcli", "show-update", pkgid];
+    } else if (GLib.find_program_in_path("pkgctl")) {
+        pkg_cmd = ["pkgctl", "show-update", pkgid];
+    } else {
+        pkg_cmd = ["pkcon", "get-update-detail", pkgid];
+    }
+
     let launcher = new Gio.SubprocessLauncher({
         flags: Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
     });
     launcher.setenv("LANG", "en_US.UTF-8", true);
     try {
-        let subprocess = launcher.spawnv(["pkcon", "get-update-detail", pkgid]);
+        let subprocess = launcher.spawnv(pkg_cmd);
         subprocess.communicate_utf8_async(null, null, (proc, res) => {
             let [ok, stdout, stderr] = proc.communicate_utf8_finish(res);
             if (ok) {
@@ -147,7 +156,7 @@ function showDetails(item) {
     };
 
     if (!isFirmware) {
-        getPkconDetails(item.values.pkgid, setText);
+        getPkgDetails(item.values.pkgid, setText);
     } else {
         getFirmwareDetails(item.values.deviceid, setText)
     }

--- a/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
+++ b/updates-notifier@zamszowy/files/updates-notifier@zamszowy/metadata.json
@@ -2,5 +2,5 @@
     "uuid": "updates-notifier@zamszowy",
     "name": "Updates notifier",
     "description": "Shows icons for pending update packages",
-    "version": "2.3.1"
+    "version": "2.3.2"
 }


### PR DESCRIPTION
With the latest Debian PackageKit package, `pkcon` is no longer shipped.