### PR TITLE
hwmonitor@sylfurd v1.4.0: Add optional GPU utilization and GPU memory graphs (NVIDIA + AMD)

### DIFF
--- a/hwmonitor@sylfurd/README.md
+++ b/hwmonitor@sylfurd/README.md
@@ -94,3 +94,12 @@ Vertical pane examples:
 *  andreevlex
 *  clefebvre
 *  jacobwills
+## GPU graphs
+
+Since v1.4.0 the applet can optionally show GPU utilization and GPU memory graphs. They are disabled by default; enable them in the applet settings under "GPU".
+
+Supported hardware:
+- NVIDIA: requires the `nvidia-smi` tool (included with the NVIDIA driver)
+- AMD: read directly from sysfs (`amdgpu` driver), no extra tools needed
+
+Intel GPUs are currently not supported, because the i915/xe drivers do not expose a utilization counter that can be read without elevated permissions.

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
@@ -162,6 +162,18 @@ GraphicalHWMonitorApplet.prototype = {
         this.settings.bind("diskwrite_use_custom_label", "diskwrite_use_custom_label", this.settingsChanged);
         this.settings.bind("diskwrite_custom_label", "diskwrite_custom_label", this.settingsChanged);
         this.settings.bind("diskwrite_show_detail_label", "diskwrite_show_detail_label", this.settingsChanged);
+        // GPU (utilization) settings
+        this.settings.bind("gpu_enable_graph", "gpu_enable_graph", this.settingsChanged);
+        this.settings.bind("gpu_size", "gpu_size", this.settingsChanged);
+        this.settings.bind("gpu_use_custom_label", "gpu_use_custom_label", this.settingsChanged);
+        this.settings.bind("gpu_custom_label", "gpu_custom_label", this.settingsChanged);
+        this.settings.bind("gpu_show_detail_label", "gpu_show_detail_label", this.settingsChanged);
+        // GPU (memory) settings
+        this.settings.bind("gpumem_enable_graph", "gpumem_enable_graph", this.settingsChanged);
+        this.settings.bind("gpumem_size", "gpumem_size", this.settingsChanged);
+        this.settings.bind("gpumem_use_custom_label", "gpumem_use_custom_label", this.settingsChanged);
+        this.settings.bind("gpumem_custom_label", "gpumem_custom_label", this.settingsChanged);
+        this.settings.bind("gpumem_show_detail_label", "gpumem_show_detail_label", this.settingsChanged);
         // BAT (battery) settings
         this.settings.bind("bat_enable_graph", "bat_enable_graph", this.settingsChanged);
         this.settings.bind("bat_size", "bat_size", this.settingsChanged);
@@ -255,6 +267,30 @@ GraphicalHWMonitorApplet.prototype = {
 
             let diskWriteProvider =  new Providers.DiskDataProvider(this.frequency, this.diskwrite_size, false, this.diskwrite_device_name);
             this.graphs.push(new Graph.Graph(diskWriteProvider, diskWriteGraphArea, this.theme_object, this.diskwrite_show_detail_label));
+        }
+
+        // Add GPU (utilization) Graph
+        if (this.gpu_enable_graph) {
+            let gpuGraphArea = null;
+            if (this.isHorizontal)
+                gpuGraphArea = this.appletArea.addGraph(this.gpu_size, this.panel_height);
+            else
+                gpuGraphArea = this.appletArea.addGraph(this.panel_height, this.gpu_size);
+
+            let gpuProvider = new Providers.GpuUtilDataProvider();
+            this.graphs.push(new Graph.Graph(gpuProvider, gpuGraphArea, this.theme_object, this.gpu_show_detail_label));
+        }
+
+        // Add GPU (memory) Graph
+        if (this.gpumem_enable_graph) {
+            let gpuMemGraphArea = null;
+            if (this.isHorizontal)
+                gpuMemGraphArea = this.appletArea.addGraph(this.gpumem_size, this.panel_height);
+            else
+                gpuMemGraphArea = this.appletArea.addGraph(this.panel_height, this.gpumem_size);
+
+            let gpuMemProvider = new Providers.GpuMemDataProvider();
+            this.graphs.push(new Graph.Graph(gpuMemProvider, gpuMemGraphArea, this.theme_object, this.gpumem_show_detail_label));
         }
 
         // Add BAT Graph
@@ -453,6 +489,10 @@ GraphicalHWMonitorApplet.prototype = {
         this.theme_object.diskwrite_custom_label = this.diskwrite_custom_label;
         this.theme_object.bat_use_custom_label = this.bat_use_custom_label;
         this.theme_object.bat_custom_label = this.bat_custom_label;
+        this.theme_object.gpu_use_custom_label = this.gpu_use_custom_label;
+        this.theme_object.gpu_custom_label = this.gpu_custom_label;
+        this.theme_object.gpumem_use_custom_label = this.gpumem_use_custom_label;
+        this.theme_object.gpumem_custom_label = this.gpumem_custom_label;
     },
 
     restartGHW: function() {

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/graph.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/graph.js
@@ -234,6 +234,10 @@ class Graph {
             cr.showText(this.theme.diskwrite_custom_label);
         else if (this.theme.bat_use_custom_label && this.provider.type == "BAT")
             cr.showText(this.theme.bat_custom_label);
+        else if (this.theme.gpu_use_custom_label && this.provider.type == "GPU")
+            cr.showText(this.theme.gpu_custom_label);
+        else if (this.theme.gpumem_use_custom_label && this.provider.type == "GPUMEM")
+            cr.showText(this.theme.gpumem_custom_label);
         else
             cr.showText(this.provider.name);
 
@@ -262,6 +266,10 @@ class Graph {
             cr.showText(this.theme.diskwrite_custom_label);
         else if (this.theme.bat_use_custom_label && this.provider.type == "BAT")
             cr.showText(this.theme.bat_custom_label);
+        else if (this.theme.gpu_use_custom_label && this.provider.type == "GPU")
+            cr.showText(this.theme.gpu_custom_label);
+        else if (this.theme.gpumem_use_custom_label && this.provider.type == "GPUMEM")
+            cr.showText(this.theme.gpumem_custom_label);
         else
             cr.showText(this.provider.name);
     }

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/providers.js
@@ -339,6 +339,146 @@ class BatteryProvider {
     }
 }
 
+// Shared GPU poller used by both GPU providers. Supports:
+//  - AMD (amdgpu driver): instant sysfs reads, no subprocess
+//  - NVIDIA: async nvidia-smi, one subprocess per refresh tick no matter
+//    how many GPU graphs are enabled; getData() returns the previous
+//    sample so the UI thread never blocks on the subprocess
+// Intel GPUs are not supported: the i915/xe drivers do not expose a
+// utilization counter that is readable without elevated permissions.
+var GpuPoller = {
+    backend: null,     // "amd" | "nvidia" | null (no supported GPU)
+    detected: false,
+    amdPath: null,
+    util: 0,           // 0..1
+    memUsed: 0,        // MiB
+    memTotal: 0,       // MiB
+    pending: false,
+    failed: true,
+
+    detect: function() {
+        this.detected = true;
+        for (let i = 0; i < 10; i++) {
+            let path = "/sys/class/drm/card" + i + "/device";
+            if (GLib.file_test(path + "/gpu_busy_percent", GLib.FileTest.EXISTS)) {
+                this.backend = "amd";
+                this.amdPath = path;
+                return;
+            }
+        }
+        if (GLib.find_program_in_path("nvidia-smi")) {
+            this.backend = "nvidia";
+            return;
+        }
+        this.backend = null;
+    },
+
+    readSysfsNumber: function(path) {
+        try {
+            let [success, contents] = GLib.file_get_contents(path);
+            if (!success)
+                return NaN;
+            return parseFloat(contents.toString().trim());
+        } catch (e) {
+            return NaN;
+        }
+    },
+
+    poll: function() {
+        if (!this.detected)
+            this.detect();
+
+        if (this.backend == "amd") {
+            let busy = this.readSysfsNumber(this.amdPath + "/gpu_busy_percent");
+            let used = this.readSysfsNumber(this.amdPath + "/mem_info_vram_used");
+            let total = this.readSysfsNumber(this.amdPath + "/mem_info_vram_total");
+            if (!isNaN(busy)) {
+                this.util = busy / 100;
+                this.memUsed = isNaN(used) ? 0 : used / 1048576;
+                this.memTotal = isNaN(total) ? 0 : total / 1048576;
+                this.failed = false;
+            } else {
+                this.failed = true;
+            }
+        } else if (this.backend == "nvidia") {
+            this.pollNvidia();
+        } else {
+            this.failed = true;
+        }
+    },
+
+    pollNvidia: function() {
+        if (this.pending)
+            return;
+        this.pending = true;
+        try {
+            let proc = new Gio.Subprocess({
+                argv: ["nvidia-smi",
+                       "--query-gpu=utilization.gpu,memory.used,memory.total",
+                       "--format=csv,noheader,nounits"],
+                flags: Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
+            });
+            proc.init(null);
+            proc.communicate_utf8_async(null, null, (p, res) => {
+                try {
+                    let [, stdout] = p.communicate_utf8_finish(res);
+                    let parts = stdout.trim().split("\n")[0].split(",").map(x => parseFloat(x));
+                    if (parts.length >= 3 && !isNaN(parts[0])) {
+                        this.util = parts[0] / 100;
+                        this.memUsed = parts[1];
+                        this.memTotal = parts[2];
+                        this.failed = false;
+                    }
+                } catch (e) {
+                    this.failed = true;
+                }
+                this.pending = false;
+            });
+        } catch (e) {
+            this.failed = true;
+            this.pending = false;
+        }
+    }
+};
+
+// Class responsible for getting GPU utilization data (via nvidia-smi)
+class GpuUtilDataProvider {
+    constructor() {
+        this.name = "GPU";
+        this.type = "GPU";
+    }
+
+    getData() {
+        GpuPoller.poll();
+        if (GpuPoller.failed) {
+            this.text = "n/a";
+            return 0;
+        }
+        this.text = (GpuPoller.util * 100).toFixed(1) + "%";
+        let tools = new Tools();
+        return tools.limit(GpuPoller.util, 0, 1);
+    }
+}
+
+// Class responsible for getting GPU memory data (via nvidia-smi)
+class GpuMemDataProvider {
+    constructor() {
+        this.name = "GMEM";
+        this.type = "GPUMEM";
+    }
+
+    getData() {
+        GpuPoller.poll();
+        let tools = new Tools();
+        if (GpuPoller.failed || GpuPoller.memTotal <= 0) {
+            this.text = "n/a";
+            return 0;
+        }
+        this.text = tools.formatBytes(GpuPoller.memUsed * 1024 * 1024);
+        return tools.limit(GpuPoller.memUsed / GpuPoller.memTotal, 0, 1);
+    }
+}
+
 class Tools {
     //https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
     formatBytes(bytes) {

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
@@ -7,6 +7,7 @@
         "Memory_page",
         "Network_page",
         "Disk_page",
+        "GPU_page",
         "Battery_page"
       ],
 
@@ -47,6 +48,14 @@
         "sections": [
           "DISK_READ_settings",
           "DISK_WRITE_settings"
+        ]
+      },
+      "GPU_page": {
+        "type": "page",
+        "title": "GPU",
+        "sections": [
+          "GPU_settings",
+          "GPU_MEM_settings"
         ]
       },
       "Battery_page": {
@@ -162,6 +171,28 @@
           "diskwrite_use_custom_label",
           "diskwrite_custom_label",
           "diskwrite_show_detail_label"
+        ]
+      },
+      "GPU_settings": {
+        "type": "section",
+        "title": "GPU utilization settings",
+        "keys": [
+          "gpu_enable_graph",
+          "gpu_size",
+          "gpu_use_custom_label",
+          "gpu_custom_label",
+          "gpu_show_detail_label"
+        ]
+      },
+      "GPU_MEM_settings": {
+        "type": "section",
+        "title": "GPU memory settings",
+        "keys": [
+          "gpumem_enable_graph",
+          "gpumem_size",
+          "gpumem_use_custom_label",
+          "gpumem_custom_label",
+          "gpumem_show_detail_label"
         ]
       },
       "BAT_settings": {
@@ -623,6 +654,80 @@
         "description": "Show details.",
         "tooltip": "Show or hide the DISK (write) usage label.",
         "dependency": "diskwrite_enable_graph"
+    },
+    "gpu_enable_graph": {
+      "type": "checkbox",
+      "default": false,
+      "description": "Show GPU utilization graph",
+      "tooltip": "Show or hide the GPU utilization graph. Requires an NVIDIA GPU with nvidia-smi installed, or an AMD GPU using the amdgpu driver."
+    },
+    "gpu_size": {
+      "type": "spinbutton",
+      "default": 50,
+      "min": 10,
+      "max": 500,
+      "step": 1,
+      "units": "",
+      "description": "Horizontal panel width or vertical panel height",
+      "tooltip": "Set the width of the graph for horizontal panels, or the height of the graph for vertical panels.",
+      "dependency": "gpu_enable_graph"
+    },
+    "gpu_use_custom_label": {
+      "type": "checkbox",
+      "default": false,
+      "description": "Use custom graph label",
+      "tooltip": "Choose your own label for the GPU utilization graph",
+      "dependency": "gpu_enable_graph"
+    },
+    "gpu_custom_label": {
+      "type": "entry",
+      "default": "GPU",
+      "description": "Set the custom label for the GPU utilization graph",
+      "dependency": "gpu_enable_graph"
+    },
+    "gpu_show_detail_label": {
+      "type": "checkbox",
+      "default": true,
+      "description": "Show details",
+      "tooltip": "Show or hide the GPU utilization detail label",
+      "dependency": "gpu_enable_graph"
+    },
+    "gpumem_enable_graph": {
+      "type": "checkbox",
+      "default": false,
+      "description": "Show GPU memory graph",
+      "tooltip": "Show or hide the GPU memory graph. Requires an NVIDIA GPU with nvidia-smi installed, or an AMD GPU using the amdgpu driver."
+    },
+    "gpumem_size": {
+      "type": "spinbutton",
+      "default": 50,
+      "min": 10,
+      "max": 500,
+      "step": 1,
+      "units": "",
+      "description": "Horizontal panel width or vertical panel height",
+      "tooltip": "Set the width of the graph for horizontal panels, or the height of the graph for vertical panels.",
+      "dependency": "gpumem_enable_graph"
+    },
+    "gpumem_use_custom_label": {
+      "type": "checkbox",
+      "default": false,
+      "description": "Use custom graph label",
+      "tooltip": "Choose your own label for the GPU memory graph",
+      "dependency": "gpumem_enable_graph"
+    },
+    "gpumem_custom_label": {
+      "type": "entry",
+      "default": "GMEM",
+      "description": "Set the custom label for the GPU memory graph",
+      "dependency": "gpumem_enable_graph"
+    },
+    "gpumem_show_detail_label": {
+      "type": "checkbox",
+      "default": true,
+      "description": "Show details",
+      "tooltip": "Show or hide the GPU memory detail label",
+      "dependency": "gpumem_enable_graph"
     },
     "bat_enable_graph": {
       "type": "checkbox",

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
@@ -13,6 +13,6 @@
     "max-instances": "-1",
     "description": "Displaying realtime system information (CPU, memory, network and disk load).",
     "uuid": "hwmonitor@sylfurd",
-    "version": "1.3.4",
+    "version": "1.4.0",
     "name": "Graphical hardware monitor"
 }


### PR DESCRIPTION
## What

Adds two new optional graphs to the Graphical hardware monitor: **GPU** (utilization %) and **GMEM** (GPU memory usage). Both are **disabled by default** and are enabled from a new "GPU" tab in the applet settings, with the same options as the existing graphs (size, custom label, detail label).

## How

A shared poller auto-detects the GPU vendor once, then feeds both graphs:

- **AMD** (amdgpu driver): read directly from sysfs (`gpu_busy_percent`, `mem_info_vram_used`, `mem_info_vram_total`). Instant reads, no subprocess.
- **NVIDIA**: `nvidia-smi --query-gpu=...` spawned **asynchronously** via Gio.Subprocess, so the Cinnamon UI thread never blocks. One subprocess per refresh tick regardless of how many GPU graphs are enabled; `getData()` returns the previous sample.
- **No supported GPU**: providers report "n/a" and return 0; since the graphs are off by default, machines without a GPU are unaffected.

Intel GPUs are not supported: the i915/xe drivers do not expose a utilization counter readable without elevated permissions (`intel_gpu_top` needs perf access), and iGPU memory is shared system RAM. This is documented in the README.

## Changes

- `3.8/providers.js`: shared `GpuPoller` + `GpuUtilDataProvider` / `GpuMemDataProvider`
- `3.8/applet.js`: settings binds, graph creation, theme object entries
- `3.8/graph.js`: custom label cases for the two new graph types
- `3.8/settings-schema.json`: new GPU page with two sections (all defaults off)
- `README.md`: GPU support and requirements section
- `metadata.json`: version 1.3.4 -> 1.4.0

## Testing

Tested on Linux Mint 22.3 (Cinnamon 6.6.5) with an NVIDIA GTX 1650 (nvidia-smi backend): graphs track utilization and VRAM correctly at 1s refresh, detail labels show % and formatted bytes, settings tab works, no errors in ~/.xsession-errors, and disabling the graphs removes them cleanly. The AMD path follows the documented amdgpu sysfs interface (same fields used by tools like radeontop); I do not have an AMD card in this machine, so review from an amdgpu user would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUKno4V7XVo8nv95eJghdj