### PR TITLE
[weather@mockturtl] Avoid rebuilding UI on manual refresh

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -21279,7 +21279,7 @@ The contents of the file saved from the applet help page goes here
     }
     AddRefreshButton() {
         const itemLabel = _("Refresh");
-        const refreshMenuItem = new MenuItem(itemLabel, REFRESH_ICON, () => this.loop.Refresh({ rebuild: true }));
+        const refreshMenuItem = new MenuItem(itemLabel, REFRESH_ICON, () => this.loop.Refresh());
         this._applet_context_menu.addMenuItem(refreshMenuItem);
     }
     HandleHTTPError(error) {

--- a/weather@mockturtl/src/3_8/main.ts
+++ b/weather@mockturtl/src/3_8/main.ts
@@ -540,7 +540,7 @@ The contents of the file saved from the applet help page goes here
 	/** Into right-click context menu */
 	private AddRefreshButton(): void {
 		const itemLabel = _("Refresh")
-		const refreshMenuItem = new MenuItem(itemLabel, REFRESH_ICON, () => this.loop.Refresh({ rebuild: true }));
+		const refreshMenuItem = new MenuItem(itemLabel, REFRESH_ICON, () => this.loop.Refresh());
 		this._applet_context_menu.addMenuItem(refreshMenuItem);
 	}
 


### PR DESCRIPTION
### Issue

The Weather applet can display a compressed or clipped current-weather row when the user selects **Refresh** from the context menu and opens the popup while the refresh is still in progress.

The manual refresh action currently calls:

```ts
this.loop.Refresh({ rebuild: true })
```

This rebuilds the popup layout before the refreshed weather data is available. If the popup is opened during that window, some actors can be allocated using their temporary or empty content and the current-weather row may remain compressed.

### Fix

Do not force a UI rebuild for a normal manual refresh:

```ts
this.loop.Refresh()
```

The existing weather actors can be updated in place when the new data arrives, so rebuilding the entire popup is unnecessary.

The equivalent change is also included in the generated `3.8/weather-applet.js` bundle.

### Before:
<img width="594" height="267" alt="Screenshot from 2026-08-17 17-50-24" src="https://github.com/user-attachments/assets/f4454364-6a9d-4bfc-8a84-cebf5697f236" />

### Testing

Tested on Cinnamon 6.6.9.

- Reproduced the issue with the original code by selecting Refresh and immediately opening the popup.
- With the change applied, repeated the same sequence 10 times without the current-weather row becoming compressed or clipped.
- Restoring the original `rebuild: true` behavior reproduced the issue again.
- Refresh with the popup already open continues to update normally.
- Repeated popup open/close operations continue to work normally.
- `validate-spice weather@mockturtl` passes.
- `git diff --check` passes.
- The generated bundle passes `node --check`.
- `npx eslint ./src/3_8/` introduces no new lint errors; the remaining `uiHourlyForecasts.ts:74` nested-ternary error is already present upstream.

### Notes

This PR intentionally does not bump the applet version yet because #8965 currently proposes the next version (`3.6.11`). Once that version is merged, this branch can be rebased and bumped to the next available version before merge.