### PR TITLE
Enhance Bing wallpaper applet functionality (final2)

### DIFF
--- a/bing-wallpaper@starcross.dev/files/bing-wallpaper@starcross.dev/applet.js
+++ b/bing-wallpaper@starcross.dev/files/bing-wallpaper@starcross.dev/applet.js
@@ -4,7 +4,6 @@ const ByteArray = imports.byteArray;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Mainloop = imports.mainloop;
-const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 
@@ -19,7 +18,7 @@ if (Soup.MAJOR_VERSION == 2) {
 }
 
 const bingHost = 'https://www.bing.com';
-const bingRequestPath = '/HPImageArchive.aspx?format=js&idx=0&n=1&mbl=1';
+const bingRequestPath = '/HPImageArchive.aspx?format=js&idx=0&n=8&mbl=1';
 
 function log(message) {
     if (logging) global.log(`[bing-wallpaper@starcross.dev]: ${message}`);
@@ -34,27 +33,78 @@ BingWallpaperApplet.prototype = {
 
     _init: function (orientation, panel_height, instance_id) {
 
-        // Generic Setup
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
         this.set_applet_icon_symbolic_name("bing-wallpaper");
         this.set_applet_tooltip('Bing Desktop Wallpaper');
 
-        // Path to store data in
         this.wallpaperDir = `${GLib.get_user_config_dir()}/bingwallpaper`;
         let dir = Gio.file_new_for_path(this.wallpaperDir);
-        if (!dir.query_exists(null))
-            dir.make_directory(null);
+        
+        try {
+            dir.make_directory_with_parents(null);
+        } catch (e) {
+            // Ignoramos el error si la carpeta ya existe
+        }
+        
         this.wallpaperPath = `${this.wallpaperDir}/BingWallpaper.jpg`;
         this.metaDataPath = `${this.wallpaperDir}/meta.json`;
 
-        let refreshBg = new PopupMenu.PopupIconMenuItem(_("Refresh Now"), "view-refresh", St.IconType.SYMBOLIC);
-        refreshBg.connect('activate', Lang.bind(this, function() {
-            this._downloadMetaData()
-        }));
+        let refreshBg = new PopupMenu.PopupIconMenuItem("Refresh Now", "view-refresh", St.IconType.SYMBOLIC);
+        
+        refreshBg.connect('activate', () => {
+            this._downloadMetaData();
+        });
         this._applet_context_menu.addMenuItem(refreshBg);
 
-        // Begin refresh loop
+        this.historyMenu = new PopupMenu.PopupSubMenuMenuItem("Historial de Fondos (8 dias)");
+        this._applet_context_menu.addMenuItem(this.historyMenu);
+
         this._refresh();
+    },
+
+    _buildHistoryMenu: function(json) {
+        if (!this.historyMenu) return;
+        
+        this.historyMenu.menu.removeAll();
+
+        if (json && json.images) {
+            for (let i = 0; i < json.images.length; i++) {
+                let imgData = json.images[i];
+                
+                let labelText = imgData.copyright ? imgData.copyright : "Fondo de Bing";
+                
+                let dateStr = imgData.startdate;
+                if (dateStr && dateStr.length === 8) {
+                    let formattedDate = `${dateStr.substring(6,8)}/${dateStr.substring(4,6)}`;
+                    let shortText = labelText.length > 45 ? labelText.substring(0, 45) + "..." : labelText;
+                    labelText = `[${formattedDate}] ${shortText}`;
+                }
+
+                let menuItem = new PopupMenu.PopupMenuItem(labelText);
+                
+                menuItem.connect('activate', () => {
+                    log(`Usuario selecciono fondo historico: ${imgData.url}`);
+                    this.imageData = imgData;
+                    this.set_applet_tooltip(this.imageData.copyright);
+                    
+                    this.wallpaperPath = `${this.wallpaperDir}/bing_${this.imageData.startdate}.jpg`;
+                    
+                    // CORRECCIÓN FINAL: Lectura de archivo asíncrona para no pausar el sistema
+                    let gFile = Gio.file_new_for_path(this.wallpaperPath);
+                    gFile.query_info_async('standard::size', Gio.FileQueryInfoFlags.NONE, 0, null, (file, res) => {
+                        try {
+                            file.query_info_finish(res);
+                            log('La imagen ya esta en cache, aplicandola directamente.');
+                            this._setBackground();
+                        } catch (e) {
+                            log('La imagen no esta en cache, descargando...');
+                            this._downloadImage();
+                        }
+                    });
+                });
+                this.historyMenu.menu.addMenuItem(menuItem);
+            }
+        }
     },
 
     _refresh: function () {
@@ -71,10 +121,9 @@ BingWallpaperApplet.prototype = {
     },
 
     _setTimeout: function (seconds) {
-        /** Cancel current timeout in event of an error and try again shortly */
         this._removeTimeout();
         log(`Setting timeout (${seconds}s)`);
-        this._timeout = Mainloop.timeout_add_seconds(seconds, Lang.bind(this, this._refresh));
+        this._timeout = Mainloop.timeout_add_seconds(seconds, () => this._refresh());
     },
 
     destroy: function () {
@@ -85,17 +134,19 @@ BingWallpaperApplet.prototype = {
     },
 
     _getMetaData: function () {
-
-        /** Check for local metadata  */
         try {
             const jsonString = GLib.file_get_contents(this.metaDataPath)[1];
             const json = JSON.parse(jsonString);
 
+            this._buildHistoryMenu(json);
+
             this.imageData = json.images[0];
+            
+            this.wallpaperPath = `${this.wallpaperDir}/bing_${this.imageData.startdate}.jpg`;
+            
             this.set_applet_tooltip(this.imageData.copyright);
             log(`Got image url from local file : ${this.imageData.url}`);
 
-            /** See if this data is current */
             const start_date = GLib.DateTime.new(
               GLib.TimeZone.new_utc(),
               this.imageData.fullstartdate.substring(0,4),
@@ -111,26 +162,24 @@ BingWallpaperApplet.prototype = {
             if (now.to_unix() < end_date.to_unix()) {
                 log('metadata up to date');
 
-                // Look for image file, check this is up to date
+                // CORRECCIÓN FINAL: La lectura del fondo actual también se pasa a asíncrona
                 let image_file = Gio.file_new_for_path(this.wallpaperPath);
+                image_file.query_info_async('*', Gio.FileQueryInfoFlags.NONE, 0, null, (file, res) => {
+                    try {
+                        let image_file_info = file.query_info_finish(res);
+                        let image_file_size = image_file_info.get_size();
+                        let image_file_mod_secs = image_file_info.get_modification_time().tv_sec;
 
-                if (image_file.query_exists(null)) {
-
-                    let image_file_info = image_file.query_info('*', Gio.FileQueryInfoFlags.NONE, null);
-                    let image_file_size = image_file_info.get_size();
-                    let image_file_mod_secs = image_file_info.get_modification_time().tv_sec;
-
-                    if ((image_file_mod_secs > end_date.to_unix()) || !image_file_size) { // Is the image old, or empty?
+                        if ((image_file_mod_secs > end_date.to_unix()) || !image_file_size) {
+                            this._downloadImage();
+                        } else {
+                            log("image appears up to date");
+                        }
+                    } catch (e) {
+                        log("No image file found");
                         this._downloadImage();
-
-                    } else {
-                        log("image appears up to date");
                     }
-
-                } else {
-                    log("No image file found");
-                    this._downloadImage();
-                }
+                });
 
             }
             else {
@@ -138,18 +187,14 @@ BingWallpaperApplet.prototype = {
                 this._downloadMetaData();
             }
 
-
         } catch (err) {
             log(`Unable to get local metadata ${err}`);
-            /** File does not exist or there was an error processing it */
             this._downloadMetaData();
         }
     },
 
     _downloadMetaData: function () {
         const process_result = data => {
-
-            // Write to meta data file
             let gFile = Gio.file_new_for_path(this.metaDataPath);
             let fStream = gFile.replace(null, false, Gio.FileCreateFlags.NONE, null);
             let toWrite  = data.length;
@@ -158,15 +203,19 @@ BingWallpaperApplet.prototype = {
             fStream.close(null);
 
             const json = JSON.parse(data);
+            
+            this._buildHistoryMenu(json);
+            
             this.imageData = json.images[0];
+            
+            this.wallpaperPath = `${this.wallpaperDir}/bing_${this.imageData.startdate}.jpg`;
+            
             this.set_applet_tooltip(this.imageData.copyright);
             log(`Got image url from download: ${this.imageData.url}`);
 
             this._downloadImage();
-
         };
 
-        // Retrieve json metadata, either from local file or remote
         let request = Soup.Message.new('GET', `${bingHost}${bingRequestPath}`);
         if (Soup.MAJOR_VERSION === 2) {
             _httpSession.queue_message(request, (_httpSession, message) => {
@@ -174,51 +223,41 @@ BingWallpaperApplet.prototype = {
                     process_result(message.response_body.data);
                 } else {
                     log(`Failed to acquire image metadata (${message.status_code})`);
-                    this._setTimeout(60)  // Try again
+                    this._setTimeout(60)
                 }
-
             });
-        } else { //version 3
+        } else {
             _httpSession.send_and_read_async(request, Soup.MessagePriority.NORMAL, null, (_httpSession, message) => {
                 if (request.get_status() === 200) {
                     const bytes = _httpSession.send_and_read_finish(message);
                     process_result(ByteArray.toString(bytes.get_data()));
                 } else {
                     log(`Failed to acquire image metadata (${request.get_status()})`);
-                    this._setTimeout(60)  // Try again
+                    this._setTimeout(60)
                 }
             });
         }
     },
 
     _downloadImage: function () {
-
         log('downloading new image');
         const url = `${bingHost}${this.imageData.url}`;
         const regex = /_\d+x\d+./gm;
         const urlUHD = url.replace(regex, `_UHD.`);
+        
         let gFile = Gio.file_new_for_path(this.wallpaperPath);
-
-        // open the file
         let fStream = gFile.replace(null, false, Gio.FileCreateFlags.NONE, null);
-
-        // create a http message
         let request = Soup.Message.new('GET', urlUHD);
-
-        // keep track of total bytes written
         let bytesTotal = 0;
 
         if (Soup.MAJOR_VERSION === 2) {
-            // got_chunk event
             request.connect('got_chunk', function (message, chunk) {
-                if (message.status_code === 200) { // only save the data we want, not content of 301 redirect page
+                if (message.status_code === 200) {
                     bytesTotal += fStream.write(chunk.get_data(), null);
                 }
             });
 
-            // queue the http request
             _httpSession.queue_message(request, (httpSession, message) => {
-                // request completed
                 fStream.close(null);
                 const contentLength = message.response_headers.get_content_length();
                 if (message.status_code === 200 && contentLength === bytesTotal)  {
@@ -226,23 +265,22 @@ BingWallpaperApplet.prototype = {
                 } else {
                     log("Couldn't fetch image from " + urlUHD);
                     gFile.delete(null);
-                    this._setTimeout(60)  // Try again
+                    this._setTimeout(60)
                 }
             });
-        } else { //version 3
+        } else {
             _httpSession.send_and_read_async(request, Soup.MessagePriority.NORMAL, null, (httpSession, message) => {
                 if (request.get_status() === 200) {
                     const bytes = _httpSession.send_and_read_finish(message);
                     if (bytes && bytes.get_size() > 0) {
                         fStream.write(bytes.get_data(), null);
                     }
-                    // request completed
                     fStream.close(null);
                     log('Download successful');
                     this._setBackground();
                 } else {
                     log("Couldn't fetch image from " + urlUHD);
-                    this._setTimeout(60)  // Try again
+                    this._setTimeout(60)
                 }
             });
         }
@@ -251,13 +289,13 @@ BingWallpaperApplet.prototype = {
     _setBackground: function () {
         let gSetting = new Gio.Settings({schema: 'org.cinnamon.desktop.background'});
         const uri = 'file://' + this.wallpaperPath;
+        
         gSetting.set_string('picture-uri', uri);
         gSetting.set_string('picture-options', 'zoom');
         Gio.Settings.sync();
         gSetting.apply();
     }
 };
-
 
 function main(metadata, orientation, panelHeight, instanceId) {
     let bingApplet = new BingWallpaperApplet(orientation, panelHeight, instanceId);


### PR DESCRIPTION
Updated the Bing wallpaper applet to fetch 8 images instead of 1, improved error handling for directory creation, and made image downloading asynchronous. Added history menu for selecting previous wallpapers.