### PR TITLE
multicore-sys-monitor@ccadeptic23: tooltip SI/IEC unit toggle, percentages-only option, ZRAM block rework

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
@@ -2141,13 +2141,13 @@ var ZramDataProvider = class ZramDataProvider {
         if (!this.isRunning) return "";
         if (!this.available || this.data == null) return "";
 
-        let trans = _("ZRAM");
+        // Fold algorithm + ratio into the section title, e.g. "ZRAM zstd (2.66x)".
+        let trans = _("ZRAM") + " " + this.data.algorithm;
+        if (this.data.ratio > 0)
+            trans += " (" + formatNumber(parseFloat(this.data.ratio.toFixed(2)), 2) + "x)";
         let len = trans.length - 2;
         let toolTipString = "-".repeat(Math.trunc((2*(spaces + 1) - len)/2)) + " " + trans + " " + "-".repeat(Math.round((2*(spaces + 1) - len)/2)) + "\n";
 
-        // Plain string rows (algorithm, mountpoint).
-        const strRow = (label, value) =>
-            label.padStart(spaces, " ") + ":\t" + ("" + value).padStart(8, " ") + " " + "".padStart(6, " ") + "\n";
         // Byte rows (data, compressed, total) formatted like the other sections.
         const bytesRow = (label, bytes) => {
             let [value, unit] = formatBytesValueUnit(Math.round(bytes), 2, false);
@@ -2155,12 +2155,9 @@ var ZramDataProvider = class ZramDataProvider {
             return label.padStart(spaces, " ") + ":\t" + value.padStart(8, " ") + " " + unit.padStart(6, " ") + "\n";
         };
 
-        toolTipString += strRow(_("Algorithm"), this.data.algorithm);
         toolTipString += bytesRow(_("Data"), this.data.orig);
         toolTipString += bytesRow(_("Compressed"), this.data.compr);
         toolTipString += bytesRow(_("Total"), this.data.total);
-        toolTipString += strRow(_("Ratio"), formatNumber(parseFloat(this.data.ratio.toFixed(2)), 2));
-        toolTipString += strRow(_("Mountpoint"), this.data.mountpoint);
         return toolTipString;
     }
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/applet.js
@@ -140,13 +140,15 @@ const formatNumber = (value, decimals=2) => {
 }
 
 
-const formatBytesValueUnit = (bytes, decimals=2, withRate=true) => {
+const formatBytesValueUnit = (bytes, decimals=2, withRate=true, forceBinary=undefined) => {
     let _rate = (withRate === true) ? rate : "";
     if (bytes < 1) {
         return "0".padStart(spaces/2 - 1) + ".00".padEnd(spaces/2 - 1) + "B".padStart(3, " ") + _rate;
     }
     let dm = (decimals + 1) || 3;
-    let isBinary = get_nemo_size_prefixes().startsWith("base-2");
+    // forceBinary lets callers pick the unit base explicitly (true = IEC, false = SI);
+    // when left undefined we fall back to the Nemo "size-prefixes" preference.
+    let isBinary = (typeof forceBinary === "boolean") ? forceBinary : get_nemo_size_prefixes().startsWith("base-2");
     let k, sizes, i;
     if (!isBinary) {
         k = 1000;
@@ -335,6 +337,7 @@ var MCSM = class MCSM extends Applet.TextIconApplet {
         this.settings.bind("Mem_method", "Mem_method");
         this.settings.bind("Mem_width", "Mem_width", () => { this.adjust_Mem_width() });
         this.settings.bind("Mem_startAt12Oclock", "Mem_startAt12Oclock");
+        this.settings.bind("Mem_showAmountsInTooltip", "Mem_showAmountsInTooltip");
         this.settings.bind("Mem_showBytesInTooltip", "Mem_showBytesInTooltip");
         this.settings.bind("Mem_value_display", "Mem_value_display");
         this.settings.bind("Mem_valueCorner", "Mem_valueCorner");
@@ -1291,10 +1294,12 @@ var MCSM = class MCSM extends Applet.TextIconApplet {
         Promise.all([
             readFileAsync("/sys/block/zram0/mm_stat"),
             readFileAsync("/sys/block/zram0/comp_algorithm"),
-            readFileAsync("/proc/swaps")
-        ]).then(([mm, algo, swaps]) => {
+            readFileAsync("/proc/swaps"),
+            readFileAsync("/sys/block/zram0/disksize")
+        ]).then(([mm, algo, swaps, disksizeRaw]) => {
             const f = mm.trim().split(/\s+/).map((x) => 1 * x);
             const orig = f[0], compr = f[1], total = f[2];
+            const disksize = 1 * disksizeRaw.trim();
             const m = algo.match(/\[([^\]]+)\]/);
             const algorithm = m ? m[1] : algo.trim();
             const isSwap = swaps.split("\n").some((l) => l.trim().split(/\s+/)[0] === "/dev/zram0");
@@ -1302,6 +1307,7 @@ var MCSM = class MCSM extends Applet.TextIconApplet {
                 orig,
                 compr,
                 total,
+                disksize,
                 ratio: total > 0 ? orig / total : 0,
                 algorithm,
                 mountpoint: isSwap ? "[SWAP]" : "-"
@@ -1941,15 +1947,22 @@ var MemDataProvider = class MemDataProvider {
             trans = this.applet.tooltipMemoryCustomTranslation;
         else
             trans = _("Memory");
-        let [strMemTotal, unitMemTotal] = formatBytesValueUnit(this.memTotal, 2, false);
-        if (this.applet.Mem_showBytesInTooltip) {
+        // Mem_showAmountsInTooltip toggles the byte amounts (Total/Used/Available); when off the
+        // tooltip is percentages-only. Mem_showBytesInTooltip selects the unit base for those amounts
+        // (ON = SI MB/GB, OFF = IEC MiB/GiB). The percentages are always shown.
+        let showAmounts = this.applet.Mem_showAmountsInTooltip;
+        let forceBinary = !this.applet.Mem_showBytesInTooltip;
+        if (showAmounts) {
+            let [strMemTotal, unitMemTotal] = formatBytesValueUnit(this.memTotal, 2, false, forceBinary);
             trans += " " + strMemTotal + " " + unitMemTotal;
         }
+        // Show the used percentage in the header, mirroring the Swap section.
+        trans += " (" + formatNumber(parseFloat((Math.round(10000 * this.currentReadings[0]) / 100)).toFixed(2), 2).padStart(5, " ") + " %)";
         let len = trans.length - 2;
         let toolTipString = "-".repeat(Math.trunc((2*(spaces + 1) - len)/2)) + " " + trans + " " + "-".repeat(Math.round((2*(spaces + 1) - len)/2)) + "\n";
-        if (this.applet.Mem_showBytesInTooltip) {
-            let [strMemUsed, unitMemUsed] = formatBytesValueUnit(this.memTotal * this.currentReadings[0], 2, false);
-            let [strMemAvail, unitMemAvail] = formatBytesValueUnit(this.memTotal * (1.0 - this.currentReadings[0]), 2, false);
+        if (showAmounts) {
+            let [strMemUsed, unitMemUsed] = formatBytesValueUnit(this.memTotal * this.currentReadings[0], 2, false, forceBinary);
+            let [strMemAvail, unitMemAvail] = formatBytesValueUnit(this.memTotal * (1.0 - this.currentReadings[0]), 2, false, forceBinary);
             toolTipString += _("Used:").split(":")[0].padStart(spaces, " ") + ":\t"  + "" + formatNumber(parseFloat(strMemUsed).toFixed(2), 2).padStart(8, " ") + " " + unitMemUsed.padStart(6, " ") + "\n";
             toolTipString += _("Available:").split(":")[0].padStart(spaces, " ") + ":\t"  + "" + formatNumber(parseFloat(strMemAvail).toFixed(2), 2).padStart(8, " ") + " " + unitMemAvail.padStart(6, " ") + "\n";
         }
@@ -2020,8 +2033,10 @@ var BufferCacheSharedDataProvider = class BufferCacheSharedDataProvider {
         let lenColon = Math.max(colon.length - 1, 0);
         let attributes = [_("Buffer"), _("Cache"), _("Shared")];
 
+        // Mem_showBytesInTooltip selects the unit base: ON = SI (MB/GB), OFF = IEC binary (MiB/GiB).
+        let forceBinary = !this.applet.Mem_showBytesInTooltip;
         for (let i=0, len=attributes.length; i<len; i++) {
-            let [value, unit] = formatBytesValueUnit(Math.round(this.currentReadings[i]), 2, false);
+            let [value, unit] = formatBytesValueUnit(Math.round(this.currentReadings[i]), 2, false, forceBinary);
             value = formatNumber(parseFloat(value).toFixed(2), 2);
             let valueLen = (""+value).length;
             toolTipString += attributes[i].padStart(spaces - lenColon, " ") + colon + "\t" + "" + value.padStart(8, " ") + " " + unit.padStart(6, " ") + "\n";
@@ -2079,18 +2094,23 @@ var SwapDataProvider = class SwapDataProvider {
             trans = this.applet.tooltipSwapCustomTranslation;
         else
             trans = _("Swap");
-        let [strSwapTotal, unitSwapTotal] = formatBytesValueUnit(this.swapTotal, 2, false);
+        // Mem_showAmountsInTooltip toggles the byte amounts (Total/Used/Available); when off the Swap
+        // tooltip is percentages-only. Mem_showBytesInTooltip selects the unit base for those amounts
+        // (ON = SI MB/GB, OFF = IEC MiB/GiB). The used percentage is always shown.
+        let showAmounts = this.applet.Mem_showAmountsInTooltip;
+        let forceBinary = !this.applet.Mem_showBytesInTooltip;
         let trans2 = trans + "";
-        if (this.applet.Mem_showBytesInTooltip) {
+        if (showAmounts) {
+            let [strSwapTotal, unitSwapTotal] = formatBytesValueUnit(this.swapTotal, 2, false, forceBinary);
             trans2 = trans + " " + strSwapTotal + " " + unitSwapTotal;
         }
         trans2 += " (" + formatNumber(parseFloat((Math.round(10000 * this.currentReadings[0]) / 100)).toFixed(2), 2).padStart(5, " ") + " %)"
         let len = trans2.length - 2;
         let toolTipString = "-".repeat(Math.trunc((2*(spaces + 1) - len)/2)) + " " + trans2 + " " + "-".repeat(Math.round((2*(spaces + 1) - len)/2)) + "\n";
-        if (this.applet.Mem_showBytesInTooltip) {
-            let [swapUsedAmount, swapUsedUnit] = formatBytesValueUnit(this.swapTotal * this.currentReadings[0], 2, false);
+        if (showAmounts) {
+            let [swapUsedAmount, swapUsedUnit] = formatBytesValueUnit(this.swapTotal * this.currentReadings[0], 2, false, forceBinary);
             if (isNaN(parseFloat(swapUsedAmount))) swapUsedAmount = "0";
-            let [swapAvailableAmount, swapAvailableUnit] = formatBytesValueUnit(this.swapTotal * (1 - this.currentReadings[0]), 2, false);
+            let [swapAvailableAmount, swapAvailableUnit] = formatBytesValueUnit(this.swapTotal * (1 - this.currentReadings[0]), 2, false, forceBinary);
             toolTipString += _("Used:").split(":")[0].padStart(spaces, " ") + ":\t"  + "" + formatNumber(parseFloat(swapUsedAmount).toFixed(2), 2).padStart(8, " ") + " " + swapUsedUnit.padStart(6, " ") + "\n";
             toolTipString += _("Available:").split(":")[0].padStart(spaces, " ") + ":\t"  + "" + formatNumber(parseFloat(swapAvailableAmount).toFixed(2), 2).padStart(8, " ") + " " + swapAvailableUnit.padStart(6, " ") + "\n";
         }
@@ -2141,23 +2161,29 @@ var ZramDataProvider = class ZramDataProvider {
         if (!this.isRunning) return "";
         if (!this.available || this.data == null) return "";
 
-        // Fold algorithm + ratio into the section title, e.g. "ZRAM zstd (2.66x)".
-        let trans = _("ZRAM") + " " + this.data.algorithm;
-        if (this.data.ratio > 0)
-            trans += " (" + formatNumber(parseFloat(this.data.ratio.toFixed(2)), 2) + "x)";
-        let len = trans.length - 2;
-        let toolTipString = "-".repeat(Math.trunc((2*(spaces + 1) - len)/2)) + " " + trans + " " + "-".repeat(Math.round((2*(spaces + 1) - len)/2)) + "\n";
+        // Mem_showBytesInTooltip selects the unit base: ON = SI (MB/GB), OFF = IEC binary (MiB/GiB).
+        let forceBinary = !this.applet.Mem_showBytesInTooltip;
 
-        // Byte rows (data, compressed, total) formatted like the other sections.
+        // Byte rows (disksize, data, compressed) formatted like the other sections.
         const bytesRow = (label, bytes) => {
-            let [value, unit] = formatBytesValueUnit(Math.round(bytes), 2, false);
+            let [value, unit] = formatBytesValueUnit(Math.round(bytes), 2, false, forceBinary);
             value = formatNumber(parseFloat(value).toFixed(2), 2);
             return label.padStart(spaces, " ") + ":\t" + value.padStart(8, " ") + " " + unit.padStart(6, " ") + "\n";
         };
 
+        // Headline = total RAM zram uses, with algorithm + ratio, e.g. "ZRAM 577.00 MiB (zstd, 3.87x)".
+        let [strTotal, unitTotal] = formatBytesValueUnit(Math.round(this.data.total), 2, false, forceBinary);
+        strTotal = formatNumber(parseFloat(strTotal).toFixed(2), 2);
+        let trans = _("ZRAM") + " " + strTotal + " " + unitTotal + " (" + this.data.algorithm;
+        if (this.data.ratio > 0)
+            trans += ", " + formatNumber(parseFloat(this.data.ratio.toFixed(2)), 2) + "x";
+        trans += ")";
+        let len = trans.length - 2;
+        let toolTipString = "-".repeat(Math.trunc((2*(spaces + 1) - len)/2)) + " " + trans + " " + "-".repeat(Math.round((2*(spaces + 1) - len)/2)) + "\n";
+
+        toolTipString += bytesRow(_("Disksize"), this.data.disksize);
         toolTipString += bytesRow(_("Data"), this.data.orig);
         toolTipString += bytesRow(_("Compressed"), this.data.compr);
-        toolTipString += bytesRow(_("Total"), this.data.total);
         return toolTipString;
     }
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/settings-schema.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/5.6/settings-schema.json
@@ -268,6 +268,7 @@
         "Mem_width",
         "Mem_chartType",
         "Mem_startAt12Oclock",
+        "Mem_showAmountsInTooltip",
         "Mem_showBytesInTooltip",
         "Mem_value_display",
         "Mem_valueCorner",
@@ -1255,10 +1256,16 @@
     "description": "Origin at 12 o'clock",
     "dependency": "Mem_chartType=pie"
   },
+  "Mem_showAmountsInTooltip": {
+    "type": "switch",
+    "default": true,
+    "description": "Show Memory/Swap byte amounts (Total, Used, Available) in the tooltip"
+  },
   "Mem_showBytesInTooltip": {
     "type": "switch",
     "default": true,
-    "description": "Show the amounts (in Bytes) of Total, Used and Available memory in the tooltip"
+    "description": "Tooltip Memory/Swap amounts: ON = SI units (kB, MB, GB); OFF = IEC binary units (KiB, MiB, GiB)",
+    "dependency": "Mem_showAmountsInTooltip"
   },
   "Mem_value_display": {
     "type": "combobox",

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v3.16.8~20260627
+  * Tooltip: more compact ZRAM block (algorithm and ratio moved into the title).
+
 ### v3.16.7~20260626
   * Fixes the "Gnome System Monitor" memory calculation method under-reporting used RAM (regression from v3.16.6). "Used" now matches Gnome System Monitor / Task Manager (MemTotal - MemAvailable), while "Free" still never goes negative.
   * Fixes [#8821](https://github.com/linuxmint/cinnamon-spices-applets/issues/8821)

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v3.16.9~20260627
+  * Tooltip: Memory and Swap amounts are now always shown; the "Show amounts in Bytes" setting selects the unit base instead of hiding them (ON = SI units MB/GB, OFF = IEC binary units MiB/GiB). Fixes the Swap section disappearing when the setting was off, and adds the used percentage to the Memory header to match Swap.
+  * Tooltip: the Buffers/Cache/Shared and ZRAM amounts now follow the same unit toggle, so the whole tooltip uses one consistent unit base (OFF = IEC, matching `free -h`).
+  * Tooltip: the ZRAM title now shows the total RAM used (e.g. "ZRAM 577 MiB (zstd, 3.87x)") and the block lists Disksize (capacity), Data and Compressed.
+  * Tooltip: new "Show Memory/Swap byte amounts" switch (default on). Turn it off for a percentages-only Memory/Swap tooltip; the SI/IEC unit setting applies only when amounts are shown.
+
 ### v3.16.8~20260627
   * Tooltip: more compact ZRAM block (algorithm and ratio moved into the title).
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "multicore-sys-monitor@ccadeptic23",
   "name": "Multi-Core System Monitor",
-  "version": "3.16.8",
+  "version": "3.16.9",
   "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
   "multiversion": true,
   "cinnamon-version": [

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "multicore-sys-monitor@ccadeptic23",
   "name": "Multi-Core System Monitor",
-  "version": "3.16.7",
+  "version": "3.16.8",
   "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
   "multiversion": true,
   "cinnamon-version": [


### PR DESCRIPTION
## multicore-sys-monitor@ccadeptic23

Tooltip improvements for the Memory / Swap / ZRAM sections (version bumps v3.16.7 → v3.16.9). Only this applet's files are touched.

### v3.16.9
- Memory and Swap tooltip amounts are now always shown; the "Show amounts in Bytes" setting selects the **unit base** (ON = SI kB/MB/GB, OFF = IEC KiB/MiB/GiB) instead of hiding them. This fixes the Swap section disappearing when the setting was off, and adds the used percentage to the Memory header to match Swap.
- Buffers/Cache/Shared and ZRAM amounts follow the same unit toggle, so the whole tooltip uses one consistent unit base (OFF = IEC, matching `free -h`).
- The ZRAM title now shows the total RAM used with algorithm and ratio (e.g. `ZRAM 577 MiB (zstd, 3.87x)`); the block lists Disksize (capacity), Data and Compressed.
- New **"Show Memory/Swap byte amounts"** switch (default on) for a percentages-only tooltip; the SI/IEC unit setting is dependent on it.

### v3.16.8
- More compact ZRAM block (algorithm and ratio moved into the title).

### Testing
- Reloaded the applet on Cinnamon (X11): loads cleanly, settings upgrade succeeds, no JS errors.
- Cross-checked tooltip values against `free -h` / `free --si`, `swapon --show`, `cat /proc/meminfo`, and `zramctl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
