### PR TITLE
Sensors v5.10.7: Avoids errors using Gentoo

### DIFF
--- a/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
+++ b/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v5.10.7~20260314
+  * Avoid errors using Gentoo.
+  * Gentoo users must install all dependencies themselves. Please refer to the README file.
+
 ### v5.10.6~20260304
   * Added option: Separator Color.
 

--- a/Sensors@claudiux/files/Sensors@claudiux/lib/checkDependencies.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/lib/checkDependencies.js
@@ -118,7 +118,8 @@ var DEPENDENCIES = {
   "openSUSE": [
     ["sensors", "/usr/bin/sensors",  "sensors"],
     ["smartctl", "/usr/sbin/smartctl", "smartmontools"]
-  ]
+  ],
+  "gentoo": []
 }
 
 
@@ -145,8 +146,8 @@ const UPDATE = {
   "debian": "apt-get update",
   "devuan": "apt-get update",
   "fedora": "sudo dnf update",
-  "openSUSE": ""//,
-  //"gentoo": "emerge --sync"
+  "openSUSE": "",
+  "gentoo": ""
 }
 
 const INSTALL = {
@@ -155,7 +156,8 @@ const INSTALL = {
   "debian": "apt-get install",
   "devuan": "apt-get install",
   "fedora": "sudo dnf install",
-  "openSUSE": "sudo zypper --non-interactive install"
+  "openSUSE": "sudo zypper --non-interactive install",
+  "gentoo": ""
 }
 
 //const HOME_DIR = GLib.get_home_dir();

--- a/Sensors@claudiux/files/Sensors@claudiux/metadata.json
+++ b/Sensors@claudiux/files/Sensors@claudiux/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "Sensors@claudiux",
   "name": "Sensors Monitor",
   "description": "Displays the values of many computer sensors concerning Temperatures (CPU - GPU - Power Supply), Fan Speed, Voltages, Intrusions. Notifies you with color changes when a value reaches or exceeds its limit.",
-  "version": "5.10.6",
+  "version": "5.10.7",
   "max-instances": 1,
   "cinnamon-version": [
     "3.8",


### PR DESCRIPTION
Fixes #8427.