### PR TITLE
app-launcher@mchilli: fix submenu clipped when list fills screen height

### DIFF
--- a/app-launcher@mchilli/files/app-launcher@mchilli/6.6/applet.js
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/6.6/applet.js
@@ -652,6 +652,23 @@ class MyPopupMenu extends Applet.AppletPopupMenu {
             this.pointerY = 0;
             this.actorPlaced = false;
 
+            // Remove the menu box to wrap it in a ScrollView
+            this.actor.remove_actor(this.box);
+
+            // Create a scrollable container for the menu
+            this._scrollView = new St.ScrollView({ hscrollbar_policy: 2, vscrollbar_policy: 1 });
+
+            // Add the box to the scrollview and add the scrollview to the actor
+            this._scrollView.add_actor(this.box);
+            this.actor.add_actor(this._scrollView);
+
+            // Limit menu height to 90% of screen to prevent it from going off-screen
+            this._signals.connect(this.actor, 'notify::visible', () => {
+                let monitor = Main.layoutManager.primaryMonitor;
+                let maxHeight = Math.round(monitor.height * 0.9);
+                this._scrollView.set_style(`max-height: ${maxHeight}px;`);
+            });
+
             this._signals.connect(this.actor, 'enter-event', this.onMouseEnter, this);
             this._signals.connect(this.actor, 'leave-event', this.onMouseLeave, this);
         } catch (error) {

--- a/app-launcher@mchilli/files/app-launcher@mchilli/6.6/applet.js
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/6.6/applet.js
@@ -656,7 +656,7 @@ class MyPopupMenu extends Applet.AppletPopupMenu {
             this.actor.remove_actor(this.box);
 
             // Create a scrollable container for the menu
-            this._scrollView = new St.ScrollView({ hscrollbar_policy: 2, vscrollbar_policy: 1 });
+            this._scrollView = new St.ScrollView({ hscrollbar_policy: St.PolicyType.NEVER, vscrollbar_policy: St.PolicyType.AUTOMATIC });
 
             // Add the box to the scrollview and add the scrollview to the actor
             this._scrollView.add_actor(this.box);


### PR DESCRIPTION
Fixes #8597

## What happened
When the launcher list is as tall as the display, clicking a group's 
right-arrow only shows the top row of pixels of the submenu because 
it has no room to expand and there is no scroll container.

## What this fix does
Wraps the menu box in a `St.ScrollView` and caps the menu height at 
90% of the monitor height, so the list becomes scrollable and submenus 
are always reachable.

## Changes
- `app-launcher@mchilli/files/app-launcher@mchilli/applet.js`

## Testing
Unable to test locally. Requesting maintainer @mchilli to verify.