### PR TITLE
CinnVIIStarkMenu@NikoKrause: Add "Properties" to the app context menu

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/2.6/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/2.6/applet.js
@@ -176,6 +176,10 @@ ApplicationContextMenuItem.prototype = {
                 Util.spawnCommandLine("gksu -m '" + _("Please enter your password to uninstall this application") + "' /usr/bin/cinnamon-remove-application '" + this._appButton.app.get_app_info().get_filename() + "'");
                 this._appButton.appsMenuButton.menu.close();
                 break;
+            case "app_properties":
+                Util.spawn(["cinnamon-desktop-editor", "-mlauncher", "-o" + this._appButton.app.get_app_info().get_filename()]);
+                this._appButton.appsMenuButton.menu.close();
+                break;
             case "run_with_nvidia_gpu":
                 Util.spawnCommandLine("optirun gtk-launch " + this._appButton.app.get_id());
                 this._appButton.appsMenuButton.menu.close();
@@ -267,6 +271,11 @@ GenericApplicationButton.prototype = {
                 this.menu.addMenuItem(menuItem);
             }else{
                 menuItem = new ApplicationContextMenuItem(this, _("Add to favorites"), "add_to_favorites", "non-starred", this.showContextIcon);
+                this.menu.addMenuItem(menuItem);
+            }
+            let appInfo = this.app.get_app_info ? this.app.get_app_info() : null;
+            if (appInfo && appInfo.get_filename()) {
+                menuItem = new ApplicationContextMenuItem(this, _("Properties"), "app_properties", "document-properties", this.showContextIcon);
                 this.menu.addMenuItem(menuItem);
             }
             if (this.appsMenuButton._canUninstallApps) {

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
@@ -175,6 +175,10 @@ ApplicationContextMenuItem.prototype = {
                 Util.spawnCommandLine("gksu -m '" + _("Please enter your password to uninstall this application") + "' /usr/bin/cinnamon-remove-application '" + this._appButton.app.get_app_info().get_filename() + "'");
                 this._appButton.appsMenuButton.menu.close();
                 break;
+            case "app_properties":
+                Util.spawn(["cinnamon-desktop-editor", "-mlauncher", "-o" + this._appButton.app.get_app_info().get_filename()]);
+                this._appButton.appsMenuButton.menu.close();
+                break;
             case "run_with_nvidia_gpu":
                 Util.spawnCommandLine("optirun gtk-launch " + this._appButton.app.get_id());
                 this._appButton.appsMenuButton.menu.close();
@@ -266,6 +270,11 @@ GenericApplicationButton.prototype = {
                 this.menu.addMenuItem(menuItem);
             }else{
                 menuItem = new ApplicationContextMenuItem(this, _("Add to favorites"), "add_to_favorites", "non-starred", this.showContextIcon);
+                this.menu.addMenuItem(menuItem);
+            }
+            let appInfo = this.app.get_app_info ? this.app.get_app_info() : null;
+            if (appInfo && appInfo.get_filename()) {
+                menuItem = new ApplicationContextMenuItem(this, _("Properties"), "app_properties", "document-properties", this.showContextIcon);
                 this.menu.addMenuItem(menuItem);
             }
             if (this.appsMenuButton._canUninstallApps) {

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.4/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.4/applet.js
@@ -174,6 +174,10 @@ ApplicationContextMenuItem.prototype = {
                 Util.spawnCommandLine("/usr/bin/cinnamon-remove-application '" + this._appButton.app.get_app_info().get_filename() + "'");
                 this._appButton.appsMenuButton.menu.close();
                 break;
+            } case "app_properties": {
+                Util.spawn(["cinnamon-desktop-editor", "-mlauncher", "-o" + this._appButton.app.get_app_info().get_filename()]);
+                this._appButton.appsMenuButton.menu.close();
+                break;
             } case "run_with_nvidia_gpu": {
                 Util.spawnCommandLine("optirun gtk-launch " + this._appButton.app.get_id());
                 this._appButton.appsMenuButton.menu.close();
@@ -266,6 +270,11 @@ GenericApplicationButton.prototype = {
                 this.menu.addMenuItem(menuItem);
             }else{
                 menuItem = new ApplicationContextMenuItem(this, _("Add to favorites"), "add_to_favorites", "non-starred", this.showContextIcon);
+                this.menu.addMenuItem(menuItem);
+            }
+            let appInfo = this.app.get_app_info ? this.app.get_app_info() : null;
+            if (appInfo && appInfo.get_filename()) {
+                menuItem = new ApplicationContextMenuItem(this, _("Properties"), "app_properties", "document-properties", this.showContextIcon);
                 this.menu.addMenuItem(menuItem);
             }
             if (this.appsMenuButton._canUninstallApps) {

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
@@ -395,6 +395,9 @@ class ApplicationContextMenuItem extends PopupMenu.PopupBaseMenuItem {
             case "uninstall":
                 Util.spawnCommandLine("/usr/bin/cinnamon-remove-application '" + this._appButton.app.get_app_info().get_filename() + "'");
                 break;
+            case "app_properties":
+                Util.spawn(["cinnamon-desktop-editor", "-mlauncher", "-o" + this._appButton.app.get_app_info().get_filename()]);
+                break;
             case "run_with_nvidia_gpu":
                 Util.spawnCommandLine("optirun gtk-launch " + this._appButton.app.get_id());
                 break;
@@ -471,6 +474,12 @@ class GenericApplicationButton extends SimpleMenuItem {
             menu.addMenuItem(menuItem);
         } else {
             menuItem = new ApplicationContextMenuItem(this, _("Add to favorites"), "add_to_favorites", "non-starred");
+            menu.addMenuItem(menuItem);
+        }
+
+        let appInfo = this.app.get_app_info ? this.app.get_app_info() : null;
+        if (appInfo && appInfo.get_filename()) {
+            menuItem = new ApplicationContextMenuItem(this, _("Properties"), "app_properties", "document-properties");
             menu.addMenuItem(menuItem);
         }
 

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/metadata.json
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "CinnVIIStarkMenu@NikoKrause",
     "name": "CinnVIIStarkMenu",
     "description": "Cinnamon Menu with the look of the Windows 7 Start Menu or the MATE Menu",
-    "version": 1.35,
+    "version": 1.36,
     "max-instances": -1,
     "multiversion": true
 }

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/po/CinnVIIStarkMenu@NikoKrause.pot
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/po/CinnVIIStarkMenu@NikoKrause.pot
@@ -44,6 +44,10 @@ msgstr ""
 msgid "Add to favorites"
 msgstr ""
 
+#: 4.2/applet.js:482 3.2/applet.js:277 2.6/applet.js:278 3.4/applet.js:277
+msgid "Properties"
+msgstr ""
+
 #: 4.2/applet.js:478 3.2/applet.js:272 2.6/applet.js:273 3.4/applet.js:272
 msgid "Uninstall"
 msgstr ""

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/po/pl.po
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/po/pl.po
@@ -46,6 +46,10 @@ msgstr "Usuń z ulubionych"
 msgid "Add to favorites"
 msgstr "Dodaj do ulubionych"
 
+#: 4.2/applet.js:482 3.2/applet.js:277 2.6/applet.js:278 3.4/applet.js:277
+msgid "Properties"
+msgstr "Właściwości"
+
 #: 4.2/applet.js:478 3.2/applet.js:272 2.6/applet.js:273 3.4/applet.js:272
 msgid "Uninstall"
 msgstr "Odinstaluj"


### PR DESCRIPTION
Right-clicking an application offered no way to edit the launcher itself. This adds a "Properties" entry that opens the launcher editor for that exact .desktop file:

    cinnamon-desktop-editor -mlauncher -o <file>

This mirrors the stock menu applet (menu@cinnamon.org), which uses the same action name, label and command. cinnamon-menu-editor itself takes no arguments and cannot be opened on a particular item, so the desktop editor is invoked directly -- as the Cinnamon Menu Editor does for its own entries.

The item is only shown when the app has an app info with a filename.

Added for all supported versions (2.6, 3.2, 3.4, 4.2), with the Polish translation and a regenerated translation template.