### PR TITLE
ddcci-monitor-control@andr35: improve popup menu layout; fixed sliders

### DIFF
--- a/ddcci-monitor-control@andr35/files/ddcci-monitor-control@andr35/applet.js
+++ b/ddcci-monitor-control@andr35/files/ddcci-monitor-control@andr35/applet.js
@@ -136,17 +136,17 @@ MyApplet.prototype = {
         this.menuItemContrastValue.set_text(this._get_contrast_label(this.currContrastValue));
 
         if (this.currBrightnessValue === undefined) {
-            this.menutItemBrightnessSlider.actor.hide();
+            this.menutItemBrightnessSlider.actor.reactive = false;
         } else {
             this.menutItemBrightnessSlider.setValue(this.currBrightnessValue);
-            this.menutItemBrightnessSlider.actor.show();
+            this.menutItemBrightnessSlider.actor.reactive = true;
         }
 
         if (this.currContrastValue === undefined) {
-            this.menutItemContrastSlider.actor.hide();
+            this.menutItemContrastSlider.actor.reactive = false;
         } else {
             this.menutItemContrastSlider.setValue(this.currContrastValue);
-            this.menutItemContrastSlider.actor.show();
+            this.menutItemContrastSlider.actor.reactive = true;
         }
     },
 
@@ -168,8 +168,6 @@ MyApplet.prototype = {
 
     _get_current_brightness: function () {
         return new Promise(Lang.bind(this, function (resolve, reject) {
-
-            this.menutItemBrightnessSlider.actor.hide();
 
             // this._spawn_cmd(['ddcutil', 'capabilities', '|', 'grep', 'Brightness'])
             this._spawn_cmd(['ddcutil', 'getvcp', '10'])
@@ -218,9 +216,7 @@ MyApplet.prototype = {
 
     _get_current_contrast: function () {
         return new Promise(Lang.bind(this, function (resolve, reject) {
-
-            this.menutItemContrastSlider.actor.hide();
-
+            
             // this._spawn_cmd(['ddcutil', 'capabilities', '|', 'grep', 'Contrast'])
             this._spawn_cmd(['ddcutil', 'getvcp', '12'])
                 .then(Lang.bind(this, function (res) {

--- a/ddcci-monitor-control@andr35/files/ddcci-monitor-control@andr35/applet.js
+++ b/ddcci-monitor-control@andr35/files/ddcci-monitor-control@andr35/applet.js
@@ -169,6 +169,8 @@ MyApplet.prototype = {
     _get_current_brightness: function () {
         return new Promise(Lang.bind(this, function (resolve, reject) {
 
+            this.menutItemBrightnessSlider.actor.reactive = false;
+
             // this._spawn_cmd(['ddcutil', 'capabilities', '|', 'grep', 'Brightness'])
             this._spawn_cmd(['ddcutil', 'getvcp', '10'])
                 .then(Lang.bind(this, function (res) {
@@ -216,7 +218,9 @@ MyApplet.prototype = {
 
     _get_current_contrast: function () {
         return new Promise(Lang.bind(this, function (resolve, reject) {
-            
+
+            this.menutItemContrastSlider.actor.reactive = false;
+
             // this._spawn_cmd(['ddcutil', 'capabilities', '|', 'grep', 'Contrast'])
             this._spawn_cmd(['ddcutil', 'getvcp', '12'])
                 .then(Lang.bind(this, function (res) {


### PR DESCRIPTION
While being loaded, the applet now disables the sliders instead of hiding so that their positions are fixed in the popup menu.

- Removed `show()` and `hide()` as they make the slider positions unpredictable
- Instead, used `reactive` property to avoid the sliders reacting while the applet is being loaded

This Pull Request resolves linuxmint/cinnamon-spices-applets#7423.

@andr35 I'd appreciate your review. This is one of my favorite Cinnamon applets. Thanks in advance!