### PR TITLE
battery-view@ccarnivore: add charge alert and REST triggers

### DIFF
--- a/battery-view@ccarnivore/README.md
+++ b/battery-view@ccarnivore/README.md
@@ -10,6 +10,8 @@ A Cinnamon panel applet that displays battery state of charge and power flow fro
 - **Tooltip** with detailed power flow information (battery, PV, grid)
 - **Click to refresh** data immediately
 - **Configurable** thresholds for SOC colors, PV production, and grid export/import significance
+- **Charge alert**: system notification and/or fullscreen dialog when the battery reaches a configured SOC while charging
+- **REST triggers**: calls a configurable endpoint when the battery starts charging from surplus, and a second one when the battery runs low while discharging (e.g. to switch a smart plug)
 
 ## Requirements
 
@@ -25,6 +27,53 @@ A Cinnamon panel applet that displays battery state of charge and power flow fro
 - **SOC yellow threshold**: SOC percentage at or above which the battery icon turns yellow (below is red)
 - **PV production threshold**: PV power below this value is considered inactive (filters noise at night)
 - **Grid export/import threshold**: Grid exchange below this value is shown as neutral (filters insignificant values)
+
+### Charge Alert
+
+Alerts you once when the battery reaches a charge level. It only fires while the battery is
+**charging**, never while discharging.
+
+- **Alert when the battery reaches a charge level**: master switch
+- **Alert at SOC**: the level that triggers the alert (default 100%)
+- **Re-arm after SOC drops this far below the alert level**: hysteresis, default 5%. A full battery
+  stops charging and gets topped up again whenever the sun comes out. Without this band, every
+  top-up would fire a new alert. With the default, the alert only re-arms once SOC drops below 95%.
+- **Alert type**: notification only, fullscreen dialog only, or both. The notification is a critical
+  one, so it stays in the message tray until dismissed. The dialog is a modal fullscreen overlay
+  that has to be acknowledged with OK.
+
+### REST Triggers
+
+Calls an HTTP endpoint when the battery changes between "charging from surplus" and "low and
+discharging". Intended for controlling a smart plug: switch a consumer on while there is surplus
+production, switch it off before the battery is drained.
+
+- **Endpoint 1** is called when the battery charges with at least *Minimum charge power* watts.
+- **Endpoint 2** is called when the battery discharges and SOC is below *SOC below which discharging
+  triggers endpoint 2*.
+- In between (neutral: idle battery, or discharging while still well charged) **nothing is called** -
+  the plug keeps its last commanded state until the opposite condition is actually met.
+
+Each endpoint takes a URL, a method (GET or POST), and an optional body plus content type for POST.
+The **Test** buttons fire the call immediately, so you can verify the configuration without waiting
+for the right weather. A test call does not change the remembered plug state.
+
+Debouncing (solar power fluctuates heavily with passing clouds):
+
+- Calls are **edge triggered**: an endpoint is called once on the state change, not on every poll.
+- The condition must hold for **Confirm condition for this many polls** consecutive polls (default 3)
+  before the call goes out.
+- Charging only counts as surplus above **Minimum charge power** (default 100 W), which ignores trickle
+  charging.
+- The last successful action is persisted, so restarting Cinnamon does not re-fire it. A failed call is
+  **not** persisted and is therefore retried on the next poll.
+
+Example URLs:
+
+| Device | On | Off |
+|--------|----|-----|
+| Shelly (Gen1) | `http://192.168.1.50/relay/0?turn=on` | `http://192.168.1.50/relay/0?turn=off` |
+| Tasmota | `http://192.168.1.51/cm?cmnd=Power%20On` | `http://192.168.1.51/cm?cmnd=Power%20Off` |
 
 ## Icon Legend
 

--- a/battery-view@ccarnivore/files/battery-view@ccarnivore/applet.js
+++ b/battery-view@ccarnivore/files/battery-view@ccarnivore/applet.js
@@ -1,9 +1,13 @@
 const Applet = imports.ui.applet;
 const Settings = imports.ui.settings;
+const Main = imports.ui.main;
+const ModalDialog = imports.ui.modalDialog;
+const Dialog = imports.ui.dialog;
 const Soup = imports.gi.Soup;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const St = imports.gi.St;
+const Clutter = imports.gi.Clutter;
 const ByteArray = imports.byteArray;
 const Gettext = imports.gettext;
 
@@ -13,6 +17,32 @@ Gettext.bindtextdomain(UUID, GLib.get_user_data_dir() + "/locale");
 
 function _(str) {
     return Gettext.dgettext(UUID, str);
+}
+
+/**
+ * Decides what to do about the charge alert.
+ * `armed` means the alert has not fired yet for the current charge cycle.
+ * Re-arming uses a hysteresis drop instead of "condition no longer true", because a full
+ * battery stops charging and would otherwise re-trigger on every top-up.
+ * Returns "fire", "rearm" or "hold".
+ */
+function evaluateAlert(soc, charging, alertSoc, rearmDrop, armed) {
+    if (armed && charging && soc >= alertSoc) return "fire";
+    if (!armed && soc < alertSoc - rearmDrop) return "rearm";
+    return "hold";
+}
+
+/**
+ * Maps the current power flow to a REST action.
+ * "on"  = battery is charging with at least `chargeWatts` (surplus production)
+ * "off" = battery is discharging and below `offSoc`
+ * null  = neutral, no action (the last action stays in effect)
+ */
+function determineRestAction(soc, pAkku, chargeWatts, offSoc) {
+    if (pAkku === null || pAkku === undefined) return null;
+    if (pAkku < 0 && Math.abs(pAkku) >= chargeWatts) return "on";
+    if (pAkku > 0 && soc < offSoc) return "off";
+    return null;
 }
 
 class SolarBatteryApplet extends Applet.TextIconApplet {
@@ -36,6 +66,13 @@ class SolarBatteryApplet extends Applet.TextIconApplet {
         this._updateTimer = 0;
         this._lastSOC = null;
 
+        this._alertArmed = true;
+        this._alertDialog = null;
+
+        this._pendingRestAction = null;
+        this._pendingRestCount = 0;
+        this._restInFlight = false;
+
         this._bindSettings(instance_id);
         this._setErrorState();
         this._startPolling();
@@ -58,6 +95,25 @@ class SolarBatteryApplet extends Applet.TextIconApplet {
         this.settings.bind("threshold_yellow", "threshold_yellow", this._onSettingsChanged.bind(this));
         this.settings.bind("threshold_production", "threshold_production", this._onSettingsChanged.bind(this));
         this.settings.bind("threshold_export", "threshold_export", this._onSettingsChanged.bind(this));
+
+        this.settings.bind("alert_enabled", "alert_enabled");
+        this.settings.bind("alert_soc", "alert_soc");
+        this.settings.bind("alert_rearm_drop", "alert_rearm_drop");
+        this.settings.bind("alert_mode", "alert_mode");
+
+        this.settings.bind("rest_enabled", "rest_enabled");
+        this.settings.bind("rest_confirm_polls", "rest_confirm_polls");
+        this.settings.bind("rest_charge_watts", "rest_charge_watts");
+        this.settings.bind("rest_off_soc", "rest_off_soc");
+        this.settings.bind("rest_on_url", "rest_on_url");
+        this.settings.bind("rest_on_method", "rest_on_method");
+        this.settings.bind("rest_on_body", "rest_on_body");
+        this.settings.bind("rest_on_content_type", "rest_on_content_type");
+        this.settings.bind("rest_off_url", "rest_off_url");
+        this.settings.bind("rest_off_method", "rest_off_method");
+        this.settings.bind("rest_off_body", "rest_off_body");
+        this.settings.bind("rest_off_content_type", "rest_off_content_type");
+        this.settings.bind("rest_last_action", "rest_last_action");
     }
 
     _onSettingsChanged() {
@@ -144,8 +200,12 @@ class SolarBatteryApplet extends Applet.TextIconApplet {
 
         this._lastSOC = soc;
 
-        // Battery icon: color by SOC, direction by charge/discharge
         const charging = pAkku !== null && pAkku < 0;
+
+        this._checkAlert(soc, charging);
+        this._checkRestTriggers(soc, pAkku);
+
+        // Battery icon: color by SOC, direction by charge/discharge
         const direction = charging ? "charging" : "discharging";
         let color;
         if (soc >= this.threshold_green) {
@@ -191,6 +251,174 @@ class SolarBatteryApplet extends Applet.TextIconApplet {
         );
     }
 
+    _checkAlert(soc, charging) {
+        if (!this.alert_enabled) {
+            return;
+        }
+
+        const action = evaluateAlert(
+            soc, charging, this.alert_soc, this.alert_rearm_drop, this._alertArmed
+        );
+
+        if (action === "fire") {
+            this._alertArmed = false;
+            this._showAlert(soc);
+        } else if (action === "rearm") {
+            this._alertArmed = true;
+        }
+    }
+
+    _showAlert(soc) {
+        const title = _("Battery charged");
+        const body = _("The battery reached %s%% (alert level: %s%%).")
+            .format(Math.round(soc), this.alert_soc);
+
+        if (this.alert_mode === "notification" || this.alert_mode === "both") {
+            Main.criticalNotify(title, body, this._alertIcon());
+        }
+        if (this.alert_mode === "dialog" || this.alert_mode === "both") {
+            this._showAlertDialog(title, body);
+        }
+    }
+
+    // MessageTray.Notification adds the icon to its table, so this has to be an actor,
+    // not a Gio.Icon.
+    _alertIcon() {
+        const file = Gio.File.new_for_path(this._appletDir + "/icons/battery-green-charging.svg");
+        return new St.Icon({
+            gicon: new Gio.FileIcon({ file: file }),
+            icon_type: St.IconType.FULLCOLOR,
+            icon_size: 24
+        });
+    }
+
+    _showAlertDialog(title, description) {
+        if (this._alertDialog) {
+            return;
+        }
+
+        const dialog = new ModalDialog.ModalDialog();
+        dialog.contentLayout.add_child(new Dialog.MessageDialogContent({ title, description }));
+        dialog.setButtons([
+            {
+                label: _("OK"),
+                action: () => {
+                    this._alertDialog = null;
+                    dialog.destroy();
+                },
+                key: Clutter.KEY_Escape,
+                default: true
+            }
+        ]);
+
+        this._alertDialog = dialog;
+        dialog.open();
+    }
+
+    _checkRestTriggers(soc, pAkku) {
+        if (!this.rest_enabled) {
+            return;
+        }
+
+        const action = determineRestAction(
+            soc, pAkku, this.rest_charge_watts, this.rest_off_soc
+        );
+
+        // Neutral does not reset rest_last_action: the plug stays in its last commanded
+        // state until the opposite condition is actually met.
+        if (action === null) {
+            this._pendingRestAction = null;
+            this._pendingRestCount = 0;
+            return;
+        }
+
+        if (action === this._pendingRestAction) {
+            this._pendingRestCount++;
+        } else {
+            this._pendingRestAction = action;
+            this._pendingRestCount = 1;
+        }
+
+        if (this._pendingRestCount < this.rest_confirm_polls) {
+            return;
+        }
+        if (action === this.rest_last_action) {
+            return;
+        }
+
+        this._fireRest(action, true);
+    }
+
+    onTestRestOn() {
+        this._fireRest("on", false);
+    }
+
+    onTestRestOff() {
+        this._fireRest("off", false);
+    }
+
+    /**
+     * @commit: when true, a successful call is remembered as the new plug state.
+     *          Test-button calls pass false so they do not disturb the state machine.
+     */
+    _fireRest(action, commit) {
+        if (this._restInFlight) {
+            return;
+        }
+
+        const url = action === "on" ? this.rest_on_url : this.rest_off_url;
+        if (!url) {
+            global.logWarning("battery-view: no URL configured for REST action '" + action + "'");
+            return;
+        }
+
+        const method = (action === "on" ? this.rest_on_method : this.rest_off_method) || "GET";
+        const body = action === "on" ? this.rest_on_body : this.rest_off_body;
+        const contentType =
+            (action === "on" ? this.rest_on_content_type : this.rest_off_content_type)
+            || "application/json";
+
+        const message = Soup.Message.new(method, url);
+        if (!message) {
+            global.logError("battery-view: invalid REST URL: " + url);
+            return;
+        }
+
+        if (method === "POST" && body) {
+            message.set_request_body_from_bytes(
+                contentType,
+                GLib.Bytes.new(ByteArray.fromString(body))
+            );
+        }
+
+        this._restInFlight = true;
+        this._httpSession.send_and_read_async(
+            message,
+            GLib.PRIORITY_DEFAULT,
+            null,
+            (session, result) => {
+                this._restInFlight = false;
+                try {
+                    this._httpSession.send_and_read_finish(result);
+                    const status = message.get_status();
+                    if (status < 200 || status >= 300) {
+                        global.logError(
+                            "battery-view: REST '" + action + "' returned HTTP " + status
+                        );
+                        return;
+                    }
+                    // Only commit on success, so a failed call is retried on the next poll.
+                    if (commit) {
+                        this.rest_last_action = action;
+                    }
+                    global.log("battery-view: REST '" + action + "' called: " + method + " " + url);
+                } catch (e) {
+                    global.logError("battery-view: REST '" + action + "' failed: " + e.message);
+                }
+            }
+        );
+    }
+
     _setSolarIcon(path) {
         const file = Gio.File.new_for_path(path);
         const gicon = new Gio.FileIcon({ file: file });
@@ -213,6 +441,10 @@ class SolarBatteryApplet extends Applet.TextIconApplet {
 
     on_applet_removed_from_panel() {
         this._stopPolling();
+        if (this._alertDialog) {
+            this._alertDialog.destroy();
+            this._alertDialog = null;
+        }
         if (this._httpSession) {
             this._httpSession.abort();
         }

--- a/battery-view@ccarnivore/files/battery-view@ccarnivore/settings-schema.json
+++ b/battery-view@ccarnivore/files/battery-view@ccarnivore/settings-schema.json
@@ -48,5 +48,173 @@
         "step": 10,
         "units": "W",
         "description": "Grid export/import threshold (below is considered neutral)"
+    },
+
+    "head_alert": {
+        "type": "header",
+        "description": "Charge alert"
+    },
+    "alert_enabled": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Alert when the battery reaches a charge level",
+        "tooltip": "Only triggers while the battery is charging, never while discharging."
+    },
+    "alert_soc": {
+        "type": "spinbutton",
+        "default": 100,
+        "min": 1,
+        "max": 100,
+        "step": 1,
+        "units": "%",
+        "description": "Alert at SOC (>=)",
+        "dependency": "alert_enabled"
+    },
+    "alert_rearm_drop": {
+        "type": "spinbutton",
+        "default": 5,
+        "min": 0,
+        "max": 50,
+        "step": 1,
+        "units": "%",
+        "description": "Re-arm after SOC drops this far below the alert level",
+        "tooltip": "Prevents repeated alerts when the inverter keeps topping up a full battery.",
+        "dependency": "alert_enabled"
+    },
+    "alert_mode": {
+        "type": "combobox",
+        "default": "both",
+        "description": "Alert type",
+        "options": {
+            "Notification only": "notification",
+            "Fullscreen dialog only": "dialog",
+            "Notification and fullscreen dialog": "both"
+        },
+        "dependency": "alert_enabled"
+    },
+
+    "head_rest": {
+        "type": "header",
+        "description": "REST triggers (smart plug)"
+    },
+    "rest_enabled": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Call REST endpoints on charge/discharge state changes",
+        "tooltip": "Endpoint 1 is called once when the battery starts charging, endpoint 2 once when the battery is low and discharging."
+    },
+    "rest_confirm_polls": {
+        "type": "spinbutton",
+        "default": 3,
+        "min": 1,
+        "max": 10,
+        "step": 1,
+        "units": "polls",
+        "description": "Confirm condition for this many polls before calling",
+        "tooltip": "Debounces fluctuating solar power so the plug does not toggle on every passing cloud.",
+        "dependency": "rest_enabled"
+    },
+    "rest_charge_watts": {
+        "type": "spinbutton",
+        "default": 100,
+        "min": 0,
+        "max": 5000,
+        "step": 50,
+        "units": "W",
+        "description": "Minimum charge power that counts as surplus",
+        "dependency": "rest_enabled"
+    },
+    "rest_off_soc": {
+        "type": "spinbutton",
+        "default": 50,
+        "min": 1,
+        "max": 100,
+        "step": 1,
+        "units": "%",
+        "description": "SOC below which discharging triggers endpoint 2 (<)",
+        "dependency": "rest_enabled"
+    },
+
+    "head_rest_on": {
+        "type": "header",
+        "description": "Endpoint 1: battery charging (surplus)"
+    },
+    "rest_on_url": {
+        "type": "entry",
+        "default": "",
+        "description": "URL",
+        "tooltip": "Example (Shelly): http://192.168.1.50/relay/0?turn=on",
+        "dependency": "rest_enabled"
+    },
+    "rest_on_method": {
+        "type": "combobox",
+        "default": "GET",
+        "description": "Method",
+        "options": {
+            "GET": "GET",
+            "POST": "POST"
+        },
+        "dependency": "rest_enabled"
+    },
+    "rest_on_body": {
+        "type": "entry",
+        "default": "",
+        "description": "Request body (POST only)",
+        "dependency": "rest_enabled"
+    },
+    "rest_on_content_type": {
+        "type": "entry",
+        "default": "application/json",
+        "description": "Content type (POST only)",
+        "dependency": "rest_enabled"
+    },
+    "rest_on_test": {
+        "type": "button",
+        "description": "Test endpoint 1 now",
+        "callback": "onTestRestOn"
+    },
+
+    "head_rest_off": {
+        "type": "header",
+        "description": "Endpoint 2: low battery, discharging"
+    },
+    "rest_off_url": {
+        "type": "entry",
+        "default": "",
+        "description": "URL",
+        "tooltip": "Example (Shelly): http://192.168.1.50/relay/0?turn=off",
+        "dependency": "rest_enabled"
+    },
+    "rest_off_method": {
+        "type": "combobox",
+        "default": "GET",
+        "description": "Method",
+        "options": {
+            "GET": "GET",
+            "POST": "POST"
+        },
+        "dependency": "rest_enabled"
+    },
+    "rest_off_body": {
+        "type": "entry",
+        "default": "",
+        "description": "Request body (POST only)",
+        "dependency": "rest_enabled"
+    },
+    "rest_off_content_type": {
+        "type": "entry",
+        "default": "application/json",
+        "description": "Content type (POST only)",
+        "dependency": "rest_enabled"
+    },
+    "rest_off_test": {
+        "type": "button",
+        "description": "Test endpoint 2 now",
+        "callback": "onTestRestOff"
+    },
+
+    "rest_last_action": {
+        "type": "generic",
+        "default": ""
     }
 }


### PR DESCRIPTION
Charge alert: fires once when the battery reaches a configurable SOC while charging (never while discharging), as a critical notification and/or a fullscreen dialog that has to be acknowledged. Re-arming uses a hysteresis band, because a full battery gets topped up on every sunny spell and would otherwise fire a new alert each time.

REST triggers: calls one endpoint when the battery charges from surplus and another when it discharges below a configurable SOC, for driving a smart plug. Calls are edge triggered, confirmed over N consecutive polls and gated by a watt threshold, so passing clouds cannot make the plug toggle.