### PR TITLE
[better-backgrounds@simonmicro] Remove obsolete sources

### DIFF
--- a/better-backgrounds@simonmicro/README.md
+++ b/better-backgrounds@simonmicro/README.md
@@ -1,10 +1,5 @@
 # Better Backgrounds for Cinnamon #
 
-![repo-size](https://img.shields.io/github/repo-size/simonmicro/better-backgrounds)
-![issue-count](https://img.shields.io/github/issues/simonmicro/better-backgrounds)
-![latest-commit](https://img.shields.io/github/last-commit/simonmicro/better-backgrounds)
-![license](https://img.shields.io/github/license/simonmicro/better-backgrounds)
-
 A Cinnamon desktop applet to change your wallpaper to random images from many customizable sources and also some effects from ImageMagick.
 
 ## Currently supported sources ##
@@ -12,8 +7,6 @@ A Cinnamon desktop applet to change your wallpaper to random images from many cu
 * [Bing](https://www.bing.com/) (no resolution modifiers available)
 * [Himawari 8](https://himawari8.nict.go.jp/) (live earth wallpaper)
 * [Picsum Photos](https://picsum.photos/)
-* [PlaceKitten](http://placekitten.com/) (does not really respect resolution modifiers)
-* [Unsplash](https://unsplash.com/) (random photos with tags)
 * Websites (page is rendered as screenshot by [cutycapt](http://cutycapt.sourceforge.net/))
 
 ## Known issues ##

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/applet.js
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/applet.js
@@ -4,7 +4,7 @@ const Soup = imports.gi.Soup;
 const ByteArray = imports.byteArray;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
-const Tweener = imports.ui.tweener;
+const Clutter = imports.gi.Clutter;
 const PopupMenu = imports.ui.popupMenu;
 
 const uuid = "better-backgrounds@simonmicro";
@@ -14,7 +14,7 @@ function log(msg) {
     global.log('[' + uuid + '] ' + msg);
 };
 
-class UnsplashBackgroundApplet extends Applet.TextIconApplet {
+class BetterBackgroundsApplet extends Applet.TextIconApplet {
     constructor(orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 
@@ -24,12 +24,12 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
         this.menuManager.addMenu(this.menu);
         this.paused = false;
         this.menuSwtchPaused = new PopupMenu.PopupSwitchMenuItem('Pause all change triggers', this.paused);
-        this.menuSwtchPaused.connect('toggled', imports.lang.bind(this, this._toggle_paused));
+        this.menuSwtchPaused.connect('toggled', this._toggle_paused.bind(this));
         this.menu.addMenuItem(this.menuSwtchPaused);
         this.menuBtnChangeBack = new PopupMenu.PopupMenuItem('Change background now');
         this.menuBtnSavePic = new PopupMenu.PopupMenuItem('Save current background');
-        this.menuBtnChangeBack.connect('activate', imports.lang.bind(this, this._change_background));
-        this.menuBtnSavePic.connect('activate', imports.lang.bind(this, this._store_background));
+        this.menuBtnChangeBack.connect('activate', this._change_background.bind(this));
+        this.menuBtnSavePic.connect('activate', this._store_background.bind(this));
         this.menu.addMenuItem(this.menuBtnChangeBack);
         this.menu.addMenuItem(this.menuBtnSavePic);
 
@@ -49,8 +49,6 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
         this.settings.bind("image-res-height", "image_res_height", this.on_settings_changed);
         this.settings.bind("image-res-himawari", "image_res_himawari", this.on_settings_changed);
         this.settings.bind("image-uri", "image_uri", this.on_settings_changed);
-        this.settings.bind("image-tag", "image_tag", this.on_settings_changed);
-        this.settings.bind("image-tag-data", "image_tag_data", this.on_settings_changed);
 
         this.set_applet_icon_name("applet");
         this._applet_icon.set_pivot_point(0.5, 0.5);
@@ -60,8 +58,7 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
         } else { //version 3
             this.httpAsyncSession = new Soup.Session();
         }
-        this.swapChainSwapped = false;
-        
+
         const defaultSavePath = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES) + '/';
         if(this.applet_save_location == '')
             //Default path is the users picture dir
@@ -93,7 +90,7 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
 
     _timeout_enable() {
         this._timeout_disable();
-        this._timeout = imports.mainloop.timeout_add_seconds(this.change_time * 60, imports.lang.bind(this, this._auto_change_background));
+        this._timeout = imports.mainloop.timeout_add_seconds(this.change_time * 60, this._auto_change_background.bind(this));
     }
 
     _toggle_paused() {
@@ -102,21 +99,21 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
     }
 
     _set_icon_rotation(newValue, seconds) {
-        if(this.applet_icon_animation)
-            Tweener.addTween(this._applet_icon, {
-                'rotation-angle-z': newValue,
-//                skipUpdates: 4, //Only render every 4th frame - this does sadly not improve the cpu usage...
-                time: seconds,
-                transition: 'easeInOutQuad'
-            });
+        if (this.applet_icon_animation) {
+        this._applet_icon.ease({
+            rotation_angle_z: newValue,
+            duration: seconds * 1000,
+            mode: Clutter.AnimationMode.EASE_IN_OUT_QUAD,
+        });
+    }
     }
 
     _icon_animate() {
-        this._set_icon_rotation(0, 0);
+        this._applet_icon.rotation_angle_z = 0;
         this._set_icon_rotation(360, 2);
 
         //And queue next step...
-        this._animator = imports.mainloop.timeout_add_seconds(2.5, imports.lang.bind(this, this._icon_animate));
+        this._animator = imports.mainloop.timeout_add_seconds(2.5, this._icon_animate.bind(this));
     }
 
     _icon_start() {
@@ -200,7 +197,7 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
                     tileId++;
                     that.set_applet_label(Math.floor(tileId / (zoomLvl * zoomLvl) * 100) + '%');
                     that._download_image('https://himawari8-dl.nict.go.jp/himawari8/img/D531106/' +
-                        zoomLvl + 'd/550/' + latestDate.getFullYear() + '/' + ('0' + (latestDate.getMonth() + 1)).slice(-2) + 
+                        zoomLvl + 'd/550/' + latestDate.getFullYear() + '/' + ('0' + (latestDate.getMonth() + 1)).slice(-2) +
                         '/' + ('0' + latestDate.getDate()).slice(-2) + '/' + ('0' + latestDate.getHours()).slice(-2) +
                         ('0' + latestDate.getMinutes()).slice(-2) + ('0' + latestDate.getSeconds()).slice(-2) + '_' +
                         y + '_' + x + '.png', tileName)
@@ -236,7 +233,7 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
                 }
                 downloadTiles();
             }
-            
+
             let request = Soup.Message.new('GET', 'https://himawari8-dl.nict.go.jp/himawari8/img/D531106/latest.json');
             if (Soup.MAJOR_VERSION === 2) {
                 this.httpAsyncSession.queue_message(request, function(http, msg) {
@@ -256,19 +253,6 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
                     }
                 });
             }
-        } else if(this.image_source == 'unsplash') {
-            let resStr = 'featured';
-            if(this.image_res_manual)
-                resStr = this.image_res_width + 'x' + this.image_res_height;
-            let tagStr = '';
-            if(this.image_tag)
-                tagStr = '?' + this.image_tag_data;
-            this._download_image('https://source.unsplash.com/' + resStr + '/' + tagStr).then(defaultEnd).catch(errorEnd);
-        } else if(this.image_source == 'placekitten') {
-            let resStr = '1920/1080';
-            if(this.image_res_manual)
-                resStr = this.image_res_width + '/' + this.image_res_height;
-            this._download_image('http://placekitten.com/' + resStr).then(defaultEnd).catch(errorEnd);
         } else if(this.image_source == 'picsum') {
             let resStr = '1920/1080';
             if(this.image_res_manual)
@@ -293,13 +277,10 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
     }
 
     _store_background() {
-        let targetPath = Math.floor(Math.random() * 899999 + 100000) + '.png'; //Random int between 100000 and 999999
-        if(this.applet_save_location.startsWith('file://'))
-            //Strip the "file://" prefix
-            targetPath = this.applet_save_location.substr(7) + '/' + targetPath
-        else 
-            targetPath = this.applet_save_location + '/' + targetPath
-    
+        let fileName = "bg_" + Date.now() + ".png";
+        let baseDir = this.applet_save_location.replace('file://', '');
+        let targetPath = baseDir + '/' + fileName;
+
         //Copy the background to users picture folder with random name and show the stored notification
         var that = this;
         this._run_cmd(['convert', this._get_swap_chain_image_current(), '-write', targetPath]).then(function() {
@@ -320,8 +301,13 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
     }
 
     _swap_chain_image_swap() {
-        //Replace current with next
-        this._run_cmd(['mv', this._get_swap_chain_image_next(), this._get_swap_chain_image_current()]);
+        let source = Gio.File.new_for_path(this._get_swap_chain_image_next());
+        let dest = Gio.File.new_for_path(this._get_swap_chain_image_current());
+        try {
+            source.move(dest, Gio.FileCopyFlags.OVERWRITE, null, null);
+        } catch (e) {
+            log("Failed to move file: " + e.message);
+        }
     }
 
     _apply_image() {
@@ -428,5 +414,5 @@ class UnsplashBackgroundApplet extends Applet.TextIconApplet {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    return new UnsplashBackgroundApplet(orientation, panel_height, instance_id);
+    return new BetterBackgroundsApplet(orientation, panel_height, instance_id);
 }

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/metadata.json
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/metadata.json
@@ -1,6 +1,6 @@
 {
     "uuid": "better-backgrounds@simonmicro",
     "name": "Better Backgrounds",
-    "description": "Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, Unsplash.com or even whole websites - specify search tags, triggers and more!",
+    "description": "Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole websites",
     "max-instances": "-1"
 }

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/better-backgrounds@simonmicro.pot
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/better-backgrounds@simonmicro.pot
@@ -1,17 +1,17 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# BETTER BACKGROUNDS
+# This file is put in the public domain.
+# simonmicro, 2020
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: better-backgrounds@simonmicro 1.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,9 +23,8 @@ msgstr ""
 
 #. metadata.json->description
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com,"
-" Unsplash.com or even whole websites - specify search tags, triggers and "
-"more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 
 #. settings-schema.json->pageBehaviour->title
@@ -43,8 +42,6 @@ msgstr ""
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -67,10 +64,6 @@ msgstr ""
 msgid "Triggers"
 msgstr ""
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr ""
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr ""
@@ -89,13 +82,6 @@ msgstr ""
 
 #. settings-schema.json->applet-show-notification->tooltip
 msgid "Bad network? Faulty setup? The applet will notify you. Every time."
-msgstr ""
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
 msgstr ""
 
 #. settings-schema.json->applet-store-location->description
@@ -176,7 +162,7 @@ msgid "None"
 msgstr ""
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+msgid "Image Source"
 msgstr ""
 
 #. settings-schema.json->image-source->options
@@ -192,15 +178,7 @@ msgid "Himawari 8"
 msgstr ""
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr ""
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
-msgstr ""
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
 msgstr ""
 
 #. settings-schema.json->source-supports-info->description
@@ -219,13 +197,6 @@ msgstr ""
 msgid ""
 "This feature uses the command 'montage' from the package 'imagemagick'. "
 "Please make sure this package or command is installed."
-msgstr ""
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
 msgstr ""
 
 #. settings-schema.json->image-res-manual->description
@@ -255,19 +226,11 @@ msgstr ""
 msgid "Height"
 msgstr ""
 
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr ""
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr ""
-
 #. settings-schema.json->image-res-himawari->description
 msgid ""
 "Image zoom factor - this factor times the tile size (550 pixels) equals the "
-"image resolution. So e.g. the factor '4x' would result in a 2200x2200 pixels"
-" image. Please note that factor² much tiles will be temporarly downloaded."
+"image resolution. So e.g. the factor '4x' would result in a 2200x2200 pixels "
+"image. Please note that factor² much tiles will be temporarly downloaded."
 msgstr ""
 
 #. settings-schema.json->image-res-himawari->options
@@ -292,22 +255,6 @@ msgstr ""
 
 #. settings-schema.json->image-res-unsupported->description
 msgid "Sorry, the selected source does not support resolution modifiers."
-msgstr ""
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the"
-" tags are understood as AND - not as OR! A valid search term could be "
-"'nature,water'..."
-msgstr ""
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr ""
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
 msgstr ""
 
 #. settings-schema.json->image-align-info->description

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/ca.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/ca.po
@@ -1,14 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2024-07-21 02:41+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -23,12 +24,13 @@ msgid "Better Backgrounds"
 msgstr "Millors Fons"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com or even whole websites - specify search tags, triggers and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
-"Aplica fons de pantalla nous de Bing, Himawari 8, Picsum Photos, PlaceKitten."
-"com, Unsplash.com o altres llocs web!"
+"Aplica fons de pantalla nous de Bing, Himawari 8, Picsum Photos, "
+"PlaceKitten.com, Unsplash.com o altres llocs web!"
 
 #. settings-schema.json->pageBehaviour->title
 msgid "Behaviour"
@@ -45,8 +47,6 @@ msgstr "Origen"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -68,10 +68,6 @@ msgstr "Efectes d'imatge"
 #. settings-schema.json->changeon->title
 msgid "Triggers"
 msgstr "Triggers"
-
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Tags"
 
 #. settings-schema.json->imageapply->title
 msgid "Apply"
@@ -96,15 +92,6 @@ msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr ""
 "Xarxa limitada? Error en la configuració o l'arranc? La miniaplicació us ho "
 "notificarà cada vegada."
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"Heu trobat un error o voleu sol·licitar funcionalitats extra? Reviseu el "
-"codi a Github https://github.com/simonmicro/better-backgrounds !"
 
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
@@ -190,7 +177,8 @@ msgid "None"
 msgstr "Cap"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Origen de la imatge"
 
 #. settings-schema.json->image-source->options
@@ -206,16 +194,8 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Picsum Photos"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
@@ -240,16 +220,6 @@ msgid ""
 msgstr ""
 "Aquesta funcionalitat utilitza l'ordre 'montage' del paquet 'imagemagick'. "
 "Assegureu-vos que està instal·lat."
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Aquest origen pot causar problemes durant hores d'alta demanada. Tingueu "
-"paciència i proveu-ho de nou més tard si experimenteu problemes. Més "
-"informació a https://status.unsplash.com/"
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -279,14 +249,6 @@ msgstr "píxels"
 #. settings-schema.json->image-res-height->description
 msgid "Height"
 msgstr "Alçada"
-
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Utilitzar etiquetes de cerca personalitzades"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Especifiqueu etiquetes personalitzades per a buscar..."
 
 #. settings-schema.json->image-res-himawari->description
 msgid ""
@@ -318,25 +280,6 @@ msgstr "20x"
 #. settings-schema.json->image-res-unsupported->description
 msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr "L'origen seleccionat no suporta modificadors de resolució."
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the "
-"tags are understood as AND - not as OR! A valid search term could be 'nature,"
-"water'..."
-msgstr ""
-"Si us plau, trieu una etiqueta disponible o el fons de pantalla no podrà ser "
-"canviat! Separeu les etiquetes per comes. Un exemple de terme de cerca vàlid "
-"podria ser 'natura,aigua'..."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Etiquetes de cerca"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Introduïu els vostres filtres de temes"
 
 #. settings-schema.json->image-align-info->description
 msgid ""

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/da.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/da.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2023-12-28 15:26+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -23,9 +24,10 @@ msgid "Better Backgrounds"
 msgstr "Bedr skrivebordsbaggrunde"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com or even whole websites - specify search tags, triggers and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "Anvend nye skrivebordsbaggrunde fra Bing, Himawari 8, Picsum Photos, "
 "PlaceKitten.com, Unsplash.com eller endda hele hjemmesider. Angiv "
@@ -46,8 +48,6 @@ msgstr "Kilde"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -70,10 +70,6 @@ msgstr "Billedeffekter"
 msgid "Triggers"
 msgstr "Udløsere"
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Mærkater"
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr "Anvend"
@@ -95,15 +91,6 @@ msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr ""
 "Dårligt netværk? Fejl i opsætningen? Panelprogrammet vil underrette dig. "
 "Hver gang."
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"Har du fundet en fejl, eller vil du foreslå en manglende funktion? Bare tjek "
-"kildekoden på Github (https://github.com/simonmicro/better-backgrounds)!"
 
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
@@ -194,7 +181,8 @@ msgid "None"
 msgstr "Ingen"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Billedkilde"
 
 #. settings-schema.json->image-source->options
@@ -210,16 +198,8 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Picsum Photos"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
@@ -242,16 +222,6 @@ msgid ""
 msgstr ""
 "Denne funktion bruger kommandoen “montage” fra pakken “imagemagick”. Sørg "
 "for, at denne pakke er installeret."
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Denne kilde er kendt for at forårsage problemer, især i perioder med stor "
-"efterspørgsel. Vær tålmodig og prøv igen senere, hvis du oplever problemer. "
-"Du kan finde flere oplysninger på: https://status.unsplash.com/."
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -281,14 +251,6 @@ msgstr "pixels"
 #. settings-schema.json->image-res-height->description
 msgid "Height"
 msgstr "Højde"
-
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Brug egne søgemærkater"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Angive egne mærkater, der skal søges efter."
 
 #. settings-schema.json->image-res-himawari->description
 msgid ""
@@ -324,26 +286,6 @@ msgstr "20x"
 #. settings-schema.json->image-res-unsupported->description
 msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr "Beklager, den valgte kilde understøtter ikke opløsningsfaktorer."
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the "
-"tags are understood as AND - not as OR! A valid search term could be 'nature,"
-"water'..."
-msgstr ""
-"Sørg for at vælge et tilgængeligt mærkat, ellers kan skrivebordsbaggrunden "
-"ikke ændres! Sørg for at adskille mærkater med et “,” og ikke mellemrum, og "
-"flere mærkater sammen forstås som OG - ikke som ELLER! Et gyldigt søgeord "
-"kunne være “nature,water”."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Søgemærkater"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Indtast dit emnefilter"
 
 #. settings-schema.json->image-align-info->description
 msgid ""

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/es.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/es.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2023-12-08 19:21-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,9 +23,10 @@ msgid "Better Backgrounds"
 msgstr "Mejores fondos"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com or even whole websites - specify search tags, triggers and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "Aplique nuevos fondos de Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
 "Unsplash.com o incluso sitios web completos: especifique etiquetas de "
@@ -45,8 +47,6 @@ msgstr "Fuente"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -69,10 +69,6 @@ msgstr "Efectos de imagen"
 msgid "Triggers"
 msgstr "Activadores"
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Etiquetas"
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr "Aplicar"
@@ -94,15 +90,6 @@ msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr ""
 "¿Problemas con la red? ¿Una configuración defectuosa? El applet se lo "
 "notificará. Siempre."
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"¿Ha encontrado un error o quiere sugerir una función que falte? Consulte el "
-"código fuente en https://github.com/simonmicro/better-backgrounds en Github!"
 
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
@@ -190,7 +177,8 @@ msgid "None"
 msgstr "Ninguno"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Fuente de la imagen"
 
 #. settings-schema.json->image-source->options
@@ -206,16 +194,8 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Picsum Photos"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
@@ -240,16 +220,6 @@ msgid ""
 msgstr ""
 "Esta función utiliza el comando 'montage' del paquete 'imagemagick'. "
 "Asegúrese de que este paquete o comando esté instalado."
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Se sabe que esta fuente causa problemas, especialmente en épocas de gran "
-"demanda. Por favor, sea paciente y vuelva a intentarlo más tarde si "
-"experimenta problemas. Más información en: https://status.unsplash.com/"
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -279,14 +249,6 @@ msgstr "pixeles"
 #. settings-schema.json->image-res-height->description
 msgid "Height"
 msgstr "Alto"
-
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Utilizar etiquetas de búsqueda propias"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Especifique etiquetas propias para buscar..."
 
 #. settings-schema.json->image-res-himawari->description
 msgid ""
@@ -323,26 +285,6 @@ msgstr "20x"
 msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr ""
 "Lo sentimos, la fuente seleccionada no admite modificadores de resolución."
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the "
-"tags are understood as AND - not as OR! A valid search term could be 'nature,"
-"water'..."
-msgstr ""
-"Asegúrese de elegir una etiqueta disponible; de lo contrario, el fondo no se "
-"podrá cambiar. Asegúrese de separar las etiquetas con un ',' y no con "
-"espacios. Además, las etiquetas se entienden como Y, no como O. Un término "
-"de búsqueda válido podría ser 'naturaleza,agua'..."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Buscar etiquetas"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Introduzca sus filtros temáticos"
 
 #. settings-schema.json->image-align-info->description
 msgid ""

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/fi.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/fi.po
@@ -1,31 +1,33 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-28 20:26+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2023-12-11 14:35+0200\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
 #. metadata.json->name
 msgid "Better Backgrounds"
 msgstr "Better Backgrounds"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com or even whole websites - specify search tags, triggers and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "Käytä uusia taustakuvia Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
 "Unsplash.com tai jopa verkkosivuilta – määritä hakuun tunnisteet, "
@@ -46,8 +48,6 @@ msgstr "Lähde"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -70,10 +70,6 @@ msgstr "Kuvatehosteet"
 msgid "Triggers"
 msgstr "Käynnistimet"
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Tagit"
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr "Käytä"
@@ -95,15 +91,6 @@ msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr ""
 "Huono nettiyhteys? Virheellinen asetus? Sovelma ilmoittaa sinulle niistä "
 "joka kerta."
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"Löysitkö virheen tai ehdottaa puuttuvaa ominaisuutta? Lähdekoodi https://"
-"github.com/simonmicro/better-backgrounds on nähtävillä Github:ssa!"
 
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
@@ -189,7 +176,8 @@ msgid "None"
 msgstr "Ei mitään"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Kuva tulee lähteestä"
 
 #. settings-schema.json->image-source->options
@@ -205,16 +193,8 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Picsum Photos"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
@@ -239,16 +219,6 @@ msgid ""
 msgstr ""
 "Tämä ominaisuus käyttää komentoa \"montage\" paketista \"imagemagick\". "
 "Varmista, että tämä paketti tai komento on asennettu."
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Tämän lähde ei aina toimi, etenkin suuren kysynnän aikana. Ole kärsivällinen "
-"ja yritä uudelleen. Jos kohtaat jatkuvasti ongelmia, lisätietoja löytyy "
-"osoitteesta: https://status.unsplash.com/"
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -278,14 +248,6 @@ msgstr "pikseliä"
 #. settings-schema.json->image-res-height->description
 msgid "Height"
 msgstr "Korkeus"
-
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Käytä omia tunnisteita kuvien hakemiseen"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Määritä omat tunnisteet eli hakusanat hakuun..."
 
 #. settings-schema.json->image-res-himawari->description
 msgid ""
@@ -320,25 +282,6 @@ msgstr "20x"
 #. settings-schema.json->image-res-unsupported->description
 msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr "Valittu lähde ei valitettavasti tue resoluution muokkaamista."
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the "
-"tags are understood as AND - not as OR! A valid search term could be 'nature,"
-"water'..."
-msgstr ""
-"Valitse saatavilla oleva nimi tunniste, muuten taustaa ei muutu! Erota "
-"tunnisteet pilkulla, älä välilyönnillä. Tunnisteet ymmärretään myös AND - "
-"mutta ei OR! Hakutermi voisi olla \"nature,water\"..."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Haku tunnisteilla"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Anna suodattimeen aihe kuten nature space green"
 
 #. settings-schema.json->image-align-info->description
 msgid ""

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/fr.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/fr.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2023-12-25 14:05+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -23,9 +24,10 @@ msgid "Better Backgrounds"
 msgstr "Meilleurs fonds d'écrans"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com or even whole websites - specify search tags, triggers and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "Appliquez de nouveaux fonds d'écran à partir de Bing, Himawari 8, Picsum "
 "Photos, PlaceKitten.com, Unsplash.com ou même des sites Web entiers - "
@@ -46,8 +48,6 @@ msgstr "Source"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -70,10 +70,6 @@ msgstr "Effets d'image"
 msgid "Triggers"
 msgstr "Déclencheurs"
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Mots-clés"
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr "Appliquer"
@@ -95,16 +91,6 @@ msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr ""
 "Mauvais réseau ? Configuration défectueuse ? L'applet vous en informera. A "
 "chaque fois."
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"Vous avez trouvé un bug ou vous voulez suggérer une fonctionnalité "
-"manquante ? Consultez le code source à l'adresse https://github.com/"
-"simonmicro/better-backgrounds sur Github !"
 
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
@@ -196,7 +182,8 @@ msgid "None"
 msgstr "Aucun"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Source de l'image"
 
 #. settings-schema.json->image-source->options
@@ -212,16 +199,8 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Picsum Photos"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
@@ -247,18 +226,6 @@ msgstr ""
 "Cette fonctionnalité utilise la commande \"montage\" du paquetage "
 "\"imagemagick\". Veuillez vous assurer que ce paquetage ou cette commande "
 "est installé(e)."
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Cette source est connue pour causer des problèmes, en particulier pendant "
-"les périodes de forte demande. Veuillez faire preuve de patience et "
-"réessayer plus tard si vous rencontrez des problèmes. De plus amples "
-"informations sont disponibles à l'adresse suivante : https://status.unsplash."
-"com/"
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -288,14 +255,6 @@ msgstr "pixels"
 #. settings-schema.json->image-res-height->description
 msgid "Height"
 msgstr "Hauteur"
-
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Utiliser vos propres mots-clé de recherche"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Précisez vos propres mots-clé de recherche."
 
 #. settings-schema.json->image-res-himawari->description
 msgid ""
@@ -333,26 +292,6 @@ msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr ""
 "Désolé, la source sélectionnée ne prend pas en charge les modificateurs de "
 "résolution."
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the "
-"tags are understood as AND - not as OR! A valid search term could be 'nature,"
-"water'..."
-msgstr ""
-"Veillez à choisir une balise disponible, sinon l'arrière-plan ne pourra pas "
-"être modifié ! Veillez à séparer les balises par un ',' et non par des "
-"espaces. Les balises sont également comprises comme AND - et non comme OR ! "
-"Un terme de recherche valide pourrait être 'nature,eau'..."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Mots-clé de recherche"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Saisissez vos filtres thématiques"
 
 #. settings-schema.json->image-align-info->description
 msgid ""

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/hu.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/hu.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2023-12-13 16:40+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -23,9 +24,10 @@ msgid "Better Backgrounds"
 msgstr "Jobb hátterek"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com or even whole websites - specify search tags, triggers and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "Alkalmazzon új háttereket a Bing, a Himawari 8, a Picsum Photos, a "
 "PlaceKitten.com, az Unsplash.com vagy akár a teljes webhelyekről – adjon meg "
@@ -46,8 +48,6 @@ msgstr "Forrás"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -70,10 +70,6 @@ msgstr "Képeffektus"
 msgid "Triggers"
 msgstr "Kiváltók"
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Címkék"
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr "Alkalmaz"
@@ -93,16 +89,6 @@ msgstr "Értesítések megjelenítése a problémákról"
 #. settings-schema.json->applet-show-notification->tooltip
 msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr "Rossz hálózat? Hibás beállítás? Az applet értesíteni fogja. Mindig."
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"Hibát talált, vagy hiányzó funkciót szeretne javasolni? Csak nézze meg a "
-"forráskódot a https://github.com/simonmicro/better-backgrounds címen "
-"közvetlenül a Githubon!"
 
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
@@ -192,7 +178,8 @@ msgid "None"
 msgstr "Nincs"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Kép forrása"
 
 #. settings-schema.json->image-source->options
@@ -208,16 +195,8 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Picsum Photos"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
@@ -242,16 +221,6 @@ msgid ""
 msgstr ""
 "Ez a funkció az 'imagemagick' csomag 'montage' parancsát használja. "
 "Győződjön meg arról, hogy ez a csomag vagy parancs telepítve van."
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Ez a forrás köztudottan gondot okoz, különösen nagy kereslet idején. Kérjük, "
-"legyen türelmes, és próbálja újra később, ha problémákat tapasztal. További "
-"információ a következő helyen található: https://status.unsplash.com/"
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -281,14 +250,6 @@ msgstr "pixel"
 #. settings-schema.json->image-res-height->description
 msgid "Height"
 msgstr "Magasság"
-
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Használjon saját keresési címkéket"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Adja meg a keresendő címkéket..."
 
 #. settings-schema.json->image-res-himawari->description
 msgid ""
@@ -324,26 +285,6 @@ msgstr "20x"
 #. settings-schema.json->image-res-unsupported->description
 msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr "Sajnáljuk, a kiválasztott forrás nem támogatja a felbontásmódosítókat."
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the "
-"tags are understood as AND - not as OR! A valid search term could be 'nature,"
-"water'..."
-msgstr ""
-"Kérjük, mindenképp válasszon elérhető címkét, különben a háttér nem "
-"módosítható! Ügyeljen arra, hogy a címkéket ',' jellel válassza el, és ne "
-"szóközzel, a címkék AND-ként is értelmezhetők, nem pedig OR-ként! Érvényes "
-"keresőkifejezés lehet „természet, víz”..."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Címkék keresése"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Adja meg a témaszűrőket"
 
 #. settings-schema.json->image-align-info->description
 msgid ""

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/it.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/it.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2023-12-11 17:58+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -23,9 +24,10 @@ msgid "Better Backgrounds"
 msgstr "Sfondi Migliori"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com or even whole websites - specify search tags, triggers and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "Applica nuovi sfondi da Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
 "Unsplash.com o anche interi siti Web: specifica tag di ricerca, trigger e "
@@ -46,8 +48,6 @@ msgstr "Sorgente"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -70,10 +70,6 @@ msgstr "Effetti immagine"
 msgid "Triggers"
 msgstr "Trigger"
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Tag"
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr "Applica"
@@ -95,16 +91,6 @@ msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr ""
 "Rete non funzionante? Configurazione difettosa? L'applet ti avviserà. Ogni "
 "volta."
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"Hai trovato un bug o vuoi suggerire una funzionalità mancante? Basta "
-"controllare il codice sorgente su https://github.com/simonmicro/better-"
-"backgrounds direttamente su Github!"
 
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
@@ -193,7 +179,8 @@ msgid "None"
 msgstr "Nessuna"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Fonte dell'immagine"
 
 #. settings-schema.json->image-source->options
@@ -209,16 +196,8 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Foto di Picsum"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
@@ -244,17 +223,6 @@ msgid ""
 msgstr ""
 "Questa funzionalità utilizza il comando 'montage' dal pacchetto "
 "'imagemagick'. Assicurati che questo pacchetto o comando sia installato."
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Questa fonte è nota per causare problemi, soprattutto durante i periodi di "
-"forte domanda. Sii paziente e riprova più tardi se riscontri problemi. "
-"Maggiori informazioni sono disponibili all'indirizzo: https://status."
-"unsplash.com/"
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -284,14 +252,6 @@ msgstr "pixels"
 #. settings-schema.json->image-res-height->description
 msgid "Height"
 msgstr "Altezza"
-
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Utilizza i propri tag di ricerca"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Specificare i propri tag da cercare..."
 
 #. settings-schema.json->image-res-himawari->description
 msgid ""
@@ -329,26 +289,6 @@ msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr ""
 "Siamo spiacenti, la fonte selezionata non supporta i modificatori di "
 "risoluzione."
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the "
-"tags are understood as AND - not as OR! A valid search term could be 'nature,"
-"water'..."
-msgstr ""
-"Assicurati di scegliere un tag disponibile, altrimenti lo sfondo non potrà "
-"essere modificato! Assicurati di separare i tag con ',' e non con spazi, "
-"inoltre i tag sono intesi come AND - non come OR! Un termine di ricerca "
-"valido potrebbe essere \"natura,acqua\"..."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Ricerca tag"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Inserisci i filtri dell'argomento"
 
 #. settings-schema.json->image-align-info->description
 msgid ""

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/nl.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/nl.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2024-04-22 12:08+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -21,9 +22,10 @@ msgid "Better Backgrounds"
 msgstr "Verbeterde achtergronden"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com or even whole websites - specify search tags, triggers and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "Pas nieuwe achtergronden toe van Bing, Himawari 8, Picsum Photos, "
 "PlaceKitten.com, Unsplash.com of zelfs hele websites - geef zoektags, "
@@ -44,8 +46,6 @@ msgstr "Bron"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -67,10 +67,6 @@ msgstr "Afbeeldingseffecten"
 #. settings-schema.json->changeon->title
 msgid "Triggers"
 msgstr "Triggers"
-
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Tags"
 
 #. settings-schema.json->imageapply->title
 msgid "Apply"
@@ -94,16 +90,6 @@ msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr ""
 "Slecht netwerk? Foutieve configuratie? De applet zal je op de hoogte "
 "stellen. Elke keer weer."
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"Heb je een bug gevonden of wil je een ontbrekende functie voorstellen? "
-"Bekijk gewoon de broncode op https://github.com/simonmicro/better-"
-"backgrounds op Github!"
 
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
@@ -196,7 +182,8 @@ msgid "None"
 msgstr "Geen"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Bron afbeelding"
 
 #. settings-schema.json->image-source->options
@@ -212,16 +199,8 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Picsum Photos"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
@@ -246,16 +225,6 @@ msgid ""
 msgstr ""
 "Deze functie maakt gebruik van het commando 'montage' uit het pakket "
 "'imagemagick'. Zorg ervoor dat dit pakket of commando is geïnstalleerd."
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Deze bron staat bekend om problemen te veroorzaken, vooral tijdens "
-"piekmomenten. Wees geduldig en probeer het later opnieuw als je problemen "
-"ondervindt. Meer informatie vind je op: https://status.unsplash.com/"
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -285,14 +254,6 @@ msgstr "pixels"
 #. settings-schema.json->image-res-height->description
 msgid "Height"
 msgstr "Hoogte"
-
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Eigen zoektags gebruiken"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Specificeer je eigen tags om te zoeken naar..."
 
 #. settings-schema.json->image-res-himawari->description
 msgid ""
@@ -328,26 +289,6 @@ msgstr "20x"
 #. settings-schema.json->image-res-unsupported->description
 msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr "Sorry, de geselecteerde bron ondersteunt geen resolutiemodifiers."
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the "
-"tags are understood as AND - not as OR! A valid search term could be 'nature,"
-"water'..."
-msgstr ""
-"Zorg ervoor dat je een beschikbare tag kiest, anders kan de achtergrond niet "
-"worden gewijzigd! Zorg ervoor dat de tags door een ',' worden gescheiden en "
-"niet door spaties, bovendien worden de tags begrepen als EN - niet als OF! "
-"Een geldige zoekterm kan bijvoorbeeld 'natuur,water' zijn..."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Zoektags"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Voer je onderwerpfilters in"
 
 #. settings-schema.json->image-align-info->description
 msgid ""

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/ru.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/ru.po
@@ -2,8 +2,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -18,14 +19,13 @@ msgid "Better Backgrounds"
 msgstr "Лучшие Фоновые Обои (Better Backgrounds)"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten."
-"com, Unsplash.com or even whole websites - specify search tags, triggers "
-"and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "Применяйте новые обои на рабочий стол из Bing, Himawari 8, Picsum Photos, "
-"PlaceKitten.com, Unsplash.com или других сайтов - используя теги и не "
-"только!"
+"PlaceKitten.com, Unsplash.com или других сайтов - используя теги и не только!"
 
 #. settings-schema.json->pageBehaviour->title
 msgid "Behaviour"
@@ -42,8 +42,6 @@ msgstr "Источник"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -66,10 +64,6 @@ msgstr "Эффекты Изображений"
 msgid "Triggers"
 msgstr "Триггеры"
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Теги"
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr "Применить"
@@ -89,15 +83,6 @@ msgstr "Показывать уведомления о проблемах"
 #. settings-schema.json->applet-show-notification->tooltip
 msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr "Плохая сеть? Неправильная настройка? Апплет уведомит вас. Каждый раз."
-
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"Вы нашли ошибку или хотите внести изменение? Просто исследуйте исходный код "
-"на https://github.com/simonmicro/better-backgrounds Github!"
 
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
@@ -183,7 +168,8 @@ msgid "None"
 msgstr ""
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Источник изображений"
 
 #. settings-schema.json->image-source->options
@@ -199,15 +185,7 @@ msgid "Himawari 8"
 msgstr ""
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr ""
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
-msgstr ""
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
 msgstr ""
 
 #. settings-schema.json->source-supports-info->description
@@ -232,16 +210,6 @@ msgstr ""
 "Эта функция требует установленного 'montage' из 'imagemagick'. Пожалуйста "
 "убедитесь что эта программа установлена."
 
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Иногда с эти источником возникают проблемы, например из за загруженности "
-"сервиса, проявите терпение и попробуйте позже. Больше информации на https://"
-"status.unsplash.com/"
-
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
 msgstr "Выбрать своё разрешение"
@@ -255,8 +223,8 @@ msgid ""
 "Please make sure to choose a common resolution, otherwise the background "
 "can't be changed!"
 msgstr ""
-"Пожалуйста, убедитесь, что вы выбрали доступное разрешение, иначе вон "
-"нельзя будет менять!"
+"Пожалуйста, убедитесь, что вы выбрали доступное разрешение, иначе вон нельзя "
+"будет менять!"
 
 #. settings-schema.json->image-res-width->description
 msgid "Width"
@@ -271,23 +239,14 @@ msgstr "пикселей"
 msgid "Height"
 msgstr "Высота"
 
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Использовать свои теги поиска"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Укажите свои собственные теги для поиска..."
-
 #. settings-schema.json->image-res-himawari->description
 msgid ""
 "Image zoom factor - this factor times the tile size (550 pixels) equals the "
-"image resolution. So e.g. the factor '4x' would result in a 2200x2200 "
-"pixels image. Please note that factor² much tiles will be temporarly "
-"downloaded."
+"image resolution. So e.g. the factor '4x' would result in a 2200x2200 pixels "
+"image. Please note that factor² much tiles will be temporarly downloaded."
 msgstr ""
-"Коэффициент масштабирования изображения - этот значение умножается на "
-"размер изображения."
+"Коэффициент масштабирования изображения - этот значение умножается на размер "
+"изображения."
 
 #. settings-schema.json->image-res-himawari->options
 msgid "1x"
@@ -313,25 +272,6 @@ msgstr ""
 msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr ""
 "Извините, выбранный источник не поддерживает смену на такое разрешения."
-
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also "
-"the tags are understood as AND - not as OR! A valid search term could be "
-"'nature,water'..."
-msgstr ""
-"Выберите тег иначе фон не сможет меняться. Теги разделяются запятыми ',' "
-"вместе теги воспринимаются как И (это и это), а не как ИЛИ! Пример "
-"правильных тегов 'природа,вода'."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Поисковые теги"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Введите ваш фильтр тем"
 
 #. settings-schema.json->image-align-info->description
 msgid ""

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/vi.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/vi.po
@@ -1,14 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2025-10-08 21:21+0700\n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -23,12 +24,14 @@ msgid "Better Backgrounds"
 msgstr "Hình nền tốt hơn"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com or even whole websites - specify search tags, triggers and more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "Áp dụng hình nền mới từ Bing, Himawari 8, Picsum Photos, PlaceKitten.com, "
-"Unsplash.com hoặc thậm chí là toàn bộ trang web - chỉ định thẻ tìm kiếm, kích hoạt và nhiều hơn nữa!"
+"Unsplash.com hoặc thậm chí là toàn bộ trang web - chỉ định thẻ tìm kiếm, "
+"kích hoạt và nhiều hơn nữa!"
 
 #. settings-schema.json->pageBehaviour->title
 msgid "Behaviour"
@@ -45,8 +48,6 @@ msgstr "Nguồn"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -69,10 +70,6 @@ msgstr "Hiệu ứng hình ảnh"
 msgid "Triggers"
 msgstr "Kích hoạt"
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "Thẻ"
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr "Áp dụng"
@@ -93,15 +90,6 @@ msgstr "Hiển thị thông báo khi có sự cố"
 msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr "Mạng kém? Cài đặt lỗi? Tiện ích sẽ thông báo cho bạn. Mỗi lần."
 
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"Bạn phát hiện lỗi hoặc muốn đề xuất tính năng còn thiếu? Hãy xem mã nguồn tại "
-"https://github.com/simonmicro/better-backgrounds trên Github!"
-
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
 msgstr "Vị trí lưu ảnh"
@@ -116,8 +104,8 @@ msgid ""
 "This feature uses the command 'convert' from the package 'imagemagick'. "
 "Please make sure this package or command is installed."
 msgstr ""
-"Tính năng này sử dụng lệnh 'convert' từ gói 'imagemagick'. "
-"Vui lòng đảm bảo gói hoặc lệnh này đã được cài đặt."
+"Tính năng này sử dụng lệnh 'convert' từ gói 'imagemagick'. Vui lòng đảm bảo "
+"gói hoặc lệnh này đã được cài đặt."
 
 #. settings-schema.json->change-onstart->description
 msgid "On applet reloading"
@@ -141,7 +129,8 @@ msgid ""
 "clicking will change the background before you've got any chance to press "
 "the corresponding button to e.g. save the image!"
 msgstr ""
-"Lưu ý rằng thao tác này sẽ tắt menu khi nhấn vào tiện ích - vì nhấn sẽ thay đổi hình nền trước khi bạn có cơ hội nhấn nút tương ứng để ví dụ như lưu ảnh!"
+"Lưu ý rằng thao tác này sẽ tắt menu khi nhấn vào tiện ích - vì nhấn sẽ thay "
+"đổi hình nền trước khi bạn có cơ hội nhấn nút tương ứng để ví dụ như lưu ảnh!"
 
 #. settings-schema.json->change-ontime->description
 msgid "After some time"
@@ -165,8 +154,8 @@ msgid ""
 "This feature uses the command 'mogrify' from the package 'imagemagick'. "
 "Please make sure this package or command is installed."
 msgstr ""
-"Tính năng này sử dụng lệnh 'mogrify' từ gói 'imagemagick'. "
-"Vui lòng đảm bảo gói hoặc lệnh này đã được cài đặt."
+"Tính năng này sử dụng lệnh 'mogrify' từ gói 'imagemagick'. Vui lòng đảm bảo "
+"gói hoặc lệnh này đã được cài đặt."
 
 #. settings-schema.json->effect-select->description
 msgid "Apply effects"
@@ -185,7 +174,8 @@ msgid "None"
 msgstr "Không có"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "Nguồn hình ảnh"
 
 #. settings-schema.json->image-source->options
@@ -201,23 +191,16 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Picsum Photos"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
 "This source supports displaying additional image autor information. It will "
 "be shown inside the applets tooltip."
 msgstr ""
-"Nguồn này hỗ trợ hiển thị thêm thông tin tác giả hình ảnh. Thông tin sẽ được hiển thị trong tooltip của tiện ích."
+"Nguồn này hỗ trợ hiển thị thêm thông tin tác giả hình ảnh. Thông tin sẽ được "
+"hiển thị trong tooltip của tiện ích."
 
 #. settings-schema.json->install-warn-cutycapt->description
 msgid ""
@@ -231,16 +214,8 @@ msgid ""
 "This feature uses the command 'montage' from the package 'imagemagick'. "
 "Please make sure this package or command is installed."
 msgstr ""
-"Tính năng này sử dụng lệnh 'montage' từ gói 'imagemagick'. "
-"Vui lòng đảm bảo gói hoặc lệnh này đã được cài đặt."
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"Nguồn này được biết là có thể gặp sự cố, đặc biệt vào thời điểm nhu cầu cao. Vui lòng kiên nhẫn và thử lại sau nếu gặp vấn đề. Thông tin thêm tại: https://status.unsplash.com/"
+"Tính năng này sử dụng lệnh 'montage' từ gói 'imagemagick'. Vui lòng đảm bảo "
+"gói hoặc lệnh này đã được cài đặt."
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -255,7 +230,8 @@ msgid ""
 "Please make sure to choose a common resolution, otherwise the background "
 "can't be changed!"
 msgstr ""
-"Vui lòng chọn độ phân giải phổ biến, nếu không hình nền sẽ không thể thay đổi!"
+"Vui lòng chọn độ phân giải phổ biến, nếu không hình nền sẽ không thể thay "
+"đổi!"
 
 #. settings-schema.json->image-res-width->description
 msgid "Width"
@@ -270,21 +246,15 @@ msgstr "pixel"
 msgid "Height"
 msgstr "Chiều cao"
 
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "Sử dụng thẻ tìm kiếm riêng"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "Chỉ định thẻ riêng để tìm kiếm..."
-
 #. settings-schema.json->image-res-himawari->description
 msgid ""
 "Image zoom factor - this factor times the tile size (550 pixels) equals the "
 "image resolution. So e.g. the factor '4x' would result in a 2200x2200 pixels "
 "image. Please note that factor² much tiles will be temporarly downloaded."
 msgstr ""
-"Hệ số phóng to hình ảnh - hệ số này nhân với kích thước ô (550 pixel) sẽ ra độ phân giải hình ảnh. Ví dụ hệ số '4x' sẽ tạo ra hình ảnh 2200x2200 pixel. Lưu ý rằng số ô tải tạm thời sẽ là bình phương của hệ số."
+"Hệ số phóng to hình ảnh - hệ số này nhân với kích thước ô (550 pixel) sẽ ra "
+"độ phân giải hình ảnh. Ví dụ hệ số '4x' sẽ tạo ra hình ảnh 2200x2200 pixel. "
+"Lưu ý rằng số ô tải tạm thời sẽ là bình phương của hệ số."
 
 #. settings-schema.json->image-res-himawari->options
 msgid "1x"
@@ -310,30 +280,14 @@ msgstr "20x"
 msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr "Xin lỗi, nguồn đã chọn không hỗ trợ thay đổi độ phân giải."
 
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the "
-"tags are understood as AND - not as OR! A valid search term could be 'nature,"
-"water'..."
-msgstr ""
-"Vui lòng chọn thẻ có sẵn, nếu không hình nền sẽ không thể thay đổi! Đảm bảo tách các thẻ bằng dấu ',' chứ không phải dấu cách, các thẻ được hiểu là AND - không phải OR! Ví dụ tìm kiếm hợp lệ: 'nature,water'..."
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "Thẻ tìm kiếm"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "Nhập bộ lọc chủ đề của bạn"
-
 #. settings-schema.json->image-align-info->description
 msgid ""
 "Note that properties for the image alignment are not modified from the "
 "original desktop wallpaper. Recommended is to choose the 'zoom' option, "
 "because it ensures always the best fit on your screen."
 msgstr ""
-"Lưu ý rằng các thuộc tính căn chỉnh hình ảnh không được thay đổi so với hình nền gốc. Khuyến nghị chọn tùy chọn 'zoom' để luôn vừa với màn hình của bạn."
+"Lưu ý rằng các thuộc tính căn chỉnh hình ảnh không được thay đổi so với hình "
+"nền gốc. Khuyến nghị chọn tùy chọn 'zoom' để luôn vừa với màn hình của bạn."
 
 #. settings-schema.json->image-uri->description
 msgid "Website URI to render"
@@ -351,5 +305,4 @@ msgstr "Áp dụng ngay"
 msgid ""
 "The settings are already stored - press this button to force a refresh of "
 "the background now."
-msgstr ""
-"Cài đặt đã được lưu - nhấn nút này để làm mới hình nền ngay lập tức."
+msgstr "Cài đặt đã được lưu - nhấn nút này để làm mới hình nền ngay lập tức."

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/zh_TW.po
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/po/zh_TW.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# BETTER BACKGROUNDS
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# simonmicro, 2020
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-07 19:16+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-04-13 04:55+0100\n"
 "PO-Revision-Date: 2025-09-04 02:21+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -21,10 +22,10 @@ msgid "Better Backgrounds"
 msgstr "Better Backgrounds"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, PlaceKitten.com,"
-" Unsplash.com or even whole websites - specify search tags, triggers and"
-"more!"
+"Apply new backgrounds from Bing, Himawari 8, Picsum Photos, or even whole "
+"websites"
 msgstr ""
 "從 Bing、Himawari 8、Picsum Photos、PlaceKitten.com、Unsplash.com 甚至整個網"
 "站套用全新桌布——可自訂搜尋標籤、觸發條件等多項設定！"
@@ -44,8 +45,6 @@ msgstr "來源"
 
 #. settings-schema.json->pageResolution->title
 #. settings-schema.json->imageresbing->title
-#. settings-schema.json->imageresunsplash->title
-#. settings-schema.json->imageresplacekitten->title
 #. settings-schema.json->imageresplacecutycapt->title
 #. settings-schema.json->imagerespicsum->title
 #. settings-schema.json->imagereshimawari->title
@@ -68,10 +67,6 @@ msgstr "圖片效果"
 msgid "Triggers"
 msgstr "觸發條件"
 
-#. settings-schema.json->imagetags->title
-msgid "Tags"
-msgstr "標籤"
-
 #. settings-schema.json->imageapply->title
 msgid "Apply"
 msgstr "套用"
@@ -92,15 +87,6 @@ msgstr "發生問題時顯示通知"
 msgid "Bad network? Faulty setup? The applet will notify you. Every time."
 msgstr "網路不穩？設定有誤？每次發生問題時，小程式都會發出通知。"
 
-#. settings-schema.json->applet-info-issues->description
-msgid ""
-"You found a bug or want to suggest a missing feature? Just checkout the "
-"source code at https://github.com/simonmicro/better-backgrounds right over "
-"on Github!"
-msgstr ""
-"發現錯誤或想建議新功能嗎？歡迎直接前往 GitHub 上的原始碼頁面："
-"https://github.com/simonmicro/better-backgrounds"
-
 #. settings-schema.json->applet-store-location->description
 msgid "Picture save location"
 msgstr "圖片儲存位置"
@@ -108,8 +94,7 @@ msgstr "圖片儲存位置"
 #. settings-schema.json->applet-store-location->tooltip
 msgid ""
 "When you choose to save the current background, where do you want to put it?"
-msgstr ""
-"選擇儲存目前桌布時，您希望將其存放至何處？"
+msgstr "選擇儲存目前桌布時，您希望將其存放至何處？"
 
 #. settings-schema.json->applet-store-info->description
 msgid ""
@@ -150,8 +135,7 @@ msgstr "經過一段時間後"
 #. settings-schema.json->change-ontime->tooltip
 msgid ""
 "After the specified number of minutes passes, we will change the background"
-msgstr ""
-"經過指定分鐘數後，桌布將會自動更換"
+msgstr "經過指定分鐘數後，桌布將會自動更換"
 
 #. settings-schema.json->change-time->description
 msgid "Change after"
@@ -185,7 +169,8 @@ msgid "None"
 msgstr "無"
 
 #. settings-schema.json->image-source->description
-msgid "Image source"
+#, fuzzy
+msgid "Image Source"
 msgstr "圖片來源"
 
 #. settings-schema.json->image-source->options
@@ -201,30 +186,20 @@ msgid "Himawari 8"
 msgstr "Himawari 8"
 
 #. settings-schema.json->image-source->options
-msgid "Placekitten"
-msgstr "Placekitten"
-
-#. settings-schema.json->image-source->options
 msgid "Picsum Photos"
 msgstr "Picsum Photos"
-
-#. settings-schema.json->image-source->options
-msgid "Unsplash"
-msgstr "Unsplash"
 
 #. settings-schema.json->source-supports-info->description
 msgid ""
 "This source supports displaying additional image autor information. It will "
 "be shown inside the applets tooltip."
-msgstr ""
-"此來源支援顯示額外的圖片作者資訊，會在小程式的工具提示中顯示。"
+msgstr "此來源支援顯示額外的圖片作者資訊，會在小程式的工具提示中顯示。"
 
 #. settings-schema.json->install-warn-cutycapt->description
 msgid ""
 "Please make sure to install the 'cutycapt' package from the package manager "
 "of your choice!"
-msgstr ""
-"請務必透過慣用的套件管理工具安裝 cutycapt 套件！"
+msgstr "請務必透過慣用的套件管理工具安裝 cutycapt 套件！"
 
 #. settings-schema.json->install-warn-imagemagick->description
 msgid ""
@@ -232,15 +207,6 @@ msgid ""
 "Please make sure this package or command is installed."
 msgstr ""
 "此功能會使用 imagemagick 套件中的 montage 指令，請確認已安裝此套件或指令。"
-
-#. settings-schema.json->source-warn-unsplash->description
-msgid ""
-"This source is known to cause trouble, especially during times of high "
-"demand. Please be patient and try again later if you experience problems. "
-"More information can be found at: https://status.unsplash.com/"
-msgstr ""
-"此來源在高流量時段可能會有問題，若遇到問題，請耐心等候並稍後再試。更多資訊請參考："
-"https://status.unsplash.com/"
 
 #. settings-schema.json->image-res-manual->description
 msgid "Use custom resolution"
@@ -254,8 +220,7 @@ msgstr "通常為 1920x1080 或更高解析度"
 msgid ""
 "Please make sure to choose a common resolution, otherwise the background "
 "can't be changed!"
-msgstr ""
-"請務必選擇常見解析度，否則桌布將無法更換！"
+msgstr "請務必選擇常見解析度，否則桌布將無法更換！"
 
 #. settings-schema.json->image-res-width->description
 msgid "Width"
@@ -270,19 +235,11 @@ msgstr "畫素"
 msgid "Height"
 msgstr "高度"
 
-#. settings-schema.json->image-tag->description
-msgid "Use own search tags"
-msgstr "自訂搜尋標籤"
-
-#. settings-schema.json->image-tag->tooltip
-msgid "Specify own tags to look for..."
-msgstr "請輸入自訂搜尋標籤…"
-
 #. settings-schema.json->image-res-himawari->description
 msgid ""
 "Image zoom factor - this factor times the tile size (550 pixels) equals the "
-"image resolution. So e.g. the factor '4x' would result in a 2200x2200 pixels"
-" image. Please note that factor² much tiles will be temporarly downloaded."
+"image resolution. So e.g. the factor '4x' would result in a 2200x2200 pixels "
+"image. Please note that factor² much tiles will be temporarly downloaded."
 msgstr ""
 "圖片縮放倍率——此倍率乘以每塊磚的大小（550 畫素）即為圖片解析度。例如倍率 4x "
 "會產生 2200x2200 畫素圖片。請注意，會暫時下載倍率平方數量的圖磚。"
@@ -311,24 +268,6 @@ msgstr "20x"
 msgid "Sorry, the selected source does not support resolution modifiers."
 msgstr "抱歉，您選擇的來源不支援解析度調整。"
 
-#. settings-schema.json->image-tag-info->description
-msgid ""
-"Please make sure to choose an available tag, otherwise the background can't "
-"be changed! Make sure to seperate the tags by a ',' and not spaces, also the"
-" tags are understood as AND - not as OR! A valid search term could be "
-"'nature,water'..."
-msgstr ""
-"請務必選擇可用標籤，否則桌布將無法更換！標籤請用半形逗號 (,) 分隔而非空格，且"
-"多個標籤會以 AND 條件組合（非 OR）。有效搜尋範例：nature,water……"
-
-#. settings-schema.json->image-tag-data->description
-msgid "Search tags"
-msgstr "搜尋標籤"
-
-#. settings-schema.json->image-tag-data->tooltip
-msgid "Enter your topic filters"
-msgstr "請輸入主題篩選條件"
-
 #. settings-schema.json->image-align-info->description
 msgid ""
 "Note that properties for the image alignment are not modified from the "
@@ -353,5 +292,4 @@ msgstr "立即套用"
 msgid ""
 "The settings are already stored - press this button to force a refresh of "
 "the background now."
-msgstr ""
-"設定已儲存 - 按下此按鈕可立即強制重新整理桌布。"
+msgstr "設定已儲存 - 按下此按鈕可立即強制重新整理桌布。"

--- a/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/settings-schema.json
+++ b/better-backgrounds@simonmicro/files/better-backgrounds@simonmicro/settings-schema.json
@@ -15,17 +15,17 @@
         "pageSource": {
             "type": "page",
             "title": "Source",
-            "sections": ["imagesource", "imagetags", "imageapply"]
+            "sections": ["imagesource", "imageapply"]
         },
         "pageResolution": {
             "type": "page",
             "title": "Resolution",
-            "sections": ["imageresbing", "imageresplacecutycapt", "imagereshimawari", "imageresplacekitten", "imagerespicsum", "imageresunsplash", "imageapply"]
+            "sections": ["imageresbing", "imageresplacecutycapt", "imagereshimawari", "imagerespicsum", "imageapply"]
         },
         "applet": {
             "type": "section",
             "title": "Applet",
-            "keys": ["applet-icon-animation", "applet-show-notification", "applet-info-issues"]
+            "keys": ["applet-icon-animation", "applet-show-notification"]
         },
         "applet-store": {
             "type": "section",
@@ -45,25 +45,13 @@
         "imagesource": {
             "type": "section",
             "title": "Source",
-            "keys": ["image-source", "source-supports-info", "install-warn-imagemagick", "install-warn-cutycapt", "source-warn-unsplash", "image-uri"]
+            "keys": ["image-source", "source-supports-info", "install-warn-imagemagick", "install-warn-cutycapt", "image-uri"]
         },
         "imageresbing": {
             "type": "section",
             "title": "Resolution",
             "dependency": "image-source=bing",
             "keys": ["image-res-unsupported"]
-        },
-        "imageresunsplash": {
-            "type": "section",
-            "title": "Resolution",
-            "dependency": "image-source=unsplash",
-            "keys": ["image-res-manual", "image-res-info", "image-res-width", "image-res-height"]
-        },
-        "imageresplacekitten": {
-            "type": "section",
-            "title": "Resolution",
-            "dependency": "image-source=placekitten",
-            "keys": ["image-res-manual", "image-res-info", "image-res-width", "image-res-height"]
         },
         "imageresplacecutycapt": {
             "type": "section",
@@ -83,12 +71,6 @@
             "dependency": "image-source=himawari",
             "keys": ["image-res-himawari"]
         },
-        "imagetags": {
-            "type": "section",
-            "title": "Tags",
-            "dependency": "image-source=unsplash",
-            "keys": ["image-tag", "image-tag-info", "image-tag-data", "image-align-info"]
-        },
         "imageapply": {
             "type": "section",
             "title": "Apply",
@@ -106,10 +88,6 @@
         "default" : true,
         "description": "Show notifications on problems",
         "tooltip": "Bad network? Faulty setup? The applet will notify you. Every time."
-    },
-    "applet-info-issues" : {
-        "type" : "label",
-        "description" : "You found a bug or want to suggest a missing feature? Just checkout the source code at https://github.com/simonmicro/better-backgrounds right over on Github!"
     },
     "applet-store-location" : {
         "type" : "filechooser",
@@ -171,15 +149,13 @@
     },
     "image-source" : {
         "type" : "combobox",
-        "description" : "Image source",
-        "default" : "unsplash",
+        "description" : "Image Source",
+        "default" : "bing",
         "options" : {
             "Bing" : "bing",
             "Cutycapt" : "cutycapt",
             "Himawari 8" : "himawari",
-            "Placekitten" : "placekitten",
-            "Picsum Photos" : "picsum",
-            "Unsplash" : "unsplash"
+            "Picsum Photos" : "picsum"
         }
     },
     "source-supports-info" : {
@@ -196,11 +172,6 @@
         "type" : "label",
         "description" : "This feature uses the command 'montage' from the package 'imagemagick'. Please make sure this package or command is installed.",
         "dependency" : "image-source=himawari"
-    },
-    "source-warn-unsplash" : {
-        "type" : "label",
-        "description" : "This source is known to cause trouble, especially during times of high demand. Please be patient and try again later if you experience problems. More information can be found at: https://status.unsplash.com/",
-        "dependency" : "image-source=unsplash"
     },
     "image-res-manual" : {
         "type" : "switch",
@@ -233,12 +204,6 @@
         "default" : 1080,
         "dependency" : "image-res-manual"
     },
-    "image-tag" : {
-        "type" : "switch",
-        "default" : false,
-        "description": "Use own search tags",
-        "tooltip": "Specify own tags to look for..."
-    },
     "image-res-himawari" : {
         "type" : "combobox",
         "description" : "Image zoom factor - this factor times the tile size (550 pixels) equals the image resolution. So e.g. the factor '4x' would result in a 2200x2200 pixels image. Please note that factor² much tiles will be temporarly downloaded.",
@@ -254,19 +219,6 @@
     "image-res-unsupported" : {
         "type" : "label",
         "description" : "Sorry, the selected source does not support resolution modifiers."
-    },
-    "image-tag-info" : {
-        "type" : "label",
-        "description" : "Please make sure to choose an available tag, otherwise the background can't be changed! Make sure to seperate the tags by a ',' and not spaces, also the tags are understood as AND - not as OR! A valid search term could be 'nature,water'...",
-        "dependency" : "image-tag"
-    },
-    "image-tag-data" : {
-        "type" : "entry",
-        "default" : "nature",
-        "description" : "Search tags",
-        "indent": true,
-        "dependency" : "image-tag",
-        "tooltip" : "Enter your topic filters"
     },
     "image-align-info" : {
         "type" : "label",


### PR DESCRIPTION
Remove image sources that are no longer available: Placekitten and Unsplash. Also remove image tags feature as this is not used with remaining sources.

Update some deprecated code.

Remove links in readme.md to previous author's github as he no longer wishes to maintain applet.