### PR TITLE
window-closer@stefan-schmidbauer: fix author field to use GitHub username

### DIFF
--- a/window-closer@stefan-schmidbauer/files/window-closer@stefan-schmidbauer/metadata.json
+++ b/window-closer@stefan-schmidbauer/files/window-closer@stefan-schmidbauer/metadata.json
@@ -2,9 +2,9 @@
     "uuid": "window-closer@stefan-schmidbauer",
     "name": "Window Closer",
     "description": "Click to see all open windows. Click a window to close it.",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "cinnamon-version": ["5.4", "5.6", "5.8", "6.0", "6.2"],
     "max-instances": 1,
-    "author": "Stefan Schmidbauer",
+    "author": "Stefan-Schmidbauer",
     "website": "https://github.com/Stefan-Schmidbauer/cinnamon-window-closer"
 }

--- a/window-closer@stefan-schmidbauer/files/window-closer@stefan-schmidbauer/po/window-closer@stefan-schmidbauer.pot
+++ b/window-closer@stefan-schmidbauer/files/window-closer@stefan-schmidbauer/po/window-closer@stefan-schmidbauer.pot
@@ -4,9 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: window-closer@stefan-schmidbauer 1.0.1\n"
+"Project-Id-Version: window-closer@stefan-schmidbauer 1.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/Stefan-Schmidbauer/cinnamon-window-closer/issues\n"
-"POT-Creation-Date: 2026-04-10 18:30+0200\n"
+"POT-Creation-Date: 2026-04-10 18:56+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language-Team: \n"

--- a/window-closer@stefan-schmidbauer/info.json
+++ b/window-closer@stefan-schmidbauer/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "Stefan Schmidbauer",
+    "author": "Stefan-Schmidbauer",
     "description": "A visual window manager applet. Click the panel icon to open a fullscreen overlay showing all open windows as cards with live thumbnails. Click any card to close that window instantly. The overlay stays open so you can close multiple windows in a row.",
     "website": "https://github.com/Stefan-Schmidbauer/cinnamon-window-closer"
 }


### PR DESCRIPTION
The `author` field in `info.json` and `metadata.json` used the display name instead of the GitHub username, causing the Spices website to generate an incorrect profile link.

Changed `"Stefan Schmidbauer"` → `"Stefan-Schmidbauer"` in both files.