### PR TITLE
[nvidia-temp@sophie-la-li] Fix temperature unit suffix placement for multi-GPU system

### DIFF
--- a/nvidia-temp@sophie-la-li/files/nvidia-temp@sophie-la-li/applet.js
+++ b/nvidia-temp@sophie-la-li/files/nvidia-temp@sophie-la-li/applet.js
@@ -62,9 +62,16 @@ NvGpuTempApplet.prototype = {
 
     updateTemperature: function() {
         let [result, stdout, stderr] = GLib.spawn_command_line_sync('nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits');
-        let value = stdout.toString().trim();
-        if (this.state.useFahrenheit) value = Math.round((value * 1.8) + 32);
-        this.set_applet_label(value + this.tempUnit); 
+        let lines = stdout.toString().trim().split('\n').filter(l => l.trim() !== '');
+        for (let i = 0; i < lines.length; i++) {
+            let temp = parseInt(lines[i], 10);
+            if (this.state.useFahrenheit) temp = Math.round((temp * 1.8) + 32);
+            lines[i] = temp.toString();
+        }
+        for (let i = 0; i < lines.length; i++) {
+            lines[i] += this.tempUnit;
+        }
+        this.set_applet_label(lines.join('\n'));
         return true;
     },
 

--- a/nvidia-temp@sophie-la-li/files/nvidia-temp@sophie-la-li/metadata.json
+++ b/nvidia-temp@sophie-la-li/files/nvidia-temp@sophie-la-li/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "nvidia-temp@sophie-la-li",
     "name": "Nvidia GPU Temperature Indicator",
     "description": "Shows Nvidia GPU Temperature",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "author": "sophie-la-li"
 }
 


### PR DESCRIPTION
**Previous state**

2 GPU systems displayed text in following form:
```
45
50°
```

Or:
```
45
50°C
```


**State proposed by this PR**

2 GPU systems displayed text in following form:
```
45°
50°
```

Or:
```
45°C
50°C
```

