### PR TITLE
multicore-sys-monitor@ccadeptic23: fix negative Memory Free % and add ZRAM tooltip block

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
@@ -329,6 +329,7 @@ var MCSM = class MCSM extends Applet.TextIconApplet {
         this.settings.bind("Mem_enabledBufferCacheSharedTooltip", "Mem_enabledBufferCacheSharedTooltip");
         this.settings.bind("Swap_enabled", "Swap_enabled");
         this.settings.bind("Swap_enabledTooltip", "Swap_enabledTooltip");
+        this.settings.bind("Swap_enabledZramTooltip", "Swap_enabledZramTooltip");
         this.settings.bind("Mem_chartType", "Mem_chartType");
         this.settings.bind("Mem_squared", "Mem_squared");
         this.settings.bind("Mem_method", "Mem_method");
@@ -536,6 +537,7 @@ var MCSM = class MCSM extends Applet.TextIconApplet {
         this.memoryProvider = new MemDataProvider(this);
         this.multiCpuProvider = new MultiCpuDataProvider(this);
         this.swapProvider = new SwapDataProvider(this);
+        this.zramProvider = new ZramDataProvider(this);
         this.buffcachesharedProvider = new BufferCacheSharedDataProvider(this);
         this.lastDataNet = {};
         this.networkProvider = new NetDataProvider(this);
@@ -762,6 +764,7 @@ var MCSM = class MCSM extends Applet.TextIconApplet {
         const rate = 1 * this.refreshRate;
         this.mainLoopId = timeout_add(rate, () => {
             this.get_mem_info();
+            this.get_zram_info();
             this.get_cpu_info();
             this.get_net_info();
             this.get_disk_info();
@@ -1280,6 +1283,32 @@ var MCSM = class MCSM extends Applet.TextIconApplet {
         });
     }
 
+    get_zram_info() {
+        if (!this.isRunning) return;
+        if (!this.Swap_enabledTooltip || !this.Swap_enabledZramTooltip) return;
+        // Same data as `zramctl /dev/zram0 --output-all`, read straight from sysfs.
+        // If /dev/zram0 doesn't exist the first read rejects -> provider hidden.
+        Promise.all([
+            readFileAsync("/sys/block/zram0/mm_stat"),
+            readFileAsync("/sys/block/zram0/comp_algorithm"),
+            readFileAsync("/proc/swaps")
+        ]).then(([mm, algo, swaps]) => {
+            const f = mm.trim().split(/\s+/).map((x) => 1 * x);
+            const orig = f[0], compr = f[1], total = f[2];
+            const m = algo.match(/\[([^\]]+)\]/);
+            const algorithm = m ? m[1] : algo.trim();
+            const isSwap = swaps.split("\n").some((l) => l.trim().split(/\s+/)[0] === "/dev/zram0");
+            this.zramProvider.setData({
+                orig,
+                compr,
+                total,
+                ratio: total > 0 ? orig / total : 0,
+                algorithm,
+                mountpoint: isSwap ? "[SWAP]" : "-"
+            });
+        }).catch(() => this.zramProvider.setData(null));
+    }
+
     get_cpu_info() {
         if (!this.isRunning) return;
         if (!this.CPU_enabled && !this.CPU_enabledTooltip) return;
@@ -1731,6 +1760,7 @@ var MCSM = class MCSM extends Applet.TextIconApplet {
             "multiCpuProvider",
             "memoryProvider",
             "swapProvider",
+            "zramProvider",
             "buffcachesharedProvider",
             "networkProvider",
             "diskProvider",
@@ -2068,6 +2098,73 @@ var SwapDataProvider = class SwapDataProvider {
 
     get isEnabledTooltip() {
         return this.applet.Swap_enabledTooltip;
+    }
+
+    get isRunning() {
+        return this.applet.isRunning;
+    }
+}
+
+var ZramDataProvider = class ZramDataProvider {
+    constructor(applet) {
+        this.applet = applet;
+        this.name = _("ZRAM");
+        this.available = false;
+        this.data = null;
+    }
+
+    getColorList() {
+        return [];
+    }
+
+    getData() {
+        return [];
+    }
+
+    setData(data) {
+        if (data == null) {
+            this.available = false;
+            this.data = null;
+        } else {
+            this.data = data;
+            this.available = true;
+        }
+    }
+
+    getTooltipString() {
+        if (!this.isEnabledTooltip || !this.isEnabledZramTooltip) return "";
+        if (!this.isRunning) return "";
+        if (!this.available || this.data == null) return "";
+
+        let trans = _("ZRAM");
+        let len = trans.length - 2;
+        let toolTipString = "-".repeat(Math.trunc((2*(spaces + 1) - len)/2)) + " " + trans + " " + "-".repeat(Math.round((2*(spaces + 1) - len)/2)) + "\n";
+
+        // Plain string rows (algorithm, mountpoint).
+        const strRow = (label, value) =>
+            label.padStart(spaces, " ") + ":\t" + ("" + value).padStart(8, " ") + " " + "".padStart(6, " ") + "\n";
+        // Byte rows (data, compressed, total) formatted like the other sections.
+        const bytesRow = (label, bytes) => {
+            let [value, unit] = formatBytesValueUnit(Math.round(bytes), 2, false);
+            value = formatNumber(parseFloat(value).toFixed(2), 2);
+            return label.padStart(spaces, " ") + ":\t" + value.padStart(8, " ") + " " + unit.padStart(6, " ") + "\n";
+        };
+
+        toolTipString += strRow(_("Algorithm"), this.data.algorithm);
+        toolTipString += bytesRow(_("Data"), this.data.orig);
+        toolTipString += bytesRow(_("Compressed"), this.data.compr);
+        toolTipString += bytesRow(_("Total"), this.data.total);
+        toolTipString += strRow(_("Ratio"), formatNumber(parseFloat(this.data.ratio.toFixed(2)), 2));
+        toolTipString += strRow(_("Mountpoint"), this.data.mountpoint);
+        return toolTipString;
+    }
+
+    get isEnabledTooltip() {
+        return this.applet.Swap_enabledTooltip;
+    }
+
+    get isEnabledZramTooltip() {
+        return this.applet.Swap_enabledZramTooltip;
     }
 
     get isRunning() {

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
@@ -1882,15 +1882,17 @@ var MemDataProvider = class MemDataProvider {
                 1 - memInfo["MemUsed"] / memInfo["MemTotal"]
             ]
         } else { // System Monitor: https://github.com/JTourteau/gnome-system-monitor/blob/main/extension.js
-            let memAvailable = 1 * memInfo["MemAvailable"];
-            let memUsed = 1 * this.memTotal - memAvailable;
+            let memFree = 1 * memInfo["MemFree"];
             let memBuffers = 1 * memInfo["Buffers"];
             let memCached = 1 * memInfo["Cached"];
+            // Used = application memory only (excludes buffers/cache) so the four
+            // segments partition MemTotal exactly and Free never goes negative.
+            let memUsed = 1 * this.memTotal - memFree - memBuffers - memCached;
             this.currentReadings = [
                 memUsed / this.memTotal,
                 memCached / this.memTotal,
                 memBuffers / this.memTotal,
-                1.0 - ((memUsed + memBuffers + memCached) / this.memTotal)
+                memFree / this.memTotal
             ]
         }
     }

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/settings-schema.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/settings-schema.json
@@ -262,6 +262,7 @@
         "Mem_enabledBufferCacheSharedTooltip",
         "Swap_enabled",
         "Swap_enabledTooltip",
+        "Swap_enabledZramTooltip",
         "Mem_method",
         "Mem_squared",
         "Mem_width",
@@ -1167,6 +1168,12 @@
     "type": "switch",
     "default": true,
     "description": "Enable Swap Tooltip"
+  },
+  "Swap_enabledZramTooltip": {
+    "type": "switch",
+    "default": true,
+    "description": "Enable ZRAM Tooltip (only shown if /dev/zram0 exists)",
+    "dependency": "Swap_enabledTooltip"
   },
   "Mem_labelOn": {
     "type": "switch",

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v3.16.6~20260623
+  * Fixes negative "Free" percentage when the Memory calculation method is "Gnome System Monitor".
+  * New: ZRAM information block in the tooltip (shown only when /dev/zram0 exists).
+
 ### v3.16.5~20260609
   * Fixes #8760: Network width always increases to 160 pixels.
   * Fixes [#8760](https://github.com/linuxmint/cinnamon-spices-applets/issues/8760)

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "multicore-sys-monitor@ccadeptic23",
   "name": "Multi-Core System Monitor",
-  "version": "3.16.5",
+  "version": "3.16.6",
   "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
   "multiversion": true,
   "cinnamon-version": [


### PR DESCRIPTION
## Summary
Two changes to **Multi-Core System Monitor** (`multicore-sys-monitor@ccadeptic23`), `5.6/` folder only.

@claudiux — would appreciate your review 🙏

### 1. Fix: negative Memory "Free" percentage (Gnome System Monitor method)
When *Memory Calculation Method* = **Gnome System Monitor**, the four memory tooltip
segments (Used / Cached / Buffers / Free) did not partition `MemTotal`: "Used" was
derived from `MemAvailable` (which already excludes the non-reclaimable page cache),
then Buffers and Cached were added again as separate segments. With a large page
cache the segments summed past 100% and **Free was shown as a negative %** (e.g. `-4.10 %`).

Now "Used" is based on `MemFree` (`Used = MemTotal − MemFree − Buffers − Cached`) and
`Free = MemFree / MemTotal`, so the four segments always sum to exactly 100% and Free
can't be negative — consistent with the existing htop method.

### 2. Feature: ZRAM info block in the tooltip
Adds a **ZRAM** section after Swap showing the same data as
`zramctl /dev/zram0 --output-all`, read directly from sysfs (no subprocess):
Algorithm, Data, Compressed, Total, compression Ratio, Mountpoint.

- Sources: `/sys/block/zram0/mm_stat`, `comp_algorithm`, and `/proc/swaps`.
- Auto-hides on machines without `/dev/zram0` (the sysfs read rejects → nothing rendered).
- New toggle **Enable ZRAM Tooltip** (`Swap_enabledZramTooltip`, depends on the Swap tooltip).

Example:
```
----------------- ZRAM -----------------
    Algorithm:        zstd
         Data:      1.6 GB
   Compressed:   389.90 MB
        Total:   403.00 MB
        Ratio:        4.00
   Mountpoint:      [SWAP]
```
(byte units follow the applet's existing binary/decimal size preference, like the Memory/Swap lines)

## Scope & testing
- Only the `5.6/` folder is changed (serves Cinnamon 5.6–6.6+); version bumped to 3.16.6 with a CHANGELOG entry.
- `validate-spice multicore-sys-monitor@ccadeptic23` → no errors; `node --check` passes.
- Tested on Cinnamon 6.6.7 / LMDE 7: Free now reads correctly; ZRAM values match `zramctl`; toggling the switch shows/hides the block.

Originally reported at ccadeptic23/Multi-Core-System-Monitor#24.