### PR TITLE
Fix: Stop Toggle Reset

### DIFF
--- a/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/6.4/applet.js
+++ b/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/6.4/applet.js
@@ -207,7 +207,7 @@ class MyApplet extends Applet.TextIconApplet {
         this.actor.add_style_class_name("timer");
 
         this.timerSwitch = new PopupMenu.PopupSwitchMenuItem(_("Timer"));
-        this.timerSwitch.connect('toggled', () => this.doTimerSwitch());
+        this.timerSwitch.connect('toggled', (item) => this.doTimerSwitch(item));
         this.menu.addMenuItem(this.timerSwitch);
 
         this.buildTimePresetMenu();
@@ -335,7 +335,9 @@ class MyApplet extends Applet.TextIconApplet {
     }
 
     doUpdateUI() {
+        if (this.timerSwitch.state !== !this.timerStopped) {
         this.timerSwitch.setToggleState(!this.timerStopped);
+        }
 
         if (this.state) this.actor.remove_style_class_name("timer-" + this.state);
         this.state = this.alarmOn ? "expired" : (this.timerStopped ? "stopped" : "running");


### PR DESCRIPTION
Stop toggle would immediately reset from stop state to start state after user clicking the toggle button, making the countdown impossible to stop/pause.

This patch restores the toggle's intended function.

Explanation of changes:

Line 210:
Previously, arrow function dropped the `item` argument.  Because item was undefined, the handler either threw a silent exception or fell through unpredictably. The stop branch was fragile.  By simply passing the item through to `DoTimerSwitch()`, item is no longer undefined. 

Line 338:
Previously `setToggleState(true)` fired the `toggled` signal - which in turn calls `doTimerSwitch()` unconditionally and on every tick, which restarts the timer. Added state check to ensure an update only if the visual state actually needs to change. 

Disclaimer:
This patch was made with the help of Claude, but it is super simple (two lines touched) and personal use shows no regression on Cinnamon 6.4.8 after one week.  Also, I took the time to parse and explain the code changes here by hand. This is not a robo-commit (not 100% anyways).  Also, it is my first ever PR so apologies for any failures of etiquette.