### PR TITLE
Modernize Duolingo Helper applet

### DIFF
--- a/duolingo-helper@nodeengineer.com/README.md
+++ b/duolingo-helper@nodeengineer.com/README.md
@@ -1,36 +1,58 @@
-**Duolingo Helper Cinnamon Spice**
+# Duolingo Helper Cinnamon Spice
 
-This applet helps you track your Duolingo progress and boost your motivation.
+This applet shows public Duolingo profile statistics in the Cinnamon panel.
 
-Features:
-- the icon is a red "D" if you haven't reached your daily goal and a green "D" if you have
-- your daily XP is also displayed on the panel
-- if you click on the icon you will see the number of your crowns, the streak lenght and the number of lingots - just like on the website
-- the data is fetched every 30 seconds
-- click on the "Practise" button to open duolingo.com in the default browser
-- authentication via Cinnamon-native keyring
+The previous version used Duolingo's obsolete password login endpoint and displayed daily-goal/crown/lingot data that is no longer reliable in the current Duolingo product. This version no longer asks for or stores a Duolingo password. It reads public profile data from:
 
-Authentication troubleshooting:
-The Duolingo Helper will prompt you to enter your credentials (you may also be asked to unlock the keyring).
-If the stored credentials are wrong they will be deleted from the keyring and you will be prompted again to enter them.
-
-If you have issues with the authentication you can use `secret-tool` for troubleshooting:
-- install secret-tool:
-```
-sudo apt-get install -y libsecret-tools
-```
-- lookup duolingo.com credentials:
-```
-secret-tool lookup site duolingo.com
-```
-- manually store credentials:
-```
-secret-tool store --label="Duolingo" site duolingo.com
-```
-- clear credentials:
-```
-secret-tool clear site duolingo.com
+```text
+https://www.duolingo.com/2017-06-30/users?username=<username>
 ```
 
-Last updated:
-Mon 06 Jun 2022 10:36:12 AM CEST
+## Features
+
+- No Duolingo password is requested or stored.
+- Multiple Duolingo usernames can be configured.
+- Right-click the panel applet and choose `Settings` to edit users. The label is translated by Cinnamon.
+- Hover over the applet to see per-user statistics.
+- Left-click the applet for a compact menu, profile links, and manual refresh.
+- Refreshes automatically every 5 minutes.
+
+## Displayed Statistics
+
+The current public profile endpoint exposes:
+
+- Streak in days
+- Total XP
+- XP in the current course
+- Current course title
+- Duolingo Plus status when present
+- Error state per configured username
+
+The panel label stays compact:
+
+```text
+<loaded-users> | <sum-of-streaks>
+```
+
+Example:
+
+```text
+3 | 42
+```
+
+## Configure
+
+1. Right-click the Duolingo Helper applet in the Cinnamon panel.
+2. Click `Settings`.
+3. Add one row per Duolingo username.
+4. Enable the rows you want to fetch.
+
+Use the Duolingo username, not the email address.
+
+Clicking a loaded user in the applet menu opens that user's Duolingo profile.
+
+## Notes
+
+This applet uses an unofficial public Duolingo endpoint. Duolingo can change or remove it without notice.
+
+If a configured username shows an error, verify that the profile exists and that the username is public.

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/applet.js
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/applet.js
@@ -1,6 +1,7 @@
 const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
 const Settings = imports.ui.settings;
+const Util = imports.misc.util;
 const St = imports.gi.St;
 const Soup = imports.gi.Soup;
 const Gio = imports.gi.Gio;
@@ -12,7 +13,7 @@ const UUID = "duolingo-helper@nodeengineer.com";
 const APPLET_PATH = global.userdatadir + "/applets/" + UUID;
 const UPDATE_INTERVAL_SECONDS = 300;
 
-Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+Gettext.bindtextdomain(UUID, GLib.get_user_data_dir() + "/locale");
 
 function _(str) {
   return Gettext.dgettext(UUID, str);
@@ -317,7 +318,7 @@ MyApplet.prototype = {
 
     this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
     let openDuolingo = new PopupMenu.PopupMenuItem(_("Open Duolingo"));
-    openDuolingo.connect("activate", () => GLib.spawn_command_line_async("xdg-open 'https://duolingo.com'"));
+    openDuolingo.connect("activate", () => Util.spawn(["xdg-open", "https://duolingo.com"]));
     this.menu.addMenuItem(openDuolingo);
 
     let refreshNow = new PopupMenu.PopupMenuItem(_("Refresh now"));
@@ -327,7 +328,7 @@ MyApplet.prototype = {
 
   openProfile: function(username) {
     let url = "https://www.duolingo.com/profile/" + encodeURIComponent(username);
-    GLib.spawn_command_line_async("xdg-open " + GLib.shell_quote(url));
+    Util.spawn(["xdg-open", url]);
   }
 };
 

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/applet.js
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/applet.js
@@ -1,18 +1,32 @@
 const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
+const Settings = imports.ui.settings;
 const St = imports.gi.St;
 const Soup = imports.gi.Soup;
-const Util = imports.misc.util;
-const ByteArray = imports.byteArray;
-
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
+const Gettext = imports.gettext;
+const ByteArray = imports.byteArray;
+
 const UUID = "duolingo-helper@nodeengineer.com";
-const Lang = imports.lang;
-
 const APPLET_PATH = global.userdatadir + "/applets/" + UUID;
+const UPDATE_INTERVAL_SECONDS = 300;
 
-var soupASyncSession;
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+
+function _(str) {
+  return Gettext.dgettext(UUID, str);
+}
+
+function formatString(template, values) {
+  let text = template;
+  for (let value of values) {
+    text = text.replace("%s", value);
+  }
+  return text;
+}
+
+let soupASyncSession;
 if (Soup.MAJOR_VERSION === 2) {
     soupASyncSession = new Soup.SessionAsync();
     Soup.Session.prototype.add_feature.call(soupASyncSession, new Soup.ProxyResolverDefault());
@@ -20,335 +34,303 @@ if (Soup.MAJOR_VERSION === 2) {
     soupASyncSession = new Soup.Session();
 }
 
-const Secret = imports.gi.Secret;
-const PASSWORD_SCHEMA = new Secret.Schema("org.freedesktop.Secret.Generic",
-    Secret.SchemaFlags.NONE,
-    {
-        "site": Secret.SchemaAttributeType.STRING
-    }
-);
-let credentials = "";
-this.token = "";
-
-function MyApplet(orientation, panelHeight, instanceId) {
-  this._init(orientation, panelHeight, instanceId);
+function MyApplet(metadata, orientation, panelHeight, instanceId) {
+  this._init(metadata, orientation, panelHeight, instanceId);
 }
 
 MyApplet.prototype = {
   __proto__: Applet.TextIconApplet.prototype,
 
-  _init: function(orientation, panelHeight, instanceId) {
+  _init: function(metadata, orientation, panelHeight, instanceId) {
     Applet.TextIconApplet.prototype._init.call(this, orientation, panelHeight, instanceId);
 
-    try {
-      this.set_applet_icon_name("duolingo");
-      this.set_applet_label("");
-      this.set_applet_tooltip("Practise with Duolingo");
+    this.metadata = metadata;
+    this.instanceId = instanceId;
+    this.usernames = [];
+    this.userData = [];
+    this.pendingRequests = 0;
+    this.refreshTimer = 0;
 
-      this.credentials_search();
+    this.settings = new Settings.AppletSettings(this, UUID, instanceId);
+    this.settings.bindProperty(
+      Settings.BindingDirection.IN,
+      "users",
+      "users",
+      this.onSettingsChanged,
+      null
+    );
 
-      this.menuManager = new PopupMenu.PopupMenuManager(this);
+    this.set_applet_icon_path(APPLET_PATH + "/icon.png");
+    this.set_applet_label("Duo");
+    this.set_applet_tooltip(_("Duolingo Helper"));
 
-      this.menu = new Applet.AppletPopupMenu(this, orientation);
-      this.menuManager.addMenu(this.menu);
-
-      this.box = new St.BoxLayout({ height: 30, width: 300 });
-      this.menu.addActor(this.box);
-
-      this.crownBox = new St.BoxLayout({ style_class: "top-box" });
-      this.crownIcon = new St.Icon({ gicon: Gio.icon_new_for_string(APPLET_PATH + "/crown.png"), style_class: "icon" });
-      this.crownLabel = new St.Label({ style_class: "label", y_align: 2 });
-      this.crownBox.add(this.crownIcon);
-      this.crownBox.add(this.crownLabel);
-      this.box.add(this.crownBox);
-
-      this.streakBox = new St.BoxLayout({ style_class: "top-box" });
-      this.streakIcon = new St.Icon({ gicon: Gio.icon_new_for_string(APPLET_PATH + "/flame.png"), style_class: "icon" });
-      this.streakLabel = new St.Label({ style_class: "label", y_align: 2 });
-      this.streakBox.add(this.streakIcon);
-      this.streakBox.add(this.streakLabel);
-      this.box.add(this.streakBox);
-
-      this.lingotBox = new St.BoxLayout({ style_class: "top-box" });
-      this.lingotIcon = new St.Icon({ gicon: Gio.icon_new_for_string(APPLET_PATH + "/diamond.png"), style_class: "icon" });
-      this.lingotLabel = new St.Label({ style_class: "label", y_align: 2 });
-      this.lingotBox.add(this.lingotIcon);
-      this.lingotBox.add(this.lingotLabel);
-      this.box.add(this.lingotBox);
-
-      this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-      this.bottomBox = new St.BoxLayout( { style_class: "bottom-box" } );
-      this.menu.addActor(this.bottomBox);
-
-      this.button = new St.Button({ style_class: "button", label: "Practise", hover: true});
-      this.button.connect('clicked', function() { GLib.spawn_command_line_async("xdg-open 'https://duolingo.com'"); } );
-      this.bottomBox.add(this.button);
-
-
-    }
-    catch (e) {
-      global.log("DUO error: " + e);
-    }
+    this.addSettingsMenuItem();
+    this.buildMenu(orientation);
+    this.refresh();
   },
 
-  on_applet_clicked: function(event) {
-    this.credentials_search();
+  addSettingsMenuItem: function() {
+    this.settingsMenuItem = new PopupMenu.PopupIconMenuItem(
+      _("Settings"),
+      "xsi-preferences",
+      St.IconType.SYMBOLIC
+    );
+    this.settingsMenuItem.connect("activate", () => this.configureApplet());
+    this._applet_context_menu.addMenuItem(this.settingsMenuItem);
+  },
+
+  buildMenu: function(orientation) {
+    this.menuManager = new PopupMenu.PopupMenuManager(this);
+    this.menu = new Applet.AppletPopupMenu(this, orientation);
+    this.menuManager.addMenu(this.menu);
+    this.rebuildMenu();
+  },
+
+  on_applet_clicked: function() {
     this.menu.toggle();
   },
 
-  credentials_search: function() {
-    let self = this;
-    Secret.password_lookup(PASSWORD_SCHEMA, { "site": "duolingo.com" },
-                       null, self.on_credentials_lookup.bind(self));
+  on_applet_removed_from_panel: function() {
+    if (this.refreshTimer > 0) {
+      GLib.source_remove(this.refreshTimer);
+      this.refreshTimer = 0;
+    }
   },
 
-  on_credentials_lookup: function (source, result) {
-    let self = this;
-    this.credentials = Secret.password_lookup_finish(result);
-    if (this.credentials == null){
-      self.set_applet_label("Unauthorized");
-      self.store_credentials();
-      this.credentials = Secret.password_lookup_finish(result);
-    }
-    this.login(self.credentials, self.getData.bind(self));
+  onSettingsChanged: function() {
+    this.refresh();
   },
 
-  store_credentials: function () {
+  getConfiguredUsers: function() {
+    let names = [];
+    let seen = {};
+    let rows = this.users || [];
 
-    let loop = GLib.MainLoop.new(null, false);
-
-    // A simple asynchronous read loop
-    function readOutput(stream, lineBuffer) {
-        stream.read_line_async(0, null, (stream, res) => {
-            try {
-                let line = stream.read_line_finish_utf8(res)[0];
-
-                if (line !== null) {
-                    lineBuffer.push(line);
-                    readOutput(stream, lineBuffer);
-                }
-            } catch (e) {
-                logError(e);
-            }
-        });
-    }
-
-    try {
-        let [, pid, stdin, stdout, stderr] = GLib.spawn_async_with_pipes(
-            // Working directory, passing %null to use the parent's
-            null,
-            // An array of arguments
-            ["zenity", "--username", "--password", "--title=Please enter your Duolingo credentials"],
-            // Process ENV, passing %null to use the parent's
-            null,
-            // Flags; we need to use PATH so `ls` can be found and also need to know
-            // when the process has finished to check the output and status.
-            GLib.SpawnFlags.SEARCH_PATH | GLib.SpawnFlags.DO_NOT_REAP_CHILD,
-            // Child setup function
-            null
-        );
-
-        // Any unsused streams still have to be closed explicitly, otherwise the
-        // file descriptors may be left open
-        GLib.close(stdin);
-
-        // Okay, now let's get output stream for `stdout`
-        let stdoutStream = new Gio.DataInputStream({
-            base_stream: new Gio.UnixInputStream({
-                fd: stdout,
-                close_fd: true
-            }),
-            close_base_stream: true
-        });
-
-        // We'll read the output asynchronously to avoid blocking the main thread
-        let stdoutLines = [];
-        readOutput(stdoutStream, stdoutLines);
-
-        // We want the real error from `stderr`, so we'll have to do the same here
-        let stderrStream = new Gio.DataInputStream({
-            base_stream: new Gio.UnixInputStream({
-                fd: stderr,
-                close_fd: true
-            }),
-            close_base_stream: true
-        });
-
-        let stderrLines = [];
-        readOutput(stderrStream, stderrLines);
-
-        // Watch for the process to finish, being sure to set a lower priority than
-        // we set for the read loop, so we get all the output
-        GLib.child_watch_add(GLib.PRIORITY_DEFAULT_IDLE, pid, (pid, status) => {
-            if (status === 0) {
-                let self = this;
-                Secret.password_store(PASSWORD_SCHEMA, {"site": "duolingo.com"}, Secret.COLLECTION_DEFAULT,
-                  "Duolingo", stdoutLines.join('\n'), null, self.credentials_search.bind(self));
-
-            } else {
-                logError(new Error(stderrLines.join('\n')));
-            }
-
-            // Ensure we close the remaining streams and process
-            stdoutStream.close(null);
-            stderrStream.close(null);
-            GLib.spawn_close_pid(pid);
-
-            loop.quit();
-        });
-    } catch (e) {
-        logError(e);
-        loop.quit();
-    }
-
-    loop.run();
-  },
-
-  login: function (password, callback) {
-    let self = this;
-
-    if ( typeof self.token == 'undefined' || self.token == null ){
-      let request = Soup.Message.new("POST", "https://www.duolingo.com/login");
-    
-      let credentials_json = `{"login": "${self.credentials.split("|")[0]}", "password": "${self.credentials.split("|")[1]}"}`;
-
-      if (Soup.MAJOR_VERSION === 2) {
-        request.set_request("application/json", 2, credentials_json);
-
-        soupASyncSession.queue_message(request, function(soupASyncSession, message){
-          if (message.status_code !== 200) {
-            self.set_applet_label("Connerror");
-            return;
-          };
-          self.token = message.response_headers.get_one("jwt");
-          callback(self.token);
-        });
-      } else {
-        const bytes = GLib.Bytes.new(ByteArray.fromString(credentials_json));
-        request.set_request_body_from_bytes('application/json', bytes);
-
-        soupASyncSession.send_and_read_async(request, Soup.MessagePriority.NORMAL, null, (session, response) => {
-            if (request.get_status() !== 200) {
-                self.set_applet_label("Connerror");
-                return;
-            }
-
-            try {
-                session.send_and_read_finish(response);
-                self.token = message.response_headers.get_one("jwt");
-                callback(self.token);
-            } catch (err) {
-                self.set_applet_label("Connerror");
-                return;
-            }
-        });
+    for (let row of rows) {
+      if (row.enabled === false) {
+        continue;
       }
-    } else {
-      callback(self.token);
+
+      let username = (row.username || "").trim();
+      if (username.length === 0 || seen[username.toLowerCase()]) {
+        continue;
+      }
+
+      seen[username.toLowerCase()] = true;
+      names.push(username);
     }
+
+    return names;
   },
 
-  getData: function(token) {
+  refresh: function() {
+    if (this.refreshTimer > 0) {
+      GLib.source_remove(this.refreshTimer);
+      this.refreshTimer = 0;
+    }
 
-    let request = Soup.Message.new("GET", `https://www.duolingo.com/users/${this.credentials.split("|")[0]}`);
-    request.request_headers.append('Authorization', `Bearer ${token}`);
+    this.usernames = this.getConfiguredUsers();
+    this.userData = [];
+    this.pendingRequests = this.usernames.length;
+
+    if (this.usernames.length === 0) {
+      this.set_applet_label("Duo");
+      this.set_applet_tooltip(_("Duolingo Helper") + "\n" + _("Right-click -> Settings"));
+      this.rebuildMenu();
+      return;
+    }
+
+    this.set_applet_label("...");
+    for (let username of this.usernames) {
+      this.fetchUser(username);
+    }
+
+    this.refreshTimer = GLib.timeout_add_seconds(
+      GLib.PRIORITY_DEFAULT,
+      UPDATE_INTERVAL_SECONDS,
+      () => {
+        this.refresh();
+        return GLib.SOURCE_REMOVE;
+      }
+    );
+  },
+
+  fetchUser: function(username) {
+    let url = `https://www.duolingo.com/2017-06-30/users?username=${encodeURIComponent(username)}`;
+    let request = Soup.Message.new("GET", url);
     request.request_headers.set_content_type("application/json", null);
 
-    let self = this;
-    let responseParsed;
-
     if (Soup.MAJOR_VERSION === 2) {
-      soupASyncSession.queue_message(request, function(soupASyncSession, message) {
+      soupASyncSession.queue_message(request, (session, message) => {
         if (message.status_code !== 200) {
-          if (message.status_code == 401) {
-            self.set_applet_label("Unauthorized");
-            Secret.password_clear(PASSWORD_SCHEMA, { "site": "duolingo.com" },
-                                null, self.credentials_search.bind(self));
-            global.log("DUO 'unauthorized' error: " + message.status + " " + request.response_body.data);
-          }
-          return;
-        };
-
-        responseParsed = JSON.parse(request.response_body.data);
-        this.process_response(responseParsed);
-
-      });
-    } else {
-      soupASyncSession.send_and_read_async(request, Soup.MessagePriority.NORMAL, null, (session, response) => {
-        if (request.get_status() !== 200) {
-          if (request.get_status() === 401) {
-            self.set_applet_label("Unauthorized");
-            Secret.password_clear(PASSWORD_SCHEMA, { "site": "duolingo.com" },
-                                null, self.credentials_search.bind(self));
-            global.log("DUO 'unauthorized' error: " + message.status + " " + request.response_body.data);
-          }
+          this.recordError(username, message.status_code);
           return;
         }
 
         try {
-            const bytes = soupASyncSession.send_and_read_finish(response);
-            responseParsed = JSON.parse(ByteArray.toString(bytes.get_data()));
-            this.process_response(responseParsed);
+          this.recordResponse(username, JSON.parse(message.response_body.data));
         } catch (err) {
-            global.log("DUO: " + err);
+          this.recordError(username, "parse");
+        }
+      });
+    } else {
+      soupASyncSession.send_and_read_async(request, Soup.MessagePriority.NORMAL, null, (session, response) => {
+        if (request.get_status() !== 200) {
+          this.recordError(username, request.get_status());
+          return;
+        }
+
+        try {
+          let bytes = session.send_and_read_finish(response);
+          this.recordResponse(username, JSON.parse(ByteArray.toString(ByteArray.fromGBytes(bytes))));
+        } catch (err) {
+          this.recordError(username, "parse");
         }
       });
     }
   },
 
-  processResponse:  function(responseParsed) {
-    let language_one = Object.keys(responseParsed.language_data)[0];
-  
-    ////////// Crowns //////////
-    let skills = responseParsed.language_data[language_one].skills;
-  
-    let crowns = 0;
-    for (let skill of skills){
-      crowns += skill.skill_progress.level;
+  recordResponse: function(username, responseParsed) {
+    if (!responseParsed.users || responseParsed.users.length === 0) {
+      this.recordError(username, "not-found");
+      return;
     }
-    self.crownLabel.set_text(crowns.toString());
-  
-    ////////// Streak //////////
-    self.streakLabel.set_text((responseParsed.language_data[language_one].streak).toString());
-  
-    ////////// Lingots //////////
-    self.lingotLabel.set_text((responseParsed.rupees).toString());
-  
-    ////////// XP //////////
-    let daily_goal = responseParsed.daily_goal.toString();
-  
-    // calculate epoch of last midnight
-    let d = new Date();
-    let midnight = d.getTime() - (d.getHours() * 3600 * 1000) - (d.getMinutes() * 60 * 1000) - (d.getSeconds() * 1000);
-  
-    // collect exercises done since midnight into an array
-    let exercises_today = new Array();
-    for (let exercise of responseParsed.calendar) {
-      if (exercise.datetime > midnight) {
-        exercises_today.push(exercise);
-      };
-    };
-  
-    // calculate XP gained since midnight
-    let xp_today = 0;
-    for (let exercise of exercises_today){
-      xp_today += exercise.improvement;
-    };
-  
-    // set icon color, display XP values
-    if (xp_today < daily_goal) {
-      self.set_applet_icon_path(APPLET_PATH + "/icon_red.png");
-    } else {
-      self.set_applet_icon_path(APPLET_PATH + "/icon.png");
-    }
-    self.set_applet_label(xp_today + "/" + daily_goal);
 
-    setTimeout(self.credentials_search.bind(self), 30000);
+    this.userData.push(this.normalizeUser(responseParsed.users[0], username));
+    this.finishRequest();
+  },
+
+  recordError: function(username, status) {
+    this.userData.push({
+      username: username,
+      error: status === "not-found" ? _("not found") : formatString(_("Error %s"), [status])
+    });
+    this.finishRequest();
+  },
+
+  finishRequest: function() {
+    this.pendingRequests--;
+    if (this.pendingRequests <= 0) {
+      this.userData.sort((a, b) => a.username.localeCompare(b.username));
+      this.updateDisplay();
+    }
+  },
+
+  normalizeUser: function(user, fallbackUsername) {
+    let courses = user.courses || [];
+    let currentCourse = null;
+
+    for (let course of courses) {
+      if (course.id === user.currentCourseId) {
+        currentCourse = course;
+        break;
+      }
+    }
+
+    if (!currentCourse && courses.length > 0) {
+      currentCourse = courses[0];
+    }
+
+    currentCourse = currentCourse || {};
+
+    return {
+      username: user.username || fallbackUsername,
+      name: user.name || user.username || fallbackUsername,
+      streak: user.streak || 0,
+      totalXp: user.totalXp || 0,
+      courseTitle: currentCourse.title || user.learningLanguage || _("no course"),
+      courseXp: currentCourse.xp || 0,
+      hasPlus: user.hasPlus === true,
+      activeRecently: user.hasRecentActivity15 === true,
+      courseCount: courses.length
+    };
+  },
+
+  updateDisplay: function() {
+    let validUsers = this.userData.filter(user => !user.error);
+
+    if (validUsers.length === 0) {
+      this.set_applet_label("Duo");
+      this.set_applet_tooltip(this.buildTooltip());
+      this.rebuildMenu();
+      return;
+    }
+
+    let totalStreak = 0;
+    for (let user of validUsers) {
+      totalStreak += user.streak;
+    }
+
+    this.set_applet_label(validUsers.length + " | " + totalStreak);
+    this.set_applet_tooltip(this.buildTooltip());
+    this.rebuildMenu();
+  },
+
+  buildTooltip: function() {
+    if (this.userData.length === 0) {
+      return _("Duolingo Helper") + "\n" + _("No users configured");
+    }
+
+    let lines = [_("Duolingo Statistics")];
+    for (let user of this.userData) {
+      if (user.error) {
+        lines.push(user.username + ": " + user.error);
+        continue;
+      }
+
+      lines.push(
+        formatString(_("%s: %s days, %s total XP, %s XP in %s%s"), [
+          user.username,
+          user.streak,
+          user.totalXp,
+          user.courseXp,
+          user.courseTitle,
+          user.hasPlus ? ", Plus" : ""
+        ])
+      );
+    }
+
+    return lines.join("\n");
+  },
+
+  rebuildMenu: function() {
+    if (!this.menu) {
+      return;
+    }
+
+    this.menu.removeAll();
+
+    if (this.userData.length === 0) {
+      this.menu.addMenuItem(new PopupMenu.PopupMenuItem(_("No users configured")));
+    } else {
+      for (let user of this.userData) {
+        let text = user.error
+          ? user.username + ": " + user.error
+          : formatString(_("%s - %s days - %s XP"), [user.username, user.streak, user.totalXp]);
+        let item = new PopupMenu.PopupMenuItem(text);
+        if (!user.error) {
+          item.connect("activate", () => this.openProfile(user.username));
+        }
+        this.menu.addMenuItem(item);
+      }
+    }
+
+    this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+    let openDuolingo = new PopupMenu.PopupMenuItem(_("Open Duolingo"));
+    openDuolingo.connect("activate", () => GLib.spawn_command_line_async("xdg-open 'https://duolingo.com'"));
+    this.menu.addMenuItem(openDuolingo);
+
+    let refreshNow = new PopupMenu.PopupMenuItem(_("Refresh now"));
+    refreshNow.connect("activate", () => this.refresh());
+    this.menu.addMenuItem(refreshNow);
+  },
+
+  openProfile: function(username) {
+    let url = "https://www.duolingo.com/profile/" + encodeURIComponent(username);
+    GLib.spawn_command_line_async("xdg-open " + GLib.shell_quote(url));
   }
 };
 
 function main(metadata, orientation, panelHeight, instanceId) {
-  let myApplet = new MyApplet(orientation, panelHeight, instanceId);
-  return myApplet;
+  return new MyApplet(metadata, orientation, panelHeight, instanceId);
 }

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/metadata.json
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/metadata.json
@@ -1,6 +1,7 @@
 {
-    "uuid": "duolingo-helper@nodeengineer.com",
-    "name": "Duolingo Helper",
-    "description": "Handy app to help practise with Duolingo.",
-    "author": "nodeengineer"
+  "uuid": "duolingo-helper@nodeengineer.com",
+  "name": "Duolingo Helper",
+  "description": "Handy app to help practise with Duolingo.",
+  "author": "nodeengineer",
+  "hide-configuration": true
 }

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/ca.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/ca.po
@@ -1,22 +1,18 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: 2024-07-05 00:47+0200\n"
-"Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
-"Language-Team: \n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: ca\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.2\n"
 
 #. metadata.json->name
 msgid "Duolingo Helper"
@@ -24,4 +20,60 @@ msgstr "Ajudant de Duolingo"
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
-msgstr "Miniaplicació convenient per a ajudar-vos a practicar amb Duolingo."
+msgstr "Aplicació pràctica per ajudar a practicar amb Duolingo."
+
+#. applet.js
+msgid "Settings"
+msgstr "Configuració"
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr "Clic dret -> Configuració"
+
+#. applet.js
+msgid "not found"
+msgstr "no trobat"
+
+#. applet.js
+msgid "Error %s"
+msgstr "Error %s"
+
+#. applet.js
+msgid "no course"
+msgstr "cap curs"
+
+#. applet.js
+msgid "No users configured"
+msgstr "No hi ha usuaris configurats"
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr "Estadístiques de Duolingo"
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr "%s: %s dies, %s XP totals, %s XP a %s%s"
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr "%s - %s dies - %s XP"
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr "Obre Duolingo"
+
+#. applet.js
+msgid "Refresh now"
+msgstr "Actualitza ara"
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr "Usuaris de Duolingo"
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr "Activat"
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
+msgstr "Nom d'usuari"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/de.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/de.po
@@ -1,27 +1,79 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: 2024-10-24 10:41+0200\n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: de\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.5\n"
 
 #. metadata.json->name
 msgid "Duolingo Helper"
-msgstr "Duolingo Helfer"
+msgstr "Duolingo-Helfer"
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
-msgstr "Praktische app welche das Üben mit Duolingo erleichtert."
+msgstr "Praktische App, die beim Üben mit Duolingo hilft."
+
+#. applet.js
+msgid "Settings"
+msgstr "Einstellungen"
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr "Rechtsklick -> Einstellungen"
+
+#. applet.js
+msgid "not found"
+msgstr "nicht gefunden"
+
+#. applet.js
+msgid "Error %s"
+msgstr "Fehler %s"
+
+#. applet.js
+msgid "no course"
+msgstr "kein Kurs"
+
+#. applet.js
+msgid "No users configured"
+msgstr "Keine Benutzer konfiguriert"
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr "Duolingo-Statistiken"
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr "%s: %s Tage, %s XP gesamt, %s XP in %s%s"
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr "%s - %s Tage - %s XP"
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr "Duolingo öffnen"
+
+#. applet.js
+msgid "Refresh now"
+msgstr "Jetzt aktualisieren"
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr "Duolingo-Benutzer"
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr "Aktiv"
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
+msgstr "Benutzername"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/duolingo-helper@nodeengineer.com.pot
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/duolingo-helper@nodeengineer.com.pot
@@ -1,17 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,4 +20,60 @@ msgstr ""
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
+msgstr ""
+
+#. applet.js
+msgid "Settings"
+msgstr ""
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr ""
+
+#. applet.js
+msgid "not found"
+msgstr ""
+
+#. applet.js
+msgid "Error %s"
+msgstr ""
+
+#. applet.js
+msgid "no course"
+msgstr ""
+
+#. applet.js
+msgid "No users configured"
+msgstr ""
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr ""
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr ""
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr ""
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr ""
+
+#. applet.js
+msgid "Refresh now"
+msgstr ""
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr ""
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr ""
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
 msgstr ""

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/es.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/es.po
@@ -1,26 +1,79 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: 2024-04-12 20:58-0400\n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: es\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.2\n"
 
 #. metadata.json->name
 msgid "Duolingo Helper"
-msgstr "Ayudante Duolingo"
+msgstr "Ayudante de Duolingo"
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
-msgstr "Práctica aplicación para ayudar a practicar con Duolingo."
+msgstr "Aplicación práctica para ayudar a practicar con Duolingo."
+
+#. applet.js
+msgid "Settings"
+msgstr "Configuración"
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr "Clic derecho -> Configuración"
+
+#. applet.js
+msgid "not found"
+msgstr "no encontrado"
+
+#. applet.js
+msgid "Error %s"
+msgstr "Error %s"
+
+#. applet.js
+msgid "no course"
+msgstr "sin curso"
+
+#. applet.js
+msgid "No users configured"
+msgstr "No hay usuarios configurados"
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr "Estadísticas de Duolingo"
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr "%s: %s días, %s XP totales, %s XP en %s%s"
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr "%s - %s días - %s XP"
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr "Abrir Duolingo"
+
+#. applet.js
+msgid "Refresh now"
+msgstr "Actualizar ahora"
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr "Usuarios de Duolingo"
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr "Activado"
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
+msgstr "Nombre de usuario"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/fr.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/fr.po
@@ -1,22 +1,18 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: 2024-09-28 20:32+0200\n"
-"Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
-"Language-Team: \n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: fr\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.2\n"
 
 #. metadata.json->name
 msgid "Duolingo Helper"
@@ -24,4 +20,60 @@ msgstr "Assistant Duolingo"
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
-msgstr "Une application pratique pour s'entraîner avec Duolingo."
+msgstr "Application pratique pour aider à pratiquer avec Duolingo."
+
+#. applet.js
+msgid "Settings"
+msgstr "Paramètres"
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr "Clic droit -> Paramètres"
+
+#. applet.js
+msgid "not found"
+msgstr "introuvable"
+
+#. applet.js
+msgid "Error %s"
+msgstr "Erreur %s"
+
+#. applet.js
+msgid "no course"
+msgstr "aucun cours"
+
+#. applet.js
+msgid "No users configured"
+msgstr "Aucun utilisateur configuré"
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr "Statistiques Duolingo"
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr "%s : %s jours, %s XP au total, %s XP dans %s%s"
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr "%s - %s jours - %s XP"
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr "Ouvrir Duolingo"
+
+#. applet.js
+msgid "Refresh now"
+msgstr "Actualiser maintenant"
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr "Utilisateurs Duolingo"
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr "Activé"
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
+msgstr "Nom d'utilisateur"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/hu.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/hu.po
@@ -1,27 +1,79 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: 2024-07-28 07:44+0200\n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: hu\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
 
 #. metadata.json->name
 msgid "Duolingo Helper"
-msgstr "Duolingo Segítő"
+msgstr "Duolingo segítő"
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
-msgstr "Praktikus alkalmazás a Duolingo gyakorlásához."
+msgstr "Hasznos alkalmazás a Duolingóval való gyakorláshoz."
+
+#. applet.js
+msgid "Settings"
+msgstr "Beállítások"
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr "Jobb kattintás -> Beállítások"
+
+#. applet.js
+msgid "not found"
+msgstr "nem található"
+
+#. applet.js
+msgid "Error %s"
+msgstr "Hiba %s"
+
+#. applet.js
+msgid "no course"
+msgstr "nincs kurzus"
+
+#. applet.js
+msgid "No users configured"
+msgstr "Nincs beállított felhasználó"
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr "Duolingo statisztikák"
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr "%s: %s nap, összesen %s XP, %s XP itt: %s%s"
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr "%s - %s nap - %s XP"
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr "Duolingo megnyitása"
+
+#. applet.js
+msgid "Refresh now"
+msgstr "Frissítés most"
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr "Duolingo-felhasználók"
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr "Engedélyezve"
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
+msgstr "Felhasználónév"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/it.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/it.po
@@ -1,27 +1,79 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: 2024-06-18 15:28+0200\n"
-"Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
-"Language-Team: \n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: it\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
 
 #. metadata.json->name
 msgid "Duolingo Helper"
-msgstr "Aiutante di Duolingo"
+msgstr "Assistente Duolingo"
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
-msgstr "Pratica app per esercitarsi con Duolingo."
+msgstr "App pratica per aiutare a esercitarsi con Duolingo."
+
+#. applet.js
+msgid "Settings"
+msgstr "Impostazioni"
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr "Clic destro -> Impostazioni"
+
+#. applet.js
+msgid "not found"
+msgstr "non trovato"
+
+#. applet.js
+msgid "Error %s"
+msgstr "Errore %s"
+
+#. applet.js
+msgid "no course"
+msgstr "nessun corso"
+
+#. applet.js
+msgid "No users configured"
+msgstr "Nessun utente configurato"
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr "Statistiche Duolingo"
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr "%s: %s giorni, %s XP totali, %s XP in %s%s"
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr "%s - %s giorni - %s XP"
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr "Apri Duolingo"
+
+#. applet.js
+msgid "Refresh now"
+msgstr "Aggiorna ora"
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr "Utenti Duolingo"
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr "Attivo"
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
+msgstr "Nome utente"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/nl.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/nl.po
@@ -1,16 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: 2024-04-21 10:39+0200\n"
-"Last-Translator: qadzek\n"
-"Language-Team: \n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: nl\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,4 +20,60 @@ msgstr "Duolingo Helper"
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
-msgstr "Handige app om te helpen bij het oefenen met Duolingo."
+msgstr "Handige app om te oefenen met Duolingo."
+
+#. applet.js
+msgid "Settings"
+msgstr "Instellingen"
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr "Rechtsklik -> Instellingen"
+
+#. applet.js
+msgid "not found"
+msgstr "niet gevonden"
+
+#. applet.js
+msgid "Error %s"
+msgstr "Fout %s"
+
+#. applet.js
+msgid "no course"
+msgstr "geen cursus"
+
+#. applet.js
+msgid "No users configured"
+msgstr "Geen gebruikers geconfigureerd"
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr "Duolingo-statistieken"
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr "%s: %s dagen, %s XP totaal, %s XP in %s%s"
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr "%s - %s dagen - %s XP"
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr "Duolingo openen"
+
+#. applet.js
+msgid "Refresh now"
+msgstr "Nu vernieuwen"
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr "Duolingo-gebruikers"
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr "Ingeschakeld"
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
+msgstr "Gebruikersnaam"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/vi.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/vi.po
@@ -1,22 +1,18 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: 2025-10-12 01:20+0700\n"
-"Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
-"Language-Team: \n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: vi\n"
 "Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.2\n"
 
 #. metadata.json->name
 msgid "Duolingo Helper"
@@ -24,4 +20,60 @@ msgstr "Trợ lý Duolingo"
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
-msgstr "Ứng dụng tiện lợi để luyện tập với Duolingo."
+msgstr "Ứng dụng tiện lợi giúp luyện tập với Duolingo."
+
+#. applet.js
+msgid "Settings"
+msgstr "Cài đặt"
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr "Nhấp chuột phải -> Cài đặt"
+
+#. applet.js
+msgid "not found"
+msgstr "không tìm thấy"
+
+#. applet.js
+msgid "Error %s"
+msgstr "Lỗi %s"
+
+#. applet.js
+msgid "no course"
+msgstr "không có khóa học"
+
+#. applet.js
+msgid "No users configured"
+msgstr "Chưa cấu hình người dùng"
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr "Thống kê Duolingo"
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr "%s: %s ngày, tổng %s XP, %s XP trong %s%s"
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr "%s - %s ngày - %s XP"
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr "Mở Duolingo"
+
+#. applet.js
+msgid "Refresh now"
+msgstr "Làm mới ngay"
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr "Người dùng Duolingo"
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr "Bật"
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
+msgstr "Tên người dùng"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/zh_TW.po
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/po/zh_TW.po
@@ -1,17 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# Duolingo Helper Cinnamon applet translations.
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: duolingo-helper@nodeengineer.com 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2024-04-09 14:22-0400\n"
-"PO-Revision-Date: 2025-04-25 00:36+0800\n"
-"Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
-"Language-Team: \n"
+"Project-Id-Version: duolingo-helper@nodeengineer.com 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/H234598/duolingo-helper-cinnamon/issues\n"
+"POT-Creation-Date: 2026-05-23 00:00+0000\n"
+"PO-Revision-Date: 2026-05-23 00:00+0000\n"
+"Last-Translator: Codex <noreply@example.com>\n"
+"Language-Team: zh_TW\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,8 +16,64 @@ msgstr ""
 
 #. metadata.json->name
 msgid "Duolingo Helper"
-msgstr "Duolingo Helper"
+msgstr "Duolingo 小幫手"
 
 #. metadata.json->description
 msgid "Handy app to help practise with Duolingo."
-msgstr "方便的小工具，協助您在 Duolingo 上練習。"
+msgstr "協助使用 Duolingo 練習的實用小程式。"
+
+#. applet.js
+msgid "Settings"
+msgstr "設定"
+
+#. applet.js
+msgid "Right-click -> Settings"
+msgstr "右鍵 -> 設定"
+
+#. applet.js
+msgid "not found"
+msgstr "找不到"
+
+#. applet.js
+msgid "Error %s"
+msgstr "錯誤 %s"
+
+#. applet.js
+msgid "no course"
+msgstr "沒有課程"
+
+#. applet.js
+msgid "No users configured"
+msgstr "尚未設定使用者"
+
+#. applet.js
+msgid "Duolingo Statistics"
+msgstr "Duolingo 統計"
+
+#. applet.js
+msgid "%s: %s days, %s total XP, %s XP in %s%s"
+msgstr "%s：%s 天，總計 %s XP，%s 中有 %s XP%s"
+
+#. applet.js
+msgid "%s - %s days - %s XP"
+msgstr "%s - %s 天 - %s XP"
+
+#. applet.js
+msgid "Open Duolingo"
+msgstr "開啟 Duolingo"
+
+#. applet.js
+msgid "Refresh now"
+msgstr "立即重新整理"
+
+#. settings-schema.json->users->description
+msgid "Duolingo users"
+msgstr "Duolingo 使用者"
+
+#. settings-schema.json->users->columns->enabled->title
+msgid "Enabled"
+msgstr "啟用"
+
+#. settings-schema.json->users->columns->username->title
+msgid "Username"
+msgstr "使用者名稱"

--- a/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/settings-schema.json
+++ b/duolingo-helper@nodeengineer.com/files/duolingo-helper@nodeengineer.com/settings-schema.json
@@ -1,0 +1,22 @@
+{
+  "users": {
+    "type": "list",
+    "description": "Duolingo users",
+    "columns": [
+      {
+        "id": "enabled",
+        "title": "Enabled",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "id": "username",
+        "title": "Username",
+        "type": "string",
+        "default": ""
+      }
+    ],
+    "height": 260,
+    "default": []
+  }
+}


### PR DESCRIPTION
## Summary

Modernizes `duolingo-helper@nodeengineer.com` for the current Duolingo profile model and Cinnamon 6.

## Changes

- Removes the obsolete Duolingo password login flow.
- Stops requesting or storing Duolingo credentials in Secret Service.
- Replaces deprecated crown/lingot/daily-goal display with currently available public profile data.
- Adds Cinnamon settings with a configurable multi-user list.
- Shows per-user statistics in the applet tooltip.
- Adds clickable profile entries in the applet menu.
- Adds manual refresh and Duolingo open actions.
- Adds gettext coverage for applet UI and settings strings.
- Keeps the panel label compact as `<loaded-users> | <sum-of-streaks>`.

## Why

The previous applet depended on `https://www.duolingo.com/login` and older Duolingo profile fields. That flow now returns unauthorized responses in current testing, and Duolingo no longer presents crowns/lingots as the relevant progress indicators.

The updated applet reads public profile information from:

```text
https://www.duolingo.com/2017-06-30/users?username=<username>
```

## Validation

- Tested locally on Cinnamon 6.6.7.
- Confirmed live API responses for multiple real users and one not-found user.
- Confirmed profile URLs return HTTP 200 for real users.
- Confirmed applet load and runtime state via Cinnamon D-Bus.
- Confirmed German gettext output after a full Cinnamon restart.
- Ran JSON validation for metadata/settings.
- Ran `msgfmt -c` for all included `.po` files.
- Ran `git diff --check`.

Note: local `validate-spice`/`test-spice` report `vc-mtime` stderr from `xgettext` when checking `.pot` files with `@` in the path. The same local stderr appears when checking unrelated existing applets, so this looks like a local validator/gettext interaction rather than an issue specific to this applet's translation files.
