### PR TITLE
orloj@faragofr v1.1.0: configurable colors and dial size

### DIFF
--- a/orloj@faragofr/README.md
+++ b/orloj@faragofr/README.md
@@ -45,6 +45,9 @@ Right-click the applet and choose *Configure*:
 | Latitude / Longitude | Observer position in decimal degrees |
 | Refresh interval | How often positions are recomputed (default 30s) |
 | Accent color | Color of the time hand and sun glyph |
+| Foreground color | Text, hands and glyphs; intermediate tones are derived from it |
+| Background color | Dial background; intermediate tones are derived from it |
+| Dial size | Diameter of the dial in the popup; larger values improve readability |
 
 Defaults to Prague (50.09°N, 14.42°E).
 

--- a/orloj@faragofr/files/orloj@faragofr/applet.js
+++ b/orloj@faragofr/files/orloj@faragofr/applet.js
@@ -61,7 +61,12 @@ class OrlojApplet extends Applet.TextApplet {
         this._settings.bind("longitude",       "longitude",      () => this._invalidateEvents());
         this._settings.bind("refresh-seconds", "refreshSeconds", () => this._scheduleRefresh());
         this._settings.bind("accent-color",    "accentColor",    () => this._refresh());
+        this._settings.bind("foreground-color","foregroundColor",() => this._applyColors());
+        this._settings.bind("background-color","backgroundColor",() => this._applyColors());
+        this._settings.bind("dial-size",       "dialSize",       () => this._applySize());
 
+        this._applyColors();
+        this._applySize();
         this._refresh();
         this._scheduleRefresh();
     }
@@ -70,6 +75,20 @@ class OrlojApplet extends Applet.TextApplet {
         this._cachedSunEvent = null;
         this._cachedMoonEvent = null;
         this._refresh();
+    }
+
+    _applyColors() {
+        Theme.setBaseColors(
+            Theme.parseColor(this.backgroundColor, Theme.BACKGROUND),
+            Theme.parseColor(this.foregroundColor, Theme.FOREGROUND));
+        this._drawingArea.queue_repaint();
+    }
+
+    _applySize() {
+        const size = Math.max(160, parseInt(this.dialSize) || DIAL_SIZE);
+        this._drawingArea.width = size;
+        this._drawingArea.height = size;
+        this._drawingArea.queue_repaint();
     }
 
     _scheduleRefresh() {
@@ -182,7 +201,8 @@ class OrlojApplet extends Applet.TextApplet {
         if (!this._state) return false;
         const [sx, sy] = event.get_coords();
         const [ax, ay] = actor.get_transformed_position();
-        const label = Dial.hitTest(DIAL_SIZE, DIAL_SIZE, this._state, sx - ax, sy - ay);
+        const [w, h] = actor.get_surface_size();
+        const label = Dial.hitTest(w, h, this._state, sx - ax, sy - ay);
         if (label === this._lastHoverLabel) return false;
         this._lastHoverLabel = label;
         if (label) {

--- a/orloj@faragofr/files/orloj@faragofr/lib/dial.js
+++ b/orloj@faragofr/files/orloj@faragofr/lib/dial.js
@@ -25,6 +25,11 @@ const PLANET_GLYPHS = {
 };
 const PLANET_ORDER = ["Mercury", "Venus", "Mars", "Jupiter", "Saturn"];
 
+// The dial is designed against this logical size. At runtime the Cairo
+// context is scaled by (actual size / REFERENCE_SIZE), so geometry, fonts,
+// line widths and marker radii all scale uniformly from a single knob.
+const REFERENCE_SIZE = 320;
+
 // Concentric ring radii as fractions of R, the inscribed dial radius.
 // `layout(w, h)` resolves these to pixels for both drawing and hit-testing.
 function layout(width, height) {
@@ -285,10 +290,14 @@ function drawHands(cr, cx, cy, ro, ri, s) {
 // --- Top-level entry -------------------------------------------------------
 
 var draw = function(cr, width, height, s) {
-    var L = layout(width, height);
+    // Draw in the fixed reference coordinate system; the transform scales
+    // everything (including text and stroke widths) to the actual size.
+    var f = Math.min(width, height) / REFERENCE_SIZE;
+    if (f !== 1) cr.scale(f, f);
+    var L = layout(REFERENCE_SIZE, REFERENCE_SIZE);
 
     setColor(cr, Theme.BACKGROUND);
-    cr.rectangle(0, 0, width, height);
+    cr.rectangle(0, 0, REFERENCE_SIZE, REFERENCE_SIZE);
     cr.fill();
 
     setColor(cr, Theme.SURFACE);
@@ -312,7 +321,11 @@ var draw = function(cr, width, height, s) {
 // or null if nothing identifiable is there.
 var hitTest = function(width, height, s, x, y) {
     if (!s) return null;
-    var L = layout(width, height);
+    // Map the pointer back into the reference coordinate system the dial is
+    // drawn in, so hit radii stay consistent at any dial size.
+    var f = Math.min(width, height) / REFERENCE_SIZE;
+    var L = layout(REFERENCE_SIZE, REFERENCE_SIZE);
+    x /= f; y /= f;
     var dx = x - L.cx, dy = y - L.cy;
     var r = Math.sqrt(dx * dx + dy * dy);
     var angle = ((Math.atan2(dx, -dy) * 180 / Math.PI) % 360 + 360) % 360;

--- a/orloj@faragofr/files/orloj@faragofr/lib/theme.js
+++ b/orloj@faragofr/files/orloj@faragofr/lib/theme.js
@@ -19,3 +19,22 @@ var parseColor = function(str, fallback) {
     if (parts.length < 3) return fallback;
     return [parts[0]/255, parts[1]/255, parts[2]/255, parts.length >= 4 ? parts[3] : 1.0];
 };
+
+var lerp = function(a, b, t) {
+    return [a[0] + (b[0] - a[0]) * t,
+            a[1] + (b[1] - a[1]) * t,
+            a[2] + (b[2] - a[2]) * t,
+            a[3] + (b[3] - a[3]) * t];
+};
+
+// Recompute the palette from the two user-facing base colors. The
+// intermediate tones are background→foreground blends, so any custom pair
+// stays internally consistent. The blend ratios are tuned to reproduce the
+// bundled default palette above when the default colors are supplied.
+var setBaseColors = function(bg, fg) {
+    BACKGROUND = bg;
+    FOREGROUND = fg;
+    SURFACE = lerp(bg, fg, 0.06); // panel/day arc: a subtle lift of background
+    FAINT   = lerp(bg, fg, 0.20); // hairlines and minor ticks
+    DIM     = lerp(bg, fg, 0.70); // dimmed foreground for minor labels
+};

--- a/orloj@faragofr/files/orloj@faragofr/metadata.json
+++ b/orloj@faragofr/files/orloj@faragofr/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "orloj@faragofr",
     "name": "Orloj",
     "description": "Prague-style astronomical clock applet",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "cinnamon-version": ["5.4", "5.6", "5.8", "6.0", "6.2", "6.4", "6.6"],
     "max-instances": -1
 }

--- a/orloj@faragofr/files/orloj@faragofr/po/es.po
+++ b/orloj@faragofr/files/orloj@faragofr/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: orloj@faragofr 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-05-11 22:18+0200\n"
+"POT-Creation-Date: 2026-07-01 22:35+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,47 +18,58 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.9\n"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->metadata.json->name
+#. metadata.json->name
 msgid "Orloj"
 msgstr "Orloj"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->metadata.json->description
+#. metadata.json->description
 msgid "Prague-style astronomical clock applet"
 msgstr "Aplicación del reloj astronómico al estilo de Praga"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->latitude->description
+#. settings-schema.json->latitude->description
 msgid "Latitude (decimal degrees, north positive)"
 msgstr "Latitud (grados decimales, norte positivo)"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->latitude->tooltip
+#. settings-schema.json->latitude->tooltip
 msgid "Your geographic latitude in decimal degrees, e.g. 50.0875 for Prague"
-msgstr ""
-"Tu latitud geográfica en grados decimales, p. ej., 50,0875 para Praga"
+msgstr "Tu latitud geográfica en grados decimales, p. ej., 50,0875 para Praga"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->longitude->description
+#. settings-schema.json->longitude->description
 msgid "Longitude (decimal degrees, east positive)"
 msgstr "Longitud (grados decimales, con el este como valor positivo)"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->longitude->tooltip
+#. settings-schema.json->longitude->tooltip
 msgid "Your geographic longitude in decimal degrees, e.g. 14.4214 for Prague"
-msgstr ""
-"Tu longitud geográfica en grados decimales, p. ej., 14,4214 para Praga"
+msgstr "Tu longitud geográfica en grados decimales, p. ej., 14,4214 para Praga"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->refresh-seconds->units
+#. settings-schema.json->refresh-seconds->units
 msgid "seconds"
 msgstr "segundos"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->refresh-seconds->description
+#. settings-schema.json->refresh-seconds->description
 msgid "Refresh interval"
 msgstr "Intervalo de actualización"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->accent-color->description
+#. settings-schema.json->accent-color->description
 msgid "Accent color"
 msgstr "Color de contraste"
+
+#. settings-schema.json->foreground-color->description
+msgid "Foreground color (text, hands, glyphs)"
+msgstr ""
+
+#. settings-schema.json->background-color->description
+msgid "Background color"
+msgstr ""
+
+#. settings-schema.json->dial-size->units
+msgid "pixels"
+msgstr ""
+
+#. settings-schema.json->dial-size->description
+msgid "Dial size"
+msgstr ""
+
+#. settings-schema.json->dial-size->tooltip
+msgid "Diameter of the dial in the popup; larger values improve readability"
+msgstr ""

--- a/orloj@faragofr/files/orloj@faragofr/po/fr.po
+++ b/orloj@faragofr/files/orloj@faragofr/po/fr.po
@@ -5,8 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: orloj@faragofr 1.0.0\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2026-05-11 22:18+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-07-01 22:35+0200\n"
 "PO-Revision-Date: 2026-05-12 10:31+0200\n"
 "Last-Translator: FabRCT\n"
 "Language-Team: none\n"
@@ -16,45 +17,62 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->metadata.json->name
+#. metadata.json->name
 msgid "Orloj"
 msgstr "Orloj"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->metadata.json->description
+#. metadata.json->description
 msgid "Prague-style astronomical clock applet"
 msgstr "Applet d'horloge astronomique de Prague"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->latitude->description
+#. settings-schema.json->latitude->description
 msgid "Latitude (decimal degrees, north positive)"
 msgstr "Latitude (degrés décimaux, Nord positif)"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->latitude->tooltip
+#. settings-schema.json->latitude->tooltip
 msgid "Your geographic latitude in decimal degrees, e.g. 50.0875 for Prague"
-msgstr "Votre latitude géographique en degrés décimaux, par exemple 50.0875 pour Prague"
+msgstr ""
+"Votre latitude géographique en degrés décimaux, par exemple 50.0875 pour "
+"Prague"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->longitude->description
+#. settings-schema.json->longitude->description
 msgid "Longitude (decimal degrees, east positive)"
 msgstr "Longitude (degrés décimaux, Est positif)"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->longitude->tooltip
+#. settings-schema.json->longitude->tooltip
 msgid "Your geographic longitude in decimal degrees, e.g. 14.4214 for Prague"
-msgstr "Votre longitude géographique en degrés décimaux, par exemple 14.214 pour Prague"
+msgstr ""
+"Votre longitude géographique en degrés décimaux, par exemple 14.214 pour "
+"Prague"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->refresh-seconds->units
+#. settings-schema.json->refresh-seconds->units
 msgid "seconds"
 msgstr "secondes"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->refresh-seconds->description
+#. settings-schema.json->refresh-seconds->description
 msgid "Refresh interval"
 msgstr "Intervalle de rafraîchissement"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->accent-color->description
+#. settings-schema.json->accent-color->description
 msgid "Accent color"
 msgstr "Couleur d'accentuation"
+
+#. settings-schema.json->foreground-color->description
+msgid "Foreground color (text, hands, glyphs)"
+msgstr ""
+
+#. settings-schema.json->background-color->description
+msgid "Background color"
+msgstr ""
+
+#. settings-schema.json->dial-size->units
+msgid "pixels"
+msgstr ""
+
+#. settings-schema.json->dial-size->description
+msgid "Dial size"
+msgstr ""
+
+#. settings-schema.json->dial-size->tooltip
+msgid "Diameter of the dial in the popup; larger values improve readability"
+msgstr ""

--- a/orloj@faragofr/files/orloj@faragofr/po/hu.po
+++ b/orloj@faragofr/files/orloj@faragofr/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: orloj@faragofr 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-05-11 22:18+0200\n"
+"POT-Creation-Date: 2026-07-01 22:35+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,45 +18,58 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->metadata.json->name
+#. metadata.json->name
 msgid "Orloj"
 msgstr "Orloj"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->metadata.json->description
+#. metadata.json->description
 msgid "Prague-style astronomical clock applet"
 msgstr "Prágai stílusú csillagászati ​​óra kisalkalmazás"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->latitude->description
+#. settings-schema.json->latitude->description
 msgid "Latitude (decimal degrees, north positive)"
 msgstr "Szélesség (tizedes fok, észak pozitív)"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->latitude->tooltip
+#. settings-schema.json->latitude->tooltip
 msgid "Your geographic latitude in decimal degrees, e.g. 50.0875 for Prague"
 msgstr "Földrajzi szélességi fok tizedfokban, pl. 50.0875 Prága esetében"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->longitude->description
+#. settings-schema.json->longitude->description
 msgid "Longitude (decimal degrees, east positive)"
 msgstr "Hosszúság (tizedes fok, kelet pozitív)"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->longitude->tooltip
+#. settings-schema.json->longitude->tooltip
 msgid "Your geographic longitude in decimal degrees, e.g. 14.4214 for Prague"
 msgstr "Földrajzi hosszúság tizedfokban, pl. Prága esetében 14,4214"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->refresh-seconds->units
+#. settings-schema.json->refresh-seconds->units
 msgid "seconds"
 msgstr "másodperc"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->refresh-seconds->description
+#. settings-schema.json->refresh-seconds->description
 msgid "Refresh interval"
 msgstr "Frissítési gyakoriság"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->accent-color->description
+#. settings-schema.json->accent-color->description
 msgid "Accent color"
 msgstr "Hangsúlyos szín"
+
+#. settings-schema.json->foreground-color->description
+msgid "Foreground color (text, hands, glyphs)"
+msgstr ""
+
+#. settings-schema.json->background-color->description
+msgid "Background color"
+msgstr ""
+
+#. settings-schema.json->dial-size->units
+msgid "pixels"
+msgstr ""
+
+#. settings-schema.json->dial-size->description
+msgid "Dial size"
+msgstr ""
+
+#. settings-schema.json->dial-size->tooltip
+msgid "Diameter of the dial in the popup; larger values improve readability"
+msgstr ""

--- a/orloj@faragofr/files/orloj@faragofr/po/orloj@faragofr.pot
+++ b/orloj@faragofr/files/orloj@faragofr/po/orloj@faragofr.pot
@@ -1,14 +1,14 @@
 # ORLOJ
 # This file is put in the public domain.
-# faragofr, 2016
+# faragofr, 2026
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: orloj@faragofr 1.0.0\n"
+"Project-Id-Version: orloj@faragofr 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-05-11 22:18+0200\n"
+"POT-Creation-Date: 2026-07-01 22:35+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,45 +17,58 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->metadata.json->name
+#. metadata.json->name
 msgid "Orloj"
 msgstr ""
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->metadata.json->description
+#. metadata.json->description
 msgid "Prague-style astronomical clock applet"
 msgstr ""
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->latitude->description
+#. settings-schema.json->latitude->description
 msgid "Latitude (decimal degrees, north positive)"
 msgstr ""
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->latitude->tooltip
+#. settings-schema.json->latitude->tooltip
 msgid "Your geographic latitude in decimal degrees, e.g. 50.0875 for Prague"
 msgstr ""
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->longitude->description
+#. settings-schema.json->longitude->description
 msgid "Longitude (decimal degrees, east positive)"
 msgstr ""
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->longitude->tooltip
+#. settings-schema.json->longitude->tooltip
 msgid "Your geographic longitude in decimal degrees, e.g. 14.4214 for Prague"
 msgstr ""
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->refresh-seconds->units
+#. settings-schema.json->refresh-seconds->units
 msgid "seconds"
 msgstr ""
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->refresh-seconds->description
+#. settings-schema.json->refresh-seconds->description
 msgid "Refresh interval"
 msgstr ""
 
-#. ..->..->..->orloj@faragofr->files->orloj@faragofr->settings-
-#. schema.json->accent-color->description
+#. settings-schema.json->accent-color->description
 msgid "Accent color"
+msgstr ""
+
+#. settings-schema.json->foreground-color->description
+msgid "Foreground color (text, hands, glyphs)"
+msgstr ""
+
+#. settings-schema.json->background-color->description
+msgid "Background color"
+msgstr ""
+
+#. settings-schema.json->dial-size->units
+msgid "pixels"
+msgstr ""
+
+#. settings-schema.json->dial-size->description
+msgid "Dial size"
+msgstr ""
+
+#. settings-schema.json->dial-size->tooltip
+msgid "Diameter of the dial in the popup; larger values improve readability"
 msgstr ""

--- a/orloj@faragofr/files/orloj@faragofr/settings-schema.json
+++ b/orloj@faragofr/files/orloj@faragofr/settings-schema.json
@@ -24,5 +24,25 @@
         "type": "colorchooser",
         "default": "rgb(245,158,11)",
         "description": "Accent color"
+    },
+    "foreground-color": {
+        "type": "colorchooser",
+        "default": "rgb(190,164,110)",
+        "description": "Foreground color (text, hands, glyphs)"
+    },
+    "background-color": {
+        "type": "colorchooser",
+        "default": "rgb(15,17,22)",
+        "description": "Background color"
+    },
+    "dial-size": {
+        "type": "spinbutton",
+        "default": 320,
+        "min": 240,
+        "max": 520,
+        "step": 20,
+        "units": "pixels",
+        "description": "Dial size",
+        "tooltip": "Diameter of the dial in the popup; larger values improve readability"
     }
 }

--- a/orloj@faragofr/info.json
+++ b/orloj@faragofr/info.json
@@ -4,5 +4,5 @@
     "description": "Prague-style astronomical clock applet",
     "author": "faragofr",
     "website": "https://github.com/faragofr/orloj-widget",
-    "version": "1.0.0"
+    "version": "1.1.0"
 }


### PR DESCRIPTION
Closes #8798
Adds configurable foreground/background colors (intermediate tones derived to stay coherent) and a dial-size setting; addresses the low-contrast/readability request. I'm the applet author.