### PR TITLE
ddcci-multi-monitor@tim-we: Monitor brightness is not always updating when slider value changes.

### DIFF
--- a/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
+++ b/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
@@ -153,8 +153,7 @@ class Monitor {
         this.menuSlider = menuSlider;
         menuSlider.connect("value-changed", async (slider) => {
             const brightness = Math.round(100 * slider.value);
-            this.brightness = brightness;
-            this.updateLabel();
+            this.setBrightness(brightness);
         });
 
         menuSlider.connect("drag-end", (slider) => {


### PR DESCRIPTION
Previously monitor brightness not changed when using mouse's scroll wheel (to change brightness value), even though slider value changed.
Pull request fixes this issue.

@GingerGigiCat Please review this pull request when convenient.