### PR TITLE
[weather@mockturtl] Center hourly toggle and stabilize refresh status

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -19067,7 +19067,6 @@ class WeatherLoop {
         this.appletRemoved = false;
         this.errorCount = 0;
         this.runningRefresh = null;
-        this.refreshingResolver = null;
         this.refreshing = null;
         this.NetworkMonitorUsed = null;
         this.OnNetworkConnectivityChanged = () => {
@@ -19088,25 +19087,29 @@ class WeatherLoop {
             }
         };
         this.DoCheck = async (options = {}) => {
-            var _a, _b, _c;
+            var _a;
             logger_Logger.Debug("Main loop check started.");
             if (this.IsStray())
                 return;
             const { rebuild = false, location = null, immediate = true } = options;
             if (!this.Online) {
                 logger_Logger.Info("No network connection, skipping this cycle.");
+                this.app.ui.ShowRefreshResult(false);
                 return;
             }
             if (this.runningRefresh && !immediate) {
                 logger_Logger.Debug("Refresh in progress and this request is not forced, skipping cycle.");
                 return;
             }
+            (_a = this.runningRefresh) === null || _a === void 0 ? void 0 : _a.cancel();
+            const refreshRequest = new imports.gi.Gio.Cancellable();
+            this.runningRefresh = refreshRequest;
+            let resolveRefreshing;
+            const refreshing = new Promise((resolve) => {
+                resolveRefreshing = () => resolve(undefined);
+            });
+            this.refreshing = refreshing;
             try {
-                (_a = this.runningRefresh) === null || _a === void 0 ? void 0 : _a.cancel();
-                this.runningRefresh = new imports.gi.Gio.Cancellable();
-                this.refreshing = new Promise((resolve) => {
-                    this.refreshingResolver = resolve;
-                });
                 this.ValidateLastUpdateTime();
                 if (this.pauseRefresh) {
                     logger_Logger.Debug("Configuration or network error, updating paused");
@@ -19117,13 +19120,18 @@ class WeatherLoop {
                     logger_Logger.Debug("No need to update yet, skipping.");
                     return;
                 }
+                this.app.ui.ShowRefreshProgress();
                 logger_Logger.Debug("Refresh triggered in main loop with these values: lastUpdated " + this.lastUpdated.toLocaleString()
                     + ", errorCount " + this.errorCount.toString() + " , loopInterval " + (this.LoopInterval() / 1000).toString()
                     + " seconds, refreshInterval " + this.app.config._refreshInterval + " minutes");
                 const state = await Promise.race([
-                    this.app["RefreshWeather"](rebuild, location, this.runningRefresh),
+                    this.app["RefreshWeather"](rebuild, location, refreshRequest),
                     delay(30000).then(() => null)
                 ]);
+                if (this.runningRefresh !== refreshRequest) {
+                    logger_Logger.Debug("Refresh superseded by a newer request, ignoring result.");
+                    return;
+                }
                 switch (state) {
                     case null:
                         logger_Logger.Info("Refreshing timed out, skipping this cycle.");
@@ -19166,16 +19174,22 @@ class WeatherLoop {
                         });
                         break;
                 }
+                this.app.ui.ShowRefreshResult(state === RefreshState.Success);
             }
             catch (e) {
                 if (e instanceof Error)
                     logger_Logger.Error("Error in Main loop: " + e.message, e);
+                if (this.runningRefresh === refreshRequest)
+                    this.app.ui.ShowRefreshResult(false);
             }
             finally {
-                (_b = this.refreshingResolver) === null || _b === void 0 ? void 0 : _b.call(this);
-                this.refreshingResolver = null;
-                (_c = this.runningRefresh) === null || _c === void 0 ? void 0 : _c.cancel();
-                this.runningRefresh = null;
+                resolveRefreshing();
+                if (this.refreshing === refreshing)
+                    this.refreshing = null;
+                if (this.runningRefresh === refreshRequest) {
+                    refreshRequest.cancel();
+                    this.runningRefresh = null;
+                }
             }
         };
         this.app = app;
@@ -20469,7 +20483,7 @@ class UIHourlyForecasts {
 
 
 
-const { BoxLayout: uiBar_BoxLayout, IconType: uiBar_IconType, Bin: uiBar_Bin, Icon: uiBar_Icon, Align: uiBar_Align, Button: uiBar_Button, Side: uiBar_Side } = imports.gi.St;
+const { BoxLayout: uiBar_BoxLayout, IconType: uiBar_IconType, Bin: uiBar_Bin, Icon: uiBar_Icon, Align: uiBar_Align, Button: uiBar_Button, Side: uiBar_Side, Widget: uiBar_Widget } = imports.gi.St;
 const { Tooltip: uiBar_Tooltip } = imports.ui.tooltips;
 const STYLE_BAR = 'bottombar';
 class UIBar {
@@ -20485,7 +20499,10 @@ class UIBar {
         this.warningButtonIcon = null;
         this.warningButton = null;
         this.warningButtonTooltip = null;
-        this.refreshIcon = null;
+        this.refreshSuccess = null;
+        this.refreshProgress = null;
+        this.refreshError = null;
+        this.refreshStatus = "progress";
         this.WarningClicked = async () => {
             var _a;
             if (((_a = this.app.CurrentData) === null || _a === void 0 ? void 0 : _a.alerts) == null)
@@ -20494,6 +20511,7 @@ class UIBar {
         };
         this.app = app;
         this.actor = new uiBar_BoxLayout({ vertical: false, style_class: STYLE_BAR });
+        this.actor.get_layout_manager().set_homogeneous(true);
     }
     SwitchButtonToShow() {
         var _a;
@@ -20611,24 +20629,36 @@ class UIBar {
         }
         this.providerCreditButton = new WeatherButton({ label: _(ELLIPSIS), reactive: true });
         this.providerCreditButton.actor.connect(SIGNAL_CLICKED, () => OpenUrl(this.providerCreditButton));
-        this.refreshIcon = new uiBar_Icon({
-            icon_name: "refresh-symbolic",
-            icon_type: uiBar_IconType.SYMBOLIC,
-            icon_size: 24,
+        const statusStyle = `font-size: ${config.CurrentFontSize + 6}px;`;
+        this.refreshSuccess = Label({
+            text: "✓",
+            style: statusStyle
         });
-        this.refreshIcon.hide();
-        this.actor.add(this.providerCreditButton.actor, {
+        this.refreshProgress = Label({
+            text: "⟳",
+            style: statusStyle
+        });
+        this.refreshError = Label({
+            text: "✕",
+            style: statusStyle
+        });
+        this.refreshError.translation_y = 1;
+        this.ApplyRefreshStatus();
+        const statusSlot = new uiBar_Widget({
+            layout_manager: new imports.gi.Clutter.BinLayout()
+        });
+        statusSlot.add_child(this.refreshSuccess);
+        statusSlot.add_child(this.refreshProgress);
+        statusSlot.add_child(this.refreshError);
+        const rightBox = new uiBar_BoxLayout({ vertical: false, y_align: uiBar_Align.MIDDLE });
+        rightBox.add_actor(this.providerCreditButton.actor);
+        rightBox.add_actor(statusSlot);
+        this.actor.add(rightBox, {
             x_fill: false,
             x_align: uiBar_Align.END,
             y_align: uiBar_Align.MIDDLE,
             y_fill: false,
             expand: true
-        });
-        this.actor.add(this.refreshIcon, {
-            x_fill: false,
-            x_align: uiBar_Align.END,
-            y_align: uiBar_Align.MIDDLE,
-            y_fill: false,
         });
     }
     BigDistanceUnitFor(unit) {
@@ -20636,13 +20666,20 @@ class UIBar {
             return _("mi");
         return _("km");
     }
-    ShowRefreshIcon() {
-        var _a;
-        (_a = this.refreshIcon) === null || _a === void 0 ? void 0 : _a.show();
+    ShowRefreshProgress() {
+        this.refreshStatus = "progress";
+        this.ApplyRefreshStatus();
     }
-    HideRefreshIcon() {
-        var _a;
-        (_a = this.refreshIcon) === null || _a === void 0 ? void 0 : _a.hide();
+    ShowRefreshResult(success) {
+        this.refreshStatus = success ? "success" : "error";
+        this.ApplyRefreshStatus();
+    }
+    ApplyRefreshStatus() {
+        if (this.refreshSuccess == null || this.refreshProgress == null || this.refreshError == null)
+            return;
+        this.refreshSuccess.opacity = this.refreshStatus == "success" ? 255 : 0;
+        this.refreshProgress.opacity = this.refreshStatus == "progress" ? 255 : 0;
+        this.refreshError.opacity = this.refreshStatus == "error" ? 255 : 0;
     }
     HideHourlyToggle() {
         var _a;
@@ -20790,11 +20827,11 @@ class UI {
         this.Bar.Display(weather, provider, config, shouldShowToggle);
         return true;
     }
-    ShowRefreshIcon() {
-        this.Bar.ShowRefreshIcon();
+    ShowRefreshProgress() {
+        this.Bar.ShowRefreshProgress();
     }
-    HideRefreshIcon() {
-        this.Bar.HideRefreshIcon();
+    ShowRefreshResult(success) {
+        this.Bar.ShowRefreshResult(success);
     }
     IsLightTheme() {
         const color = this.menu.actor.get_theme_node().get_color("color");
@@ -21086,7 +21123,6 @@ class WeatherApplet extends TextIconApplet {
                     return RefreshState.Error;
                 }
             }
-            this.ui.ShowRefreshIcon();
             let weatherInfo = await this.provider.GetWeather(location, cancellable, this.config, this.config.GetServiceConfig(this.provider.name));
             if (weatherInfo == null) {
                 return RefreshState.NoWeather;
@@ -21108,9 +21144,6 @@ class WeatherApplet extends TextIconApplet {
                 logger_Logger.Error("Generic Error while refreshing Weather info: " + e.message + ", ", e);
             this.ShowError({ type: "hard", detail: "unknown", message: _("Unexpected Error While Refreshing Weather, please see log in Looking Glass") });
             return RefreshState.Error;
-        }
-        finally {
-            this.ui.HideRefreshIcon();
         }
     }
     DisplayWeather(weather) {

--- a/weather@mockturtl/files/weather@mockturtl/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/metadata.json
@@ -3,7 +3,7 @@
   "name": "Weather",
   "description": "View your local weather forecast",
   "max-instances": 3,
-  "version": "3.6.10",
+  "version": "3.6.11",
   "multiversion": true,
   "cinnamon-version": [
     "2.2",

--- a/weather@mockturtl/src/3_8/loop.ts
+++ b/weather@mockturtl/src/3_8/loop.ts
@@ -48,7 +48,6 @@ export class WeatherLoop {
 
 	private runningRefresh: imports.gi.Gio.Cancellable | null = null;
 
-	private refreshingResolver: (() => void) | null = null;
 	private refreshing: Promise<void> | null = null;
 	public get Refreshing(): Promise<void> {
 		if (this.refreshing == null)
@@ -145,6 +144,7 @@ export class WeatherLoop {
 
 		if (!this.Online) {
 			Logger.Info("No network connection, skipping this cycle.");
+			this.app.ui.ShowRefreshResult(false);
 			return;
 		}
 
@@ -154,13 +154,17 @@ export class WeatherLoop {
 			return;
 		}
 
-		try {
-			this.runningRefresh?.cancel();
-			this.runningRefresh = new imports.gi.Gio.Cancellable();
-			this.refreshing = new Promise<void>((resolve) => {
-				this.refreshingResolver = resolve;
-			});
+		this.runningRefresh?.cancel();
+		const refreshRequest = new imports.gi.Gio.Cancellable();
+		this.runningRefresh = refreshRequest;
 
+		let resolveRefreshing!: () => void;
+		const refreshing = new Promise<void>((resolve) => {
+			resolveRefreshing = () => resolve(undefined);
+		});
+		this.refreshing = refreshing;
+
+		try {
 			this.ValidateLastUpdateTime();
 
 			if (this.pauseRefresh) {
@@ -174,6 +178,7 @@ export class WeatherLoop {
 				return;
 			}
 
+			this.app.ui.ShowRefreshProgress();
 
 			Logger.Debug("Refresh triggered in main loop with these values: lastUpdated " + this.lastUpdated.toLocaleString()
 				+ ", errorCount " + this.errorCount.toString() + " , loopInterval " + (this.LoopInterval() / 1000).toString()
@@ -181,9 +186,16 @@ export class WeatherLoop {
 
 
 			const state = await Promise.race([
-				this.app["RefreshWeather"](rebuild, location, this.runningRefresh),
+				this.app["RefreshWeather"](rebuild, location, refreshRequest),
 				delay(30000).then(() => null)
 			]);
+
+			// A newer refresh replaced this one. Its result and cleanup
+			// must not affect the currently running request.
+			if (this.runningRefresh !== refreshRequest) {
+				Logger.Debug("Refresh superseded by a newer request, ignoring result.");
+				return;
+			}
 
 			switch (state) {
 				case null:
@@ -228,16 +240,25 @@ export class WeatherLoop {
 					break;
 			}
 
+			this.app.ui.ShowRefreshResult(state === RefreshState.Success);
 		}
 		catch (e) {
 			if (e instanceof Error)
 				Logger.Error("Error in Main loop: " + e.message, e);
+
+			if (this.runningRefresh === refreshRequest)
+				this.app.ui.ShowRefreshResult(false);
 		}
 		finally {
-			this.refreshingResolver?.();
-			this.refreshingResolver = null;
-			this.runningRefresh?.cancel();
-			this.runningRefresh = null;
+			resolveRefreshing();
+
+			if (this.refreshing === refreshing)
+				this.refreshing = null;
+
+			if (this.runningRefresh === refreshRequest) {
+				refreshRequest.cancel();
+				this.runningRefresh = null;
+			}
 		}
 	}
 

--- a/weather@mockturtl/src/3_8/main.ts
+++ b/weather@mockturtl/src/3_8/main.ts
@@ -218,7 +218,6 @@ export class WeatherApplet extends TextIconApplet {
 				}
 			}
 
-			this.ui.ShowRefreshIcon();
 			let weatherInfo = await this.provider.GetWeather(location, cancellable, this.config, this.config.GetServiceConfig(this.provider.name));
 
 			if (weatherInfo == null) {
@@ -245,9 +244,6 @@ export class WeatherApplet extends TextIconApplet {
 				Logger.Error("Generic Error while refreshing Weather info: " + e.message + ", ", e);
 			this.ShowError({ type: "hard", detail: "unknown", message: _("Unexpected Error While Refreshing Weather, please see log in Looking Glass") });
 			return RefreshState.Error;
-		}
-		finally {
-			this.ui.HideRefreshIcon();
 		}
 	}
 

--- a/weather@mockturtl/src/3_8/ui.ts
+++ b/weather@mockturtl/src/3_8/ui.ts
@@ -154,12 +154,12 @@ export class UI {
 		return true;
 	}
 
-	public ShowRefreshIcon(): void {
-		this.Bar.ShowRefreshIcon();
+	public ShowRefreshProgress(): void {
+		this.Bar.ShowRefreshProgress();
 	}
 
-	public HideRefreshIcon(): void {
-		this.Bar.HideRefreshIcon();
+	public ShowRefreshResult(success: boolean): void {
+		this.Bar.ShowRefreshResult(success);
 	}
 
 	// --------------------------------------------------------------------

--- a/weather@mockturtl/src/3_8/ui_elements/uiBar.ts
+++ b/weather@mockturtl/src/3_8/ui_elements/uiBar.ts
@@ -3,14 +3,14 @@ import type { Config, DistanceUnits } from "../config";
 import { SIGNAL_CLICKED, ELLIPSIS } from "../consts";
 import { Event } from "../lib/events";
 import type { WeatherApplet } from "../main";
-import type { CustomIcons, WeatherData, AlertData, AlertLevel, BuiltinIcons } from "../weather-data";
+import type { CustomIcons, WeatherData, AlertData, AlertLevel } from "../weather-data";
 import type { WeatherProvider } from "../types";
-import { _, AwareDateString, GetAlertColor, MetreToUserUnits } from "../utils";
+import { _, AwareDateString, GetAlertColor, Label, MetreToUserUnits } from "../utils";
 import { WeatherButton } from "../ui_elements/weatherbutton";
 import { DateTime } from "luxon";
 import { Logger } from "../lib/services/logger";
 
-const { BoxLayout, IconType, Bin, Icon, Align, Button, Side } = imports.gi.St;
+const { BoxLayout, IconType, Bin, Icon, Align, Button, Side, Widget } = imports.gi.St;
 const { Tooltip } = imports.ui.tooltips;
 
 const STYLE_BAR = 'bottombar'
@@ -36,13 +36,17 @@ export class UIBar {
 	private warningButtonIcon: imports.gi.St.Icon | null = null;
 	private warningButton: WeatherButton | null = null;
 	private warningButtonTooltip: imports.ui.tooltips.Tooltip<imports.gi.St.Button> | null = null;
-	private refreshIcon: imports.gi.St.Icon | null = null;
+	private refreshSuccess: imports.gi.St.Label | null = null;
+	private refreshProgress: imports.gi.St.Label | null = null;
+	private refreshError: imports.gi.St.Label | null = null;
+	private refreshStatus: "progress" | "success" | "error" = "progress";
 
 	private app: WeatherApplet;
 
 	constructor(app: WeatherApplet) {
 		this.app = app;
 		this.actor = new BoxLayout({ vertical: false, style_class: STYLE_BAR });
+		(this.actor.get_layout_manager() as imports.gi.Clutter.BoxLayout).set_homogeneous(true);
 	}
 
 	public SwitchButtonToShow(): void {
@@ -180,26 +184,45 @@ export class UIBar {
 
 		this.providerCreditButton = new WeatherButton({ label: _(ELLIPSIS), reactive: true });
 		this.providerCreditButton.actor.connect(SIGNAL_CLICKED, () => OpenUrl(this.providerCreditButton!));
-		this.refreshIcon = new Icon({
-			icon_name: "refresh-symbolic" as BuiltinIcons,
-			icon_type: IconType.SYMBOLIC,
-			icon_size: 24,
-		});
-		this.refreshIcon.hide();
 
-		this.actor.add(this.providerCreditButton.actor, {
+		const statusStyle = `font-size: ${config.CurrentFontSize + 6}px;`;
+
+		this.refreshSuccess = Label({
+			text: "✓",
+			style: statusStyle
+		});
+		this.refreshProgress = Label({
+			text: "⟳",
+			style: statusStyle
+		});
+		this.refreshError = Label({
+			text: "✕",
+			style: statusStyle
+		});
+		this.refreshError.translation_y = 1;
+
+		// Keep all states in the layout so its preferred width never
+		// changes when the refresh state changes.
+		this.ApplyRefreshStatus();
+
+		const statusSlot = new Widget({
+			layout_manager: new imports.gi.Clutter.BinLayout()
+		});
+		statusSlot.add_child(this.refreshSuccess);
+		statusSlot.add_child(this.refreshProgress);
+		statusSlot.add_child(this.refreshError);
+
+		const rightBox = new BoxLayout({ vertical: false, y_align: Align.MIDDLE });
+		rightBox.add_actor(this.providerCreditButton.actor);
+		rightBox.add_actor(statusSlot);
+
+		this.actor.add(rightBox, {
 			x_fill: false,
 			x_align: Align.END,
 			y_align: Align.MIDDLE,
 			y_fill: false,
 			expand: true
 		});
-		this.actor.add(this.refreshIcon, {
-			x_fill: false,
-			x_align: Align.END,
-			y_align: Align.MIDDLE,
-			y_fill: false,
-		})
 	}
 
 	/**
@@ -212,12 +235,23 @@ export class UIBar {
 		return _("km");
 	}
 
-	public ShowRefreshIcon(): void {
-		this.refreshIcon?.show();
+	public ShowRefreshProgress(): void {
+		this.refreshStatus = "progress";
+		this.ApplyRefreshStatus();
 	}
 
-	public HideRefreshIcon(): void {
-		this.refreshIcon?.hide();
+	public ShowRefreshResult(success: boolean): void {
+		this.refreshStatus = success ? "success" : "error";
+		this.ApplyRefreshStatus();
+	}
+
+	private ApplyRefreshStatus(): void {
+		if (this.refreshSuccess == null || this.refreshProgress == null || this.refreshError == null)
+			return;
+
+		this.refreshSuccess.opacity = this.refreshStatus == "success" ? 255 : 0;
+		this.refreshProgress.opacity = this.refreshStatus == "progress" ? 255 : 0;
+		this.refreshError.opacity = this.refreshStatus == "error" ? 255 : 0;
 	}
 
 	private HideHourlyToggle() {


### PR DESCRIPTION
### Issue

This fixes a documented Known Issue in the Weather applet:

> Hourly forecast toggle button is not centered to the middle of the popup menu (See the [Weather applet page](https://cinnamon-spices.linuxmint.com/applets/view/17).)

The toggle uses `Align.MIDDLE`, but it is centered within its expanded `BoxLayout` allocation rather than relative to the whole bottom bar. Since the left and right sides have different natural widths, the toggle is shifted away from the actual center of the popup.

The refresh indicator also changes the natural width of the right side when it appears or disappears, which can shift the bottom-bar geometry during refreshes.

### Fix

- Make the three top-level bottom-bar regions homogeneous, keeping the hourly toggle geometrically centered.
- Group the provider credit and refresh status into the right-hand region.
- Keep the refresh-status width stable by overlaying the success, progress, and error states (`✓`, `⟳`, `✕`) and switching them with opacity instead of adding or removing actors.
- Preserve the refresh status across UI rebuilds.
- Move refresh-status ownership to `WeatherLoop`.
- Make refresh cleanup request-specific so a cancelled or superseded refresh cannot overwrite the status or cleanup of a newer request.

### Before / After

**Before**

<img width="595" height="269" alt="Screenshot from 2026-08-17 17-50-11" src="https://github.com/user-attachments/assets/f8321e54-9674-4036-b4b0-e1974d70ae5c" />

**After**

<img width="622" height="269" alt="Screenshot from 2026-08-17 17-55-30" src="https://github.com/user-attachments/assets/6b120a6a-d571-4d30-983e-ecaeb6db8db8" />

### Testing

Tested on Cinnamon 6.6.9:

- The hourly toggle remains centered after the popup layout settles.
- Normal refresh transitions correctly from success → progress → success.
- UI rebuilds preserve the current refresh status.
- Two refreshes started 200 ms apart complete without a stale request incorrectly showing an error.
- Bottom-bar width remains stable across refresh states.
- Offline state shows the error indicator, and reconnecting starts a new progress state.
- `validate-spice weather@mockturtl` passes.
- `git diff --check` passes.
- The generated bundle passes `node --check`.
- `npx eslint ./src/3_8/` introduces no new lint errors; the remaining `uiHourlyForecasts.ts:74` nested-ternary error is already present upstream.

### Notes

Version bumped from 3.6.10 to 3.6.11.

The TypeScript source was built successfully with webpack during development.

A fresh webpack build also introduces several thousand lines of unrelated toolchain/transpilation changes in the tracked generated bundle, so the equivalent generated JavaScript changes were applied minimally to keep the PR diff reviewable.