### PR TITLE
hwmonitor@sylfurd v1.3.3: Refresh network device list on every poll to stop log spam

### DIFF
--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/applet.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/applet.js
@@ -17,7 +17,11 @@ You should have received a copy of the GNU General Public License along
 with Foobar. If not, see http://www.gnu.org/licenses/.
 */
 
-// 2019-10-15 : I added a version to metadata.json, please increase that 
+// Original author: Renaud Delcoigne (Sylfurd)
+// Past maintainer: hultan
+// Current maintainer: UditDewan
+
+// 2019-10-15 : I added a version to metadata.json, please increase that
 // when making changes to this applet
 
 const Applet = imports.ui.applet;

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/providers.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/providers.js
@@ -1,5 +1,6 @@
 const Gio = imports.gi.Gio;
 const St = imports.gi.St;
+const GLib = imports.gi.GLib;
 
 //
 // Initialize GTop
@@ -181,11 +182,11 @@ NetDataProvider.prototype = {
         catch(e) {
             // Get network devices from filesystem : /sys/class/net
             devices = [];
-            let d = Gio.File.new_for_path("/sys/class/net");
-            let en = d.enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
-            let info;
-            while ((info = en.next_file(null)))
-                devices.push(info.get_name())
+            let dir = GLib.Dir.open("/sys/class/net", 0);
+            let name;
+            while ((name = dir.read_name()) !== null)
+                devices.push(name);
+            dir.close();
         }
         // Don't measure loopback interface
         return devices.filter(v => v !== "lo");

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/providers.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/providers.js
@@ -124,22 +124,7 @@ NetDataProvider.prototype = {
         this.max_speed = max_speed * 1024 * 1024 / 8;
 
         this.gtop = new GTop.glibtop_netload();
-        try {
-            // Get network devices from gtop
-            let nl = new GTop.glibtop_netlist();
-            this.devices = GTop.glibtop.get_netlist(nl);
-        }
-        catch(e) {
-            // Get network devices from filesystem : /sys/class/net
-            this.devices = [];
-            let d = Gio.File.new_for_path("/sys/class/net");
-            let en = d.enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
-            let info;
-            while ((info = en.next_file(null)))
-                this.devices.push(info.get_name())
-        }
-        // Don't measure loopback interface
-        this.devices = this.devices.filter(v => v !== "lo"); 
+        this.devices = this.getDevices();
         try {
             //Workaround, because string match() function throws an error for some reason if called after GTop.glibtop.get_netlist(). After the error is thrown, everything works fine.
             //If the match() would not be called here, the error would be thrown somewhere in Cinnamon applet init code and applet init would fail.
@@ -157,8 +142,9 @@ NetDataProvider.prototype = {
     getData : function() {
         try {
             let [down, up] = this.getNetLoad();
-            let down_delta = (down - this.down_last) / this.frequency;
-            let up_delta = (up - this.up_last) / this.frequency;
+            // Counters can drop when a device disappears, don't report negative rates
+            let down_delta = Math.max(0, (down - this.down_last) / this.frequency);
+            let up_delta = Math.max(0, (up - this.up_last) / this.frequency);
             this.down_last = down;
             this.up_last = up;
             let format = new Tools();
@@ -185,10 +171,34 @@ NetDataProvider.prototype = {
         }
     },
 
+    getDevices : function() {
+        let devices;
+        try {
+            // Get network devices from gtop
+            let nl = new GTop.glibtop_netlist();
+            devices = GTop.glibtop.get_netlist(nl);
+        }
+        catch(e) {
+            // Get network devices from filesystem : /sys/class/net
+            devices = [];
+            let d = Gio.File.new_for_path("/sys/class/net");
+            let en = d.enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
+            let info;
+            while ((info = en.next_file(null)))
+                devices.push(info.get_name())
+        }
+        // Don't measure loopback interface
+        return devices.filter(v => v !== "lo");
+    },
+
     getNetLoad : function() {
         try {
             let down = 0;
             let up = 0;
+            // Refresh the device list on every poll so interfaces that no longer
+            // exist (e.g. docker veth devices) are not queried anymore, which
+            // would make glibtop flood the log with warnings
+            this.devices = this.getDevices();
             for (let i = 0; i < this.devices.length; ++i)
             {
                 GTop.glibtop.get_netload(this.gtop, this.devices[i]);

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
@@ -17,6 +17,10 @@ You should have received a copy of the GNU General Public License along
 with Foobar. If not, see http://www.gnu.org/licenses/.
 */
 
+// Original author: Renaud Delcoigne (Sylfurd)
+// Past maintainer: hultan
+// Current maintainer: UditDewan
+
 // 2019-10-15 : I added a version to metadata.json, please increase that
 // when making changes to this applet
 

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
@@ -113,22 +113,7 @@ class NetDataProvider {
         this.max_speed = max_speed * 1024 * 1024 / 8;
 
         this.gtop = new GTop.glibtop_netload();
-        try {
-            // Get network devices from gtop
-            let nl = new GTop.glibtop_netlist();
-            this.devices = GTop.glibtop.get_netlist(nl);
-        }
-        catch(e) {
-            // Get network devices from filesystem : /sys/class/net
-            this.devices = [];
-            let d = Gio.File.new_for_path("/sys/class/net");
-            let en = d.enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
-            let info;
-            while ((info = en.next_file(null)))
-                this.devices.push(info.get_name())
-        }
-        // Don't measure loopback interface
-        this.devices = this.devices.filter(v => v !== "lo"); 
+        this.devices = this.getDevices();
         try {
             //Workaround, because string match() function throws an error for some reason if called after GTop.glibtop.get_netlist(). After the error is thrown, everything works fine.
             //If the match() would not be called here, the error would be thrown somewhere in Cinnamon applet init code and applet init would fail.
@@ -146,8 +131,9 @@ class NetDataProvider {
     getData() {
         try {
             let [down, up] = this.getNetLoad();
-            let down_delta = (down - this.down_last) / this.frequency;
-            let up_delta = (up - this.up_last) / this.frequency;
+            // Counters can drop when a device disappears, don't report negative rates
+            let down_delta = Math.max(0, (down - this.down_last) / this.frequency);
+            let up_delta = Math.max(0, (up - this.up_last) / this.frequency);
             this.down_last = down;
             this.up_last = up;
             let format = new Tools();
@@ -172,10 +158,34 @@ class NetDataProvider {
         }
     }
 
+    getDevices() {
+        let devices;
+        try {
+            // Get network devices from gtop
+            let nl = new GTop.glibtop_netlist();
+            devices = GTop.glibtop.get_netlist(nl);
+        }
+        catch(e) {
+            // Get network devices from filesystem : /sys/class/net
+            devices = [];
+            let d = Gio.File.new_for_path("/sys/class/net");
+            let en = d.enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
+            let info;
+            while ((info = en.next_file(null)))
+                devices.push(info.get_name())
+        }
+        // Don't measure loopback interface
+        return devices.filter(v => v !== "lo");
+    }
+
     getNetLoad() {
         try {
             let down = 0;
             let up = 0;
+            // Refresh the device list on every poll so interfaces that no longer
+            // exist (e.g. docker veth devices) are not queried anymore, which
+            // would make glibtop flood the log with warnings
+            this.devices = this.getDevices();
             for (let i = 0; i < this.devices.length; ++i)
             {
                 GTop.glibtop.get_netload(this.gtop, this.devices[i]);

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
@@ -168,11 +168,11 @@ class NetDataProvider {
         catch(e) {
             // Get network devices from filesystem : /sys/class/net
             devices = [];
-            let d = Gio.File.new_for_path("/sys/class/net");
-            let en = d.enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
-            let info;
-            while ((info = en.next_file(null)))
-                devices.push(info.get_name())
+            let dir = GLib.Dir.open("/sys/class/net", 0);
+            let name;
+            while ((name = dir.read_name()) !== null)
+                devices.push(name);
+            dir.close();
         }
         // Don't measure loopback interface
         return devices.filter(v => v !== "lo");

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
@@ -13,6 +13,6 @@
     "max-instances": "-1",
     "description": "Displaying realtime system information (CPU, memory, network and disk load).",
     "uuid": "hwmonitor@sylfurd",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "name": "Graphical hardware monitor"
 }

--- a/hwmonitor@sylfurd/info.json
+++ b/hwmonitor@sylfurd/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "none",
+    "author": "UditDewan",
     "contributor": "hultan",
     "original_author": "sylfurd"
 }


### PR DESCRIPTION
Fixes #8540

## Problem

The network monitor enumerated network interfaces once at applet startup and kept querying that list forever. When an interface later disappears — most commonly docker `veth` devices being removed when containers stop — glibtop prints warnings like

```
glibtop(c=3496): [WARNING] Failed to open "/sys/class/net/veth9374893/statistics/rx_bytes": No such file or directory
```

on every poll (7 lines per stale device per refresh), which grows `~/.xsession-errors` to gigabytes within days, as reported in the issue.

## Fix

- Re-enumerate the network device list on each poll (extracted into a `getDevices()` helper, same gtop-with-`/sys/class/net`-fallback logic as before), so removed interfaces are no longer queried and newly added ones are picked up automatically.
- Clamp the computed rate deltas to zero: when a device vanishes, the summed byte counters drop below the previous sample, which previously produced bogus negative rates on the graph for one tick.

Applied to both the 3.2 and 3.8 code paths, version bumped to 1.3.3.

Verified the logic with a stubbed-GTop harness: a device removed between polls is not queried again (no more glibtop warnings), the counter drop reports 0 B instead of a negative rate, and normal traffic measurement is unaffected.

cc @hultan