### PR TITLE
vertical-speedmeter v1.1.0: Add user-selectable network interface

### DIFF
--- a/vertical-speedmeter@2u841r/README.md
+++ b/vertical-speedmeter@2u841r/README.md
@@ -8,6 +8,7 @@ Vertical Speedmeter is a minimal Cinnamon applet that shows current network uplo
 
 - Vertical two-line speed display
 - Asynchronous interface detection and counter reads
+- User-selectable network interface via popup menu
 - No runtime writes to the applet install directory
 
 ## Layout
@@ -24,19 +25,37 @@ The panel display is kept to a compact 3-character style:
 
 ## Interaction
 
-- Left click opens a popup menu with the active interface, session totals, and today totals.
-- The popup menu also includes `Reset Session Stats`.
+- Left click opens a popup menu with:
+  - Active interface name and live rates
+  - Session totals and today totals
+  - **Interface selector** — pick any detected interface or revert to auto-detect
+  - `Reset Session Stats`
+- Right click → **Configure** allows typing an interface name manually (useful for VPNs or bridges not listed automatically).
 - Right click opens the standard Cinnamon context menu.
 - The panel text stays compact and only shows live upload on the top line and download on the bottom line.
+
+## Interface Selection
+
+By default the applet auto-detects the primary interface via NetworkManager, falling back to `ip route get 1.1.1.1`. If the wrong interface is selected (e.g. `docker0` instead of `eno1`), open the left-click menu and pick the correct one from the **Interface** submenu. The choice is saved across restarts.
 
 ## Notes
 
 The applet reads `/sys/class/net/<iface>/statistics/{rx_bytes,tx_bytes}`.
 
-Interface detection order:
+Interface detection order (when set to auto-detect):
 
 - NetworkManager activated device first
 - `ip route get 1.1.1.1` as fallback when NetworkManager does not provide a usable device
+
+## Version History
+
+### 1.1.0
+- Add user-selectable network interface via left-click popup menu submenu
+- Add settings support (`settings-schema.json`) for persisting interface preference
+- Interface choice saved across restarts; revert to auto-detect at any time
+
+### 1.0.0
+- Initial release
 
 ## Credits
 

--- a/vertical-speedmeter@2u841r/files/vertical-speedmeter@2u841r/applet.js
+++ b/vertical-speedmeter@2u841r/files/vertical-speedmeter@2u841r/applet.js
@@ -6,6 +6,7 @@ const ByteArray = imports.byteArray;
 const Gettext = imports.gettext;
 const NM = imports.gi.NM;
 const PopupMenu = imports.ui.popupMenu;
+const { AppletSettings } = imports.ui.settings;
 
 const UUID = "vertical-speedmeter@2u841r";
 
@@ -18,6 +19,9 @@ function _(text) {
 class VerticalPanelDownloadAndUploadSpeedApplet extends Applet.TextIconApplet {
     constructor(metadata, orientation, panelHeight, instanceId) {
         super(orientation, panelHeight, instanceId);
+
+        this.settings = new AppletSettings(this, UUID, instanceId);
+        this.settings.bind("preferred-interface", "preferredInterface", this._onPreferredInterfaceChanged.bind(this));
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
@@ -77,6 +81,16 @@ class VerticalPanelDownloadAndUploadSpeedApplet extends Applet.TextIconApplet {
         }
     }
 
+    _onPreferredInterfaceChanged() {
+        let preferred = (this.preferredInterface || "").trim();
+        if (this.ifaceSubmenu) {
+            this.ifaceSubmenu.label.text = preferred
+                ? _("Interface: %s").format(preferred)
+                : _("Interface: Auto");
+        }
+        this.refreshNow(true);
+    }
+
     buildMenu() {
         this.interfaceItem = new PopupMenu.PopupMenuItem(_("Interface: detecting..."));
         this.interfaceItem.actor.reactive = false;
@@ -95,6 +109,11 @@ class VerticalPanelDownloadAndUploadSpeedApplet extends Applet.TextIconApplet {
 
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
+        this.ifaceSubmenu = new PopupMenu.PopupSubMenuMenuItem(_("Interface: Auto"));
+        this.menu.addMenuItem(this.ifaceSubmenu);
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
         let resetItem = new PopupMenu.PopupMenuItem(_("Reset Session Stats"));
         resetItem.connect("activate", () => {
             this.sessionRX = 0;
@@ -102,6 +121,57 @@ class VerticalPanelDownloadAndUploadSpeedApplet extends Applet.TextIconApplet {
             this.updateMenuStats();
         });
         this.menu.addMenuItem(resetItem);
+
+        this.menu.connect("open-state-changed", (menu, open) => {
+            if (open) this._refreshInterfaceSubmenu();
+        });
+    }
+
+    _listInterfaces() {
+        let ifaces = [];
+        try {
+            let dir = Gio.File.new_for_path("/sys/class/net");
+            let enumerator = dir.enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
+            let info;
+            while ((info = enumerator.next_file(null)) !== null) {
+                let name = info.get_name();
+                if (name !== "lo") {
+                    ifaces.push(name);
+                }
+            }
+            enumerator.close(null);
+        } catch (e) {
+            global.logError(e);
+        }
+        return ifaces.sort();
+    }
+
+    _refreshInterfaceSubmenu() {
+        this.ifaceSubmenu.menu.removeAll();
+
+        let preferred = (this.preferredInterface || "").trim();
+
+        let autoItem = new PopupMenu.PopupMenuItem(
+            (preferred === "" ? "✓ " : "    ") + _("Auto-detect")
+        );
+        autoItem.connect("activate", () => {
+            this.settings.setValue("preferred-interface", "");
+            this.preferredInterface = "";
+            this._onPreferredInterfaceChanged();
+        });
+        this.ifaceSubmenu.menu.addMenuItem(autoItem);
+
+        for (let iface of this._listInterfaces()) {
+            let item = new PopupMenu.PopupMenuItem(
+                (preferred === iface ? "✓ " : "    ") + iface
+            );
+            item.connect("activate", () => {
+                this.settings.setValue("preferred-interface", iface);
+                this.preferredInterface = iface;
+                this._onPreferredInterfaceChanged();
+            });
+            this.ifaceSubmenu.menu.addMenuItem(item);
+        }
     }
 
     initNetworkManager() {
@@ -163,6 +233,12 @@ class VerticalPanelDownloadAndUploadSpeedApplet extends Applet.TextIconApplet {
     }
 
     detectPrimaryInterface(callback) {
+        let preferred = (this.preferredInterface || "").trim();
+        if (preferred) {
+            callback(preferred);
+            return;
+        }
+
         let nmIface = this.getNetworkManagerInterface();
         if (nmIface) {
             callback(nmIface);

--- a/vertical-speedmeter@2u841r/files/vertical-speedmeter@2u841r/applet.js
+++ b/vertical-speedmeter@2u841r/files/vertical-speedmeter@2u841r/applet.js
@@ -127,23 +127,31 @@ class VerticalPanelDownloadAndUploadSpeedApplet extends Applet.TextIconApplet {
         });
     }
 
-    _listInterfaces() {
-        let ifaces = [];
-        try {
-            let dir = Gio.File.new_for_path("/sys/class/net");
-            let enumerator = dir.enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
-            let info;
-            while ((info = enumerator.next_file(null)) !== null) {
-                let name = info.get_name();
-                if (name !== "lo") {
-                    ifaces.push(name);
+    _listInterfaces(callback) {
+        let dir = Gio.File.new_for_path("/sys/class/net");
+        dir.enumerate_children_async(
+            "standard::name",
+            Gio.FileQueryInfoFlags.NONE,
+            GLib.PRIORITY_DEFAULT,
+            null,
+            (source, result) => {
+                let ifaces = [];
+                try {
+                    let enumerator = source.enumerate_children_finish(result);
+                    let info;
+                    while ((info = enumerator.next_file(null)) !== null) {
+                        let name = info.get_name();
+                        if (name !== "lo") {
+                            ifaces.push(name);
+                        }
+                    }
+                    enumerator.close(null);
+                } catch (e) {
+                    global.logError(e);
                 }
+                callback(ifaces.sort());
             }
-            enumerator.close(null);
-        } catch (e) {
-            global.logError(e);
-        }
-        return ifaces.sort();
+        );
     }
 
     _refreshInterfaceSubmenu() {
@@ -151,27 +159,29 @@ class VerticalPanelDownloadAndUploadSpeedApplet extends Applet.TextIconApplet {
 
         let preferred = (this.preferredInterface || "").trim();
 
-        let autoItem = new PopupMenu.PopupMenuItem(
-            (preferred === "" ? "✓ " : "    ") + _("Auto-detect")
-        );
-        autoItem.connect("activate", () => {
-            this.settings.setValue("preferred-interface", "");
-            this.preferredInterface = "";
-            this._onPreferredInterfaceChanged();
-        });
-        this.ifaceSubmenu.menu.addMenuItem(autoItem);
-
-        for (let iface of this._listInterfaces()) {
-            let item = new PopupMenu.PopupMenuItem(
-                (preferred === iface ? "✓ " : "    ") + iface
+        this._listInterfaces((ifaces) => {
+            let autoItem = new PopupMenu.PopupMenuItem(
+                (preferred === "" ? "✓ " : "    ") + _("Auto-detect")
             );
-            item.connect("activate", () => {
-                this.settings.setValue("preferred-interface", iface);
-                this.preferredInterface = iface;
+            autoItem.connect("activate", () => {
+                this.settings.setValue("preferred-interface", "");
+                this.preferredInterface = "";
                 this._onPreferredInterfaceChanged();
             });
-            this.ifaceSubmenu.menu.addMenuItem(item);
-        }
+            this.ifaceSubmenu.menu.addMenuItem(autoItem);
+
+            for (let iface of ifaces) {
+                let item = new PopupMenu.PopupMenuItem(
+                    (preferred === iface ? "✓ " : "    ") + iface
+                );
+                item.connect("activate", () => {
+                    this.settings.setValue("preferred-interface", iface);
+                    this.preferredInterface = iface;
+                    this._onPreferredInterfaceChanged();
+                });
+                this.ifaceSubmenu.menu.addMenuItem(item);
+            }
+        });
     }
 
     initNetworkManager() {

--- a/vertical-speedmeter@2u841r/files/vertical-speedmeter@2u841r/metadata.json
+++ b/vertical-speedmeter@2u841r/files/vertical-speedmeter@2u841r/metadata.json
@@ -3,7 +3,7 @@
     "name": "Vertical Speedmeter",
     "description": "A minimal vertical panel applet with stacked upload and download rates.",
     "max-instances": 1,
-    "version": "1.0.0",
+    "version": "1.1.0",
     "author": "2u841r",
     "cinnamon-version": ["5.8", "6.0", "6.2", "6.4", "6.6", "6.8"]
 }

--- a/vertical-speedmeter@2u841r/files/vertical-speedmeter@2u841r/settings-schema.json
+++ b/vertical-speedmeter@2u841r/files/vertical-speedmeter@2u841r/settings-schema.json
@@ -1,0 +1,12 @@
+{
+    "network-header": {
+        "type": "header",
+        "description": "Network Interface"
+    },
+    "preferred-interface": {
+        "type": "entry",
+        "default": "",
+        "description": "Preferred interface (e.g. eno1, eth0, wlan0)",
+        "tooltip": "Leave blank to auto-detect. If set, this interface is used directly and auto-detection is skipped."
+    }
+}


### PR DESCRIPTION
- Add interface submenu to left-click popup menu; lists all /sys/class/net interfaces, checkmarks current selection, persists across restarts
- Add settings-schema.json for storing preferred interface preference
- Fix: manually invoke handler after setValue so label and monitor update immediately
- Bump version 1.0.0 -> 1.1.0, update README with interface selection docs and version history