### PR TITLE
[weather@mockturtl] Resolve existing ESLint errors and warnings

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -14721,21 +14721,21 @@ class AccuWeather {
                     case "Rain":
                         precipitation = {
                             type: "rain",
-                            chance: hour.RainProbability,
+                            chance: hour.RainProbability == null ? undefined : hour.RainProbability,
                             volume: (_c = (_b = hour === null || hour === void 0 ? void 0 : hour.Rain) === null || _b === void 0 ? void 0 : _b.Value) !== null && _c !== void 0 ? _c : undefined
                         };
                         break;
                     case "Snow":
                         precipitation = {
                             type: "snow",
-                            chance: hour.SnowProbability,
+                            chance: hour.SnowProbability == null ? undefined : hour.SnowProbability,
                             volume: (_e = (_d = hour === null || hour === void 0 ? void 0 : hour.Snow) === null || _d === void 0 ? void 0 : _d.Value) !== null && _e !== void 0 ? _e : undefined
                         };
                         break;
                     case "Ice":
                         precipitation = {
                             type: "ice pellets",
-                            chance: hour.IceProbability,
+                            chance: hour.IceProbability == null ? undefined : hour.IceProbability,
                             volume: (_g = (_f = hour === null || hour === void 0 ? void 0 : hour.Ice) === null || _f === void 0 ? void 0 : _f.Value) !== null && _g !== void 0 ? _g : undefined
                         };
                         break;
@@ -15475,6 +15475,8 @@ class WeatherUnderground {
             };
             for (const observations of observationData) {
                 const station = stations.find(v => v.stationId == observations.stationID);
+                if (station == null)
+                    continue;
                 if (result.date == null && observations.obsTimeUtc != null)
                     result.date = DateTime.fromISO(observations.obsTimeUtc).setZone(tz);
                 if (result.location.city == null && observations.neighborhood != null)
@@ -16097,6 +16099,7 @@ class PirateWeather {
         try {
             const sunrise = DateTime.fromSeconds(json.daily.data[0].sunriseTime, { zone: json.timezone });
             const sunset = DateTime.fromSeconds(json.daily.data[0].sunsetTime, { zone: json.timezone });
+            const hourlyForecasts = [];
             const result = {
                 date: DateTime.fromSeconds(json.currently.time, { zone: json.timezone }),
                 coord: {
@@ -16130,7 +16133,7 @@ class PirateWeather {
                 },
                 uvIndex: (_e = (_c = (_a = json.currently.uvIndex) !== null && _a !== void 0 ? _a : (_b = json.hourly.data[0]) === null || _b === void 0 ? void 0 : _b.uvIndex) !== null && _c !== void 0 ? _c : (_d = json.daily.data[0]) === null || _d === void 0 ? void 0 : _d.uvIndex) !== null && _e !== void 0 ? _e : null,
                 forecasts: [],
-                hourlyForecasts: [],
+                hourlyForecasts,
             };
             for (const day of json.daily.data) {
                 const forecast = {
@@ -16163,7 +16166,7 @@ class PirateWeather {
                         chance: hour.precipProbability * 100
                     }
                 };
-                result.hourlyForecasts.push(forecast);
+                hourlyForecasts.push(forecast);
             }
             if (json.minutely != null) {
                 const immediate = {
@@ -19885,8 +19888,12 @@ class UIForecasts {
         try {
             if (!weather.forecasts)
                 return false;
-            if (this.forecasts.length > weather.forecasts.length)
-                this.Rebuild(this.app.config, this.app.config.textColorStyle, weather.forecasts.length);
+            if (this.forecasts.length > weather.forecasts.length) {
+                const textColorStyle = this.app.config.textColorStyle;
+                if (textColorStyle == null)
+                    return false;
+                this.Rebuild(this.app.config, textColorStyle, weather.forecasts.length);
+            }
             const len = Math.min(this.forecasts.length, weather.forecasts.length);
             for (let i = 0; i < len; i++) {
                 const forecastData = weather.forecasts[i];
@@ -20126,8 +20133,12 @@ class UIHourlyForecasts {
         this.actor.connect("scroll-event", (owner, event) => {
             const adjustment = hScroll.get_adjustment();
             const direction = event.get_scroll_direction();
-            const newVal = adjustment.get_value() +
-                ((direction === ScrollDirection.UP) ? -adjustment.step_increment : (direction === ScrollDirection.DOWN) ? adjustment.step_increment : 0);
+            let scrollDelta = 0;
+            if (direction === ScrollDirection.UP)
+                scrollDelta = -adjustment.step_increment;
+            else if (direction === ScrollDirection.DOWN)
+                scrollDelta = adjustment.step_increment;
+            const newVal = adjustment.get_value() + scrollDelta;
             if (global.settings.get_boolean("desktop-effects-on-menus"))
                 addTween(adjustment, { value: newVal, time: 0.25 });
             else
@@ -20179,7 +20190,10 @@ class UIHourlyForecasts {
         if (!forecasts || !this.hourlyForecasts)
             return true;
         if (this.hourlyForecasts.length > forecasts.length) {
-            this.Rebuild(this.app.config, this.app.config.textColorStyle, forecasts.length);
+            const textColorStyle = this.app.config.textColorStyle;
+            if (textColorStyle == null)
+                return false;
+            this.Rebuild(this.app.config, textColorStyle, forecasts.length);
         }
         this.hourlyForecastDates = [];
         this.hourlyForecastData = [];
@@ -20609,8 +20623,9 @@ class UIBar {
         if (this.app.GetMaxHourlyForecasts() <= 0) {
             this.HideHourlyToggle();
         }
-        this.providerCreditButton = new WeatherButton({ label: _(ELLIPSIS), reactive: true });
-        this.providerCreditButton.actor.connect(SIGNAL_CLICKED, () => OpenUrl(this.providerCreditButton));
+        const providerCreditButton = new WeatherButton({ label: _(ELLIPSIS), reactive: true });
+        this.providerCreditButton = providerCreditButton;
+        providerCreditButton.actor.connect(SIGNAL_CLICKED, () => OpenUrl(providerCreditButton));
         this.refreshIcon = new uiBar_Icon({
             icon_name: "refresh-symbolic",
             icon_type: uiBar_IconType.SYMBOLIC,

--- a/weather@mockturtl/src/3_8/providers/accuWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/accuWeather.ts
@@ -185,25 +185,25 @@ export class AccuWeather implements WeatherProvider<Services.AccuWeather, AccuWe
 		for (const hour of hourly) {
 			let precipitation: Precipitation | undefined = undefined;
 			if (hour.PrecipitationProbability ?? 0 > 0) {
-				switch (hour.PrecipitationType!) {
+				switch (hour.PrecipitationType) {
 					case "Rain":
 						precipitation = {
 							type: "rain",
-							chance: hour.RainProbability!,
+							chance: hour.RainProbability ?? undefined,
 							volume: hour?.Rain?.Value ?? undefined
 						}
 						break;
 					case "Snow":
 						precipitation = {
 							type: "snow",
-							chance: hour.SnowProbability!,
+							chance: hour.SnowProbability ?? undefined,
 							volume: hour?.Snow?.Value ?? undefined
 						}
 						break;
 					case "Ice":
 						precipitation = {
 							type: "ice pellets",
-							chance: hour.IceProbability!,
+							chance: hour.IceProbability ?? undefined,
 							volume: hour?.Ice?.Value ?? undefined
 						}
 						break;

--- a/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
@@ -75,6 +75,7 @@ export class PirateWeather implements WeatherProvider<Services.PirateWeather, Pi
 		try {
 			const sunrise = DateTime.fromSeconds(json.daily.data[0].sunriseTime, { zone: json.timezone });
 			const sunset = DateTime.fromSeconds(json.daily.data[0].sunsetTime, { zone: json.timezone });
+			const hourlyForecasts: HourlyForecastData[] = [];
 			const result: WeatherData = {
 				date: DateTime.fromSeconds(json.currently.time, { zone: json.timezone }),
 				coord: {
@@ -108,7 +109,7 @@ export class PirateWeather implements WeatherProvider<Services.PirateWeather, Pi
 				},
 				uvIndex: json.currently.uvIndex ?? json.hourly.data[0]?.uvIndex ?? json.daily.data[0]?.uvIndex ?? null,
 				forecasts: [],
-				hourlyForecasts: [],
+				hourlyForecasts,
 			}
 
 			// Forecast
@@ -151,7 +152,7 @@ export class PirateWeather implements WeatherProvider<Services.PirateWeather, Pi
 				};
 
 				// never null here
-				result.hourlyForecasts!.push(forecast);
+				hourlyForecasts.push(forecast);
 			}
 
 			if (json.minutely != null) {

--- a/weather@mockturtl/src/3_8/providers/weatherUnderground.ts
+++ b/weather@mockturtl/src/3_8/providers/weatherUnderground.ts
@@ -126,7 +126,7 @@ export class WeatherUnderground implements WeatherProvider<Services.WeatherUnder
 			const tempmin = forecast.temperatureMin[index];
 			const data: ForecastData = {
 				date: DateTime.fromSeconds(forecast.validTimeUtc[index]).setZone(loc.timeZone),
-				condition: this.IconToCondition(icons[0] ?? icons[1]!),
+				condition: this.IconToCondition(icons[0] ?? icons[1]),
 				temp_max: tempMax == null ? null : this.ToKelvin(tempMax, config),
 				temp_min: tempmin == null ? null : this.ToKelvin(tempmin, config),
 			}
@@ -195,7 +195,9 @@ export class WeatherUnderground implements WeatherProvider<Services.WeatherUnder
 		};
 
 		for (const observations of observationData) {
-			const station = stations.find(v => v.stationId == observations.stationID)!;
+			const station = stations.find(v => v.stationId == observations.stationID);
+			if (station == null)
+				continue;
 			if (result.date == null && observations.obsTimeUtc != null)
 				result.date = DateTime.fromISO(observations.obsTimeUtc).setZone(tz);
 			if (result.location.city == null && observations.neighborhood != null)
@@ -318,7 +320,7 @@ export class WeatherUnderground implements WeatherProvider<Services.WeatherUnder
 		}
 	}
 
-	private IconToCondition = (icon: number): Condition => {
+	private IconToCondition = (icon: number | null | undefined): Condition => {
 		switch (icon) {
 			case 0:
 				return {

--- a/weather@mockturtl/src/3_8/ui_elements/uiBar.ts
+++ b/weather@mockturtl/src/3_8/ui_elements/uiBar.ts
@@ -178,8 +178,9 @@ export class UIBar {
 			this.HideHourlyToggle();
 		}
 
-		this.providerCreditButton = new WeatherButton({ label: _(ELLIPSIS), reactive: true });
-		this.providerCreditButton.actor.connect(SIGNAL_CLICKED, () => OpenUrl(this.providerCreditButton!));
+		const providerCreditButton = new WeatherButton({ label: _(ELLIPSIS), reactive: true });
+		this.providerCreditButton = providerCreditButton;
+		providerCreditButton.actor.connect(SIGNAL_CLICKED, () => OpenUrl(providerCreditButton));
 		this.refreshIcon = new Icon({
 			icon_name: "refresh-symbolic" as BuiltinIcons,
 			icon_type: IconType.SYMBOLIC,

--- a/weather@mockturtl/src/3_8/ui_elements/uiForecasts.ts
+++ b/weather@mockturtl/src/3_8/ui_elements/uiForecasts.ts
@@ -76,8 +76,12 @@ export class UIForecasts {
 			if (!weather.forecasts)
 				return false;
 
-			if (this.forecasts.length > weather.forecasts.length)
-				this.Rebuild(this.app.config, this.app.config.textColorStyle!, weather.forecasts.length);
+			if (this.forecasts.length > weather.forecasts.length) {
+				const textColorStyle = this.app.config.textColorStyle;
+				if (textColorStyle == null)
+					return false;
+				this.Rebuild(this.app.config, textColorStyle, weather.forecasts.length);
+			}
 
 			const len = Math.min(this.forecasts.length, weather.forecasts.length);
 			for (let i = 0; i < len; i++) {

--- a/weather@mockturtl/src/3_8/ui_elements/uiHourlyForecasts.ts
+++ b/weather@mockturtl/src/3_8/ui_elements/uiHourlyForecasts.ts
@@ -70,8 +70,12 @@ export class UIHourlyForecasts {
 		this.actor.connect("scroll-event", (owner, event) => {
 			const adjustment = hScroll.get_adjustment();
 			const direction = event.get_scroll_direction();
-			const newVal = adjustment.get_value() +
-				((direction === ScrollDirection.UP) ? -adjustment.step_increment : (direction === ScrollDirection.DOWN) ? adjustment.step_increment : 0);
+			let scrollDelta = 0;
+			if (direction === ScrollDirection.UP)
+				scrollDelta = -adjustment.step_increment;
+			else if (direction === ScrollDirection.DOWN)
+				scrollDelta = adjustment.step_increment;
+			const newVal = adjustment.get_value() + scrollDelta;
 
 			if (global.settings.get_boolean("desktop-effects-on-menus"))
 				addTween(adjustment, { value: newVal, time: 0.25 });
@@ -153,7 +157,10 @@ export class UIHourlyForecasts {
 			return true;
 
 		if (this.hourlyForecasts.length > forecasts.length) {
-			this.Rebuild(this.app.config, this.app.config.textColorStyle!, forecasts.length);
+			const textColorStyle = this.app.config.textColorStyle;
+			if (textColorStyle == null)
+				return false;
+			this.Rebuild(this.app.config, textColorStyle, forecasts.length);
 		}
 
 		this.hourlyForecastDates = [];


### PR DESCRIPTION
### Issue

Running:

```bash
npx eslint ./src/3_8/
```

on the current Weather applet source reports 11 existing issues:

- 1 `unicorn/no-nested-ternary` error
- 10 `@typescript-eslint/no-non-null-assertion` warnings

### Fix

Resolves the existing lint issues without disabling or suppressing any ESLint rules.
The changes:

- replace non-null assertions with explicit nullable handling where API data may legitimately be absent;
- guard `Array.find()` results before using them;
- keep guaranteed local references where objects are initialized locally;
- verify `textColorStyle` is available before rebuilding forecast UI;
- replace the nested hourly-scroll ternary with explicit direction handling.

No ESLint rules, ignores, or configuration were changed.

The equivalent runtime changes are included in the generated `3.8/weather-applet.js` bundle.

### Testing

Tested on Cinnamon 6.6.9.

- Upstream baseline: `11 problems (1 error, 10 warnings)`.
- `npx eslint ./src/3_8/` completes with no lint errors or warnings after the changes.
- `git diff --check` passes.
- `validate-spice weather@mockturtl` passes.
- The TypeScript source builds successfully with webpack.
- The generated bundle passes `node --check`.
- The full webpack build was installed with `./test.sh` and tested locally.
- The final minimal generated bundle was also installed and tested locally.
- Daily and hourly forecasts, hourly scrolling, refresh, forecast rebuilds, and provider credit interaction continue to work normally.
- No Weather, JavaScript, St, or Clutter errors were observed in the user journal during testing.

### Notes

A fresh webpack build introduces several thousand lines of unrelated toolchain/transpilation changes in the tracked generated bundle, so only the equivalent runtime changes are included in `3.8/weather-applet.js` to keep the diff reviewable.

`cinnamon-spices-makepot weather@mockturtl` was also run successfully. Since this change adds or modifies no translatable strings, the broad mechanical updates it produced in the existing `.po` files were not included in this PR.

This PR intentionally does not bump the applet version because #8965 currently proposes the next version (`3.6.11`). The appropriate version can be assigned according to merge order; feel free to apply the version bump during merge, or I can rebase and update it if preferred.