### PR TITLE
[spicy-clipboard-applet] Add keyboard shortcut + fix history save crash

### DIFF
--- a/spicy-clipboard-applet@Twilight0/files/spicy-clipboard-applet@Twilight0/applet.js
+++ b/spicy-clipboard-applet@Twilight0/files/spicy-clipboard-applet@Twilight0/applet.js
@@ -293,7 +293,7 @@ MyApplet.prototype = {
             Main.keybindingManager.addHotKey(
                 this._keybindingId,
                 this.openShortcut,
-                Lang.bind(this, this._onOpenShortcut)
+                () => this._onOpenShortcut()
             );
         }
     },

--- a/spicy-clipboard-applet@Twilight0/files/spicy-clipboard-applet@Twilight0/applet.js
+++ b/spicy-clipboard-applet@Twilight0/files/spicy-clipboard-applet@Twilight0/applet.js
@@ -59,6 +59,7 @@ MyApplet.prototype = {
 
             // Bind settings
             this.settings = new Settings.AppletSettings(this, metadata.uuid, this.instance_id);
+            this.settings.bind("openShortcut", "openShortcut", this._onShortcutChanged);
             this.settings.bind("historySize", "_historySize", this.settings_changed);
             this.settings.bind("autoPaste", "_autoPaste", this.settings_changed);
             this.settings.bind("pasteTool", "_pasteTool", this.settings_changed);
@@ -67,6 +68,8 @@ MyApplet.prototype = {
             this.settings.bind("leftClickAction", "_leftClickAction", this.settings_changed);
             this.settings.bind("middleClickAction", "_middleClickAction", this.settings_changed);
             this.settings.bind("rightClickAction", "_rightClickAction", this.settings_changed);
+
+            this._onShortcutChanged();
 
             // Set up UI Menu
             this.menuManager = new PopupMenu.PopupMenuManager(this);
@@ -214,38 +217,38 @@ MyApplet.prototype = {
         let historyPath = configDir + "/history.dat";
         let file = Gio.File.new_for_path(historyPath);
         let parent = file.get_parent();
-        
-        parent.make_directory_with_parents_async(GLib.PRIORITY_DEFAULT, null, (parentDir, dir_res) => {
-            try {
-                parentDir.make_directory_with_parents_finish(dir_res);
-            } catch (err) {
-                if (!err.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.EXISTS)) {
-                    global.logError("Failed to create history directory: " + err);
-                    return;
-                }
+
+        // make_directory_with_parents_async is unavailable in this GJS version,
+        // so create the directory synchronously (fast, idempotent).
+        try {
+            parent.make_directory_with_parents(null);
+        } catch (err) {
+            if (!err.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.EXISTS)) {
+                global.logError("Failed to create history directory: " + err);
+                return;
             }
-            
-            try {
-                let data = JSON.stringify(this._history, null, 2);
-                let bytes = GLib.Bytes.new(data);
-                file.replace_contents_async(
-                    bytes,
-                    null,
-                    false,
-                    Gio.FileCreateFlags.REPLACE_DESTINATION,
-                    null,
-                    (f, replace_res) => {
-                        try {
-                            f.replace_contents_finish(replace_res);
-                        } catch (err) {
-                            global.logError("Failed to save clipboard history contents: " + err);
-                        }
+        }
+
+        try {
+            let data = JSON.stringify(this._history, null, 2);
+            let bytes = GLib.Bytes.new(data);
+            file.replace_contents_async(
+                bytes,
+                null,
+                false,
+                Gio.FileCreateFlags.REPLACE_DESTINATION,
+                null,
+                (f, replace_res) => {
+                    try {
+                        f.replace_contents_finish(replace_res);
+                    } catch (err) {
+                        global.logError("Failed to save clipboard history contents: " + err);
                     }
-                );
-            } catch (e) {
-                global.logError("Failed to serialize history: " + e);
-            }
-        });
+                }
+            );
+        } catch (e) {
+            global.logError("Failed to serialize history: " + e);
+        }
     },
 
     _loadHistory: function () {
@@ -277,6 +280,27 @@ MyApplet.prototype = {
                 this._history = [];
             }
         });
+    },
+
+    _onShortcutChanged: function () {
+        if (this._keybindingId) {
+            Main.keybindingManager.removeHotKey(this._keybindingId);
+            this._keybindingId = null;
+        }
+
+        if (this.openShortcut && this.openShortcut !== "unassigned") {
+            this._keybindingId = UUID + "-" + this.instance_id;
+            Main.keybindingManager.addHotKey(
+                this._keybindingId,
+                this.openShortcut,
+                Lang.bind(this, this._onOpenShortcut)
+            );
+        }
+    },
+
+    _onOpenShortcut: function () {
+        this._buildMenu();
+        this.menu.toggle();
     },
 
     on_applet_clicked: function (event) {
@@ -803,6 +827,10 @@ MyApplet.prototype = {
         if (this._monitorTimeout) {
             Mainloop.source_remove(this._monitorTimeout);
             this._monitorTimeout = null;
+        }
+        if (this._keybindingId) {
+            Main.keybindingManager.removeHotKey(this._keybindingId);
+            this._keybindingId = null;
         }
     }
 };

--- a/spicy-clipboard-applet@Twilight0/files/spicy-clipboard-applet@Twilight0/settings-schema.json
+++ b/spicy-clipboard-applet@Twilight0/files/spicy-clipboard-applet@Twilight0/settings-schema.json
@@ -3,6 +3,12 @@
     "type": "section",
     "description": "General Settings"
   },
+  "openShortcut": {
+    "type": "keybinding",
+    "default": "",
+    "description": "Keyboard Shortcut",
+    "tooltip": "Press this shortcut to quickly open the clipboard menu."
+  },
   "historySize": {
     "type": "spinbutton",
     "default": 20,


### PR DESCRIPTION
## Note:

> I am not a developer, and I have only been diving into Linux for less than a week now. I made these small changes to help speed up my workflow. If I have missed something or there are issues with my changes, I would really appreciate it if you could fix them on your end, since I am still learning. Hoping to see this update included in a future release. Thanks! 🙏

---

## Summary of changes

This PR adds two improvements to **spicy-clipboard-applet@Twilight0**:

### 1. Keyboard shortcut to open the clipboard menu

The applet previously had no way to open the clipboard history via keyboard. This adds a configurable keybinding setting:

- New `openShortcut` entry in `settings-schema.json` (type `keybinding`, unassigned by default)
- In `applet.js`: registers/unregisters the hotkey via `Main.keybindingManager` when the setting changes
- Hotkey is properly cleaned up in `on_applet_removed_from_panel`

### 2. Fix crash: `make_directory_with_parents_async` is not a function

The `_saveHistory` function used `Gio.File.make_directory_with_parents_async()`, which does not exist in the version of GJS shipped with Cinnamon. This caused a JS critical error every time an item was copied, preventing history from being saved.

Fix: replaced with the synchronous `make_directory_with_parents()`, which is appropriate here (directory creation is instant and idempotent). The actual file write remains async.

### Files changed
- `applet.js` — keyboard shortcut binding + directory creation fix
- `settings-schema.json` — new `openShortcut` keybinding setting