### PR TITLE
multicore-sys-monitor@ccadeptic23: Fix disk I/O calculation by adding fallback logic for discGran

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
@@ -943,7 +943,7 @@ class MCSM extends Applet.IconApplet {
                             mntPoint = _mntPoint.pop();
                         }
                         let mntName = child["kname"];
-                        let discGran = child["disc-gran"];
+                        let discGran = child["disc-gran"] ? child["disc-gran"] : child["log-sec"];
                         if (knownDevices.indexOf(mntName) < 0) {
                             new_Disk_devicesList.push({
                                 "enabled": true,


### PR DESCRIPTION
Friendly ping @claudiux to check if this is relevant.

On my computer, I found that the DiskIO section was not reporting any values for my HDD, only for my SSD. After investigating the applet's code, I discovered that the current implementation uses DISC-GRAN to calculate throughput from `/proc/diskstats`.

However, `lsblk` shows DISC-GRAN as zero for my HDD, causing the applet to always report zero for my HDD I/O. I found that LOG-SEC for my HDD is 512. According to common Linux conventions, using a 512-byte sector size as a fallback appears to be the correct approach.

I have updated the logic to use the logical sector size (LOG-SEC) when DISC-GRAN is falsey, ensuring accurate reporting across all drive types.

(tested locally on Cinnamon 6.0.4 and it works fine)