### PR TITLE
hwmonitor@sylfurd v1.3.4: Fix startup failure when GTop netlist fallback runs

### DIFF
--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/providers.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/providers.js
@@ -181,12 +181,21 @@ NetDataProvider.prototype = {
         }
         catch(e) {
             // Get network devices from filesystem : /sys/class/net
+            // (Gio instead of GLib.Dir, which is not introspectable on older GJS.
+            // Never throw here: this runs in the constructor at session startup,
+            // and the device list is refreshed on every poll anyway.)
             devices = [];
-            let dir = GLib.Dir.open("/sys/class/net", 0);
-            let name;
-            while ((name = dir.read_name()) !== null)
-                devices.push(name);
-            dir.close();
+            try {
+                let enumerator = Gio.File.new_for_path("/sys/class/net")
+                    .enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
+                let info;
+                while ((info = enumerator.next_file(null)) !== null)
+                    devices.push(info.get_name());
+                enumerator.close(null);
+            }
+            catch (e2) {
+                global.logError("Exception listing network devices: " + e2.message);
+            }
         }
         // Don't measure loopback interface
         return devices.filter(v => v !== "lo");

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
@@ -167,12 +167,21 @@ class NetDataProvider {
         }
         catch(e) {
             // Get network devices from filesystem : /sys/class/net
+            // (Gio instead of GLib.Dir, which is not introspectable on older GJS.
+            // Never throw here: this runs in the constructor at session startup,
+            // and the device list is refreshed on every poll anyway.)
             devices = [];
-            let dir = GLib.Dir.open("/sys/class/net", 0);
-            let name;
-            while ((name = dir.read_name()) !== null)
-                devices.push(name);
-            dir.close();
+            try {
+                let enumerator = Gio.File.new_for_path("/sys/class/net")
+                    .enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
+                let info;
+                while ((info = enumerator.next_file(null)) !== null)
+                    devices.push(info.get_name());
+                enumerator.close(null);
+            }
+            catch (e2) {
+                global.logError("Exception listing network devices: " + e2.message);
+            }
         }
         // Don't measure loopback interface
         return devices.filter(v => v !== "lo");

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
@@ -13,6 +13,6 @@
     "max-instances": "-1",
     "description": "Displaying realtime system information (CPU, memory, network and disk load).",
     "uuid": "hwmonitor@sylfurd",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "name": "Graphical hardware monitor"
 }


### PR DESCRIPTION
Fixes #8888

## Problem

On Linux Mint 21.3 / Cinnamon 6.0, the applet can fail to initialize at session startup with:

```
[hwmonitor@sylfurd]: GLib.Dir.open is not a function
[hwmonitor@sylfurd]: Failed to evaluate 'main' function on applet: hwmonitor@sylfurd
```

When GTop's `get_netlist()` fails during early session startup (it recovers on a later reload), `NetDataProvider.getDevices()` falls back to enumerating `/sys/class/net` with `GLib.Dir.open`. On the GJS shipped with Mint 21.3, `GLib.Dir.open` is not introspectable, so the fallback itself throws and aborts applet construction entirely — the applet stays dead until Cinnamon or the applet is manually reloaded.

## Fix

- Enumerate `/sys/class/net` with `Gio.File.enumerate_children` instead, which is available on all GJS versions (`Gio` was already imported).
- Wrap the fallback in its own try/catch so a failure can never again prevent the applet from initializing. Worst case is an empty device list for one poll — the device list is refreshed on every poll, so it recovers on its own as soon as enumeration succeeds.
- Applied to both the 3.8 and 3.2 multiversion directories; version bumped to 1.3.4.

Thanks to @Dragster716 for the detailed report and diagnosis.
