### PR TITLE
CinnVIIStarkMenu@NikoKrause: Fix context menu opening in the wrong pane

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
@@ -2495,15 +2495,14 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         if (!button.withMenu)
             return;
         
+        let targetBox = (button instanceof FavoritesButton) ? this.favoritesBox : this.applicationsBox;
+
         if (!this.contextMenu) {
             let menu = new PopupMenu.PopupSubMenu(null); // hack: creating without actor
             menu.actor.set_style_class_name('menu-context-menu');
             menu.connect('open-state-changed', Lang.bind(this, this._contextMenuOpenStateChanged));
             this.contextMenu = menu;
-            if (button instanceof FavoritesButton)
-                this.favoritesBox.add_actor(menu.actor);
-            else
-                this.applicationsBox.add_actor(menu.actor);
+            targetBox.add_actor(menu.actor);
         } else if (this.contextMenu.isOpen &&
                    this.contextMenu.sourceActor != button.actor) {
             this.contextMenu.close();
@@ -2511,10 +2510,16 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         if (!this.contextMenu.isOpen) {
             this.contextMenu.box.destroy_all_children();
-            if (button instanceof FavoritesButton)
-                this.favoritesBox.set_child_above_sibling(this.contextMenu.actor, button.actor);
-            else
-                this.applicationsBox.set_child_above_sibling(this.contextMenu.actor, button.actor);
+            // A single context menu is shared by both panes, so move it to the box
+            // the clicked button lives in - otherwise it stays in the box it was
+            // first created in and opens off-screen.
+            let parent = this.contextMenu.actor.get_parent();
+            if (parent !== targetBox) {
+                if (parent)
+                    parent.remove_actor(this.contextMenu.actor);
+                targetBox.add_actor(this.contextMenu.actor);
+            }
+            targetBox.set_child_above_sibling(this.contextMenu.actor, button.actor);
             this.contextMenu.sourceActor = button.actor;
             button.populateMenu(this.contextMenu);
         }

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/metadata.json
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "CinnVIIStarkMenu@NikoKrause",
     "name": "CinnVIIStarkMenu",
     "description": "Cinnamon Menu with the look of the Windows 7 Start Menu or the MATE Menu",
-    "version": 1.35,
+    "version": 1.36,
     "max-instances": -1,
     "multiversion": true
 }


### PR DESCRIPTION
toggleContextMenu() creates one PopupSubMenu for the whole applet and adds it to favoritesBox or applicationsBox depending on which button type was right-clicked first. The actor was never moved afterwards, so once the context menu had been opened on an application button, right-clicking a favorite opened it inside the hidden applications pane instead: the menu reported isOpen with the correct items, but was never mapped, and

    clutter_actor_set_child_above_sibling: assertion 'child->priv->parent == self' failed

was logged, since the box it was stacked in was not its parent.

Switching panes clears this.contextMenu, which is why visiting "All applications" and coming back appeared to fix it.

Move the actor to the box the clicked button lives in before stacking it.