### PR TITLE
multicore-sys-monitor@ccadeptic23: fix Gnome System Monitor memory method under-reporting used RAM

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
@@ -1911,17 +1911,22 @@ var MemDataProvider = class MemDataProvider {
                 memInfo["Buffers"] / memInfo["MemTotal"],
                 1 - memInfo["MemUsed"] / memInfo["MemTotal"]
             ]
-        } else { // System Monitor: https://github.com/JTourteau/gnome-system-monitor/blob/main/extension.js
-            let memFree = 1 * memInfo["MemFree"];
+        } else { // System Monitor: used = MemTotal - MemAvailable
+                 // https://github.com/JTourteau/gnome-system-monitor/blob/main/extension.js
+            let memAvailable = 1 * memInfo["MemAvailable"];
             let memBuffers = 1 * memInfo["Buffers"];
-            let memCached = 1 * memInfo["Cached"];
-            // Used = application memory only (excludes buffers/cache) so the four
-            // segments partition MemTotal exactly and Free never goes negative.
-            let memUsed = 1 * this.memTotal - memFree - memBuffers - memCached;
+            // "Used" must match Gnome System Monitor: MemTotal - MemAvailable.
+            let memUsed = this.memTotal - memAvailable;
+            // Split the remainder (= MemAvailable) into free / buffers / cached so the pie
+            // segments sum to MemTotal exactly and "Free" never goes negative.
+            let memFree = Math.min(1 * memInfo["MemFree"], memAvailable);
+            let reclaimable = memAvailable - memFree;            // >= 0
+            let memBuffersSeg = Math.min(memBuffers, reclaimable);
+            let memCachedSeg = reclaimable - memBuffersSeg;      // >= 0
             this.currentReadings = [
                 memUsed / this.memTotal,
-                memCached / this.memTotal,
-                memBuffers / this.memTotal,
+                memCachedSeg / this.memTotal,
+                memBuffersSeg / this.memTotal,
                 memFree / this.memTotal
             ]
         }

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v3.16.7~20260626
+  * Fixes the "Gnome System Monitor" memory calculation method under-reporting used RAM (regression from v3.16.6). "Used" now matches Gnome System Monitor / Task Manager (MemTotal - MemAvailable), while "Free" still never goes negative.
+  * Fixes [#8821](https://github.com/linuxmint/cinnamon-spices-applets/issues/8821)
+
 ### v3.16.6~20260623
   * Fixes negative "Free" percentage when the Memory calculation method is "Gnome System Monitor".
   * New: ZRAM information block in the tooltip (shown only when /dev/zram0 exists).

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "multicore-sys-monitor@ccadeptic23",
   "name": "Multi-Core System Monitor",
-  "version": "3.16.6",
+  "version": "3.16.7",
   "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
   "multiversion": true,
   "cinnamon-version": [


### PR DESCRIPTION
Fixes #8821

## Problem

After v3.16.6, the **"Gnome System Monitor"** memory calculation method under-reports used RAM: the applet shows ~664 MB while GNOME System Monitor / the Mint Task Manager shows ~1.0–1.1 GB (reported by @NextDNSFan on Mint 22.3 / Cinnamon 6.8). Before that update the value matched the system tool.

## Root cause

The v3.16.6 fix for the negative "Free" percentage (#8816) redefined "Used" in the System Monitor branch of `MemDataProvider.setData()` as:

```
memUsed = MemTotal − MemFree − Buffers − Cached
```

That is *application-only* memory — algebraically identical to the **htop** branch — so the two methods produced the same, too-low number. It also subtracted an already-adjusted `Cached` value (`Cached + SReclaimable − Shmem`), pushing "Used" even lower.

## Fix

Restore the GNOME System Monitor definition (per the referenced extension, `const used = total - available;`):

```
Used = MemTotal − MemAvailable
```

and split the remainder (= `MemAvailable`) into free / buffers / cached so the pie segments still sum to `MemTotal` exactly and "Free" never goes negative (so the original #8816 fix stays fixed):

```js
let memUsed = this.memTotal - memAvailable;
let memFree = Math.min(1 * memInfo["MemFree"], memAvailable);
let reclaimable = memAvailable - memFree;          // >= 0
let memBuffersSeg = Math.min(memBuffers, reclaimable);
let memCachedSeg = reclaimable - memBuffersSeg;    // >= 0
```

For any `/proc/meminfo`: `currentReadings[0] = (MemTotal − MemAvailable) / MemTotal` (matches the system tool), all four pie segments are `>= 0`, and they sum to `MemTotal`. The **htop** method is unchanged, so the two methods are distinct again (htop = application memory, System Monitor = `MemTotal − MemAvailable`).

## Changes
- `5.6/applet.js`: corrected the System Monitor branch of `MemDataProvider.setData()`.
- `metadata.json`: version `3.16.6` → `3.16.7`.
- `CHANGELOG.md`: new `v3.16.7` entry.

cc @claudiux (maintainer) for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
