### PR TITLE
[weather@mockturtl] Fix "Powered by AccuWeather (NaN)"

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -14660,7 +14660,8 @@ class AccuWeather {
         ]);
         if (!current.Success || !forecast.Success || !hourly.Success)
             return null;
-        this.remainingQuota = Math.min(Number.parseInt(current.ResponseHeaders["RateLimit-Remaining"]), Number.parseInt(forecast.ResponseHeaders["RateLimit-Remaining"]), Number.parseInt(hourly.ResponseHeaders["RateLimit-Remaining"]));
+        const quotas = [current, forecast, hourly].map(r => Number.parseInt(r.ResponseHeaders["RateLimit-Remaining"])).filter(n => !Number.isNaN(n));
+        this.remainingQuota = quotas.length > 0 ? Math.min(...quotas) : null;
         this.SetTier(Number.parseInt(current.ResponseHeaders["RateLimit-Limit"]));
         return this.ParseWeather(current.Data[0], forecast.Data, hourly.Data, location);
     }

--- a/weather@mockturtl/files/weather@mockturtl/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/metadata.json
@@ -3,7 +3,7 @@
   "name": "Weather",
   "description": "View your local weather forecast",
   "max-instances": 3,
-  "version": "3.6.9",
+  "version": "3.6.10",
   "multiversion": true,
   "cinnamon-version": [
     "2.2",

--- a/weather@mockturtl/src/3_8/providers/accuWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/accuWeather.ts
@@ -108,11 +108,15 @@ export class AccuWeather implements WeatherProvider<Services.AccuWeather, AccuWe
 		if (!current.Success || !forecast.Success || !hourly.Success)
 			return null;
 
-		this.remainingQuota = Math.min(
-			Number.parseInt(current.ResponseHeaders["RateLimit-Remaining"]),
-			Number.parseInt(forecast.ResponseHeaders["RateLimit-Remaining"]),
-			Number.parseInt(hourly.ResponseHeaders["RateLimit-Remaining"])
-		);
+		// AccuWeather no longer always returns the RateLimit-Remaining header
+		// (e.g. after their API/plan changes), so Number.parseInt yields NaN and
+		// Math.min(NaN, ...) makes remainingQuota NaN -- which the "!= null" check
+		// downstream does not catch, surfacing as "Powered by AccuWeather (NaN)".
+		// Ignore missing/unparseable headers; leave the quota unknown (null) if none parse.
+		const quotas = [current, forecast, hourly]
+			.map(r => Number.parseInt(r.ResponseHeaders["RateLimit-Remaining"]))
+			.filter(n => !Number.isNaN(n));
+		this.remainingQuota = quotas.length > 0 ? Math.min(...quotas) : null;
 
 		// Base
 		this.SetTier(Number.parseInt(current.ResponseHeaders["RateLimit-Limit"]));


### PR DESCRIPTION
### Issue
The AccuWeather provider shows **"Powered by AccuWeather (NaN)"** in the provider credit.

### Cause
The `RateLimit-Remaining` response header is no longer present in current AccuWeather responses -- coinciding with AccuWeather's 2025 developer-API overhaul ([new portal + retirement of the old *Free Limited Trials*](https://web.archive.org/web/20250823165727/https://developer.accuweather.com/new-portal), replaced by 14-day trials / paid plans). With the header gone, `Number.parseInt(undefined)` is `NaN`, so `Math.min(NaN, NaN, NaN)` sets `remainingQuota = NaN`, and the credit guard `if (provider.remainingCalls != null)` does not catch it (`NaN != null` is `true`) -- printing ` (NaN)`.

### Fix
Parse each header, drop missing/unparseable (`NaN`) values, and leave the quota `null` when none parse -- which correctly omits the parenthetical. With the headers present, behaviour is unchanged.

### Testing
On Cinnamon with the AccuWeather provider: after the change and a Cinnamon reload, the credit reads **"Powered by AccuWeather"** with the "(NaN)" gone.

### Notes
- Version bumped 3.6.9 -> 3.6.10.
- `3.8/weather-applet.js` carries the equivalent minimal change: a fresh `npm start` (webpack 5.75) rebuild diverged only in tool-version noise (~5.5k lines), so I applied the same one-statement change directly to keep the diff reviewable -- happy to submit a full rebuilt bundle if you would prefer.
