### PR TITLE
kdecapplet@joejoetv: fix browsing single storage mounts

### DIFF
--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
@@ -1343,12 +1343,29 @@ class SFTPModule extends KDECModule {
     }
 
     startBrowsing() {
-        // NOTE: There is also a DBus method to open the file manager at the mount point, but that is currently broken, at least for me
+    if (this.mounted == true) {
+        let path = this.mountPoint;
 
-        if (this.mounted == true) {
-            CommonUtils.openURL("file://"+this.mountPoint);
+        try {
+            let directories = this.proxy.getDirectoriesSync()[0];
+            let paths = Object.keys(directories);
+
+            // If KDE Connect exposes a single storage location, open it
+            // directly. Preserve the existing mount-root behavior when
+            // multiple locations are exposed.
+            if (paths.length === 1) {
+                path = paths[0];
+            }
+        } catch (error) {
+            this.info(
+                "Could not get remote directories, falling back to mount point: " + error,
+                CommonUtils.LogLevel.DEBUG
+            );
         }
+
+        CommonUtils.openURL("file://" + path);
     }
+}
 
     _createMenuItem() {
         // Create Menu Item

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
@@ -1343,29 +1343,29 @@ class SFTPModule extends KDECModule {
     }
 
     startBrowsing() {
-    if (this.mounted == true) {
-        let path = this.mountPoint;
+        if (this.mounted == true) {
+            let path = this.mountPoint;
 
-        try {
-            let directories = this.proxy.getDirectoriesSync()[0];
-            let paths = Object.keys(directories);
+            try {
+                let directories = this.proxy.getDirectoriesSync()[0];
+                let paths = Object.keys(directories);
 
-            // If KDE Connect exposes a single storage location, open it
-            // directly. Preserve the existing mount-root behavior when
-            // multiple locations are exposed.
-            if (paths.length === 1) {
-                path = paths[0];
+                // If KDE Connect exposes a single storage location, open it
+                // directly. Preserve the existing mount-root behavior when
+                // multiple locations are exposed.
+                if (paths.length === 1) {
+                    path = paths[0];
+                }
+            } catch (error) {
+                this.info(
+                    "Could not get remote directories, falling back to mount point: " + error,
+                    CommonUtils.LogLevel.DEBUG
+                );
             }
-        } catch (error) {
-            this.info(
-                "Could not get remote directories, falling back to mount point: " + error,
-                CommonUtils.LogLevel.DEBUG
-            );
-        }
 
-        CommonUtils.openURL("file://" + path);
+            CommonUtils.openURL("file://" + path);
+        }
     }
-}
 
     _createMenuItem() {
         // Create Menu Item


### PR DESCRIPTION
Addresses the mount-path problem described in #8693.

When KDE Connect reports exactly one remote storage directory through
`getDirectories()`, the applet now opens that directory instead of
always opening the SFTP mount root.

On the affected device, the mount root exists but returns "Permission denied"
when listed, while the directory reported by KDE Connect is accessible normally.

When multiple directories are reported, the existing mount-root
behavior is preserved. The same fallback is also used if
`getDirectories()` is unavailable or fails.

Tested with:
- Linux Mint
- Cinnamon 6.6.9
- KDE Connect 23.08.5
- CJS 115.1

Tested scenarios:
- mount and unmount
- repeated remounting
- Cinnamon reload
- device disconnect and reconnect
- remount after force-stopping KDE Connect on Android

@JoeJoeTV