### PR TITLE
[weather@mockturtl] Prevent hourly precipitation graph from overlapping labels

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -20049,6 +20049,7 @@ class UIHourlyForecasts {
     }
     constructor(app, menu) {
         this.tempGraphHeight = 45;
+        this.precipGraphHeight = 16;
         this.volumeGraphWidth = 20;
         this.hourlyForecasts = [];
         this.hourlyForecastData = [];
@@ -20073,7 +20074,11 @@ class UIHourlyForecasts {
             const totalHeight = this.hourlyContainers[0].height;
             const itemWidth = this.hourlyContainers[0].width;
             const tempHeightOffset = this.hourlyForecasts[0].Hour.get_height() + this.hourlyForecasts[0].Icon.get_height();
-            const precipitationHeight = this.hourlyForecasts[0].PrecipPercent.get_height() + this.hourlyForecasts[0].PrecipVolume.get_height();
+            const provider = this.app.Provider;
+            const precipitationTextHeight =
+                (provider && provider.supportHourlyPrecipChance ? this.hourlyForecasts[0].PrecipPercent.get_height() : 0) +
+                (provider && provider.supportHourlyPrecipVolume ? this.hourlyForecasts[0].PrecipVolume.get_height() : 0);
+            const precipitationGraphTop = totalHeight - precipitationTextHeight - this.precipGraphHeight;
             const tempPadding = 6;
             const points = [];
             const precipitation = [];
@@ -20102,8 +20107,8 @@ class UIHourlyForecasts {
             for (let i = 0; i < precipitation.length; i++) {
                 const element = precipitation[i];
                 const point = points[i];
-                const normalized = precipitationHeight * (element / Math.max(maxPrecipVolume, 2));
-                ctx.rectangle(point.x - this.volumeGraphWidth / 2, totalHeight - normalized, this.volumeGraphWidth, normalized);
+                const normalized = this.precipGraphHeight * (element / Math.max(maxPrecipVolume, 2));
+                ctx.rectangle(point.x - this.volumeGraphWidth / 2, precipitationGraphTop + this.precipGraphHeight - normalized, this.volumeGraphWidth, normalized);
                 ctx.fill();
             }
             return true;
@@ -20395,6 +20400,8 @@ class UIHourlyForecasts {
             box.add_child(hourlySet.Hour);
             box.add_child(hourlySet.Icon);
             box.add_child(hourlySet.Temperature);
+            if (this.app.Provider && this.app.Provider.supportHourlyPrecipVolume)
+                box.add_child(new uiHourlyForecasts_BoxLayout({ height: this.precipGraphHeight }));
             if ((_a = this.app.Provider) === null || _a === void 0 ? void 0 : _a.supportHourlyPrecipChance)
                 box.add_child(hourlySet.PrecipPercent);
             if ((_b = this.app.Provider) === null || _b === void 0 ? void 0 : _b.supportHourlyPrecipVolume)

--- a/weather@mockturtl/src/3_8/ui_elements/uiHourlyForecasts.ts
+++ b/weather@mockturtl/src/3_8/ui_elements/uiHourlyForecasts.ts
@@ -15,6 +15,7 @@ const { BoxLayout, Side, ScrollView, Icon, Align } = imports.gi.St;
 export class UIHourlyForecasts {
 	private app: WeatherApplet;
 	private readonly tempGraphHeight = 45;
+	private readonly precipGraphHeight = 16;
 	private readonly volumeGraphWidth = 20;
 	// Hourly Weather
 	public actor: imports.gi.St.ScrollView;
@@ -423,6 +424,10 @@ export class UIHourlyForecasts {
 			box.add_child(hourlySet.Hour);
 			box.add_child(hourlySet.Icon,);
 			box.add_child(hourlySet.Temperature);
+
+			if (this.app.Provider?.supportHourlyPrecipVolume)
+				box.add_child(new BoxLayout({ height: this.precipGraphHeight }));
+
 			if (this.app.Provider?.supportHourlyPrecipChance)
 				box.add_child(hourlySet.PrecipPercent);
 			if (this.app.Provider?.supportHourlyPrecipVolume)
@@ -456,7 +461,10 @@ export class UIHourlyForecasts {
 		const itemWidth = this.hourlyContainers[0].width;
 		// const totalWidth = this.hourlyContainers.length * itemWidth;
 		const tempHeightOffset = this.hourlyForecasts[0].Hour.get_height() + this.hourlyForecasts[0].Icon.get_height();
-		const precipitationHeight = this.hourlyForecasts[0].PrecipPercent.get_height() + this.hourlyForecasts[0].PrecipVolume.get_height();
+		const precipitationTextHeight =
+			(this.app.Provider?.supportHourlyPrecipChance ? this.hourlyForecasts[0].PrecipPercent.get_height() : 0) +
+			(this.app.Provider?.supportHourlyPrecipVolume ? this.hourlyForecasts[0].PrecipVolume.get_height() : 0);
+		const precipitationGraphTop = totalHeight - precipitationTextHeight - this.precipGraphHeight;
 		const tempPadding = 6;
 
 		const points: Array<{ x: number, y: number }> = [];
@@ -494,8 +502,13 @@ export class UIHourlyForecasts {
 			const element = precipitation[i];
 			const point = points[i];
 			// Normalize the precipitation height to the max precipitation volume, but make sure it's at least 2 mm
-			const normalized = precipitationHeight * (element / Math.max(maxPrecipVolume, 2));
-			ctx.rectangle(point.x - this.volumeGraphWidth / 2, totalHeight - normalized, this.volumeGraphWidth, normalized);
+			const normalized = this.precipGraphHeight * (element / Math.max(maxPrecipVolume, 2));
+			ctx.rectangle(
+				point.x - this.volumeGraphWidth / 2,
+				precipitationGraphTop + this.precipGraphHeight - normalized,
+				this.volumeGraphWidth,
+				normalized
+			);
 			ctx.fill();
 		}
 		return true;


### PR DESCRIPTION
### Issue

The hourly precipitation-volume graph is drawn from the bottom of the hourly forecast container.

Its height is currently derived from the combined height of the precipitation percentage and volume labels:

```ts
const precipitationHeight =
    PrecipPercent.get_height() + PrecipVolume.get_height();
```

The bars are then drawn upward from the bottom of the container. As a result, the graph can occupy the same vertical space as the precipitation text and overlap the `%` and `mm` labels.

### Fix

Reserve a dedicated 16 px vertical band for the precipitation-volume graph above the precipitation labels.

The graph position now accounts only for the precipitation labels actually supported by the active provider, and the bars are normalized within the dedicated graph band rather than using the text height as their drawing area.

This keeps the precipitation graph visually separate from the textual values without changing the existing horizontal scrollbar or removing any forecast information.

The equivalent change is also included in the generated `3.8/weather-applet.js` bundle.

### Before
<img width="649" height="455" alt="Screenshot from 2026-08-17 18-27-39" src="https://github.com/user-attachments/assets/472d77d0-776f-452c-9567-3f4ea5ba231d" />

### After
<img width="652" height="467" alt="Screenshot from 2026-08-17 18-29-14" src="https://github.com/user-attachments/assets/2af61636-8b38-4709-ab2a-aebe839c1370" />

### Testing

Tested on Cinnamon 6.6.9.

- Precipitation bars remain above the `%` and `mm` labels without overlapping them.
- Hourly temperature graph remains correctly positioned.
- Horizontal scrolling continues to work normally.
- The existing horizontal scrollbar remains available.
- `validate-spice weather@mockturtl` passes.
- `git diff --check` passes.
- The generated bundle passes `node --check`.
- `npx eslint ./src/3_8/` introduces no new lint errors; the remaining `uiHourlyForecasts.ts:75` nested-ternary error is already present upstream.

### Notes

This PR intentionally does not bump the applet version yet because #8965 currently proposes the next version (`3.6.11`). Once that version is merged, this branch can be rebased and bumped to the next available version before merge.