### PR TITLE
[modern-sound] v1.2.0 release over-amplification support

### DIFF
--- a/modern-sound@husain-anabtawi.com/README.md
+++ b/modern-sound@husain-anabtawi.com/README.md
@@ -9,7 +9,6 @@ A modern Cinnamon panel sound applet — compact by default, expandable when nee
 3. Search for **Modern Sound** and install
 4. Add it to your panel
 
-After updating, reload Cinnamon: **Alt+F2** → type `r` → Enter
 
 ## Using the applet
 

--- a/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/CHANGELOG.md
+++ b/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Release notes for **Modern Sound**.
 
+## [1.2.0] — 2026-08-03
+
+### Added
+
+- **Overamplification Reflection** — when **Overamplification is enabled** in Sound settings, master volume can go up to 150% (menu slider and panel scroll).
+- **Volume tooltip** — hover the panel icon to see the current level (e.g. `Volume: 78%`).
+
+---
+
 ## [1.1.0] — 2026-08-02
 
 ### Added

--- a/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/applet.js
+++ b/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/applet.js
@@ -5,7 +5,9 @@ const Main = imports.ui.main;
 const Util = imports.misc.util;
 const Cvc = imports.gi.Cvc;
 
+const { volumePercent } = require("./utils/volume-math");
 const { connectIconScrollHandler } = require("./handlers/on-icon-scroll-handler");
+const { connectOveramplificationHandler } = require("./handlers/on-overamplification-change");
 const { MasterVolumeItem, MicVolumeItem } = require("./widgets/stream-volume-item");
 const { InputDeviceItem, OutputDeviceItem } = require("./widgets/device-picker-item");
 const { ApplicationsItem } = require("./widgets/applications-item");
@@ -53,6 +55,8 @@ class ModernSoundApplet extends Applet.IconApplet {
         this._masterVolume = new MasterVolumeItem(this);
         this._menu.addMenuItem(this._masterVolume);
 
+        connectOveramplificationHandler(this);
+
         this._micVolume = new MicVolumeItem(this);
         this._menu.addMenuItem(this._micVolume);
 
@@ -86,7 +90,7 @@ class ModernSoundApplet extends Applet.IconApplet {
         this._setKeybinding();
         connectIconScrollHandler(this);
         this.set_applet_icon_symbolic_name("audio-volume-high-symbolic");
-        this.set_applet_tooltip(_("Sound"));
+        this._updatePanelIcon();
         global.log("[modern-sound] applet initialized");
     }
 
@@ -164,13 +168,15 @@ class ModernSoundApplet extends Applet.IconApplet {
     _updatePanelIcon() {
         if (!this._output) {
             this.set_applet_icon_symbolic_name("audio-volume-muted-symbolic");
+            this.set_applet_tooltip(`${_("Volume")}: 0%`);
             return;
         }
 
         const norm = this._volumeNorm || 1;
-        const max = this._output.volume_max || norm;
+        const max = this._masterVolumeMax;
         const volume = this._output.is_muted ? 0 : this._output.volume;
         const ratio = volume / max;
+        const percent = volumePercent(this._output.volume, norm, this._output.is_muted);
 
         let icon = "audio-volume-muted-symbolic";
         if (!this._output.is_muted) {
@@ -183,6 +189,7 @@ class ModernSoundApplet extends Applet.IconApplet {
         }
 
         this.set_applet_icon_symbolic_name(icon);
+        this.set_applet_tooltip(`${_("Volume")}: ${percent}%`);
     }
 
     _setKeybinding() {

--- a/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/handlers/on-icon-scroll-handler.js
+++ b/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/handlers/on-icon-scroll-handler.js
@@ -4,7 +4,7 @@ const Clutter = imports.gi.Clutter;
 const { adjustStreamVolume } = require("./utils/volume-math");
 
 function adjustMasterVolume(applet, deltaSteps) {
-    if (!adjustStreamVolume(applet._output, applet._volumeNorm, deltaSteps))
+    if (!adjustStreamVolume(applet._output, applet._volumeNorm, deltaSteps, applet._masterVolumeMax))
         return false;
 
     if (Main.soundManager)

--- a/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/handlers/on-overamplification-change.js
+++ b/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/handlers/on-overamplification-change.js
@@ -1,0 +1,38 @@
+const Gio = imports.gi.Gio;
+
+const CINNAMON_DESKTOP_SOUNDS = "org.cinnamon.desktop.sound";
+const OVERAMPLIFICATION_KEY = "allow-amplified-volume";
+const OVERAMPLIFICATION_FACTOR = 1.5;
+
+function _syncMasterVolumeMax(applet) {
+    const norm = applet._volumeNorm || 1;
+    applet._masterVolumeMax = applet._allowOveramplification ? OVERAMPLIFICATION_FACTOR * norm : norm;
+}
+
+function onOveramplificationChange(applet) {
+    applet._allowOveramplification = applet._soundSettings.get_boolean(OVERAMPLIFICATION_KEY);
+    _syncMasterVolumeMax(applet);
+    if (!applet._allowOveramplification && applet._output && applet._output.volume > applet._volumeNorm) {
+        applet._output.volume = applet._volumeNorm;
+        applet._output.push_volume();
+    }
+
+    if (applet._masterVolume)
+        applet._masterVolume._sync();
+    if (applet._output && applet._updatePanelIcon)
+        applet._updatePanelIcon();
+}
+
+function connectOveramplificationHandler(applet) {
+    applet._allowOveramplification = false;
+    applet._soundSettings = new Gio.Settings({ schema_id: CINNAMON_DESKTOP_SOUNDS });
+    applet._soundSettings.connect("changed::" + OVERAMPLIFICATION_KEY, () => {
+        onOveramplificationChange(applet);
+    });
+    onOveramplificationChange(applet);
+}
+
+module.exports = {
+    connectOveramplificationHandler,
+    onOveramplificationChange
+};

--- a/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/metadata.json
+++ b/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/metadata.json
@@ -3,6 +3,6 @@
     "name": "Modern Sound",
     "description": "A modern Cinnamon sound applet with volume control",
     "max-instances": 1,
-    "version": "1.1.0",
+    "version": "1.2.0",
     "cinnamon-version": ["6.0"]
 }

--- a/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/utils/volume-math.js
+++ b/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/utils/volume-math.js
@@ -1,12 +1,30 @@
 const VOLUME_ADJUSTMENT_STEP = 0.05;
 const MUTE_THRESHOLD = 0.005;
 
-function adjustStreamVolume(stream, norm, deltaSteps) {
+function volumePercent(volume, norm, muted = false) {
+    if (muted)
+        return 0;
+    const targetNorm = norm || 1;
+    return Math.round((volume / targetNorm) * 100) || 0;
+}
+
+function snapVolumeToNorm(volume, norm) {
+    const targetNorm = norm || 1;
+    if (
+        volume !== targetNorm &&
+        volume > targetNorm * (1 - VOLUME_ADJUSTMENT_STEP / 2) &&
+        volume < targetNorm * (1 + VOLUME_ADJUSTMENT_STEP / 2)
+    )
+        return targetNorm;
+    return volume;
+}
+
+function adjustStreamVolume(stream, norm, deltaSteps, maxVolume) {
     if (!stream || !deltaSteps)
         return false;
 
     const targetNorm = norm || 1;
-    const max = stream.volume_max || targetNorm;
+    const max = maxVolume ?? stream.volume_max ?? targetNorm;
     const step = targetNorm * VOLUME_ADJUSTMENT_STEP;
     const currentVolume = stream.volume;
 
@@ -17,22 +35,12 @@ function adjustStreamVolume(stream, norm, deltaSteps) {
             stream.volume = 0;
             if (!prevMuted)
                 stream.change_is_muted(true);
-        } else if (
-            stream.volume !== targetNorm &&
-            stream.volume > targetNorm * (1 - VOLUME_ADJUSTMENT_STEP / 2) &&
-            stream.volume < targetNorm * (1 + VOLUME_ADJUSTMENT_STEP / 2)
-        ) {
-            stream.volume = targetNorm;
+        } else {
+            stream.volume = snapVolumeToNorm(stream.volume, targetNorm);
         }
     } else {
         stream.volume = Math.min(max, currentVolume + deltaSteps * step);
-        if (
-            stream.volume !== targetNorm &&
-            stream.volume > targetNorm * (1 - VOLUME_ADJUSTMENT_STEP / 2) &&
-            stream.volume < targetNorm * (1 + VOLUME_ADJUSTMENT_STEP / 2)
-        ) {
-            stream.volume = targetNorm;
-        }
+        stream.volume = snapVolumeToNorm(stream.volume, targetNorm);
         stream.change_is_muted(false);
     }
 
@@ -43,5 +51,7 @@ function adjustStreamVolume(stream, norm, deltaSteps) {
 module.exports = {
     VOLUME_ADJUSTMENT_STEP,
     MUTE_THRESHOLD,
+    volumePercent,
+    snapVolumeToNorm,
     adjustStreamVolume
 };

--- a/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/widgets/stream-volume-item.js
+++ b/modern-sound@husain-anabtawi.com/files/modern-sound@husain-anabtawi.com/widgets/stream-volume-item.js
@@ -4,7 +4,7 @@ const Slider = imports.ui.slider;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 
-const { MUTE_THRESHOLD } = require("./utils/volume-math");
+const { MUTE_THRESHOLD, snapVolumeToNorm, volumePercent } = require("./utils/volume-math");
 const { volumeIconName, micIconName } = require("./utils/volume-icon-resolver");
 
 const LEVEL_SLIDER_WIDTH = 140;
@@ -125,6 +125,14 @@ class StreamVolumeItem extends PopupMenu.PopupBaseMenuItem {
         return this._applet._volumeNorm;
     }
 
+    _streamVolumeMax(norm) {
+        return this._stream.volume_max || norm;
+    }
+
+    _sliderRatio(volume, max) {
+        return Math.min(1, volume / max);
+    }
+
     _setSliderValue(value) {
         this._updating = true;
         this._slider.setValue(value);
@@ -136,10 +144,10 @@ class StreamVolumeItem extends PopupMenu.PopupBaseMenuItem {
             return;
 
         const norm = this._volumeNorm() || 1;
-        const max = this._stream.volume_max || norm;
+        const max = this._streamVolumeMax(norm);
         const volume = this._stream.is_muted ? 0 : this._stream.volume;
-        const ratio = Math.min(1, volume / max);
-        const percent = Math.round((volume / norm) * 100) || 0;
+        const ratio = this._sliderRatio(volume, max);
+        const percent = volumePercent(volume, norm, this._stream.is_muted);
 
         this._setSliderValue(ratio);
         this._percentLabel.text = `${percent}%`;
@@ -152,10 +160,10 @@ class StreamVolumeItem extends PopupMenu.PopupBaseMenuItem {
             return;
 
         const norm = this._volumeNorm() || 1;
-        const max = this._stream.volume_max || norm;
-        const volume = value * max;
+        const max = this._streamVolumeMax(norm);
+        const volume = snapVolumeToNorm(value * max, norm);
         const muted = value < MUTE_THRESHOLD;
-        const percent = Math.round((volume / norm) * 100) || 0;
+        const percent = volumePercent(volume, norm, muted);
 
         this._stream.volume = volume;
         this._stream.push_volume();
@@ -184,6 +192,14 @@ class MasterVolumeItem extends StreamVolumeItem {
 
     _actorStyleClasses() {
         return ["modern-sound-level-item"];
+    }
+
+    _streamVolumeMax(norm) {
+        return this._applet._masterVolumeMax || norm;
+    }
+
+    _sliderRatio(volume, max) {
+        return volume / max;
     }
 
     _updateVolumeDisplay(ratio, muted) {


### PR DESCRIPTION
# Modern sound v1.2.0 

More Mature Sound Applet.

## Changes 

### Added

- **Overamplification Reflection** — when **Overamplification is enabled** in Sound settings, master volume can go up to 150% (menu slider and panel scroll).
- **Volume tooltip** — hover the panel icon to see the current level (e.g. `Volume: 78%`).

### Documentation 

- Move Readme.md out of files/UUID to match the required structure for cinnamon-spices-applets repo



## Screenshots
<img width="376" height="648" alt="screenshot" src="https://github.com/user-attachments/assets/d560df44-59b3-4bb9-8ea7-da22bbe31ae1" />

<img width="140" height="106" alt="Screenshot from 2026-08-03 22-22-41" src="https://github.com/user-attachments/assets/67ac1456-5242-4d47-bd9b-9c11dc8b989b" />

