### PR TITLE
hwmonitor@sylfurd: fix GUdev.Client FD leak crashing Cinnamon

### DIFF
--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
@@ -166,6 +166,7 @@ GraphicalHWMonitorApplet.prototype = {
         this.settings.bind("bat_show_detail_label", "bat_show_detail_label", this.settingsChanged);
 
         this.createThemeObject();
+        this._udevClient = new GUdev.Client();
         this.createAppletArea();
         this.actor.set_offscreen_redirect(Clutter.OffscreenRedirect.ALWAYS);
         this.addUpdateLoop(this.frequency);
@@ -376,7 +377,7 @@ GraphicalHWMonitorApplet.prototype = {
     // Queries the system for available block devices which the user may select from
     getAvailableDisks: function() {
         let devices_options = {};
-        let block_devices = new GUdev.Client().query_by_subsystem("block");
+        let block_devices = this._udevClient.query_by_subsystem("block");
 
         for (var n = 0; n < block_devices.length; n++) {
             let options_labels = [];

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
@@ -222,6 +222,7 @@ class DiskDataProvider {
         this.device_name = device_name;
         this.sample_size = sample_size;
         this.sample_history = [];
+        this.udevClient = new GUdev.Client();
 
         [this.read_last, this.written_last] = this.getDiskLoad();
     }
@@ -257,7 +258,7 @@ class DiskDataProvider {
 
     getDiskLoad() {
         try {
-            let device = new GUdev.Client().query_by_subsystem_and_name("block", this.device_name);
+            let device = this.udevClient.query_by_subsystem_and_name("block", this.device_name);
             let stats_data = device.get_sysfs_attr_as_strv("stat");
             let read = stats_data[2] * 512;
             let written = stats_data[6] * 512;


### PR DESCRIPTION
## Problem

`DiskDataProvider.getDiskLoad()` calls `new GUdev.Client()` on **every poll tick** (every N seconds). Each instance opens netlink sockets and file descriptors without releasing them. Over time this exhausts the per-process FD limit, causing libgtop to call `abort()` and crashing Cinnamon with SIGABRT inside `glibtop_get_cpu_l`.

The same pattern appears in `getAvailableDisks()` in `applet.js`, which is called on every settings change via `restartGHW()`.

Evidence from `~/.xsession-errors` just before the crash:
```
[LookingGlass/error] Exception in getDiskLoad(): device is null
glibtop(c=XXXX): [ERROR] open (/proc/stat): Too many open files
```
After the FD limit is exhausted, glibtop can no longer open `/proc/stat`, triggers abort, and Cinnamon falls back to metacity.

## Fix

Instantiate `GUdev.Client` **once** and reuse it:

- `providers.js`: store as `this.udevClient` in `DiskDataProvider` constructor, reuse in `getDiskLoad()`
- `applet.js`: store as `this._udevClient` in `_init()` (before `createAppletArea()`), reuse in `getAvailableDisks()`

## Testing

Verified on Linux Mint 22 / Cinnamon 6.6.7 — applet loads cleanly and no longer crashes after extended use with disk monitoring enabled.