### PR TITLE
c-eyes@anaximeno: Version 3.3.1 - Update panel height/width retrieve method

### DIFF
--- a/c-eyes@anaximeno/files/c-eyes@anaximeno/6.2/applet.js
+++ b/c-eyes@anaximeno/files/c-eyes@anaximeno/6.2/applet.js
@@ -352,11 +352,11 @@ class Eye extends Applet.Applet {
 		if (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT) {
 			this.actor.set_style("padding-top: 0px; padding-bottom: 0px; margin-top: 0px; margin-bottom: 0px;");
 			height = (Configs.AREA_DEFAULT_WIDTH + 2 * this.margin) * global.ui_scale;
-			width = this.panel.height;
+			width = this.panel.get_width ? this.panel.get_width() : this._panelHeight;
 		} else {
 			this.actor.set_style("padding-left: 0px; padding-right: 0px; margin-left: 0px; margin-right: 0px;");
 			width = (Configs.AREA_DEFAULT_WIDTH + 2 * this.margin) * global.ui_scale;
-			height = this.panel.height;
+			height = this.panel.get_height ? this.panel.get_height() : this._panelHeight;
 		}
 
 		this.area.set_width(width);

--- a/c-eyes@anaximeno/files/c-eyes@anaximeno/metadata.json
+++ b/c-eyes@anaximeno/files/c-eyes@anaximeno/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.3.0",
+  "version": "3.3.1",
   "uuid": "c-eyes@anaximeno",
   "name": "Cinnamon Eyes",
   "multiversion": true,


### PR DESCRIPTION
This is needed because `this.panel.height` is going to be deprecated as of Cinnamon 6.8