### PR TITLE
orloj@faragofr v1.1.1: Fix tooltips on HiDPI displays

### DIFF
--- a/orloj@faragofr/files/orloj@faragofr/applet.js
+++ b/orloj@faragofr/files/orloj@faragofr/applet.js
@@ -201,7 +201,10 @@ class OrlojApplet extends Applet.TextApplet {
         if (!this._state) return false;
         const [sx, sy] = event.get_coords();
         const [ax, ay] = actor.get_transformed_position();
-        const [w, h] = actor.get_surface_size();
+        // Use the logical allocation, not get_surface_size(): the surface is
+        // sized in device pixels (× the HiDPI resource scale), whereas the
+        // pointer coords above are logical. hitTest must see the same space.
+        const [w, h] = actor.get_size();
         const label = Dial.hitTest(w, h, this._state, sx - ax, sy - ay);
         if (label === this._lastHoverLabel) return false;
         this._lastHoverLabel = label;

--- a/orloj@faragofr/files/orloj@faragofr/metadata.json
+++ b/orloj@faragofr/files/orloj@faragofr/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "orloj@faragofr",
     "name": "Orloj",
     "description": "Prague-style astronomical clock applet",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "cinnamon-version": ["5.4", "5.6", "5.8", "6.0", "6.2", "6.4", "6.6"],
     "max-instances": -1
 }

--- a/orloj@faragofr/info.json
+++ b/orloj@faragofr/info.json
@@ -4,5 +4,5 @@
     "description": "Prague-style astronomical clock applet",
     "author": "faragofr",
     "website": "https://github.com/faragofr/orloj-widget",
-    "version": "1.1.0"
+    "version": "1.1.1"
 }


### PR DESCRIPTION
Hit-test tooltips against the logical size instead of the surface 
  size, fixing tooltip positioning on HiDPI displays.