### PR TITLE
[kdecapplet@joejoetv] Version 2.3.0

### DIFF
--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/4.8/settings-schema.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/4.8/settings-schema.json
@@ -446,7 +446,7 @@
 
     "module_sftp_description": {
         "type": "label",
-        "description": "Lets you remotely browse the storage selected on the device"
+        "description": "Lets you remotely browse the storage of the device"
     },
 
     "module_sms_description": {

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/applet.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/applet.js
@@ -521,8 +521,7 @@ class Device {
             // Workaround to add icon, because Cinnamon didn't like me making a PopupMenu class in another file
             this.menuItemIcon = new St.Icon({ style_class: 'popup-menu-icon', icon_name: this.statusIconName, icon_type: St.IconType.SYMBOLIC });
 
-            //this.menuItem.addActor(this.menuItemIcon, {span: 0, position: 0});
-            Utils.addActorAtPos(this.menuItem, this.menuItemIcon, { span: 0, position: 0 });
+            this.menuItem.addActor(this.menuItemIcon, {span: 0, position: 0});
 
             // Add info modules
             let infoModules = this.getModulesByType(Modules.ModuleType.INFO);
@@ -1120,8 +1119,7 @@ class KDEConnectApplet extends Applet.TextIconApplet {
 
                 let debugIcon = new St.Icon({ style_class: 'popup-menu-icon', icon_name: 'tools-symbolic', icon_type: St.IconType.SYMBOLIC });
 
-                //debugMenuItemParent.addActor(debugIcon, {span: 0, position: 0});
-                Utils.addActorAtPos(debugMenuItemParent, debugIcon, { span: 0, position: 0 });
+                debugMenuItemParent.addActor(debugIcon, {span: 0, position: 0});
 
                 // Simulate plugins changed signal
                 let debugMenuitem1 = new PopupMenu.PopupMenuItem("Manually call 'onDevicePluginsChanged'");

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/applet.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/applet.js
@@ -709,6 +709,8 @@ class KDEConnectApplet extends Applet.TextIconApplet {
         this.settings.bind("combobox_icon-type", "iconType", this.onPanelSettingsChanged.bind(this), "iconType");
         this.settings.bind("switch_use-custom-icon", "useCustomIcon", this.onPanelSettingsChanged.bind(this), "useCustomIcon");
         this.settings.bind("icon_custom-icon", "customIcon", this.onPanelSettingsChanged.bind(this), "customIcon");
+        this.settings.bind("switch_different-icon-no-connected-devices", "differentIconNoDevices", this.onPanelSettingsChanged.bind(this), "differentIconNoDevices");
+        this.settings.bind("icon_no-connected-devices", "noDevicesIcon", this.onPanelSettingsChanged.bind(this), "noDevicesIcon");
         this.settings.bind("switch_expand-only-device", "expandOnlyDevice", function () { });
 
         this.settings.bind("generic_device-order", "deviceOrder", this.onDeviceOrderChanged.bind(this), "deviceOrder");
@@ -1242,8 +1244,19 @@ class KDEConnectApplet extends Applet.TextIconApplet {
     updatePanel() {
         KDEConnectApplet.LOGGER.debug("Updating panel information...");
 
+        // Get number of rechable devices
+        let deviceCount = 0;
+
+        for (let [deviceID, device] of Object.entries(this.devices)) {
+            if (device.getReachableStatus() == true) {
+                deviceCount += 1;
+            }
+        }
+
         // Update Applet Icon
-        if (this.options.useCustomIcon == false) {
+        if (deviceCount == 0 && this.options.differentIconNoDevices) {
+            this.set_applet_icon_symbolic_name(this.options.noDevicesIcon);
+        } else if (this.options.useCustomIcon == false) {
             // Use default icon
             if (this.options.iconType == "COLOR") {
                 this.set_applet_icon_name(Utils.DefaultIcons[this.options.iconType]);
@@ -1260,15 +1273,6 @@ class KDEConnectApplet extends Applet.TextIconApplet {
                 this.set_applet_icon_symbolic_name(this.options.customIcon);
             } else {
                 KDEConnectApplet.LOGGER.error(`Invalid icon type: '${this.options.iconType}'`);
-            }
-        }
-
-        // Get number of rechable devices
-        let deviceCount = 0;
-
-        for (let [deviceID, device] of Object.entries(this.devices)) {
-            if (device.getReachableStatus() == true) {
-                deviceCount += 1;
             }
         }
 
@@ -1395,6 +1399,11 @@ class KDEConnectApplet extends Applet.TextIconApplet {
         if (option == "customIcon" && this.options.useCustomIcon != true) {
             return;
         }
+
+        if (option == "noDevicesIcon" && this.options.differentIconNoDevices != true) {
+            return;
+        }
+
         this.updatePanel();
     }
 

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/js/modules.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/js/modules.js
@@ -715,6 +715,7 @@ class DeviceInfoModule extends KDECModule {
             case "laptop":
                 return "laptop-symbolic";
             case "smartphone":
+            case "phone":
                 return "phone-symbolic";
             case "tablet":
                 return "tablet-symbolic";
@@ -838,7 +839,7 @@ class ConnectivityModule extends KDECModule {
                 networkText = this.networkType;
             }
     
-            return signalStrengthText + " (" + networkText + ")";
+            return `${signalStrengthText} (${networkText})`;
         } else {
             return signalStrengthText;
         }

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/js/modules.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/js/modules.js
@@ -162,7 +162,7 @@ class BatteryUniversalProxy {
                     if (this._onStateChanged) {
                         this.proxy.disconnectSignal(this._onStateChanged);
                     }
-                    
+
                 default: // Newer Versions
                     if (this._onRefreshed) {
                         this.proxy.disconnectSignal(this._onRefreshed);
@@ -391,10 +391,10 @@ class SMSUniversalProxy {
                 case 1: // Version 1.4
                     this.proxy.sendSmsSync(phoneNumber, message);
                     return true;
-            
+
                 default: // Newer versions
                     let addressVariant = new GLib.Variant('(s)', [phoneNumber]);
-    
+
                     this.proxy.sendSmsSync([addressVariant], message, []);
                     return true;
             }
@@ -611,11 +611,11 @@ class BatteryModule extends KDECModule {
     _createProxy() {
         try {
             this.proxy = new BatteryUniversalProxy(this.device.getID(), this.compatMode);
-            
+
             this.charge = this.proxy.getCharge();
             this.isCharging = this.proxy.getChargingState();
 
-            this._signals.connect(this.proxy, "refreshed",this._onRefreshed.bind(this));
+            this._signals.connect(this.proxy, "refreshed", this._onRefreshed.bind(this));
         } catch (error) {
             this._logger.error("Error while connecting to the DBus interface, using default values", error);
         }
@@ -624,10 +624,10 @@ class BatteryModule extends KDECModule {
     _getBatteryIconName() {
         if (this.charge >= 0 && this.charge <= 100) {
             let chargeLevel = Math.floor(this.charge / 10) * 10;
-    
+
             if (this.isCharging) {
                 if (chargeLevel == 100) {
-    
+
                     return `battery-level-${chargeLevel.toString()}-charged-symbolic`;
                 } else {
                     return `battery-level-${chargeLevel.toString()}-charging-symbolic`;
@@ -663,7 +663,7 @@ class BatteryModule extends KDECModule {
     }
 
     _createMenuItem() {
-        this.menuItem = new PopupMenu.PopupIconMenuItem(this._getLabelText(), this._getBatteryIconName(), St.IconType.SYMBOLIC, {reactive: false});
+        this.menuItem = new PopupMenu.PopupIconMenuItem(this._getLabelText(), this._getBatteryIconName(), St.IconType.SYMBOLIC, { reactive: false });
     }
 
     _destroyContent() {
@@ -691,10 +691,10 @@ class DeviceInfoModule extends KDECModule {
         // Default values
         this.deviceType = "unknown";
     }
-    
+
     _createProxy() {
         try {
-            this._signals.connect(this.device, "type-changed",this._onTypeChanged.bind(this));
+            this._signals.connect(this.device, "type-changed", this._onTypeChanged.bind(this));
         } catch (error) {
             this._logger.error("Error while connecting 'type-changed' signal", error);
         }
@@ -709,7 +709,7 @@ class DeviceInfoModule extends KDECModule {
     }
 
     _getTypeIconName() {
-        switch(this.device.getType()) {
+        switch (this.device.getType()) {
             case "desktop":
                 return "computer-symbolic";
             case "laptop":
@@ -729,9 +729,9 @@ class DeviceInfoModule extends KDECModule {
     _createMenuItem() {
         // Create Menu Item
         this.menuItem = new PopupMenu.PopupIconMenuItem(_("ID: {id}").replace("{id}", this.device.getID().toString()), this._getTypeIconName(), St.IconType.SYMBOLIC);
-        
+
         // Copy ID, when clicked
-        this.menuItem._signals.connect(this.menuItem, "activate", function(menuItem, keepMenu) {
+        this.menuItem._signals.connect(this.menuItem, "activate", function (menuItem, keepMenu) {
             Utils.copyAndNotify(this.device.getApplet().notificationSource, this.device.getID(), _("Device ID"));
         }, this);
 
@@ -765,7 +765,7 @@ class ConnectivityModule extends KDECModule {
     _createProxy() {
         try {
             this.proxy = new DeviceConnectivityProxy(Gio.DBus.session, Utils.KDECONNECT_DBUS_NAME, `/modules/kdeconnect/devices/${this.device.getID()}/connectivity_report`);
-            
+
             this.signalStrength = this.proxy.cellularNetworkStrength;
             this.networkType = this.proxy.cellularNetworkType;
 
@@ -799,7 +799,7 @@ class ConnectivityModule extends KDECModule {
                 return "network-cellular-signal-good-symbolic";
             case 4:
                 return "network-cellular-signal-excellent-symbolic";
-        
+
             default:
                 return "network-cellular-no-route-symbolic";
         }
@@ -824,7 +824,7 @@ class ConnectivityModule extends KDECModule {
             case 4:
                 signalStrengthText = _("Excellent");
                 break;
-        
+
             default:
                 signalStrengthText = "?";
                 break;
@@ -832,13 +832,13 @@ class ConnectivityModule extends KDECModule {
 
         if (this.options.showNetworkType == true && this.signalStrength > 0) {
             let networkText = ""
-    
+
             if (this.networkType == "Unknown") {
                 networkText = _("Unknown");
             } else {
                 networkText = this.networkType;
             }
-    
+
             return `${signalStrengthText} (${networkText})`;
         } else {
             return signalStrengthText;
@@ -846,7 +846,7 @@ class ConnectivityModule extends KDECModule {
     }
 
     _createMenuItem() {
-        this.menuItem = new PopupMenu.PopupIconMenuItem(this._getLabelText(), this._getConnectivityIconName(), St.IconType.SYMBOLIC, {reactive: false});
+        this.menuItem = new PopupMenu.PopupIconMenuItem(this._getLabelText(), this._getConnectivityIconName(), St.IconType.SYMBOLIC, { reactive: false });
     }
 
     _destroyContent() {
@@ -930,7 +930,7 @@ class RequestPhotoModule extends KDECModule {
 
             // Build filename from date and time
             let cdate = new Date();
-            let filename = "photo_"+cdate.toLocaleDateString().replaceAll(".","-").replaceAll("/","-")+"_"+cdate.toLocaleTimeString().replaceAll(":","-").replaceAll("/","-");
+            let filename = "photo_" + cdate.toLocaleDateString().replaceAll(".", "-").replaceAll("/", "-") + "_" + cdate.toLocaleTimeString().replaceAll(":", "-").replaceAll("/", "-");
             let filepath = Utils.getAvailableFilename(this.options.saveDirectory, filename, "jpg");
 
             if (filepath !== null) {
@@ -958,10 +958,10 @@ class RequestPhotoModule extends KDECModule {
             case Dialogs.DialogStatus.CANCEL:
                 this._logger.debug("Dialog for selecting photo save location was canceled.");
                 break;
-        
+
             default:
                 // Error
-                this._logger.error("Photo request dialog returned error: "+stderr);
+                this._logger.error("Photo request dialog returned error: " + stderr);
                 break;
         }
     }
@@ -970,9 +970,9 @@ class RequestPhotoModule extends KDECModule {
         this._logger.debug(`Received Photo from device: ${fileName}`);
 
         let notificationSource = this.device.getApplet().notificationSource;
-        let notification = new MessageTray.Notification(notificationSource, _("Photo received from '{deviceName}'").replace("{deviceName}", this.device.getName()), fileName+"\n"+_("Click to open in default application"));
+        let notification = new MessageTray.Notification(notificationSource, _("Photo received from '{deviceName}'").replace("{deviceName}", this.device.getName()), fileName + "\n" + _("Click to open in default application"));
         notification.setTransient(true);
-        this._signals.connect(notification, "clicked", function() {
+        this._signals.connect(notification, "clicked", function () {
             Utils.openURL(`file://${fileName}`);
         })
         notificationSource.notify(notification);
@@ -982,7 +982,7 @@ class RequestPhotoModule extends KDECModule {
         this.menuItem = new PopupMenu.PopupIconMenuItem(_("Request Photo"), "camera-photo-symbolic", St.IconType.SYMBOLIC, {});
         this.menuItemTooltip = new Tooltips.Tooltip(this.menuItem.actor, _("Click to request a photo from the device"));
 
-        this.menuItem._signals.connect(this.menuItem, "activate", function() {
+        this.menuItem._signals.connect(this.menuItem, "activate", function () {
             try {
                 Dialogs.openReceivePhotoDialog(this.device.getApplet().metadata, this.device.getName(), this.requestPhotoCallback.bind(this));
             } catch (error) {
@@ -1090,10 +1090,10 @@ class ShareModule extends KDECModule {
             case Dialogs.DialogStatus.CANCEL:
                 this._logger.debug("Dialog for entering URL to send was canceled.");
                 break;
-        
+
             default:
                 // Error
-                this._logger.error("Dialog for entering URL to send returned error: "+stderr);
+                this._logger.error("Dialog for entering URL to send returned error: " + stderr);
                 break;
         }
     }
@@ -1111,10 +1111,10 @@ class ShareModule extends KDECModule {
             case Dialogs.DialogStatus.CANCEL:
                 this._logger.debug("Dialog for entering text to send was canceled.");
                 break;
-        
+
             default:
                 // Error
-                this._logger.error("Error while opening dialog for entering text to send: "+stderr);
+                this._logger.error("Error while opening dialog for entering text to send: " + stderr);
                 break;
         }
     }
@@ -1122,8 +1122,8 @@ class ShareModule extends KDECModule {
     sendFilesCallback(status, filenameArray, stderr) {
         switch (status) {
             case Dialogs.DialogStatus.SUCCESS:
-                filenameArray = filenameArray.map(function(filename) {
-                    return "file://"+filename
+                filenameArray = filenameArray.map(function (filename) {
+                    return "file://" + filename
                 });
 
                 try {
@@ -1136,10 +1136,10 @@ class ShareModule extends KDECModule {
             case Dialogs.DialogStatus.CANCEL:
                 this._logger.debug("Dialog for selecting files to send was canceled.");
                 break;
-        
+
             default:
                 // Error
-                this._logger.error("Error while opening dialog for selecting files to send: "+stderr);
+                this._logger.error("Error while opening dialog for selecting files to send: " + stderr);
                 break;
         }
     }
@@ -1148,9 +1148,9 @@ class ShareModule extends KDECModule {
         this._logger.debug(`Received Share from device: ${url}`);
 
         let notificationSource = this.device.getApplet().notificationSource;
-        let notification = new MessageTray.Notification(notificationSource, _("Share received from '{deviceName}'").replace("{deviceName}", this.device.getName()), url+"\n"+_("Click to open in default application"));
+        let notification = new MessageTray.Notification(notificationSource, _("Share received from '{deviceName}'").replace("{deviceName}", this.device.getName()), url + "\n" + _("Click to open in default application"));
         notification.setTransient(true);
-        this._signals.connect(notification, "clicked", function() {
+        this._signals.connect(notification, "clicked", function () {
             Utils.openURL(url);
         })
         notificationSource.notify(notification);
@@ -1186,9 +1186,9 @@ class ShareModule extends KDECModule {
             this.menuItem = new PopupMenu.PopupSubMenuMenuItem(_("Share"));
 
             // Workaround to add icon, because Cinnamon didn't like me making a PopupMenu class in another file
-            this.menuIcon = new St.Icon({ style_class: 'popup-menu-icon', icon_name: "send-to-symbolic", icon_type: St.IconType.SYMBOLIC});
-            
-            this.menuItem.addActor(this.menuIcon, {span: 0, position: 0});
+            this.menuIcon = new St.Icon({ style_class: 'popup-menu-icon', icon_name: "send-to-symbolic", icon_type: St.IconType.SYMBOLIC });
+
+            this.menuItem.addActor(this.menuIcon, { span: 0, position: 0 });
         } else {
             this.menuItem = new PopupMenu.PopupMenuSection();
         }
@@ -1198,7 +1198,7 @@ class ShareModule extends KDECModule {
             this.sendURLMenuItem = new PopupMenu.PopupIconMenuItem(_("Send URL"), "link-symbolic", St.IconType.SYMBOLIC, {});
             this.sendURLMenuItemTooltip = new Tooltips.Tooltip(this.sendURLMenuItem.actor, _("Click to send a URL to the device"));
 
-            this.sendURLMenuItem._signals.connect(this.sendURLMenuItem, "activate", function() {
+            this.sendURLMenuItem._signals.connect(this.sendURLMenuItem, "activate", function () {
                 Dialogs.openSendURLDialog(this.device.getApplet().metadata, this.device.getName(), this.sendURLCallback.bind(this));
             }, this);
             this._addMenuItem(this.sendURLMenuItem);
@@ -1208,7 +1208,7 @@ class ShareModule extends KDECModule {
             this.sendTextMenuItem = new PopupMenu.PopupIconMenuItem(_("Send Text"), "text-field", St.IconType.SYMBOLIC, {});
             this.sendTextMenuItemTooltip = new Tooltips.Tooltip(this.sendTextMenuItem.actor, _("Click to send text to the device"));
 
-            this.sendTextMenuItem._signals.connect(this.sendTextMenuItem, "activate", function() {
+            this.sendTextMenuItem._signals.connect(this.sendTextMenuItem, "activate", function () {
                 Dialogs.openSendTextDialog(this.device.getApplet().metadata, this.device.getName(), this.sendTextCallback.bind(this));
             }, this);
             this._addMenuItem(this.sendTextMenuItem);
@@ -1218,7 +1218,7 @@ class ShareModule extends KDECModule {
             this.sendFilesMenuItem = new PopupMenu.PopupIconMenuItem(_("Send File(s)"), "emblem-documents-symbolic", St.IconType.SYMBOLIC, {});
             this.sendFilesMenuItemTooltip = new Tooltips.Tooltip(this.sendFilesMenuItem.actor, _("Click to send file(s) to the device"));
 
-            this.sendFilesMenuItem._signals.connect(this.sendFilesMenuItem, "activate", function() {
+            this.sendFilesMenuItem._signals.connect(this.sendFilesMenuItem, "activate", function () {
                 Dialogs.openSendFilesDialog(this.device.getApplet().metadata, this.device.getName(), this.sendFilesCallback.bind(this));
             }, this);
             this._addMenuItem(this.sendFilesMenuItem);
@@ -1265,7 +1265,7 @@ class SFTPModule extends KDECModule {
                 this.mountPoint = this.proxy.mountPointSync()[0];
                 try {
                     let dirs = this.proxy.getDirectoriesSync()[0];
-                    this.directories = Object.entries(dirs).map(([dir,v]) => [dir, v.get_string()[0]]);
+                    this.directories = Object.entries(dirs).map(([dir, v]) => [dir, v.get_string()[0]]);
                 } catch (error) {
                     this._logger.warn("Available directiories could not be fetched! Falling back to mount point.");
                     this.directories = []
@@ -1322,13 +1322,13 @@ class SFTPModule extends KDECModule {
 
         try {
             this.mountPoint = this.proxy.mountPointSync()[0];
-                try {
-                    let dirs = this.proxy.getDirectoriesSync()[0];
-                    this.directories = Object.entries(dirs).map(([dir,v]) => [dir, v.get_string()[0]]);
-                } catch (error) {
-                    this._logger.warn("Available directiories could not be fetched! Falling back to mount point.");
-                    this.directories = []
-                }
+            try {
+                let dirs = this.proxy.getDirectoriesSync()[0];
+                this.directories = Object.entries(dirs).map(([dir, v]) => [dir, v.get_string()[0]]);
+            } catch (error) {
+                this._logger.warn("Available directiories could not be fetched! Falling back to mount point.");
+                this.directories = []
+            }
         } catch (error) {
             this._logger.error("Error while getting mount point", error);
         }
@@ -1372,7 +1372,7 @@ class SFTPModule extends KDECModule {
                 // If there are multiple, either ask the user or open the first one (if selected in settings)
                 default:
                     if (this.options.selectFirstDirectory) {
-                    this._logger.debug(`Opening first directory (${this.directories[0][0]})`);
+                        this._logger.debug(`Opening first directory (${this.directories[0][0]})`);
                         Utils.openURL(`file://${this.directories[0][0]}`);
                         return;
                     }
@@ -1403,10 +1403,10 @@ class SFTPModule extends KDECModule {
             case Dialogs.DialogStatus.CANCEL:
                 this._logger.debug("Dialog for selecting remote directory to open was canceled.");
                 break;
-        
+
             default:
                 // Error
-                this._logger.error("Error while opening dialog for selecting remote directory to open: "+stderr);
+                this._logger.error("Error while opening dialog for selecting remote directory to open: " + stderr);
                 break;
         }
     }
@@ -1507,10 +1507,10 @@ class SMSModule extends KDECModule {
             case Dialogs.DialogStatus.CANCEL:
                 this._logger.debug("Dialog for entering SMS to send was canceled.");
                 break;
-        
+
             default:
                 // Error
-                this._logger.error("SMS dialog reported error: "+stderr);
+                this._logger.error("SMS dialog reported error: " + stderr);
                 break;
         }
     }
@@ -1532,9 +1532,9 @@ class SMSModule extends KDECModule {
             this.menuItem = new PopupMenu.PopupSubMenuMenuItem(_("SMS"));
 
             // Workaround to add icon, because Cinnamon didn't like me making a PopupMenu class in another file
-            let menuIcon = new St.Icon({ style_class: 'popup-menu-icon', icon_name: "dialog-messages", icon_type: St.IconType.SYMBOLIC});
-            
-            this.menuItem.addActor(menuIcon, {span: 0, position: 0});
+            let menuIcon = new St.Icon({ style_class: 'popup-menu-icon', icon_name: "dialog-messages", icon_type: St.IconType.SYMBOLIC });
+
+            this.menuItem.addActor(menuIcon, { span: 0, position: 0 });
         } else {
             this.menuItem = new PopupMenu.PopupMenuSection();
         }
@@ -1552,7 +1552,7 @@ class SMSModule extends KDECModule {
             this.sendSMSMenuItem = new PopupMenu.PopupIconMenuItem(_("Send SMS"), "chat-message-new-symbolic", St.IconType.SYMBOLIC, {});
             this.sendSMSMenuItemTooltip = new Tooltips.Tooltip(this.sendSMSMenuItem.actor, _("Click to send text to the device"));
 
-            this.sendSMSMenuItem._signals.connect(this.sendSMSMenuItem, "activate", function() {
+            this.sendSMSMenuItem._signals.connect(this.sendSMSMenuItem, "activate", function () {
                 Dialogs.openSendSMSDialog(this.device.getApplet().metadata, this.device.getName(), this.sendSMSCallback.bind(this));
             }, this);
             this._addMenuItem(this.sendSMSMenuItem);

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/js/modules.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/js/modules.js
@@ -1187,8 +1187,7 @@ class ShareModule extends KDECModule {
             // Workaround to add icon, because Cinnamon didn't like me making a PopupMenu class in another file
             this.menuIcon = new St.Icon({ style_class: 'popup-menu-icon', icon_name: "send-to-symbolic", icon_type: St.IconType.SYMBOLIC});
             
-            //this.menuItem.addActor(this.menuIcon, {span: 0, position: 0});
-            Utils.addActorAtPos(this.menuItem, this.menuIcon, {span: 0, position: 0});
+            this.menuItem.addActor(this.menuIcon, {span: 0, position: 0});
         } else {
             this.menuItem = new PopupMenu.PopupMenuSection();
         }
@@ -1534,8 +1533,7 @@ class SMSModule extends KDECModule {
             // Workaround to add icon, because Cinnamon didn't like me making a PopupMenu class in another file
             let menuIcon = new St.Icon({ style_class: 'popup-menu-icon', icon_name: "dialog-messages", icon_type: St.IconType.SYMBOLIC});
             
-            //this.menuItem.addActor(menuIcon, {span: 0, position: 0});
-            Utils.addActorAtPos(this.menuItem, menuIcon, {span: 0, position: 0});
+            this.menuItem.addActor(menuIcon, {span: 0, position: 0});
         } else {
             this.menuItem = new PopupMenu.PopupMenuSection();
         }

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/js/utils.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/js/utils.js
@@ -132,25 +132,6 @@ function copyAndNotify(notificationSource, text, typestring) {
 }
 
 /**
- * Method emulating the addActor method of PopupMenu.PopupBaseMenuItem available in cinnamon 5.4.1 and up,
- * which added the ability to specify the position and align parameters
- * 
- * @param {PopupMenu.PopupBaseMenuItem} menuItem - The menu item to add the child to
- * @param {Clutter.Actor} child - The child actor to add
- * @param {object} params - Parameters for how to add the actor
- */
-function addActorAtPos(menuItem, child, params) {
-    params = Params.parse(params, { span: 1,
-                                    expand: false,
-                                    align: St.Align.START,
-                                    position: -1 });
-    params.actor = child;
-    menuItem._children.splice(params.position >= 0 ? params.position : Number.MAX_SAFE_INTEGER, 0, params);
-    menuItem._signals.connect(menuItem.actor, 'destroy', menuItem._removeChild.bind(menuItem, child));
-    menuItem.actor.insert_child_at_index(child, params.position);
-}
-
-/**
  * Migrates settings from single-instance to multi-instance (<uuid>.json -> <instance_id>.json) if required
  * @param {string} uuid UUID of the applet (used in the config file path/name)
  * @param {string} instanceId Instance ID of the applet (used in the config file name)

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/settings-schema.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/settings-schema.json
@@ -460,7 +460,7 @@
 
     "module_sftp_description": {
         "type": "label",
-        "description": "Lets you remotely browse the storage selected on the device"
+        "description": "Lets you remotely browse the storage of the device"
     },
 
     "module_sftp_selectFirstDirectory": {

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/settings-schema.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/5.8/settings-schema.json
@@ -47,7 +47,9 @@
                 "switch_show-device-count-tooltip",
                 "combobox_icon-type",
                 "switch_use-custom-icon",
-                "icon_custom-icon"
+                "icon_custom-icon",
+                "switch_different-icon-no-connected-devices",
+                "icon_no-connected-devices"
             ]
         },
         "section_kdecsettings": {
@@ -198,6 +200,17 @@
         "description": "Custom icon to use",
         "default": "kdeconnect",
         "dependency": "switch_use-custom-icon"
+    },
+    "switch_different-icon-no-connected-devices": {
+        "type": "switch",
+        "description": "Display a different icon when no devices are connected",
+        "default": false
+    },
+    "icon_no-connected-devices": {
+        "type": "iconfilechooser",
+        "description": "Icon to use when no devices are connected",
+        "default": "emblem-important-symbolic",
+        "dependency": "switch_different-icon-no-connected-devices"
     },
 
     "button_open-kdec-settings": {

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/metadata.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/metadata.json
@@ -4,7 +4,7 @@
   "description": "Enables interacting with devices connected via KDE Connect",
   "comments": "KDE Connect Applet makes it easy to use the various features provided by KDE Connect to interact with connected devices, like sending files, sending SMS messages, browsing the storage of the device and more",
   "website": "https://github.com/linuxmint/cinnamon-spices-applets/tree/master/kdecapplet@joejoetv",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "contributors": "Johannes Schoeneberger - Author,Severga - Inspiration for the Applet",
   "max-instances": "-1"
 }

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/ca.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/ca.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2024-07-17 01:29+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -19,24 +19,25 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "No hi ha mòduls disponibles"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect no està disponible, assegureu-vos que està instal·lat i en marxa."
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Recarregar la miniaplicació"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "S'ha retornat una versió invàlida de KDE Connect!"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -44,283 +45,352 @@ msgstr ""
 "El servei DBus de KDE Connect ha retornat una versió invàlida. Intenteu "
 "recarregar la miniaplicació!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "No hi ha dispositius connectats!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Afegiu-los a les opcions de KDE Connect"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Contingut amb finalitats de debug, no tocar!"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "Versió de KDE Connect: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "ID pròpia: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "id pròpia"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Clic per a copiar la ID pròpia"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Configurar KDE Connect"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Clic per a obrir la configuració de KDE Connect"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "No hi ha dispositius disponibles"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} dispositiu disponible"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} dispositius disponibles"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "S'ha copiat {typestring} al porta-papers"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Mòduls"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Mòdul d'informació de bateria"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Carregant"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Mòdul d'informació dels dispositius"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "ID del dispositiu"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Clic per copiar la ID"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Mòdul d'informació de connectivitat"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "No hi ha senyal"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Baixa"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Ok"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Bona"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Excel·lent"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Desconeguda"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "Mòdul d'acció FindMyPhone"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Trucar al dispositiu"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Clic per trucar al dispositiu"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Mòdul d'acció Request-Photo"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Foto rebuda des de '{deviceName}'"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Clic per a obrir amb l'aplicació per defecte"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Sol·licitar foto"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Clic per sol·licitar una foto del dispositiu"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Mòdul d'acció Ping"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "S'ha enviat un ping al dispositiu '{deviceName}'"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Enviar ping al dispositiu"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Clic per a enviar l'ordre ping al dispositiu"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Mòdul d'acció Share"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Fitxer compartit rebut de  '{deviceName}'"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Compartir"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Enviar URL"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Clic per enviar una URL al dispositiu"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Enviar Text"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Clic per enviar text al dispositiu"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Enviar Fitxer(s)"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Clic per enviar fitxer(s) al dispositiu"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "Mòdul d'acció SFTP"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Desmuntar"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Muntar"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Clic per desmuntar"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Clic per muntar"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Clic per navegar pels fitxers"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "Mòdul d'acció SMS"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Iniciar l'aplicació d'SMS"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Clic per obrir l'aplicació d'SMS de KDE Connect"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Enviar SMS"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "Miniaplicació KDE Connect"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "S'ha copiat {typestring} al porta-papers"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Moure l'element seleccionat cap a dalt"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Moure l'element seleccionat cap a baix"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Enviar URL a '{device_name}'"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Cancel·lar"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Enviar"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Introduïu una URL per enviar a '{device_name}'"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Enviar SMS utilitzant '{device_name}'"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Número de telèfon:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Número de telèfon"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Missatge:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Enviar text a '{device_name}'"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Text a enviar:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Enviar text a '{device_name}'"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Seleccioneu fitxers per enviar a '{deviceName}'"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Seleccioneu on es guardarà la foto rebuda de '{deviceName}'"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "foto.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "Foto JPEG"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "Miniaplicació KDE Connect"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -344,230 +414,301 @@ msgstr "Autor - Johannes Schoeneberger"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Inspiració per la miniaplicació"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "General"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Mòduls"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Menú contextual"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Tauler"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Dispositius"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Informació dels mòduls"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Mòduls d'acció"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Mòdul d'informació de bateria"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Mòdul d'informació dels dispositius"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Mòdul d'informació de connectivitat"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Mòdul d'acció FindMyPhone"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Mòdul d'acció Request-Photo"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Mòdul d'acció Ping"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Mòdul d'acció Share"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "Mòdul d'acció SFTP"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "Mòdul d'acció SMS"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Mostrar la ID pròpia al menú contextual de la miniaplicació"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr ""
 "Mostrar la versió de KDE Connect al menú contextual de la miniaplicació"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr ""
 "Mostrar el número de dispositius connectats al costat de la icona al tauler"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr ""
 "Mostrar el número de dispositius a la informació d'eines de la miniaplicació"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Tipus d'icona"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Simbòlica"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Color"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Utilitzar icona personalitzada"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Icona personalitzada a utilitzar"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "Obrir la configuració de KDE Connect"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 "Expandir el menú de dispositius automàticament quan un dispositiu estigui "
 "disponible"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Nom"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Expandir"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Activat"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "Mostra l'estat actual de la bateria i si s'està carregant o no"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Mostra la icona del dispositiu juntament amb la seva ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr ""
 "Mostrar l'estat actual de la connectivitat i el tipus de xarxa del dispositiu"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Mostrar el tipus de xarxa mòbil"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 "Us permet trucar al dispositiu de manera que pugueu trobar-lo en cas d'haver-"
 "lo perdut de vista"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Us permet sol·licitar una foto del dispositiu remot i guardar-la en aquest "
 "dispositiu"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Guardar les fotos rebudes directament al directori"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "El directori on es guardaran les fotos rebutes"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr "Us permet fer ping al dispositiu per a confirmar que està connectat"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Utilitzar un missatge personalitzat pel ping"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Missatge personalitzat"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Us permet compartir URLs, fitxers o text amb el dispositiu"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Mostrar elements del menú al submenú"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Activar l'element del menú per enviar una URL"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Activar l'element del menú per enviar text"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Activar l'element del menú per enviar fitxer(s)"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr ""
 "Us permet navegar pel sistema de fitxers del dispositiu de manera remota"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Us permet enviar SMS des del dispositiu de manera remota"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Activar l'element del menú per enviar missatges SMS"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr ""
 "Activar l'element del menú per a iniciar l'aplicació d'SMS de KDE Connect"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/da.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2023-12-30 16:54+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -19,24 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Ingen moduler tilgængelige"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect er ikke tilgængelig. Sørg for, den er installeret og kører."
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Genindlæs panelprogrammet"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Ugyldig version af KDE Connect returneret!"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -44,283 +45,352 @@ msgstr ""
 "KDE Connect DBus-tjenesten returnerede en ugyldig version. Prøv at "
 "genindlæse panelprogrammet!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Ingen forbundne enheder!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Tilføj dem i indstillingerne for KDE Connect"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Fejlsøgningsting, niks pille!"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect-version: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Eget ID: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "eget ID"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Klik for at kopiere eget ID"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Konfigurér KDE Connect"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Klik for at åbne konfigurationen af KDE Connect"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Ingen tilgængelige enheder"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} tilgængelig enhed"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} tilgængelige enheder"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "Kopierede {typestring} til udklipsholderen"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Moduler"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Batterimodul"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Oplader"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Enhedsinfomodul"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "Enheds-ID"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Klik for at kopiere ID"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Forbindelsesmodul"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Intet signal"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Lavt"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "OK"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Godt"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Fremragende"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Ukendt"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "FindMinTelefon-modul"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Ring til enhed"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Klik for at ringe til enheden"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Bed-om-foto-modul"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Foto modtaget fra “{deviceName}”"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Klik for at åbne med standardprogrammet"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Bed om foto"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Klik for at bede om et foto fra enheden"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Pingmodul"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Sendte ping til enheden “{deviceName}”"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Ping enhed"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Klik for at sende et ping til enheden"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Delingsmodul"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Deling modtaget fra “{deviceName}”"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Deling"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Send URL"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Klik for at sende en URL til enheden"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Send tekst"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Klik for at sende tekst til enheden"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Send filer"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Klik for at sende filer til enheden"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "SFTP-modul"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Afmontér"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Montér"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Klik for at afmontere"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Klik for at montere"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Klik for at gennemse filer"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "SMS-modul"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Start SMS-appen"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Klik for at åbne KDE Connects SMS-app"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Send SMS"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "KDE Connect-panelprogram"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "Kopierede {typestring} til udklipsholderen"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Flyt markeret indgang op"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Flyt markeret indgang ned"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Send URL til “{device_name}”"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Annullér"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Send"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Indtast en URL, der skal sendes til “{device_name}”"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Send SMS med brug af “{device_name}”"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Telefonnummer:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Meddelelse:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Send tekst til “{device_name}”"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Tekst der skal sendes:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Send tekst til “{device_name}”"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Vælg filer, der skal sendes til “{deviceName}”"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Vælg, hvor fotos modtaget fra “{deviceName}” skal gemmes"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "photo.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "JPEG-foto"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "KDE Connect-panelprogram"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -344,223 +414,294 @@ msgstr "Johannes Schoeneberger - forfatter"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Inspiration til panelprogrammet"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Generelt"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Moduler"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Genvejsmenu"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Panel"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Enheder"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Infomoduler"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Handlingsmoduler"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Batterimodul"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Enhedsinfomodul"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Forbindelsesmodul"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "FindMinTelefon-modul"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Bed-om-foto-modul"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Pingmodul"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Delingsmodul"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "SFTP-modul"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "SMS-modul"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Vis eget ID i panelprogrammets genvejsmenu"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Vis KDE Connect-versionen i panelprogrammets genvejsmenu"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "Vis antallet af forbundne enheder ved siden af ikonet i panelet"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Vis antal enheder i panelprogrammets værktøjstip"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Ikontype"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Symbolsk"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Farve"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Brug tilpasset ikon"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Tilpasset ikon der skal bruges"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "Åbn konfigurationen af KDE Connect"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 "Udfold automatisk enhedens undermenu, hvis der kun er en enhed tilgængelig"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Navn"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Udfold"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Aktiveret"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "Viser den aktuelle batteriopladning og opladningsstatus for enheden"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Viser enhedens ikon sammen med dens ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "Viser enhedens aktuelle forbindelsesstatus og netværkstype"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Vis mobilnetværkstypen"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 "Giver dig mulighed for at få enheden til at ringe, så du kan finde den, hvis "
 "du har forlagt den"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Giver dig mulighed for at bede om et foto fra den eksterne enhed og gemme "
 "det på denne enhed"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Gem modtagne fotos direkte i mappen"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Den mappe de modtagne fotos skal gemmes i"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr "Lader dig pinge enheden for at sikre, at den er forbundet"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Brug selvvalgt meddelelse til ping"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Selvvalgt meddelelse"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Lader dig dele URL'er, filer eller tekst med enheden"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Vis menupunkter i undermenuen"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Aktivér menupunktet for at sende en URL"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Aktivér menupunktet for at sende noget tekst"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Aktivér menupunktet for at sende filer"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr "Giver dig mulighed for at fjernbrowse det valgte lager på enheden"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Lader dig fjernsende SMS'er fra enheden"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Aktivér menupunktet for at sende en SMS"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Aktivér menupunktet for at starte KDE Connects SMS-app"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
 "POT-Creation-Date: 2026-08-22 17:38+0200\n"
-"PO-Revision-Date: 2026-08-22 17:43+0200\n"
+"PO-Revision-Date: 2026-08-22 17:52+0200\n"
 "Last-Translator: \n"
 "Language-Team: Johannes Schöneberger <joejoetv@joejoetv.de>\n"
 "Language: de\n"
@@ -680,9 +680,8 @@ msgstr "Menüeintrag zum senden von Datei(en) aktivieren"
 
 #. 5.8->settings-schema.json->module_sftp_description->description
 #. 4.8->settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
-msgstr ""
-"Ermöglicht es, auf dem Gerät ausgewählte Speicherabschnitte zu durchsuchen"
+msgid "Lets you remotely browse the storage of the device"
+msgstr "Erlaubt entfernten Zugriff auf den Gerätespeicher"
 
 #. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
 msgid "Select the first directory automatically"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: kdecapplet@joejoetv\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-22 17:38+0200\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2026-08-22 17:52+0200\n"
 "Last-Translator: \n"
 "Language-Team: Johannes Schöneberger <joejoetv@joejoetv.de>\n"
@@ -19,26 +19,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: 5.8/applet.js:547 4.8/applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Keine Module verfügbar"
 
-#: 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect ist nicht verfügbar, stelle sicher, dass es installiert ist und "
 "ausgeführt wird."
 
-#: 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
-#: 4.8/applet.js:1085 4.8/applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Applet neuladen"
 
-#: 5.8/applet.js:1033 4.8/applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Ungültige KDE Connect Version erhalten!"
 
-#: 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -46,341 +46,341 @@ msgstr ""
 "Der KDE Connect DBus Dienst hat eine ungültige Version zurückgegeben, bitte "
 "versuche, das Applet neu zu laden!"
 
-#: 5.8/applet.js:1075 4.8/applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Keine verbundenen Geräte!"
 
-#: 5.8/applet.js:1075 4.8/applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Füge sie in den KDE Connect Einstellungen hinzu"
 
-#: 5.8/applet.js:1120 4.8/applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Debug Zeug, nicht anfassen!"
 
-#: 5.8/applet.js:1209 4.8/applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect Version: {version}"
 
-#: 5.8/applet.js:1221 4.8/applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Eigene ID: {own_id}"
 
-#: 5.8/applet.js:1223 4.8/applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "Eigene ID"
 
-#: 5.8/applet.js:1225 4.8/applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Klicken, um eigene ID zu kopieren"
 
-#: 5.8/applet.js:1235 4.8/applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "KDE Connect konfigurieren"
 
-#: 5.8/applet.js:1237 4.8/applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Klicken, um die KDE Connect Einstellungen zu öffnen"
 
-#: 5.8/applet.js:1283 4.8/applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Keine verfügbaren Geräte"
 
-#: 5.8/applet.js:1285 4.8/applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} verfügbares Gerät"
 
-#: 5.8/applet.js:1287 4.8/applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} verfügbare Geräte"
 
-#: 5.8/js/modules.js:450
+#. 5.8/js/modules.js:450
 msgid "Module"
 msgstr "Modul"
 
-#: 5.8/js/modules.js:597
+#. 5.8/js/modules.js:597
 msgid "Battery Module"
 msgstr "Akku Modul"
 
-#: 5.8/js/modules.js:646 4.8/js/modules.js:658
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Ladend"
 
-#: 5.8/js/modules.js:682
+#. 5.8/js/modules.js:682
 msgid "Device-Info Module"
 msgstr "Geräte-Info Modul"
 
-#: 5.8/js/modules.js:731 4.8/js/modules.js:741
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#: 5.8/js/modules.js:735 4.8/js/modules.js:745
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "Geräte ID"
 
-#: 5.8/js/modules.js:739 4.8/js/modules.js:749
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Klicken, um ID zu kopieren"
 
-#: 5.8/js/modules.js:751
+#. 5.8/js/modules.js:751
 msgid "Connectivity Module"
 msgstr "Konnektivität Modul"
 
-#: 5.8/js/modules.js:813 4.8/js/modules.js:822
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Kein Empfang"
 
-#: 5.8/js/modules.js:816 4.8/js/modules.js:825
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Schlecht"
 
-#: 5.8/js/modules.js:819 4.8/js/modules.js:828
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Ok"
 
-#: 5.8/js/modules.js:822 4.8/js/modules.js:831
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Gut"
 
-#: 5.8/js/modules.js:825 4.8/js/modules.js:834
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Exzellent"
 
-#: 5.8/js/modules.js:837 4.8/js/modules.js:846
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: 5.8/js/modules.js:867
+#. 5.8/js/modules.js:867
 msgid "FindMyPhone Module"
 msgstr "FindMyPhone Modul"
 
-#: 5.8/js/modules.js:892 4.8/js/modules.js:900
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Gerät anklingeln"
 
-#: 5.8/js/modules.js:893 4.8/js/modules.js:901
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Klicken, um Gerät anzuklingeln"
 
-#: 5.8/js/modules.js:907
+#. 5.8/js/modules.js:907
 msgid "Request Photo Module"
 msgstr "Foto-Anfragen Modul"
 
-#: 5.8/js/modules.js:973 4.8/js/modules.js:980
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Foto von '{deviceName}' empfangen"
 
-#: 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
-#: 4.8/js/modules.js:1156
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Klicken, um in Standardanwendung zu öffnen"
 
-#: 5.8/js/modules.js:982 4.8/js/modules.js:989
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Foto anfragen"
 
-#: 5.8/js/modules.js:983 4.8/js/modules.js:990
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Klicken, um Foto von dem Gerät anzufordern"
 
-#: 5.8/js/modules.js:1009
+#. 5.8/js/modules.js:1009
 msgid "Ping Module"
 msgstr "Ping Modul"
 
-#: 5.8/js/modules.js:1034 4.8/js/modules.js:1040
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#: 5.8/js/modules.js:1041 4.8/js/modules.js:1047
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Ping-Nachricht an Gerät '{deviceName}' gesendet"
 
-#: 5.8/js/modules.js:1047 4.8/js/modules.js:1053
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Ping-Nachricht an Gerät senden"
 
-#: 5.8/js/modules.js:1048 4.8/js/modules.js:1054
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Klicken, um Ping-Nachricht an Gerät zu senden"
 
-#: 5.8/js/modules.js:1062
+#. 5.8/js/modules.js:1062
 msgid "Share Module"
 msgstr "Teilen Modul"
 
-#: 5.8/js/modules.js:1151 4.8/js/modules.js:1156
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Freigabe von '{deviceName}' empfangen"
 
-#: 5.8/js/modules.js:1186 4.8/js/modules.js:1191
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Teilen"
 
-#: 5.8/js/modules.js:1198 4.8/js/modules.js:1204
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Teile URL"
 
-#: 5.8/js/modules.js:1199 4.8/js/modules.js:1205
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Klicken, um eine URL an das Gerät zu senden"
 
-#: 5.8/js/modules.js:1208 4.8/js/modules.js:1214
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Teile Text"
 
-#: 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
-#: 4.8/js/modules.js:1490
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Klicken, um Text an das Gerät zu senden"
 
-#: 5.8/js/modules.js:1218 4.8/js/modules.js:1224
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Teile Datei(en)"
 
-#: 5.8/js/modules.js:1219 4.8/js/modules.js:1225
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Klicken, um Datei(en) an das Gerät zu senden"
 
-#: 5.8/js/modules.js:1243
+#. 5.8/js/modules.js:1243
 msgid "SFTP Module"
 msgstr "SFTP Modul"
 
-#: 5.8/js/modules.js:1284 4.8/js/modules.js:1281
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Aushängen"
 
-#: 5.8/js/modules.js:1286 4.8/js/modules.js:1283
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Einhängen"
 
-#: 5.8/js/modules.js:1292 4.8/js/modules.js:1289
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Klicken zum aushängen"
 
-#: 5.8/js/modules.js:1294 4.8/js/modules.js:1291
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Klicken zum einhängen"
 
-#: 5.8/js/modules.js:1424 4.8/js/modules.js:1364
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Klicken, um Dateien zu durchsuchen"
 
-#: 5.8/js/modules.js:1463
+#. 5.8/js/modules.js:1463
 msgid "SMS Module"
 msgstr "SMS Modul"
 
-#: 5.8/js/modules.js:1532 4.8/js/modules.js:1468
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#: 5.8/js/modules.js:1544 4.8/js/modules.js:1481
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "SMS Anwendung starten"
 
-#: 5.8/js/modules.js:1545 4.8/js/modules.js:1482
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Klicken, um KDE Connect SMS Anwendung zu starten"
 
-#: 5.8/js/modules.js:1552 4.8/js/modules.js:1489
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "SMS senden"
 
 #. metadata.json->name
-#: 5.8/js/utils.js:24
+#. 5.8/js/utils.js:24
 msgid "KDE Connect Applet"
 msgstr "KDE Connect Applet"
 
-#: 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
 msgid "Copied {typestring} to the clipboard"
 msgstr "{typestring} in die Zwischenablage kopiert"
 
-#: 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Ausgewählten Eintrag nach oben bewegen"
 
-#: 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Ausgewählten Eintrag nach unten bewegen"
 
-#: 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Sende URl an '{device_name}'"
 
-#: 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
-#: 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
-#: 4.8/py/dialogs.py:169
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
-#: 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Senden"
 
-#: 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "URL eingeben, um an '{device_name}' zu senden"
 
-#: 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#: 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "SMS via '{device_name}' senden"
 
-#: 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Telefonnummer:"
 
-#: 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#: 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Nachricht:"
 
-#: 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Text an '{device_name}' senden"
 
-#: 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Text zu senden:"
 
-#: 5.8/py/dialogs.py:271
+#. 5.8/py/dialogs.py:271
 #, python-brace-format
 msgid "Open remote directory on '{device_name}'"
 msgstr "Entferntes Verzeichnis auf '{device_name}' öffnen"
 
-#: 5.8/py/dialogs.py:290
+#. 5.8/py/dialogs.py:290
 msgid "Open"
 msgstr "Öffnen"
 
-#: 5.8/py/dialogs.py:300
+#. 5.8/py/dialogs.py:300
 msgid "Directory to open:"
 msgstr "Verzeichnis zu öffnen:"
 
-#: 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Datei(en) auswählen, um an '{deviceName}' zu senden"
 
-#: 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr ""
 "Auswählen, wo angefordertes Foto von '{deviceName}' gespeichert werden soll"
 
-#: 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "foto.jpg"
 
-#: 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "JPEG Foto"
 

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: kdecapplet@joejoetv\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-19 00:45+0200\n"
-"PO-Revision-Date: 2026-08-19 00:57+0200\n"
+"POT-Creation-Date: 2026-08-22 17:38+0200\n"
+"PO-Revision-Date: 2026-08-22 17:43+0200\n"
 "Last-Translator: \n"
 "Language-Team: Johannes Schöneberger <joejoetv@joejoetv.de>\n"
 "Language: de\n"
@@ -19,25 +19,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: applet.js:548
+#: 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Keine Module verfügbar"
 
-#: applet.js:1012 applet.js:1015
+#: 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect ist nicht verfügbar, stelle sicher, dass es installiert ist und "
 "ausgeführt wird."
 
-#: applet.js:1019 applet.js:1032 applet.js:1222
+#: 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#: 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Applet neuladen"
 
-#: applet.js:1024
+#: 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Ungültige KDE Connect Version erhalten!"
 
-#: applet.js:1025 applet.js:1028
+#: 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -45,336 +46,341 @@ msgstr ""
 "Der KDE Connect DBus Dienst hat eine ungültige Version zurückgegeben, bitte "
 "versuche, das Applet neu zu laden!"
 
-#: applet.js:1066
+#: 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Keine verbundenen Geräte!"
 
-#: applet.js:1066
+#: 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Füge sie in den KDE Connect Einstellungen hinzu"
 
-#: applet.js:1111
+#: 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Debug Zeug, nicht anfassen!"
 
-#: applet.js:1201
+#: 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect Version: {version}"
 
-#: applet.js:1213
+#: 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Eigene ID: {own_id}"
 
-#: applet.js:1215
+#: 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "Eigene ID"
 
-#: applet.js:1217
+#: 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Klicken, um eigene ID zu kopieren"
 
-#: applet.js:1227
+#: 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "KDE Connect konfigurieren"
 
-#: applet.js:1229
+#: 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Klicken, um die KDE Connect Einstellungen zu öffnen"
 
-#: applet.js:1273
+#: 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Keine verfügbaren Geräte"
 
-#: applet.js:1275
+#: 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} verfügbares Gerät"
 
-#: applet.js:1277
+#: 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} verfügbare Geräte"
 
-#: js/modules.js:450
+#: 5.8/js/modules.js:450
 msgid "Module"
 msgstr "Modul"
 
-#: js/modules.js:597
+#: 5.8/js/modules.js:597
 msgid "Battery Module"
 msgstr "Akku Modul"
 
-#: js/modules.js:646
+#: 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Ladend"
 
-#: js/modules.js:682
+#: 5.8/js/modules.js:682
 msgid "Device-Info Module"
 msgstr "Geräte-Info Modul"
 
-#: js/modules.js:730
+#: 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#: js/modules.js:734
+#: 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "Geräte ID"
 
-#: js/modules.js:738
+#: 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Klicken, um ID zu kopieren"
 
-#: js/modules.js:750
+#: 5.8/js/modules.js:751
 msgid "Connectivity Module"
 msgstr "Konnektivität Modul"
 
-#: js/modules.js:812
+#: 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Kein Empfang"
 
-#: js/modules.js:815
+#: 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Schlecht"
 
-#: js/modules.js:818
+#: 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Ok"
 
-#: js/modules.js:821
+#: 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Gut"
 
-#: js/modules.js:824
+#: 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Exzellent"
 
-#: js/modules.js:836
+#: 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: js/modules.js:866
+#: 5.8/js/modules.js:867
 msgid "FindMyPhone Module"
 msgstr "FindMyPhone Modul"
 
-#: js/modules.js:891
+#: 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Gerät anklingeln"
 
-#: js/modules.js:892
+#: 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Klicken, um Gerät anzuklingeln"
 
-#: js/modules.js:906
+#: 5.8/js/modules.js:907
 msgid "Request Photo Module"
 msgstr "Foto-Anfragen Modul"
 
-#: js/modules.js:972
+#: 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Foto von '{deviceName}' empfangen"
 
-#: js/modules.js:972 js/modules.js:1150
+#: 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#: 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Klicken, um in Standardanwendung zu öffnen"
 
-#: js/modules.js:981
+#: 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Foto anfragen"
 
-#: js/modules.js:982
+#: 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Klicken, um Foto von dem Gerät anzufordern"
 
-#: js/modules.js:1008
+#: 5.8/js/modules.js:1009
 msgid "Ping Module"
 msgstr "Ping Modul"
 
-#: js/modules.js:1033
+#: 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#: js/modules.js:1040
+#: 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Ping-Nachricht an Gerät '{deviceName}' gesendet"
 
-#: js/modules.js:1046
+#: 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Ping-Nachricht an Gerät senden"
 
-#: js/modules.js:1047
+#: 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Klicken, um Ping-Nachricht an Gerät zu senden"
 
-#: js/modules.js:1061
+#: 5.8/js/modules.js:1062
 msgid "Share Module"
 msgstr "Teilen Modul"
 
-#: js/modules.js:1150
+#: 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Freigabe von '{deviceName}' empfangen"
 
-#: js/modules.js:1185
+#: 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Teilen"
 
-#: js/modules.js:1198
+#: 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Teile URL"
 
-#: js/modules.js:1199
+#: 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Klicken, um eine URL an das Gerät zu senden"
 
-#: js/modules.js:1208
+#: 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Teile Text"
 
-#: js/modules.js:1209 js/modules.js:1554
+#: 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#: 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Klicken, um Text an das Gerät zu senden"
 
-#: js/modules.js:1218
+#: 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Teile Datei(en)"
 
-#: js/modules.js:1219
+#: 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Klicken, um Datei(en) an das Gerät zu senden"
 
-#: js/modules.js:1243
+#: 5.8/js/modules.js:1243
 msgid "SFTP Module"
 msgstr "SFTP Modul"
 
-#: js/modules.js:1284
+#: 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Aushängen"
 
-#: js/modules.js:1286
+#: 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Einhängen"
 
-#: js/modules.js:1292
+#: 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Klicken zum aushängen"
 
-#: js/modules.js:1294
+#: 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Klicken zum einhängen"
 
-#: js/modules.js:1424
+#: 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Klicken, um Dateien zu durchsuchen"
 
-#: js/modules.js:1463
+#: 5.8/js/modules.js:1463
 msgid "SMS Module"
 msgstr "SMS Modul"
 
-#: js/modules.js:1532
+#: 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#: js/modules.js:1545
+#: 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "SMS Anwendung starten"
 
-#: js/modules.js:1546
+#: 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Klicken, um KDE Connect SMS Anwendung zu starten"
 
-#: js/modules.js:1553
+#: 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "SMS senden"
 
 #. metadata.json->name
-#: js/utils.js:21
+#: 5.8/js/utils.js:24
 msgid "KDE Connect Applet"
 msgstr "KDE Connect Applet"
 
-#: js/utils.js:123
+#: 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
 msgid "Copied {typestring} to the clipboard"
 msgstr "{typestring} in die Zwischenablage kopiert"
 
-#: settingsWidgets.py:153
+#: 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Ausgewählten Eintrag nach oben bewegen"
 
-#: settingsWidgets.py:160
+#: 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Ausgewählten Eintrag nach unten bewegen"
 
-#: py/dialogs.py:50
+#: 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Sende URl an '{device_name}'"
 
-#: py/dialogs.py:60 py/dialogs.py:132 py/dialogs.py:207 py/dialogs.py:285
+#: 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#: 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#: 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: py/dialogs.py:65 py/dialogs.py:137 py/dialogs.py:212
+#: 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#: 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Senden"
 
-#: py/dialogs.py:76
+#: 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "URL eingeben, um an '{device_name}' zu senden"
 
-#: py/dialogs.py:83
+#: 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#: py/dialogs.py:122
+#: 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "SMS via '{device_name}' senden"
 
-#: py/dialogs.py:147
+#: 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Telefonnummer:"
 
-#: py/dialogs.py:151
+#: 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#: py/dialogs.py:154
+#: 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Nachricht:"
 
-#: py/dialogs.py:197
+#: 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Text an '{device_name}' senden"
 
-#: py/dialogs.py:222
+#: 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Text zu senden:"
 
-#: py/dialogs.py:271
+#: 5.8/py/dialogs.py:271
 #, python-brace-format
 msgid "Open remote directory on '{device_name}'"
 msgstr "Entferntes Verzeichnis auf '{device_name}' öffnen"
 
-#: py/dialogs.py:290
+#: 5.8/py/dialogs.py:290
 msgid "Open"
 msgstr "Öffnen"
 
-#: py/dialogs.py:300
+#: 5.8/py/dialogs.py:300
 msgid "Directory to open:"
 msgstr "Verzeichnis zu öffnen:"
 
-#: py/dialogs.py:375
+#: 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Datei(en) auswählen, um an '{deviceName}' zu senden"
 
-#: py/dialogs.py:442
+#: 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr ""
 "Auswählen, wo angefordertes Foto von '{deviceName}' gespeichert werden soll"
 
-#: py/dialogs.py:449
+#: 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "foto.jpg"
 
-#: py/dialogs.py:452
+#: 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "JPEG Foto"
 
@@ -403,230 +409,296 @@ msgstr "Johannes Schöneberger - Autor"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Inspiration für das Applet"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Allgemein"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Module"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Kontextmenü"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Leiste"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Geräte"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Info-Module"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Aktionsmodule"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Akku Info-Modul"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Geräte-Info Info-Modul"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Konnektivität Info-Modul"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "FindMyPhone Aktions-Modul"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Foto-Anfragen Aktions-Modul"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Ping Aktions-Modul"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Teilen Aktions-Modul"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "SFTP Aktions-Modul"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "SMS Aktions-Modul"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Eigene ID im Kontextmenü des Applets anzeigen"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "KDE Connect Version im Kontextmenü des Applets anzeigen"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "Anzahl an verfügbaren Geräten neben dem Symbol in der Leiste anzeigen"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Anzahl an verfügbaren Geräten im Tooltip des Applets anzeigen"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Symboltyp"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Symbolisch"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Farbig"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Benutzerdefiniertes Symbol benutzen"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Benutzerdefiniertes Symbol"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr "Ein anderes Symbol anzeigen, falls keine Geräte verbunden sind"
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr "Symbol, welches verwendet wird, falls keine Geräte verbunden sind"
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "KDE Connect Einstellungen öffnen"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 "Erstes Geräte-Untermenü automatisch ausklappen, wenn nur ein Gerät verfügbar "
 "ist"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Name"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Ausklappen"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "Zeigt die momentane Akkuladung und den Ladezustand des Gerätes an"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Zeigt das Symbol des Gerätes und dessen ID an"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "Zeigt die momentane Empfangsstärke und den Netzwerktyp des Gerätes an"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Zeige den mobilen Netzwerktyp an"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 "Ermöglicht das Gerät anzuklingeln, so dass du es finden kannst, wenn du es "
 "verlegt hast"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Ermöglicht es, ein Foto von dem Gerät anzufragen und es lokal zu speichern"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Empfangene Fotos direkt in Verzeichnis speichern"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Das Verzeichnis, in dem die Fotos gespeichert werden sollen"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr ""
 "Ermöglicht es, dem Gerät eine Ping-Nachricht zu senden, um die Verbindung zu "
 "dem Gerät zu testen"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Benutzerdefinierter Text für die Ping-Nachricht benutzen"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Benutzerdefinierter Text"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Ermöglicht das Teilen von URLs, Dateien oder Text mit dem Gerät"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Zeige Menüeinträge in einem Untermenü"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Menüeintrag zum senden einer URL aktivieren"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Menüeintrag zum senden von Text aktivieren"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Menüeintrag zum senden von Datei(en) aktivieren"
 
-#. settings-schema.json->module_sftp_description->description
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
 msgid "Lets you remotely browse the storage selected on the device"
 msgstr ""
 "Ermöglicht es, auf dem Gerät ausgewählte Speicherabschnitte zu durchsuchen"
 
-#. settings-schema.json->module_sftp_selectFirstDirectory->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
 msgid "Select the first directory automatically"
 msgstr "Das erste Verzeichnis automatisch auswählen"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Ermöglicht das Senden von SMS-Nachrichten über das Gerät"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Menüeintrag zum senden einer SMS-Nachricht aktivieren"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Menüeintrag zum öffnen der KDE Connect SMS Anwendung aktivieren"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/es.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-19 00:45+0200\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2026-08-20 17:13-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,25 +19,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.9\n"
 
-#: applet.js:548
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "No hay módulos disponibles"
 
-#: applet.js:1012 applet.js:1015
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect no está disponible, asegúrese de que esté instalado y "
 "funcionando."
 
-#: applet.js:1019 applet.js:1032 applet.js:1222
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Recargar Applet"
 
-#: applet.js:1024
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Versión de KDE Connect no válida!"
 
-#: applet.js:1025 applet.js:1028
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -45,335 +46,340 @@ msgstr ""
 "¡El servicio KDE Connect DBus devolvió una versión no válida, intente volver "
 "a cargar el Applet!"
 
-#: applet.js:1066
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "¡No hay dispositivos conectados!"
 
-#: applet.js:1066
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Añádalos en la configuración de KDE Connect"
 
-#: applet.js:1111
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Cosas de depuración, ¡no las toques!"
 
-#: applet.js:1201
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "Versión de KDE Connect: {version}"
 
-#: applet.js:1213
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Su ID: {own_id}"
 
-#: applet.js:1215
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "su ID"
 
-#: applet.js:1217
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Haga clic para copiar su ID"
 
-#: applet.js:1227
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Configurar KDE Connect"
 
-#: applet.js:1229
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Haz clic para abrir la configuración de KDE Connect"
 
-#: applet.js:1273
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "No hay dispositivos disponibles"
 
-#: applet.js:1275
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} dispositivo disponible"
 
-#: applet.js:1277
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} dispositivos disponibles"
 
-#: js/modules.js:450
+#. 5.8/js/modules.js:450
 msgid "Module"
 msgstr "Módulo"
 
-#: js/modules.js:597
+#. 5.8/js/modules.js:597
 msgid "Battery Module"
 msgstr "Módulo de batería"
 
-#: js/modules.js:646
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Cargando"
 
-#: js/modules.js:682
+#. 5.8/js/modules.js:682
 msgid "Device-Info Module"
 msgstr "Módulo de información del dispositivo"
 
-#: js/modules.js:730
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#: js/modules.js:734
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "ID del dispositivo"
 
-#: js/modules.js:738
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Haga clic para copiar la ID"
 
-#: js/modules.js:750
+#. 5.8/js/modules.js:751
 msgid "Connectivity Module"
 msgstr "Módulo de conectividad"
 
-#: js/modules.js:812
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Sin señal"
 
-#: js/modules.js:815
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Baja"
 
-#: js/modules.js:818
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Ok"
 
-#: js/modules.js:821
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Buena"
 
-#: js/modules.js:824
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Excelente"
 
-#: js/modules.js:836
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: js/modules.js:866
+#. 5.8/js/modules.js:867
 msgid "FindMyPhone Module"
 msgstr "Módulo de Buscar mi teléfono"
 
-#: js/modules.js:891
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Hacer sonar dispositivo"
 
-#: js/modules.js:892
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Haga clic para hacer sonar el dispositivo"
 
-#: js/modules.js:906
+#. 5.8/js/modules.js:907
 msgid "Request Photo Module"
 msgstr "Módulo de de Solicitud de fotografía"
 
-#: js/modules.js:972
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Foto recibida de \"{deviceName}\""
 
-#: js/modules.js:972 js/modules.js:1150
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Haga clic para abrir en la aplicación por defecto"
 
-#: js/modules.js:981
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Solicitar foto"
 
-#: js/modules.js:982
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Pulse para solicitar una foto del dispositivo"
 
-#: js/modules.js:1008
+#. 5.8/js/modules.js:1009
 msgid "Ping Module"
 msgstr "Módulo de Ping"
 
-#: js/modules.js:1033
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#: js/modules.js:1040
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Ping enviado al dispositivo '{deviceName}'"
 
-#: js/modules.js:1046
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Hacer Ping al dispositivo"
 
-#: js/modules.js:1047
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Haga clic para enviar un ping al dispositivo"
 
-#: js/modules.js:1061
+#. 5.8/js/modules.js:1062
 msgid "Share Module"
 msgstr "Módulo de Compartir"
 
-#: js/modules.js:1150
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Recurso compartido desde '{deviceName}'"
 
-#: js/modules.js:1185
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Compartir"
 
-#: js/modules.js:1198
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Enviar URL"
 
-#: js/modules.js:1199
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Haga clic para enviar una URL al dispositivo"
 
-#: js/modules.js:1208
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Enviar un texto"
 
-#: js/modules.js:1209 js/modules.js:1554
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Haga clic para enviar texto al dispositivo"
 
-#: js/modules.js:1218
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Enviar archivo(s)"
 
-#: js/modules.js:1219
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Haga clic para enviar archivo(s) al dispositivo"
 
-#: js/modules.js:1243
+#. 5.8/js/modules.js:1243
 msgid "SFTP Module"
 msgstr "Módulo de SFTP"
 
-#: js/modules.js:1284
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Desmontar"
 
-#: js/modules.js:1286
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Montar"
 
-#: js/modules.js:1292
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Haga clic para desmontar"
 
-#: js/modules.js:1294
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Haga clic para montar"
 
-#: js/modules.js:1424
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Haga clic para buscar archivos"
 
-#: js/modules.js:1463
+#. 5.8/js/modules.js:1463
 msgid "SMS Module"
 msgstr "Módulo de SMS"
 
-#: js/modules.js:1532
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#: js/modules.js:1545
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Iniciar la aplicación SMS"
 
-#: js/modules.js:1546
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Haga clic para abrir la aplicación KDE Connect SMS"
 
-#: js/modules.js:1553
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Enviar SMS"
 
 #. metadata.json->name
-#: js/utils.js:21
+#. 5.8/js/utils.js:24
 msgid "KDE Connect Applet"
 msgstr "Applet KDE Connect"
 
-#: js/utils.js:123
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
 msgid "Copied {typestring} to the clipboard"
 msgstr "Copiado {typestring} al portapapeles"
 
-#: settingsWidgets.py:153
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Mover la entrada seleccionada hacia arriba"
 
-#: settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Mover la entrada seleccionada hacia abajo"
 
-#: py/dialogs.py:50
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Enviar URL a '{device_name}'"
 
-#: py/dialogs.py:60 py/dialogs.py:132 py/dialogs.py:207 py/dialogs.py:285
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: py/dialogs.py:65 py/dialogs.py:137 py/dialogs.py:212
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Enviar"
 
-#: py/dialogs.py:76
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Ingrese una URL para enviar a '{device_name}'"
 
-#: py/dialogs.py:83
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#: py/dialogs.py:122
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Enviar SMS utilizando '{device_name}'"
 
-#: py/dialogs.py:147
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Número de teléfono:"
 
-#: py/dialogs.py:151
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Número de teléfono"
 
-#: py/dialogs.py:154
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Mensaje:"
 
-#: py/dialogs.py:197
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Enviar texto a '{device_name}'"
 
-#: py/dialogs.py:222
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Texto a enviar:"
 
-#: py/dialogs.py:271
+#. 5.8/py/dialogs.py:271
 #, python-brace-format
 msgid "Open remote directory on '{device_name}'"
 msgstr "Abrir el directorio remoto en '{device_name}'"
 
-#: py/dialogs.py:290
+#. 5.8/py/dialogs.py:290
 msgid "Open"
 msgstr "Abrir"
 
-#: py/dialogs.py:300
+#. 5.8/py/dialogs.py:300
 msgid "Directory to open:"
 msgstr "Directorio que se va a abrir:"
 
-#: py/dialogs.py:375
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Seleccionar archivos para enviar a '{deviceName}'"
 
-#: py/dialogs.py:442
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Seleccione dónde guardar la foto recibida de \"{deviceName}\"."
 
-#: py/dialogs.py:449
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "foto.jpg"
 
-#: py/dialogs.py:452
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "Foto JPEG"
 
@@ -401,235 +407,302 @@ msgstr "Johannes Schoeneberger - Autor"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Inspiración para el Applet"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "General"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Módulos"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Menú contextual"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Panel"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Dispositivos"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Módulos de información"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Módulos de acción"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Módulo de información de la batería"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Módulo de información del dispositivo"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Módulo de información de conectividad"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Módulo de acción Buscar mi teléfono"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Módulo de acción de Solicitud de fotografía"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Módulo de acción Ping"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Módulo de acción Compartir"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "Módulo de acción SFTP"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "Módulo de acción SMS"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Mostrar su ID en el menú contextual del applet"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Mostrar la versión de KDE Connect en el menú contextual del applet"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "Mostrar el número de dispositivos conectados junto al icono del panel"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr ""
 "Mostrar el recuento de dispositivos en la información sobre herramientas del "
 "applet"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Tipo de icono"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Simbólico"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Color"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Utilizar icono personalizado"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Icono personalizado"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "Abrir la configuración de KDE Connect"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 "Desplegar automáticamente el submenú de dispositivos, si sólo hay un "
 "dispositivo disponible"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Nombre"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Desplegar"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Activado"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr ""
 "Mostrar la carga actual de la batería y el estado de carga del dispositivo"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Mostrar el icono del dispositivo junto con su ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr ""
 "Mostrar el estado de conectividad actual y el tipo de red del dispositivo"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Mostrar el tipo de red móvil"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 "Permite hacer que el dispositivo suene, para que pueda encontrarlo, si lo ha "
 "perdido"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Permite solicitar una foto desde el dispositivo remoto y guardarla en este "
 "dispositivo"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Guardar las fotos recibidas directamente en el directorio"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Directorio donde guardar las fotos recibidas"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr ""
 "Permite hacer ping al dispositivo para asegurarte de que está conectado"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Usar mensaje personalizado para el ping"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Mensaje personalizado"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Permite compartir URL, archivos o texto con el dispositivo"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Mostrar elementos de menú en el submenú"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Activar la opción de menú para enviar una URL"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Activar la opción de menú para enviar algún texto"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Activar la opción de menú para enviar archivo(s)"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr ""
 "Permite navegar de forma remota por el almacenamiento seleccionado en el "
 "dispositivo"
 
-#. settings-schema.json->module_sftp_selectFirstDirectory->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
 msgid "Select the first directory automatically"
 msgstr "Seleccionar automáticamente el primer directorio"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Permite enviar mensajes SMS a distancia desde el dispositivo"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Activar la opción de menú para enviar un mensaje SMS"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Activar la opción de menú para iniciar la aplicación KDE Connect SMS"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/fi.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2023-12-09 16:03+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -19,24 +19,25 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Moduuleja ei ole saatavilla"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect ei ole käytettävissä, varmista että se on asennettu ja käynnissä."
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Lataa sovelma uudelleen"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Väärä KDE Connect versio havaittu!"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -44,283 +45,352 @@ msgstr ""
 "KDE Connect DBus palvelu ilmoitti väärän versionumeron, yritä ladata sovelma "
 "uudelleen!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Ei kytkettyjä laitteita!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Lisää ne KDE Connect asetuksiin"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Virheenkorjaus, älä koske!"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect versio: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Oma ID: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "oma ID"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Kopioi oma id painamalla"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Määritä KDE Connect"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Avaa KDE Connect määritykset painamalla"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Ei saatavilla olevia laitteita"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} laite saatavilla"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} laitetta saatavilla"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "Kopioitu {typestring} leikepöydälle"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Moduulit"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Akkutieto moduuli"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Latauksessa"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Laitetieto moduuli"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "Laite ID"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Kopioi id painamalla"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Yhteystieto moduuli"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Ei signaalia"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Matala"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Selvä"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Hyvä"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Erinomainen"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "Etsi puhelimeni moduuli"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Lähetä äänimerkki"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Lähetä äänimerkki painamalla"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Pyydä kuvaa moduuli"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Kuva vastaanotettu '{deviceName}'"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Paina ja avaa oletussovelluksessa"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Pyydä valokuva"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Pyydä laitteelta valokuvaa painamalla"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Kilutus moduuli"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Lähetä kilahdus!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Kilahdus lähetetty laitteeseen '{deviceName}'"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Kilauta laitetta"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Lähetä kilautus laitteeseen painamalla"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Jakaminen moduuli"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Jako vastaanotettu '{deviceName}'"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Jako"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Lähetä URL"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Lähetä URL laitteeseen painamalla"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Lähetä teksti"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Lähetä teksti laitteeseen painamalla"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Lähetä tiedosto"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Lähetä tiedostot laitteeseen painamalla"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "SFTP moduuli"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Poista laite"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Liitä laite"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Poista laite painamalla"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Liitä laite painamalla"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Selaa tiedostoja painamalla"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "Tekstiviesti moduuli"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "Tekstiviesti"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Tekstiviestit"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Avaa KDE Connect tekstiviestisovellus painamalla"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Lähetä tekstiviesti"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "KDE Connect sovelma"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "Kopioitu {typestring} leikepöydälle"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Siirrä valittu kohta ylöspäin"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Siirrä valittu kohta alaspäin"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Lähetä URL '{device_name}'"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Peru"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Lähetä"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Kirjoita URL ja lähetä se '{device_name}'"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Lähetä tekstiviesti '{device_name}'"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Puhelinnumero:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Puhelinnumero"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Viesti:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Lähetä teksti '{device_name}'"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Lähetettävä teksti:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Lähetä teksti '{device_name}'"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Valitse tiedostot ja lähetä '{deviceName}'"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Valitse, mihin tallennat vastaanotetun valokuvan '{deviceName}'"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "photo.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "JPEG kuva"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "KDE Connect sovelma"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -344,222 +414,293 @@ msgstr "Kehittäjä - Johannes Schoeneberger"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - inspiraatio tähän sovelmaan"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Yleistä"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Moduulit"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Pudotusvalikko"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Paneeli"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Laitteet"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Moduulien tiedot"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Moduulien toiminta"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Akkutieto moduuli"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Laitetieto moduuli"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Yhteystieto moduuli"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Etsi puhelimeni moduuli"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Pyydä kuvaa moduuli"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Kilutus moduuli"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Jakaminen moduuli"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "SFTP moduuli"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "Tekstiviesti moduuli"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Näytä oma id sovelman valikossa"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Näytä KDE Connect versio sovelman valikossa"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "Näytä yhdistettyjen laitteiden määrä paneelin kuvakkeen vieressä"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Näytä laitteiden lukumäärä sovelman valikossa"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Kuvakkeen tyyppi"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Symbolinen"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Väri"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Käytä omaa kuvaketta"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Kuvake jota käytetään"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "KDE Connect määritykset"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 "Avaa laitteen alavalikot automaattisesti, jos käytössä on vain yksi laite"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Nimi"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Laajenna"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Käytössä"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "Näyttää laitteen akun latauksen ja lataustilan"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Näyttää laitteen kuvakkeen ja sen id:n"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "Näyttää laitteen nykyisen yhteystilan ja verkon tyypin"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Näytä matkapuhelinverkko"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr "Voit saada laitteen soimaan, joten voit löytää sen helposti"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Voit pyytää valokuvaa puhelimesta tai tabletista ja tallentaa se tähän "
 "tietokoneeseen"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Tallenna vastaanotettu kuva suoraan kansioon"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Kasio, johon vastaanotetut valokuvat tallennetaan"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr "Voit kutsua laitetta ja varmistaa, että se on kytketty verkkoon"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Käytä omaa viestiä kutsuun"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Oma viesti"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Voit jakaa URL-osoitteella, tiedostoja tai tekstiä laitteeseen"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Näytä valikossa alivalikot"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Ota käyttöön kohde valikossa URL-osoitteen lähettämiseksi"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Ota käyttöön kohde tekstiviestien lähettämiseksi"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Ota käyttöön kohde tiedostojen lähettämiseksi"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr "Voit selata laitteelle valittua tallennustilaa"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Voit lähettää tekstiviestejä laitteesta"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Ota käyttöön kohta tekstiviestin lähettämiseksi"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr ""
 "Ota käyttöön kohta joka käynnistää KDE Connect tekstiviestit sovelluksen"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/fr.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-19 00:45+0200\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2026-08-22 06:43+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -19,25 +19,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:548
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Aucun Module disponible"
 
-#: applet.js:1012 applet.js:1015
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect n'est pas disponible, assurez-vous qu'il est installé et en "
 "cours d'exécution."
 
-#: applet.js:1019 applet.js:1032 applet.js:1222
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Relancer cette applet"
 
-#: applet.js:1024
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Version invalide de KDE Connect renvoyée !"
 
-#: applet.js:1025 applet.js:1028
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -45,335 +46,340 @@ msgstr ""
 "Le service KDE Connect DBus a renvoyé une version invalide, veuillez essayer "
 "de recharger l'applet !"
 
-#: applet.js:1066
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Aucun appareil connecté !"
 
-#: applet.js:1066
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Les ajouter dans les paramètres de KDE Connect"
 
-#: applet.js:1111
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Remplissage auto pour vérification, ne rien modifier !"
 
-#: applet.js:1201
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "Version de KDE Connect : {version}"
 
-#: applet.js:1213
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "ID personnel : {own_id}"
 
-#: applet.js:1215
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "votre ID"
 
-#: applet.js:1217
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Cliquez pour copier votre propre ID"
 
-#: applet.js:1227
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Configurer KDE Connect"
 
-#: applet.js:1229
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Clic pour ouvrir la configuration de KDE Connect"
 
-#: applet.js:1273
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Aucun appareil disponible"
 
-#: applet.js:1275
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} appareil disponible"
 
-#: applet.js:1277
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} appareils disponibles"
 
-#: js/modules.js:450
+#. 5.8/js/modules.js:450
 msgid "Module"
 msgstr "Module"
 
-#: js/modules.js:597
+#. 5.8/js/modules.js:597
 msgid "Battery Module"
 msgstr "Module d'info Batterie"
 
-#: js/modules.js:646
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Chargement"
 
-#: js/modules.js:682
+#. 5.8/js/modules.js:682
 msgid "Device-Info Module"
 msgstr "Module d'info de l'appareil"
 
-#: js/modules.js:730
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#: js/modules.js:734
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "ID de l'appareil"
 
-#: js/modules.js:738
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Cliquer pour copier l'ID"
 
-#: js/modules.js:750
+#. 5.8/js/modules.js:751
 msgid "Connectivity Module"
 msgstr "Module d'info Connectivité"
 
-#: js/modules.js:812
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Aucun signal"
 
-#: js/modules.js:815
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Bas"
 
-#: js/modules.js:818
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Ok"
 
-#: js/modules.js:821
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Bon"
 
-#: js/modules.js:824
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Excellent"
 
-#: js/modules.js:836
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: js/modules.js:866
+#. 5.8/js/modules.js:867
 msgid "FindMyPhone Module"
 msgstr "Module d'action Localiser mon téléphone"
 
-#: js/modules.js:891
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Faire sonner l'appareil"
 
-#: js/modules.js:892
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Clic pour faire sonner l'appareil"
 
-#: js/modules.js:906
+#. 5.8/js/modules.js:907
 msgid "Request Photo Module"
 msgstr "Module d'action Demander une photo"
 
-#: js/modules.js:972
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Photo reçue depuis \"{deviceName}\""
 
-#: js/modules.js:972 js/modules.js:1150
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Clic pour ouvrir dans l'application par défaut"
 
-#: js/modules.js:981
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Demander une photo"
 
-#: js/modules.js:982
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Cliquez pour demander une photo à partir de l'appareil"
 
-#: js/modules.js:1008
+#. 5.8/js/modules.js:1009
 msgid "Ping Module"
 msgstr "Ping Module Action"
 
-#: js/modules.js:1033
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping !"
 
-#: js/modules.js:1040
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Ping envoyé  à \"{device_name}\""
 
-#: js/modules.js:1046
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Pinguer l'appareil"
 
-#: js/modules.js:1047
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Clic pour envoyer un ping à l'appareil"
 
-#: js/modules.js:1061
+#. 5.8/js/modules.js:1062
 msgid "Share Module"
 msgstr "Module d'action Partage"
 
-#: js/modules.js:1150
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Partage reçu depuis \"{deviceName}\""
 
-#: js/modules.js:1185
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Partage"
 
-#: js/modules.js:1198
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Envoyer une URL"
 
-#: js/modules.js:1199
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Clic pour envoyer une URL à l'appareil"
 
-#: js/modules.js:1208
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Envoyer du texte"
 
-#: js/modules.js:1209 js/modules.js:1554
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Clic pour envoyer un texte à l'appareil"
 
-#: js/modules.js:1218
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Envoyer le ou les fichiers"
 
-#: js/modules.js:1219
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Clic pour envoyer des fichiers à l'appareil"
 
-#: js/modules.js:1243
+#. 5.8/js/modules.js:1243
 msgid "SFTP Module"
 msgstr "Module d'action SFTP"
 
-#: js/modules.js:1284
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Démonter"
 
-#: js/modules.js:1286
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Monter"
 
-#: js/modules.js:1292
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Clic pour démonter"
 
-#: js/modules.js:1294
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Clic pour monter"
 
-#: js/modules.js:1424
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Clic pour parcourir les fichiers"
 
-#: js/modules.js:1463
+#. 5.8/js/modules.js:1463
 msgid "SMS Module"
 msgstr "Module d'action SMS"
 
-#: js/modules.js:1532
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#: js/modules.js:1545
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Lancer l'application SMS"
 
-#: js/modules.js:1546
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Clic pour ouvrir l'application SMS de KDE Connect"
 
-#: js/modules.js:1553
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Envoyer un SMS"
 
 #. metadata.json->name
-#: js/utils.js:21
+#. 5.8/js/utils.js:24
 msgid "KDE Connect Applet"
 msgstr "Applet KDE Connect"
 
-#: js/utils.js:123
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
 msgid "Copied {typestring} to the clipboard"
 msgstr "{typestring} copié dans le presse-papier"
 
-#: settingsWidgets.py:153
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Monter l'entrée sélectionnée"
 
-#: settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Descendre l'entrée sélectionnée"
 
-#: py/dialogs.py:50
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Envoyer une URL à \"{device_name}\""
 
-#: py/dialogs.py:60 py/dialogs.py:132 py/dialogs.py:207 py/dialogs.py:285
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Abandon"
 
-#: py/dialogs.py:65 py/dialogs.py:137 py/dialogs.py:212
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Envoyer"
 
-#: py/dialogs.py:76
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Entrer l'URL à envoyer à '{device_name}'"
 
-#: py/dialogs.py:83
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#: py/dialogs.py:122
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Envoyer un SMS avec \"{device_name}\""
 
-#: py/dialogs.py:147
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "N° de téléphone :"
 
-#: py/dialogs.py:151
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "N° de téléphone"
 
-#: py/dialogs.py:154
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Message :"
 
-#: py/dialogs.py:197
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Envoyer le texte à \"{device_name}\""
 
-#: py/dialogs.py:222
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Texte à envoyer :"
 
-#: py/dialogs.py:271
+#. 5.8/py/dialogs.py:271
 #, python-brace-format
 msgid "Open remote directory on '{device_name}'"
 msgstr "Ouvrir le répertoire distant sur \"{device_name}\""
 
-#: py/dialogs.py:290
+#. 5.8/py/dialogs.py:290
 msgid "Open"
 msgstr "Ouvrir"
 
-#: py/dialogs.py:300
+#. 5.8/py/dialogs.py:300
 msgid "Directory to open:"
 msgstr "Répertoire à ouvrir :"
 
-#: py/dialogs.py:375
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Choisir les fichiers à envoyer à \"{deviceName}\""
 
-#: py/dialogs.py:442
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Sélectionner où enregistrer la photo reçue de \"{deviceName}\""
 
-#: py/dialogs.py:449
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "photo.jpg"
 
-#: py/dialogs.py:452
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "Photo JPEG"
 
@@ -400,235 +406,302 @@ msgstr "Johannes Schoeneberger - Auteur"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Inspiration pour l'Applet"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Général"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Modules"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Menu contextuel"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Panneau"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Appareils"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Info Modules"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Modules d'actions"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Module d'info Batterie"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Module d'info de l'appareil"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Module d'info Connectivité"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Module d'action Localiser mon téléphone"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Module d'action Demander une photo"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Ping Module Action"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Module d'action Partage"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "Module d'action SFTP"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "Module d'action SMS"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Afficher l'ID personnel dans le menu contextuel de l'applet"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Afficher la version de KDE Connect dans le menu contextuel de l'applet"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr ""
 "Afficher le nombre d'appareils connectés à côté de l'icône dans le panneau"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Afficher le nombre d'appareils dans l'info-bulle de l'applet"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Type d'icône"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Symbolique"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Couleur"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Utiliser une icône personnalisée"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Icône personnalisée à utiliser"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "Ouvrir la configuration de KDE Connect"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 "Développer automatiquement le sous-menu de l'appareil, si un seul appareil "
 "est disponible"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Nom"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Déplier"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Activé"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr ""
 "Affiche la charge actuelle de la batterie et l'état de charge de l'appareil"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Affiche l'icône de l'appareil avec son ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr ""
 "Affiche l'état actuel de la connectivité et le type de réseau de l'appareil"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Afficher le type de réseau mobile"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 "Permet de faire sonner l'appareil afin de pouvoir le retrouver si vous "
 "l'avez égaré"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Vous permet de demander une photo à partir de l'ordinateur et de "
 "l'enregistrer sur l'appareil"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Enregistrer les photos reçues directement dans le répertoire"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Répertoire dans lequel enregistrer les photos reçues"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr ""
 "Vous permet de pinguer l'appareil pour vous assurer qu'il est bien connecté"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Utiliser un message personnalisé pour pinguer"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Message personnalisé"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr ""
 "Vous permet de partager des URL, des fichiers ou du texte avec l'appareil"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Afficher les éléments de menu dans le sous-menu"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Activer l'élément de menu pour envoyer une URL"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Activer l'élément de menu pour envoyer du texte"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Activer l'élément de menu pour envoyer des fichiers"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr ""
 "Vous permet de parcourir à distance le stockage sélectionné sur l'appareil"
 
-#. settings-schema.json->module_sftp_selectFirstDirectory->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
 msgid "Select the first directory automatically"
 msgstr "Sélectionner automatiquement le premier répertoire"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr ""
 "Permet d'envoyer des SMS à distance, comme s'ils provenaient de l'appareil"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Activer l'élément de menu pour envoyer un SMS"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Activer l'élément de menu pour lancer l'application KDE Connect SMS"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/hu.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2023-05-07 21:00+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -18,25 +18,26 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Nincsenek elérhető modulok"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "A KDE Connect nem érhető el, győződjön meg róla, hogy az alkalmazás "
 "telepítve van és fut."
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Kisalkalmazás újratöltése"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Nem megfelelő KDE Connect verzió."
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -44,284 +45,353 @@ msgstr ""
 "A KDE Connect DBus szolgáltatás érvénytelen verziót adott vissza, próbálja "
 "meg újratölteni a kisalkalmazást."
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Nincsenek csatlakoztatott eszközök"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Hozzáadhatja őket a KDE Connect beállításaiban"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Hibakeresési eszközök, ne állítsa el."
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect verzió: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Saját telefonszám: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "saját telefonszám"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Kattintson a saját telefonszám másolásához"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "KDE Connect beállítása"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Kattintson a KDE Connect beállításához"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Nincsenek elérhető eszközök"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} elérhető eszköz"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} elérhető eszköz"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "A(z) „{typestring}” szöveg a vágólapra másolva"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Modulok"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Akkumulátor információs modul"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Töltődik"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Eszköz-információ információs modul"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "Telefonszám: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "Eszközazonosító"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Kattintson a saját telefonszám másolásához"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Kapcsolat információs modul"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Nincs jelerősség"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Alacsony"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Ok"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Jó"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Kiváló"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "Telefon keresés művelet modul"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Eszköz megcsöngetése"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Kattintson az eszköz megcsöngetéséhez"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Fotó kérés művelet modul"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Fénykép érkezett innen: „{deviceName}”"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Megnyitás az alapértelmezett alkalmazással"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Fotó kérése"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Kattintson fotó kéréséhez az eszközről"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Ping művelet modul"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Ping küldés a(z) „{deviceName}”  eszközre"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Ping küldés"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Kattintson ping küldéséhez az eszközre"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Megosztás művelet modul"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Megosztás érkezett innen: „{deviceName}”"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Megosztás"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "URL küldés"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Kattintson URL küldéséhez az eszközre"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Szöveges üzenet küldés"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Kattintson szöveges üzenet küldéséhez az eszközre"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Fájlok küldése"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Kattintson a fájlküldéshez az eszközre"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "SFTP művelet modul"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Leválasztás"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Csatolás"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Kattintson a leválasztáshoz"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Kattintson a csatoláshoz"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Kattintson a fájlok tallózásához"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "SMS művelet modul"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "SMS alkalmazás elindítása"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Kattintson a KDE Connect SMS alkalmazás elindításához"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "SMS küldés"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "KDE Connect kisalkalmazás"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "A(z) „{typestring}” szöveg a vágólapra másolva"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Kijelölt bejegyzés mozgatása fel"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Kijelölt bejegyzés mozgatása le"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "URL küldése ide: „{device_name}”"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Mégse"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Küldés"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Adja meg a(z) „{device_name}” eszközre küldendő URL-t"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "SMS-üzenet küldése ide: „{device_name}”"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Telefonszám:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Telefonszám"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Üzenet:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Üzenet küldése ide: „{device_name}”"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Szöveges üzenet:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Üzenet küldése ide: „{device_name}”"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Válassza ki a(z) „{deviceName}” eszközre küldeni kívánt fájlokat"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr ""
 "Válassza ki, hogy hova mentse a(z) „{deviceName}” eszköztől kapott fotót"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "foto.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "JPEG-kép"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "KDE Connect kisalkalmazás"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -348,229 +418,300 @@ msgstr "Johannes Schoeneberger - szerző"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - inspiráció a kisalkalmazáshoz"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Általános"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Modulok"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Helyi menü"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Panel"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Eszközök"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Információs modulok"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Művelet modulok"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Akkumulátor információs modul"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Eszköz-információ információs modul"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Kapcsolat információs modul"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Telefon keresés művelet modul"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Fotó kérés művelet modul"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Ping művelet modul"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Megosztás művelet modul"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "SFTP művelet modul"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "SMS művelet modul"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Saját azonosító megjelenítése a kisalkalmazás helyi menüjében"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr ""
 "A KDE Connect verziójának megjelenítése a kisalkalmazás helyi menüjében"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr ""
 "Csatlakoztatott eszközök számának megjelenítése az ikon mellett a panelen"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Csatlakoztatott eszközök számának megjelenítése az eszköztipjében"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Ikon típus"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Szimbolikus"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Szín"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Egyéni ikon használata"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Egyéni ikon használata"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "KDE Connect beállítások megnyitása"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr "Eszköz almenüjének automatikus kibontása, ha csak egy eszköz érhető el"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Név"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Kibontás"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "Azonosító"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr ""
 "Készülék akkumulátor töltöttségének és töltési állapotának megjelenítése"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Az eszköz ikonjának és telefonszámának megjelenítése"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr ""
 "A készülék aktuális kapcsolati állapotának és hálózattípusának megjelenítése"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Mobilhálózat típusának megjelenítése"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr "Lehetővé teszi az eszköz csengésének aktiválását, hogy megtalálja azt"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Lehetővé teszi, hogy egy fényképet kérjen le a távoli eszközről, majd mentse "
 "azt ezen az eszközön"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Kapott fényképek közvetlenül mentése mappába"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Képek mentése a mappába"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr ""
 "Lehetővé teszi a készülék pingelését annak ellenőrzéséhez, hogy "
 "csatlakoztatva van-e"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Egyéni ping-üzenet használata"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Egyéni üzenet"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr ""
 "Lehetővé teszi, hogy megosszon URL-hivatkozásokat, fájlokat vagy szöveget az "
 "eszközzel"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Menüelemek megjelenítése az almenüben"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "URL-hivatkozás küldéséhez menüpont engedélyezése"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Üzenet küldéséhez menüpont engedélyezése"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Fájl(ok) küldéséhez menüpont engedélyezése"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr ""
 "Lehetővé teszi, hogy távolról böngéssze az eszközön kiválasztott tárterületet"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Lehetővé teszi, hogy távolról SMS-üzeneteket küldjön az eszközről"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "SMS-üzenet küldéséhez menüpont engedélyezése"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Engedélyezze a menüelemet a KDE Connect SMS alkalmazás indításához"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/it.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2023-03-29 16:33+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,24 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Nessun Modulo disponibile"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect non è disponibile, verifica che sia installato e in esecuzione."
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Ricarica Applet"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Restituita versione di KDE Connect non valida!"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -44,283 +45,352 @@ msgstr ""
 "Il servizio KDE Connect DBus ha restituito una versione non valida, prova a "
 "ricaricare l'applet!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Nessun Dispositivo connesso!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Aggiungili nelle impostazioni di KDE Connect"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Roba di Debug, non toccare!"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect Versione: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Own ID: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "own ID"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Clicca per copiare l'own ID"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Configura KDE Connect"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Clicca per aprire la Configurazione di KDE Connect"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Nessun dispositivo disponibile"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} dispositivo disponibile"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} dispositivi disponibili"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "Copiato {typestring} negli appunti"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Moduli"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Modulo Info Batteria"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Ricarica"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Modulo Info-Dispositivo"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "ID Dispositivo"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Clicca per copiare l'ID"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Modulo Info Connettività"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Nessun Segnale"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Basso"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "OK"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Buono"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Eccellente"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "Modulo Azione FindMyPhone"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Squilla"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Clicca per far squillare il dispositivo"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Modulo Azione Richiedi-Foto"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Foto ricevuta da '{deviceName}'"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Clicca per aprire nell'applicazione predefinita"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Richiedi Foto"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Clicca per richiedere una foto dal dispositivo"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Modulo Azione Ping"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Invia un ping al dispositivo '{deviceName}'"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Pinga Dispositivo"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Clicca per inviare un ping al dispositivo"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Modulo Azione Condividi"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Condivisione ricevuta da '{deviceName}'"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Condividi"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Invia URL"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Clicca per inviare un URL al dispositivo"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Invia Testo"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Clicca per inviare del testo al dispositivo"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Invia File"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Clicca per inviare file al dispositivo"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "Modulo Azione SFTP"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Smonta"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Monta"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Clicca per smontare"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Clicca per montare"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Clicca per esplorare i file"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "Modulo Azione SMS"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Avvia App SMS"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Clicca per aprire l'App KDE Connect SMS"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Invia SMS"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "Applet KDE Connect"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "Copiato {typestring} negli appunti"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Sposta sopra voce selezionata"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Sposta sotto voce selezionata"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Invia URL a '{device_name}'"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Annulla"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Invia"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Inserisci un URL da inviare a '{device_name}'"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Invia SMS usando '{device_name}'"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Numero di Telefono:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Numero di Telefono"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Messaggio:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Invia testo a '{device_name}'"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Testo da inviare:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Invia testo a '{device_name}'"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Seleziona file da inviare a '{deviceName}'"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Seleziona dove salvare le foto ricevute da '{deviceName}'"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "foto.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "Foto JPEG"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "Applet KDE Connect"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -345,230 +415,301 @@ msgstr "Johannes Schoeneberger - Autore"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Ispirazione per l'applet"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Generale"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Moduli"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Menù Contestuale"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Pannello"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Dispositivi"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Moduli di Info"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Moduli di Azione"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Modulo Info Batteria"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Modulo Info-Dispositivo"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Modulo Info Connettività"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Modulo Azione FindMyPhone"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Modulo Azione Richiedi-Foto"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Modulo Azione Ping"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Modulo Azione Condividi"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "Modulo Azione SFTP"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "Modulo Azione SMS"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Mostra l'own ID nel menù contestuale dell'applet"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Mostra la versione di KDE Connect nel menù contestuale dell'applet"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr ""
 "Mostra il numero di dispositivi connessi accanto all'icona nel pannello"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Mostra il conteggio dei dispositivi nel tooltip dell'applet"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Tipo icona"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Simbolica"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Colore"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Usa icona personalizzata"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Icona personalizzata da utilizzare"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "Apri Configurazione di KDE Connect"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 "Espandere automaticamente il sottomenù del dispositivo, se è disponibile un "
 "solo dispositivo"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Nome"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Espandi"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Abilitato"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr ""
 "Mostra la carica attuale della batteria e lo stato di carica del dispositivo"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Mostra l'icona del dispositivo insieme al relativo ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr ""
 "Mostra lo stato di connettività corrente e il tipo di rete del dispositivo"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Mostra il tipo di rete mobile"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 "Ti consente di far squillare il dispositivo, così puoi trovarlo, se lo hai "
 "smarrito"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Consente di richiedere una foto dal dispositivo remoto e di salvarla su "
 "questo dispositivo"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Salva le foto ricevute direttamente nella directory"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "La directory in cui salvare le foto ricevute"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr ""
 "Consente di eseguire il ping del dispositivo per assicurarsi che sia connesso"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Usa un messaggio personalizzato per il ping"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Messaggio personalizzato"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Consente di condividere URL, file o testo sul dispositivo"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Mostra le voci di menù nel sottomenù"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Abilita la voce di menù per inviare un URL"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Abilita la voce di menù per inviare del testo"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Abilita la voce di menù per inviare dei file"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr ""
 "Consente di sfogliare in remoto lo spazio di archiviazione selezionato sul "
 "dispositivo"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Consente di inviare in remoto messaggi SMS dal dispositivo"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Abilita la voce di menù per inviare un messaggio SMS"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Abilita la voce di menù per lanciare l'app KDE Connect SMS"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
@@ -5,7 +5,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: kdecapplet@joejoetv 2.2.0\n"
+"Project-Id-Version: kdecapplet@joejoetv 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
 "POT-Creation-Date: 2026-08-22 17:38+0200\n"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: kdecapplet@joejoetv 2.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-19 00:45+0200\n"
+"POT-Creation-Date: 2026-08-22 17:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,357 +17,363 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:548
+#: 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr ""
 
-#: applet.js:1012 applet.js:1015
+#: 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 
-#: applet.js:1019 applet.js:1032 applet.js:1222
+#: 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#: 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr ""
 
-#: applet.js:1024
+#: 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr ""
 
-#: applet.js:1025 applet.js:1028
+#: 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
 msgstr ""
 
-#: applet.js:1066
+#: 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr ""
 
-#: applet.js:1066
+#: 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr ""
 
-#: applet.js:1111
+#: 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr ""
 
-#: applet.js:1201
+#: 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr ""
 
-#: applet.js:1213
+#: 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr ""
 
-#: applet.js:1215
+#: 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr ""
 
-#: applet.js:1217
+#: 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr ""
 
-#: applet.js:1227
+#: 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr ""
 
-#: applet.js:1229
+#: 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr ""
 
-#: applet.js:1273
+#: 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr ""
 
-#: applet.js:1275
+#: 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr ""
 
-#: applet.js:1277
+#: 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr ""
 
-#: js/modules.js:450
+#: 5.8/js/modules.js:450
 msgid "Module"
 msgstr ""
 
-#: js/modules.js:597
+#: 5.8/js/modules.js:597
 msgid "Battery Module"
 msgstr ""
 
-#: js/modules.js:646
+#: 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr ""
 
-#: js/modules.js:682
+#: 5.8/js/modules.js:682
 msgid "Device-Info Module"
 msgstr ""
 
-#: js/modules.js:730
+#: 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr ""
 
-#: js/modules.js:734
+#: 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr ""
 
-#: js/modules.js:738
+#: 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr ""
 
-#: js/modules.js:750
+#: 5.8/js/modules.js:751
 msgid "Connectivity Module"
 msgstr ""
 
-#: js/modules.js:812
+#: 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr ""
 
-#: js/modules.js:815
+#: 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr ""
 
-#: js/modules.js:818
+#: 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr ""
 
-#: js/modules.js:821
+#: 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr ""
 
-#: js/modules.js:824
+#: 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr ""
 
-#: js/modules.js:836
+#: 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr ""
 
-#: js/modules.js:866
+#: 5.8/js/modules.js:867
 msgid "FindMyPhone Module"
 msgstr ""
 
-#: js/modules.js:891
+#: 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr ""
 
-#: js/modules.js:892
+#: 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr ""
 
-#: js/modules.js:906
+#: 5.8/js/modules.js:907
 msgid "Request Photo Module"
 msgstr ""
 
-#: js/modules.js:972
+#: 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr ""
 
-#: js/modules.js:972 js/modules.js:1150
+#: 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#: 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr ""
 
-#: js/modules.js:981
+#: 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr ""
 
-#: js/modules.js:982
+#: 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr ""
 
-#: js/modules.js:1008
+#: 5.8/js/modules.js:1009
 msgid "Ping Module"
 msgstr ""
 
-#: js/modules.js:1033
+#: 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr ""
 
-#: js/modules.js:1040
+#: 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr ""
 
-#: js/modules.js:1046
+#: 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr ""
 
-#: js/modules.js:1047
+#: 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr ""
 
-#: js/modules.js:1061
+#: 5.8/js/modules.js:1062
 msgid "Share Module"
 msgstr ""
 
-#: js/modules.js:1150
+#: 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr ""
 
-#: js/modules.js:1185
+#: 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr ""
 
-#: js/modules.js:1198
+#: 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr ""
 
-#: js/modules.js:1199
+#: 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr ""
 
-#: js/modules.js:1208
+#: 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr ""
 
-#: js/modules.js:1209 js/modules.js:1554
+#: 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#: 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr ""
 
-#: js/modules.js:1218
+#: 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr ""
 
-#: js/modules.js:1219
+#: 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr ""
 
-#: js/modules.js:1243
+#: 5.8/js/modules.js:1243
 msgid "SFTP Module"
 msgstr ""
 
-#: js/modules.js:1284
+#: 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr ""
 
-#: js/modules.js:1286
+#: 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr ""
 
-#: js/modules.js:1292
+#: 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr ""
 
-#: js/modules.js:1294
+#: 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr ""
 
-#: js/modules.js:1424
+#: 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr ""
 
-#: js/modules.js:1463
+#: 5.8/js/modules.js:1463
 msgid "SMS Module"
 msgstr ""
 
-#: js/modules.js:1532
+#: 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr ""
 
-#: js/modules.js:1545
+#: 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr ""
 
-#: js/modules.js:1546
+#: 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr ""
 
-#: js/modules.js:1553
+#: 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr ""
 
 #. metadata.json->name
-#: js/utils.js:21
+#: 5.8/js/utils.js:24
 msgid "KDE Connect Applet"
 msgstr ""
 
-#: js/utils.js:123
+#: 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
 msgid "Copied {typestring} to the clipboard"
 msgstr ""
 
-#: settingsWidgets.py:153
+#: 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr ""
 
-#: settingsWidgets.py:160
+#: 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr ""
 
-#: py/dialogs.py:50
+#: 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr ""
 
-#: py/dialogs.py:60 py/dialogs.py:132 py/dialogs.py:207 py/dialogs.py:285
+#: 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#: 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#: 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr ""
 
-#: py/dialogs.py:65 py/dialogs.py:137 py/dialogs.py:212
+#: 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#: 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr ""
 
-#: py/dialogs.py:76
+#: 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr ""
 
-#: py/dialogs.py:83
+#: 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr ""
 
-#: py/dialogs.py:122
+#: 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr ""
 
-#: py/dialogs.py:147
+#: 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr ""
 
-#: py/dialogs.py:151
+#: 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr ""
 
-#: py/dialogs.py:154
+#: 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr ""
 
-#: py/dialogs.py:197
+#: 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr ""
 
-#: py/dialogs.py:222
+#: 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr ""
 
-#: py/dialogs.py:271
+#: 5.8/py/dialogs.py:271
 #, python-brace-format
 msgid "Open remote directory on '{device_name}'"
 msgstr ""
 
-#: py/dialogs.py:290
+#: 5.8/py/dialogs.py:290
 msgid "Open"
 msgstr ""
 
-#: py/dialogs.py:300
+#: 5.8/py/dialogs.py:300
 msgid "Directory to open:"
 msgstr ""
 
-#: py/dialogs.py:375
+#: 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr ""
 
-#: py/dialogs.py:442
+#: 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr ""
 
-#: py/dialogs.py:449
+#: 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr ""
 
-#: py/dialogs.py:452
+#: 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr ""
 
@@ -390,222 +396,288 @@ msgstr ""
 msgid "Severga - Inspiration for the Applet"
 msgstr ""
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr ""
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr ""
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr ""
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr ""
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr ""
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr ""
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr ""
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr ""
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr ""
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr ""
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr ""
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr ""
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr ""
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr ""
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr ""
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr ""
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr ""
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr ""
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr ""
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr ""
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr ""
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr ""
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr ""
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr ""
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr ""
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr ""
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr ""
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr ""
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr ""
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr ""
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr ""
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr ""
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr ""
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr ""
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr ""
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr ""
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr ""
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr ""
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr ""
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr ""
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr ""
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr ""
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr ""
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr ""
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr ""
 
-#. settings-schema.json->module_sftp_description->description
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
 msgid "Lets you remotely browse the storage selected on the device"
 msgstr ""
 
-#. settings-schema.json->module_sftp_selectFirstDirectory->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
 msgid "Select the first directory automatically"
 msgstr ""
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr ""
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr ""
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr ""

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
@@ -660,7 +660,7 @@ msgstr ""
 
 #. 5.8->settings-schema.json->module_sftp_description->description
 #. 4.8->settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+msgid "Lets you remotely browse the storage of the device"
 msgstr ""
 
 #. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
@@ -1,6 +1,6 @@
 # KDE CONNECT APPLET
 # This file is put in the public domain.
-# JoeJoeTV, 2026
+# JoeJoeTV, 2020
 #
 #, fuzzy
 msgid ""
@@ -8,372 +8,372 @@ msgstr ""
 "Project-Id-Version: kdecapplet@joejoetv 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-22 17:38+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 5.8/applet.js:547 4.8/applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr ""
 
-#: 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 
-#: 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
-#: 4.8/applet.js:1085 4.8/applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr ""
 
-#: 5.8/applet.js:1033 4.8/applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr ""
 
-#: 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
 msgstr ""
 
-#: 5.8/applet.js:1075 4.8/applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr ""
 
-#: 5.8/applet.js:1075 4.8/applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr ""
 
-#: 5.8/applet.js:1120 4.8/applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr ""
 
-#: 5.8/applet.js:1209 4.8/applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr ""
 
-#: 5.8/applet.js:1221 4.8/applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr ""
 
-#: 5.8/applet.js:1223 4.8/applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr ""
 
-#: 5.8/applet.js:1225 4.8/applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr ""
 
-#: 5.8/applet.js:1235 4.8/applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr ""
 
-#: 5.8/applet.js:1237 4.8/applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr ""
 
-#: 5.8/applet.js:1283 4.8/applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr ""
 
-#: 5.8/applet.js:1285 4.8/applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr ""
 
-#: 5.8/applet.js:1287 4.8/applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr ""
 
-#: 5.8/js/modules.js:450
+#. 5.8/js/modules.js:450
 msgid "Module"
 msgstr ""
 
-#: 5.8/js/modules.js:597
+#. 5.8/js/modules.js:597
 msgid "Battery Module"
 msgstr ""
 
-#: 5.8/js/modules.js:646 4.8/js/modules.js:658
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr ""
 
-#: 5.8/js/modules.js:682
+#. 5.8/js/modules.js:682
 msgid "Device-Info Module"
 msgstr ""
 
-#: 5.8/js/modules.js:731 4.8/js/modules.js:741
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr ""
 
-#: 5.8/js/modules.js:735 4.8/js/modules.js:745
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr ""
 
-#: 5.8/js/modules.js:739 4.8/js/modules.js:749
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr ""
 
-#: 5.8/js/modules.js:751
+#. 5.8/js/modules.js:751
 msgid "Connectivity Module"
 msgstr ""
 
-#: 5.8/js/modules.js:813 4.8/js/modules.js:822
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr ""
 
-#: 5.8/js/modules.js:816 4.8/js/modules.js:825
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr ""
 
-#: 5.8/js/modules.js:819 4.8/js/modules.js:828
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr ""
 
-#: 5.8/js/modules.js:822 4.8/js/modules.js:831
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr ""
 
-#: 5.8/js/modules.js:825 4.8/js/modules.js:834
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr ""
 
-#: 5.8/js/modules.js:837 4.8/js/modules.js:846
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr ""
 
-#: 5.8/js/modules.js:867
+#. 5.8/js/modules.js:867
 msgid "FindMyPhone Module"
 msgstr ""
 
-#: 5.8/js/modules.js:892 4.8/js/modules.js:900
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr ""
 
-#: 5.8/js/modules.js:893 4.8/js/modules.js:901
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr ""
 
-#: 5.8/js/modules.js:907
+#. 5.8/js/modules.js:907
 msgid "Request Photo Module"
 msgstr ""
 
-#: 5.8/js/modules.js:973 4.8/js/modules.js:980
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr ""
 
-#: 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
-#: 4.8/js/modules.js:1156
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr ""
 
-#: 5.8/js/modules.js:982 4.8/js/modules.js:989
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr ""
 
-#: 5.8/js/modules.js:983 4.8/js/modules.js:990
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr ""
 
-#: 5.8/js/modules.js:1009
+#. 5.8/js/modules.js:1009
 msgid "Ping Module"
 msgstr ""
 
-#: 5.8/js/modules.js:1034 4.8/js/modules.js:1040
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr ""
 
-#: 5.8/js/modules.js:1041 4.8/js/modules.js:1047
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr ""
 
-#: 5.8/js/modules.js:1047 4.8/js/modules.js:1053
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr ""
 
-#: 5.8/js/modules.js:1048 4.8/js/modules.js:1054
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr ""
 
-#: 5.8/js/modules.js:1062
+#. 5.8/js/modules.js:1062
 msgid "Share Module"
 msgstr ""
 
-#: 5.8/js/modules.js:1151 4.8/js/modules.js:1156
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr ""
 
-#: 5.8/js/modules.js:1186 4.8/js/modules.js:1191
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr ""
 
-#: 5.8/js/modules.js:1198 4.8/js/modules.js:1204
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr ""
 
-#: 5.8/js/modules.js:1199 4.8/js/modules.js:1205
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr ""
 
-#: 5.8/js/modules.js:1208 4.8/js/modules.js:1214
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr ""
 
-#: 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
-#: 4.8/js/modules.js:1490
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr ""
 
-#: 5.8/js/modules.js:1218 4.8/js/modules.js:1224
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr ""
 
-#: 5.8/js/modules.js:1219 4.8/js/modules.js:1225
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr ""
 
-#: 5.8/js/modules.js:1243
+#. 5.8/js/modules.js:1243
 msgid "SFTP Module"
 msgstr ""
 
-#: 5.8/js/modules.js:1284 4.8/js/modules.js:1281
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr ""
 
-#: 5.8/js/modules.js:1286 4.8/js/modules.js:1283
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr ""
 
-#: 5.8/js/modules.js:1292 4.8/js/modules.js:1289
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr ""
 
-#: 5.8/js/modules.js:1294 4.8/js/modules.js:1291
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr ""
 
-#: 5.8/js/modules.js:1424 4.8/js/modules.js:1364
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr ""
 
-#: 5.8/js/modules.js:1463
+#. 5.8/js/modules.js:1463
 msgid "SMS Module"
 msgstr ""
 
-#: 5.8/js/modules.js:1532 4.8/js/modules.js:1468
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr ""
 
-#: 5.8/js/modules.js:1544 4.8/js/modules.js:1481
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr ""
 
-#: 5.8/js/modules.js:1545 4.8/js/modules.js:1482
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr ""
 
-#: 5.8/js/modules.js:1552 4.8/js/modules.js:1489
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr ""
 
 #. metadata.json->name
-#: 5.8/js/utils.js:24
+#. 5.8/js/utils.js:24
 msgid "KDE Connect Applet"
 msgstr ""
 
-#: 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
 msgid "Copied {typestring} to the clipboard"
 msgstr ""
 
-#: 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr ""
 
-#: 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr ""
 
-#: 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr ""
 
-#: 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
-#: 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
-#: 4.8/py/dialogs.py:169
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr ""
 
-#: 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
-#: 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr ""
 
-#: 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr ""
 
-#: 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr ""
 
-#: 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr ""
 
-#: 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr ""
 
-#: 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr ""
 
-#: 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr ""
 
-#: 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr ""
 
-#: 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr ""
 
-#: 5.8/py/dialogs.py:271
+#. 5.8/py/dialogs.py:271
 #, python-brace-format
 msgid "Open remote directory on '{device_name}'"
 msgstr ""
 
-#: 5.8/py/dialogs.py:290
+#. 5.8/py/dialogs.py:290
 msgid "Open"
 msgstr ""
 
-#: 5.8/py/dialogs.py:300
+#. 5.8/py/dialogs.py:300
 msgid "Directory to open:"
 msgstr ""
 
-#: 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr ""
 
-#: 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr ""
 
-#: 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr ""
 
-#: 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr ""
 
@@ -383,9 +383,9 @@ msgstr ""
 
 #. metadata.json->comments
 msgid ""
-"KDE Connect Applet makes it easy to use the various features provided by KDE"
-" Connect to interact with connected devices, like sending files, sending SMS"
-" messages, browsing the storage of the device and more"
+"KDE Connect Applet makes it easy to use the various features provided by KDE "
+"Connect to interact with connected devices, like sending files, sending SMS "
+"messages, browsing the storage of the device and more"
 msgstr ""
 
 #. metadata.json->contributors

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/nl.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2024-04-22 17:42+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -17,25 +17,26 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Geen modules beschikbaar"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect is niet beschikbaar, zorg ervoor dat het is geïnstalleerd en "
 "actief is."
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Applet herladen"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Ongeldige versie van KDE Connect geretourneerd!"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -43,283 +44,352 @@ msgstr ""
 "De KDE Connect DBus-service heeft een ongeldige versie geretourneerd, "
 "probeer de applet opnieuw te laden!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Geen verbonden apparaten!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Voeg ze toe in de instellingen van KDE Connect"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Debug-dingen, niet aanraken!"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect-versie: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Eigen ID: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "Eigen ID"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Klik om eigen ID te kopiëren"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "KDE Connect configureren"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Klik om de configuratie van KDE Connect te openen"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Geen beschikbare apparaten"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} beschikbaar apparaat"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} beschikbare apparaten"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "{typestring} gekopieerd naar het klembord"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Modules"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Batterij-informatiemodule"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Opladen"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Apparaatinfo-informatiemodule"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "Apparaat-ID"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Klik om ID te kopiëren"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Verbindingsinformatiemodule"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Geen signaal"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Laag"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Oké"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Goed"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Uitstekend"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Onbekend"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "Vind mijn telefoon Actiemodule"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Apparaat laten rinkelen"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Klik om het apparaat te laten rinkelen"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Verzoek-foto Actiemodule"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Foto ontvangen van '{deviceName}'"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Klik om te openen in de standaardapplicatie"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Foto verzoeken"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Klik om een foto van het apparaat te verzoeken"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Ping Actiemodule"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Ping verzonden naar apparaat '{deviceName}'"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Apparaat pingen"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Klik om een ping naar het apparaat te sturen"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Delen Actiemodule"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Delen ontvangen van '{deviceName}'"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Delen"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "URL verzenden"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Klik om een URL naar het apparaat te sturen"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Tekst verzenden"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Klik om tekst naar het apparaat te sturen"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Bestand(en) verzenden"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Klik om bestand(en) naar het apparaat te sturen"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "SFTP Actiemodule"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Uitwerpen"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Aankoppelen"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Klik om uit te werpen"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Klik om aan te koppelen"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Klik om bestanden te bekijken"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "SMS Actiemodule"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "SMS-app starten"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Klik om de KDE Connect SMS-app te openen"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "SMS verzenden"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "KDE Connect Applet"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "{typestring} gekopieerd naar het klembord"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Geselecteerde invoer omhoog verplaatsen"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Geselecteerde invoer omlaag verplaatsen"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "URL verzenden naar '{device_name}'"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Annuleren"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Verzenden"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Voer een URL in om naar '{device_name}' te sturen"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "SMS verzenden via '{device_name}'"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Telefoonnummer:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Telefoonnummer"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Bericht:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Tekst verzenden naar '{device_name}'"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Tekst om te verzenden:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Tekst verzenden naar '{device_name}'"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Bestanden selecteren om naar '{deviceName}' te verzenden"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Selecteer waar u de foto ontvangen van '{deviceName}' wilt opslaan"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "foto.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "JPEG-foto"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "KDE Connect Applet"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -345,227 +415,298 @@ msgstr "Johannes Schoeneberger - Auteur"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Inspiratie voor de applet"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Algemeen"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Modules"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Contextmenu"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Paneel"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Apparaten"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Informatiemodules"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Actiemodules"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Batterij-informatiemodule"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Apparaatinfo-informatiemodule"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Verbindingsinformatiemodule"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Vind mijn telefoon Actiemodule"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Verzoek-foto Actiemodule"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Ping Actiemodule"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Delen Actiemodule"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "SFTP Actiemodule"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "SMS Actiemodule"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Toon eigen ID in het contextmenu van de applet"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Toon KDE Connect-versie in het contextmenu van de applet"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "Toon het aantal verbonden apparaten naast het pictogram in het paneel"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Toon het aantal apparaten in de tooltip van de applet"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Pictogramtype"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Symbolisch"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Kleur"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Gebruik aangepast pictogram"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Aangepast pictogram om te gebruiken"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "KDE Connect-configuratie openen"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 "Automatisch het submenu van het apparaat uitvouwen, als slechts één apparaat "
 "beschikbaar is"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Naam"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Uitvouwen"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "Toont de huidige batterijlading en laadstatus van het apparaat"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Toont het apparaatpictogram samen met zijn ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "Toont de huidige verbindingsstatus en netwerktype van het apparaat"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Toon het mobiele netwerktype"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 "Hiermee kunt u het apparaat laten rinkelen, zodat u het kunt vinden als u "
 "het kwijt bent"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Hiermee kunt u een foto verzoeken van het externe apparaat en deze op dit "
 "apparaat opslaan"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Ontvangen foto's direct opslaan naar map"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "De map om ontvangen foto's naar op te slaan"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr ""
 "Hiermee kunt u het apparaat pingen om ervoor te zorgen dat het is verbonden"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Aangepast bericht voor ping gebruiken"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Aangepast bericht"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Hiermee kunt u URL's, bestanden of tekst delen met het apparaat"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Menu-items weergeven in submenu"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Menu-item inschakelen om een URL te verzenden"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Menu-item inschakelen om wat tekst te verzenden"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Menu-item inschakelen om bestand(en) te verzenden"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr ""
 "Hiermee kunt u op afstand bladeren door de geselecteerde opslag op het "
 "apparaat"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Hiermee kunt u op afstand sms-berichten verzenden vanaf het apparaat"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Menu-item inschakelen om een SMS-bericht te verzenden"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Menu-item inschakelen om de KDE Connect SMS-app te starten"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/pl.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/pl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: kdecapplet@joejoetv 2.1.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2025-10-26 17:48-0200\n"
 "Last-Translator: Skajmer<skajmer@proton.me>\n"
 "Language-Team: \n"
@@ -17,305 +17,379 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Brak dostępnych modułów"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
-msgstr "KDE Connect nie jest dostępny, upewnij się że jest zainstalowany i uruchomiony"
+msgstr ""
+"KDE Connect nie jest dostępny, upewnij się że jest zainstalowany i "
+"uruchomiony"
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Przeładuj applet"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Została zwrócona nieprawidłowa wersja KDE Connect!"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
-msgstr "Usługa DBUS KDE Connect zwróciła nieprawidłową wersję, spróbuj "
-"przeładować applet!"
-#. applet.js:1120
+msgstr ""
+"Usługa DBUS KDE Connect zwróciła nieprawidłową wersję, spróbuj przeładować "
+"applet!"
+
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Brak połączonych urządzeń!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Dodaj je w ustawieniach KDE Connect"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Rzeczy do debugowania, nie dotykać!"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect Wersja: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Własne ID: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "własne ID"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Kliknij, aby skopiować własne ID"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Skonfiguruj KDE Connect"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Kliknij, aby otworzyć konfigurację KDE Connect"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Brak dostępnych urządzeń"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} dostępne urządzenie"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} dostępnych urządzeń"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "Skopiowano {typestring} do schowka"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Moduły"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Moduł informacji o baterii"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Ładowanie"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Moduł informacji o urządzeniu"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "ID urządzenia"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Kliknij, aby skopiować ID"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Moduł informacji o łączności"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Brak sygnału"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Niski"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Ok"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Dobry"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Znakomity"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Nieznany"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "Moduł akcji FindMyPhone"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Zadzwoń urządzeniem"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Kliknij, aby zadzwonić urządzeniem"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Moduł akcji Request-Photo"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Otrzymano zdjęcie z '{deviceName}'"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Kliknij, aby otworzyć w domyślnym programie"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Zrób zdjęcię"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Kliknij, aby poprosić urządzenie o zdjęcie"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Moduł akcji Ping"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Wysłano ping do urządzenia '{deviceName}'"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Spinguj  urządzenie"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Kliknij, aby wysłać ping do urządzenia"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Moduł akcji Share"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Otrzymano udostępnienie od '{deviceName}'"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Udostępnij"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Wyślij URL"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Kliknij, aby wysłać adres URL do urządzenia"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Wyślij tekst"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Kliknij, aby wysłać tekst do urządzenia"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Wyślij plik(i)"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Kliknij, aby wysłać plik(i) do urządzenia"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "Moduł akcji SFTP"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Odmontuj"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Zamontuj"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Kliknij, aby odmontować"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Kliknij, aby zamontować"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Kliknij, aby przeglądać pliki"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "Moduł akcji SMS"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Włącz progam SMS"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Kliknij, aby otworzyć program KDE Connect SMS"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Wyślij SMS"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "Aplet KDE Connect"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "Skopiowano {typestring} do schowka"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Przenieś wybrany wpis wyżej"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Przenieś wybrany wpis niżej"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Wyślij adres URL do urządzenia '{device_name}'"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Anuluj"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Wyślij"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Wpisz adres URL do wysłania do urządzenia '{device_name}'"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "Adres URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Wyślij SMS za pomocą '{device_name}'"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Numer telefonu:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Numer telefonu:"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Wiadomość:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Wyślij tekst do urządzenia '{device_name}'"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Tekst do wysłania:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Wyślij tekst do urządzenia '{device_name}'"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Wybierz pliki do wysłania do '{deviceName}'"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Wybierz gdzie chcesz zapisać zdjęcie otrzymane od '{deviceName}'"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "zdjęcie.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "Zdjęcie JPEG"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "Aplet KDE Connect"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -326,9 +400,11 @@ msgid ""
 "KDE Connect Applet makes it easy to use the various features provided by KDE "
 "Connect to interact with connected devices, like sending files, sending SMS "
 "messages, browsing the storage of the device and more"
-msgstr "Aplet KDE Connect pozwala na łatwe korzystanie z różnych funkcji które daje KDE"
-"Connect, aby mieć interakcję  z połączonymi urządzeniami, takie jak wysyłanie plików, wysyłanie wiadomości"
-"SMS, przeglądanie pamięci urządzenia i wiele innych"
+msgstr ""
+"Aplet KDE Connect pozwala na łatwe korzystanie z różnych funkcji które daje "
+"KDEConnect, aby mieć interakcję  z połączonymi urządzeniami, takie jak "
+"wysyłanie plików, wysyłanie wiadomościSMS, przeglądanie pamięci urządzenia i "
+"wiele innych"
 
 #. metadata.json->contributors
 msgid "Johannes Schoeneberger - Author"
@@ -338,219 +414,295 @@ msgstr "Johannes Schoeneberger - Autor"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Inspiracja do Apletu"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Ogólne"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Moduły"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Menu kontekstowe"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Panel"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Urządzenia"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Moduły informacyjne"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Moduły akcji"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Moduł informacji o baterii"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Moduł informacji o urządzeniu"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Moduł informacji o łączności"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Moduł akcji FindMyPhone"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Moduł akcji Request-Photo"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Moduł akcji Ping"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Moduł akcji Share"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "Moduł akcji SFTP"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "Moduł akcji SMS"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Pokaż własne ID w menu kontekstowym apletu"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Pokaż wersję KDE Connect w menu kontekstowym appletu"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "Pokaż liczbę podłączonych urządzeń obok ikony w panelu"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Pokaż liczbę urządzeń w dymku apletu"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Typ ikony"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Symboliczna"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Kolorowa"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Używaj niestandardowej ikony"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Niestandardowa ikona do użycia"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "Otwórz konfigurację KDE Connect"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
-"Rozwiń sub menu urządzenia automatycznie, jeżeli dostępne jest tylko jedno urządzenie"
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+"Rozwiń sub menu urządzenia automatycznie, jeżeli dostępne jest tylko jedno "
+"urządzenie"
+
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Nazwa"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Rozwijaj"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Włączone"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr ""
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Pokazuje ikonę urządzenia razem z jego ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "Pokazuje aktualny stan połączenia i typ sieci urządzenia"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Pokaż typ sieci komórkowej"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
-"Pozwala zadzwonić twoim urządzeniem, aby je znaleźć, jeżeli gdzieś je zgubiłeś"
+"Pozwala zadzwonić twoim urządzeniem, aby je znaleźć, jeżeli gdzieś je "
+"zgubiłeś"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
-"Pozwala poprosić o zdjęcie z zdalnego urządzenia, aby zapisać je na tym urządzeniu"
-#. settings-schema.json->module_requestphoto_saveToDir->description
+"Pozwala poprosić o zdjęcie z zdalnego urządzenia, aby zapisać je na tym "
+"urządzeniu"
+
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Zapisuj otrzymane zdjęcia prosto do katalogu"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Katalog do zapisania otrzymanych zdjęć"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr "Pozwala spingować urządzenie, aby sprawdzić czy jest dalej połączone"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Użyj niestandardowej wiadomości do pingu"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Niestandardowa wiadomość"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Pozwala ci wysyłać adresy URL, pliki lub tekst do urządzenia"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Pokaż elementy menu w sub menu"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Włącz element menu do wysyłania adresów URL"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Włącz element menu do wysyłania tekstu"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Włącz element menu do wysyłania plik(ów)"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr "Pozwala zdalnie przeglądać pamięć wybraną na urządzeniu"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Pozwala zdalnie wysyłać wiadomości SMS z urządzenia"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Włącz element menu do wysyłania wiadomości SMS"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Włącz element menu do włączania programu KDE Connect SMS"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/ru.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: kdecapplet@joejoetv 2.1.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2026-06-10 00:00-0000\n"
 "Last-Translator: Grom-TS\n"
 "Language-Team: Russian\n"
@@ -17,23 +17,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Нет доступных модулей"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr "KDE Connect недоступен, убедитесь, что он установлен и запущен."
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Перезапустить апплет"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Получена недопустимая версия KDE Connect!"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -41,287 +42,359 @@ msgstr ""
 "Служба D-Bus KDE Connect вернула недопустимую версию. Попробуйте "
 "перезапустить апплет."
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Нет подключённых устройств!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Добавьте их в настройках KDE Connect."
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Отладочная информация, не трогать!"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "Версия KDE Connect: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Собственный ID: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "Собственный ID"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Нажмите, чтобы скопировать собственный ID"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Настроить KDE Connect"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Нажмите, чтобы открыть настройки KDE Connect"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Нет доступных устройств"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} доступное устройство"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} доступных устройств"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "{typestring} скопирован(о) в буфер обмена"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Модули"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Модуль информации о батарее"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Заряжается"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Модуль информации об устройстве"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "ID устройства"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Нажмите, чтобы скопировать ID"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Модуль информации о подключении"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Нет сигнала"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Низкий"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Нормальный"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Хороший"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Отличный"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "Модуль действия «Поиск телефона»"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Подать сигнал на устройство"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Нажмите, чтобы подать сигнал на устройство"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Модуль действия «Запрос фотографии»"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Получена фотография с устройства «{deviceName}»"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Нажмите, чтобы открыть в приложении по умолчанию"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Запросить фотографию"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Нажмите, чтобы запросить фотографию с устройства"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Модуль действия «Пинг»"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Пинг!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Пинг отправлен на устройство «{deviceName}»"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Отправить пинг устройству"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Нажмите, чтобы отправить пинг устройству"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Модуль передачи файлов"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Получен файл от устройства «{deviceName}»"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Общий доступ"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Отправить URL"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Нажмите, чтобы отправить URL устройству"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Отправить текст"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Нажмите, чтобы отправить текст устройству"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Отправить файлы"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Нажмите, чтобы отправить файлы устройству"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "Модуль действий SFTP"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Отключить"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Подключить"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Нажмите, чтобы отключить"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Нажмите, чтобы подключить"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Нажмите, чтобы просмотреть файлы"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "Модуль действий SMS"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Открыть приложение SMS"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Нажмите, чтобы открыть приложение SMS в KDE Connect"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Отправить SMS"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "Апплет KDE Connect"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "{typestring} скопирован(о) в буфер обмена"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Переместить выбранный элемент вверх"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Переместить выбранный элемент вниз"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Отправить URL устройству «{device_name}»"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Отмена"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Отправить"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Введите URL для отправки устройству «{device_name}»"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Отправить SMS через устройство «{device_name}»"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Номер телефона:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Номер телефона"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Сообщение:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Отправить текст устройству «{device_name}»"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Текст для отправки:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Отправить текст устройству «{device_name}»"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Выберите файлы для отправки устройству «{deviceName}»"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
-msgstr "Выберите место для сохранения фотографии, полученной с устройства «{deviceName}»"
+msgstr ""
+"Выберите место для сохранения фотографии, полученной с устройства "
+"«{deviceName}»"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "photo.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "Фотография JPEG"
 
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "Апплет KDE Connect"
-
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
-msgstr "Позволяет взаимодействовать с устройствами, подключёнными через KDE Connect"
+msgstr ""
+"Позволяет взаимодействовать с устройствами, подключёнными через KDE Connect"
 
 #. metadata.json->comments
 msgid ""
@@ -330,8 +403,8 @@ msgid ""
 "messages, browsing the storage of the device and more"
 msgstr ""
 "Апплет KDE Connect упрощает использование возможностей KDE Connect для "
-"взаимодействия с подключёнными устройствами: отправки файлов и SMS-сообщений, "
-"просмотра хранилища устройства и многого другого."
+"взаимодействия с подключёнными устройствами: отправки файлов и SMS-"
+"сообщений, просмотра хранилища устройства и многого другого."
 
 #. metadata.json->contributors
 msgid "Johannes Schoeneberger - Author"
@@ -341,221 +414,295 @@ msgstr "Johannes Schoeneberger — автор"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga — вдохновитель проекта"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Общие"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Модули"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Контекстное меню"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Панель"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Устройства"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Информационные модули"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Модули действий"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Модуль информации о батарее"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Модуль информации об устройстве"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Модуль информации о подключении"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Модуль действия «Поиск телефона»"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Модуль действия «Запрос фотографии»"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Модуль действия «Пинг»"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Модуль передачи файлов"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "Модуль действий SFTP"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "Модуль действий SMS"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Показывать собственный ID в контекстном меню апплета"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Показывать версию KDE Connect в контекстном меню апплета"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
-msgstr "Показывать количество подключённых устройств рядом со значком на панели"
+msgstr ""
+"Показывать количество подключённых устройств рядом со значком на панели"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Показывать количество устройств во всплывающей подсказке апплета"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Тип значка"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Символьный"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Цветной"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Использовать пользовательский значок"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Пользовательский значок"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "Открыть настройки KDE Connect"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
-"Автоматически раскрывать подменю устройства, если доступно только одно устройство"
+"Автоматически раскрывать подменю устройства, если доступно только одно "
+"устройство"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Название"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Раскрывать"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Включён"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "Показывает текущий уровень заряда и состояние зарядки устройства"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Показывает значок устройства и его ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "Показывает текущее состояние подключения и тип сети устройства"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Показать тип мобильной сети"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
-msgstr ""
-"Позволяет подать звуковой сигнал на устройство, чтобы помочь найти его"
+msgstr "Позволяет подать звуковой сигнал на устройство, чтобы помочь найти его"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
-"Позволяет запросить фотографию с удалённого устройства и сохранить её на этом устройстве"
+"Позволяет запросить фотографию с удалённого устройства и сохранить её на "
+"этом устройстве"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Сохранять полученные фотографии сразу в каталог"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Каталог для сохранения полученных фотографий"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
-msgstr "Позволяет отправить пинг устройству, чтобы убедиться, что оно подключено"
+msgstr ""
+"Позволяет отправить пинг устройству, чтобы убедиться, что оно подключено"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Использовать пользовательское сообщение для пинга"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Пользовательское сообщение"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Позволяет отправлять на устройство URL, файлы и текст"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Показывать пункты в подменю"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Включить пункт меню для отправки URL"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Включить пункт меню для отправки текста"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Включить пункт меню для отправки файлов"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr "Позволяет удалённо просматривать хранилище, выбранное на устройстве"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Позволяет удалённо отправлять SMS-сообщения через устройство"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Включить пункт меню для отправки SMS-сообщений"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Включить пункт меню для запуска приложения SMS KDE Connect"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/sv.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/sv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2023-03-13 09:02+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -19,24 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Inga moduler tillgängliga"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect är inte tillgängligt, tillse att det är installerat och igång."
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Uppdatera panelprogrammet"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Ogiltig KDE Connect-version returnerat!"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -44,283 +45,352 @@ msgstr ""
 "KDE Connects DBus-tjänst returnerade en ogiltig version, försök uppdatera "
 "panelprogrammet!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Inga anslutna enheter!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Lägg till dem i KDE Connects inställningar"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Felsökningsgrejer, rör ej!"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect Version: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Eget ID: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "eget ID"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Klicka för att kopiera eget ID"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Konfigurera KDE Connect"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Klicka för att öppna KDE Connects inställningar"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Inga enheter tillgängliga"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} tillgänglig enhet"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} tillgängliga enheter"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "Kopierade {typestring} till urklipp"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Moduler"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Modul för bateriinformation"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Laddar"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Modul för enhetsinformation"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "Enhets-ID"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Klicka för att kopiera ID"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Modul för anslutningsinformation"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Ingen signal"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Låg"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "OK"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Bra"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Utmärkt"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Okänd"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "Åtgärdsmodul för HittaMinTelefon"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Ring enheten"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Klicka för att ringa enheten"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Åtgärdsmodul för bildöverföring"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Bild mottagen från \"{deviceName}\""
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Klicka för att öppna i standardprogram"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Begär bild"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Klicka för att begära en bild från enheten"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Åtgärdsmodul för Ping"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Skicka ping till enheten \"{deviceName}\""
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Pinga enheten"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Klicka för att pinga enheten"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Åtgärdsmodul för delning"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Delning mottagen från \"{deviceName}\""
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Dela"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Skicka URL"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Klicka för att skicka en URL till enheten"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Skicka text"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Klicka för att skicka text till enheten"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Skicka fil(er)"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Klicka för att skicka fil(er) till enheten"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "Åtgärdsmodul för SFTP"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Avmontera"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Montera"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Klicka för att avmontera"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Klicka för att montera"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Klicka för att bläddra filer"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "Åtgärdsmodul för SMS"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Starta SMS-programmet"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Klicka för att öppna KDE Connects SMS-program"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Skicka SMS"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "KDE Connect panelprogram"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "Kopierade {typestring} till urklipp"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Flytta upp markerad post"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Flytta ner markerad post"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Skicka URL till \"{device_name}\""
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Avbryt"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Skicka"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Ange en URL att skicka till \"{device_name}\""
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Skicka SMS med \"{device_name}\""
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Telefonnummer:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Meddelande:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Skicka text till \"{device_name}\""
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Text att skicka:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Skicka text till \"{device_name}\""
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Välj filer att skicka till \"{deviceName}\""
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Välj var bild mottagen från \"{deviceName}\" skall sparas"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "bild.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "JPEG-bild"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "KDE Connect panelprogram"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -344,222 +414,293 @@ msgstr "Johannes Schoeneberger - Utvecklare"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Inspiration till panelprogrammet"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Allmänt"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Moduler"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Kontextmeny"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Panel"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Enheter"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "InfoModuler"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Åtgärdsmoduler"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Modul för bateriinformation"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Modul för enhetsinformation"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Modul för anslutningsinformation"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Åtgärdsmodul för HittaMinTelefon"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Åtgärdsmodul för bildöverföring"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Åtgärdsmodul för Ping"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Åtgärdsmodul för delning"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "Åtgärdsmodul för SFTP"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "Åtgärdsmodul för SMS"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Visa eget ID i panelprogrammets högerklicksmeny"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Visa KDE Connect-version i panelprogrammets högerklicksmeny"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "Visa antal anslutna enheter vid sidan av panelikonen"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Visa antal enheter i panelprogrammets knappbeskrivning"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Ikontyp"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Symbolisk"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Färg"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Använd anpassad ikon"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Anpassad ikon att använda"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "Öppna KDE Connects inställningar"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr ""
 "Expandera enhetens undermeny automatiskt, om endast en enhet finns "
 "tillgänglig"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Namn"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Expandera"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Aktiv"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "Visar aktuell batterinivå och laddningsstatus för enheten"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Visar enhetens ikon tillsammans med dess ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "Visar aktuell anslutningsstatus och nätverkstyp för enheten"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Visa mobilnätverkstyp"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 "Får enheten att ringa, så att du kan hitta den, om du har tappat bort den."
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Låter dig ta emot en bild från fjärrenheten och spara den på den här enheten"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Spara mottagna bilder direkt i mapp"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Mapp att spara mottagna bilder i"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr "Pingar enheten för att se om den är ansluten"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Använd anpassat meddelande för ping"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Anpassat meddelande"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Låter dig dela webbadresser, filer eller text till enheten"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Visa menyposter i undermeny"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Aktivera menyalternativet för att skicka en URL"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Aktivera menyalternativet för att skicka text"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Aktivera menyalternativet för att skicka fil(er)"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr "Låter dig fjärrbläddra i vald lagringsmapp på enheten"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Låter dig fjärrskicka SMS från enheten"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Aktivera menyalternativet för att skicka ett SMS"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Aktivera menyalternativet för att starta KDE Connects SMS-program"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/vi.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: kdecapplet@joejoetv 2.1.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -18,305 +18,379 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "Không có mô-đun nào khả dụng"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
-msgstr "KDE Connect không khả dụng, hãy chắc chắn rằng nó đã được cài đặt và đang chạy."
+msgstr ""
+"KDE Connect không khả dụng, hãy chắc chắn rằng nó đã được cài đặt và đang "
+"chạy."
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "Tải lại Applet"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Phiên bản KDE Connect trả về không hợp lệ!"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
-msgstr "Dịch vụ DBus của KDE Connect trả về phiên bản không hợp lệ, hãy thử tải lại Applet!"
+msgstr ""
+"Dịch vụ DBus của KDE Connect trả về phiên bản không hợp lệ, hãy thử tải lại "
+"Applet!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "Không có thiết bị kết nối!"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Thêm chúng trong cài đặt KDE Connect"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Thông tin gỡ lỗi, đừng chạm!"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "Phiên bản KDE Connect: {version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "ID của bạn: {own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "ID của bạn"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Nhấn để sao chép ID của bạn"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "Cấu hình KDE Connect"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Nhấn để mở Cấu hình KDE Connect"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "Không có thiết bị khả dụng"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} thiết bị khả dụng"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} thiết bị khả dụng"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "Đã sao chép {typestring} vào clipboard"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "Module"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "Module thông tin pin"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "Đang sạc"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "Module thông tin thiết bị"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "ID thiết bị"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "Nhấn để sao chép ID"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "Module thông tin kết nối"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "Không có tín hiệu"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "Thấp"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "Ổn"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "Tốt"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "Xuất sắc"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "Không xác định"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "Module hành động Tìm điện thoại"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "Gọi thiết bị"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "Nhấn để gọi thiết bị"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "Module hành động Yêu cầu ảnh"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "Đã nhận ảnh từ '{deviceName}'"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "Nhấn để mở trong ứng dụng mặc định"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "Yêu cầu ảnh"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "Nhấn để yêu cầu ảnh từ thiết bị"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Module hành động Ping"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Đã gửi ping đến thiết bị '{deviceName}'"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Ping thiết bị"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "Nhấn để gửi ping đến thiết bị"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "Module hành động Chia sẻ"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "Đã nhận chia sẻ từ '{deviceName}'"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "Chia sẻ"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "Gửi URL"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "Nhấn để gửi URL đến thiết bị"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "Gửi văn bản"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "Nhấn để gửi văn bản đến thiết bị"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "Gửi tập tin"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "Nhấn để gửi tập tin đến thiết bị"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "Module hành động SFTP"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "Ngắt kết nối"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "Kết nối"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "Nhấn để ngắt kết nối"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "Nhấn để kết nối"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "Nhấn để duyệt tập tin"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "Module hành động SMS"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "Mở ứng dụng SMS"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Nhấn để mở ứng dụng SMS của KDE Connect"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "Gửi SMS"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "Applet KDE Connect"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "Đã sao chép {typestring} vào clipboard"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "Di chuyển mục đã chọn lên trên"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "Di chuyển mục đã chọn xuống dưới"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "Gửi URL đến '{device_name}'"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "Hủy"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "Gửi"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "Nhập URL để gửi đến '{device_name}'"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "Gửi SMS qua '{device_name}'"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "Số điện thoại:"
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "Số điện thoại"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "Tin nhắn:"
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "Gửi văn bản đến '{device_name}'"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "Văn bản gửi:"
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "Gửi văn bản đến '{device_name}'"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "Chọn tập tin để gửi đến '{deviceName}'"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "Chọn nơi lưu ảnh nhận từ '{deviceName}'"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "anh.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "Ảnh JPEG"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "Applet KDE Connect"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -327,7 +401,10 @@ msgid ""
 "KDE Connect Applet makes it easy to use the various features provided by KDE "
 "Connect to interact with connected devices, like sending files, sending SMS "
 "messages, browsing the storage of the device and more"
-msgstr "Applet KDE Connect giúp dễ dàng sử dụng các tính năng của KDE Connect để tương tác với thiết bị, như gửi tập tin, gửi SMS, duyệt bộ nhớ thiết bị và nhiều hơn nữa"
+msgstr ""
+"Applet KDE Connect giúp dễ dàng sử dụng các tính năng của KDE Connect để "
+"tương tác với thiết bị, như gửi tập tin, gửi SMS, duyệt bộ nhớ thiết bị và "
+"nhiều hơn nữa"
 
 #. metadata.json->contributors
 msgid "Johannes Schoeneberger - Author"
@@ -337,218 +414,289 @@ msgstr "Johannes Schoeneberger - Tác giả"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Nguồn cảm hứng cho Applet"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "Chung"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Module"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Menu ngữ cảnh"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Thanh panel"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "Thiết bị"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "Module thông tin"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "Module hành động"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Module thông tin pin"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "Module thông tin thiết bị"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Module thông tin kết nối"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "Module hành động Tìm điện thoại"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Module hành động Yêu cầu ảnh"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Module hành động Ping"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Module hành động Chia sẻ"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "Module hành động SFTP"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "Module hành động SMS"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Hiển thị ID của bản thân trong menu ngữ cảnh của applet"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "Hiển thị phiên bản KDE Connect trong menu ngữ cảnh của applet"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "Hiển thị số thiết bị kết nối bên cạnh biểu tượng trên thanh panel"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Hiển thị số thiết bị trong tooltip của applet"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "Loại biểu tượng"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "Biểu tượng ký hiệu"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "Màu sắc"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "Sử dụng biểu tượng tùy chỉnh"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "Biểu tượng tùy chỉnh để sử dụng"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "Mở Cấu hình KDE Connect"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr "Tự động mở rộng menu phụ của thiết bị nếu chỉ có một thiết bị có sẵn"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "Tên"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "Mở rộng"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "Bật"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "Hiển thị dung lượng pin hiện tại và trạng thái sạc của thiết bị"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Hiển thị biểu tượng thiết bị cùng với ID của nó"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "Hiển thị trạng thái kết nối hiện tại và loại mạng của thiết bị"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Hiển thị loại mạng di động"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr "Cho phép thiết bị đổ chuông để bạn có thể tìm thấy nếu bị thất lạc"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr "Cho phép yêu cầu ảnh từ thiết bị từ xa và lưu trên thiết bị này"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Lưu ảnh nhận được trực tiếp vào thư mục"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Thư mục để lưu các ảnh nhận được"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr "Cho phép gửi ping đến thiết bị để đảm bảo nó đang kết nối"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Sử dụng thông điệp tùy chỉnh cho ping"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Thông điệp tùy chỉnh"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Cho phép chia sẻ URL, tập tin hoặc văn bản đến thiết bị"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Hiển thị mục menu trong menu phụ"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Bật mục menu để gửi URL"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Bật mục menu để gửi văn bản"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Bật mục menu để gửi tập tin"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr "Cho phép duyệt bộ nhớ đã chọn trên thiết bị từ xa"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Cho phép gửi SMS từ xa từ thiết bị"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Bật mục menu để gửi tin nhắn SMS"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Bật mục menu để mở ứng dụng SMS của KDE Connect"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/zh_CN.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/zh_CN.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2025-04-28 05:49-0400\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2023-03-13 10:12+0800\n"
 "Last-Translator: Slinet6056 <slinet6056@gmail.com>\n"
 "Language-Team: \n"
@@ -19,305 +19,375 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#. applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "没有可用的模块"
 
-#. applet.js:1065 applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr "KDE Connect 不可用，请确保它已安装并运行。"
 
-#. applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "重载小程序"
 
-#. applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "返回了无效的 KDE Connect 版本！"
 
-#. applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
 msgstr "KDE Connect DBus 服务返回了一个无效的版本，请尝试重载小程序！"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "没有连接的设备！"
 
-#. applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "在 KDE Connect 设置中添加它们"
 
-#. applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "用于调试的东西，不要碰！"
 
-#. applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect 版本：{version}"
 
-#. applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "自己的 ID：{own_id}"
 
-#. applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "自己的 ID"
 
-#. applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "点击复制自己的 ID"
 
-#. applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "配置 KDE Connect"
 
-#. applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "点击打开 KDE Connect 配置"
 
-#. applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "没有可用的设备"
 
-#. applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} 个可用的设备"
 
-#. applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} 个可用的设备"
 
-#. js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "已将 {typestring} 复制到剪贴板上"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "模块"
 
-#. js/modules.js:656
+#. 5.8/js/modules.js:597
+#, fuzzy
+msgid "Battery Module"
+msgstr "电池信息模块"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "正在充电"
 
-#. js/modules.js:739
+#. 5.8/js/modules.js:682
+#, fuzzy
+msgid "Device-Info Module"
+msgstr "设备信息模块"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#. js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "设备 ID"
 
-#. js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "点击复制 ID"
 
-#. js/modules.js:820
+#. 5.8/js/modules.js:751
+#, fuzzy
+msgid "Connectivity Module"
+msgstr "连接信息模块"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "无信号"
 
-#. js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "差"
 
-#. js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "一般"
 
-#. js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "好"
 
-#. js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "极好"
 
-#. js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "未知"
 
-#. js/modules.js:898
+#. 5.8/js/modules.js:867
+#, fuzzy
+msgid "FindMyPhone Module"
+msgstr "寻找手机操作模块"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "呼叫设备"
 
-#. js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "点击使设备响铃"
 
-#. js/modules.js:978
+#. 5.8/js/modules.js:907
+#, fuzzy
+msgid "Request Photo Module"
+msgstr "获取照片操作模块"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "从 “{deviceName}” 收到照片"
 
-#. js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "点击在默认应用程序中打开"
 
-#. js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "获取照片"
 
-#. js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "点击从设备获取照片"
 
-#. js/modules.js:1038
+#. 5.8/js/modules.js:1009
+#, fuzzy
+msgid "Ping Module"
+msgstr "Ping 操作模块"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#. js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "向设备 “{deviceName}” 发送 ping 信号"
 
-#. js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Ping 设备"
 
-#. js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "点击向设备发送 ping 信号"
 
-#. js/modules.js:1154
+#. 5.8/js/modules.js:1062
+#, fuzzy
+msgid "Share Module"
+msgstr "分享操作模块"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "从 “{deviceName}” 收到了分享"
 
-#. js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "分享"
 
-#. js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "发送 URL"
 
-#. js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "点击发送一个 URL 到设备"
 
-#. js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "发送文本"
 
-#. js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "点击发送文本到设备"
 
-#. js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "发送文件"
 
-#. js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "点击发送文件到设备"
 
-#. js/modules.js:1279
+#. 5.8/js/modules.js:1243
+#, fuzzy
+msgid "SFTP Module"
+msgstr "SFTP 操作模块"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "卸载"
 
-#. js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "挂载"
 
-#. js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "点击卸载"
 
-#. js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "点击挂载"
 
-#. js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "点击浏览文件"
 
-#. js/modules.js:1466
+#. 5.8/js/modules.js:1463
+#, fuzzy
+msgid "SMS Module"
+msgstr "短信操作模块"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "短信"
 
-#. js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "启动短信应用程序"
 
-#. js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "点击打开 KDE Connect 短信应用程序"
 
-#. js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "发送短信"
 
-#. settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "KDE Connect 小程序"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "已将 {typestring} 复制到剪贴板上"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "上移所选条目"
 
-#. settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "下移所选条目"
 
-#. py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "发送 URL 到 “{device_name}”"
 
-#. py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "取消"
 
-#. py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "发送"
 
-#. py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "输入一个要发送到 “{device_name}” 的 URL"
 
-#. py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "URL"
 
-#. py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "使用 “{device_name}” 发送短信"
 
-#. py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "电话号码："
 
-#. py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "电话号码"
 
-#. py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "信息："
 
-#. py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "发送文本到 “{device_name}”"
 
-#. py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "要发送的文本："
 
-#. py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "发送文本到 “{device_name}”"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "选择要发送到 “{deviceName}” 的文件"
 
-#. py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "选择从 “{deviceName}” 收到的照片的保存位置"
 
-#. py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "照片.jpg"
 
-#. py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "JPEG 照片"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "KDE Connect 小程序"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -340,218 +410,289 @@ msgstr "Johannes Schoeneberger - 作者"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - 小程序的灵感来源"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "常规"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "模块"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "右键菜单"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "面板"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "设备"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "信息模块"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "操作模块"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "电池信息模块"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "设备信息模块"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "连接信息模块"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "寻找手机操作模块"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "获取照片操作模块"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Ping 操作模块"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "分享操作模块"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "SFTP 操作模块"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "短信操作模块"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "在小程序的右键菜单中显示自己的 ID"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "在小程序的右键菜单中显示 KDE Connect 版本"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "在面板的图标旁边显示连接的设备数量"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "在小程序的提示框中显示设备数量"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "图标类型"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "符号"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "彩色"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "使用自定义图标"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "要使用的自定义图标"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "打开 KDE Connect 配置"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
 msgstr "如果只有一个设备可用，则自动展开设备子菜单"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "名称"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "展开"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "启用"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "显示设备当前的电池电量和充电状态"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "显示设备图标和它的 ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "显示设备当前的连接状态和网络类型"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "显示移动网络类型"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr "使您的设备响铃，这样您就可以在放错位置时找到它"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr "让您从远程设备获取一张照片并保存在这个设备上"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "将收到的照片直接保存到目录中"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "保存接收到的照片的目录"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr "让您 ping 设备以确保它已连接"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "使用自定义消息进行 ping"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "自定义消息"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "让您与设备共享 URL、文件或文本"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "在子菜单中显示菜单项"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "启用发送 URL 的菜单项"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "启用发送文本的菜单项"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "启用发送文件的菜单项"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr "让您远程浏览设备上选择的存储空间"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "允许您在此设备远程发送短信"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "启用发送短信的菜单项"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "启用启动 KDE Connect 短信程序的菜单项"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/zh_TW.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/zh_TW.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: kdecapplet@joejoetv 2025\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-26 19:50+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-08-22 18:28+0200\n"
 "PO-Revision-Date: 2025-08-02 00:57+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -17,310 +18,366 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: applet.js:574
+#. 5.8/applet.js:547 4.8/applet.js:574
 msgid "No Modules available"
 msgstr "沒有可用的模組"
 
-#: applet.js:1065
-msgid "KDE Connect not available"
-msgstr "KDE Connect 無法使用"
-
-#: applet.js:1068
+#. 5.8/applet.js:1021 5.8/applet.js:1024 4.8/applet.js:1065 4.8/applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr "KDE Connect 無法使用，請確認已正確安裝並且為執行狀態。"
 
-#: applet.js:1072 applet.js:1085 applet.js:1270
+#. 5.8/applet.js:1028 5.8/applet.js:1041 5.8/applet.js:1230 4.8/applet.js:1072
+#. 4.8/applet.js:1085 4.8/applet.js:1270
 msgid "Reload Applet"
 msgstr "重新載入小程式"
 
-#: applet.js:1077
+#. 5.8/applet.js:1033 4.8/applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "KDE Connect 回傳的版本無效！"
 
-#: applet.js:1078 applet.js:1081
+#. 5.8/applet.js:1034 5.8/applet.js:1037 4.8/applet.js:1078 4.8/applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
-msgstr ""
-"KDE Connect DBus 服務回傳的版本無效，請嘗試重新載入小程式！"
+msgstr "KDE Connect DBus 服務回傳的版本無效，請嘗試重新載入小程式！"
 
-#: applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "No connected Devices!"
 msgstr "沒有已連線的裝置！"
 
-#: applet.js:1120
+#. 5.8/applet.js:1075 4.8/applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "請在 KDE Connect 設定中新增裝置"
 
-#: applet.js:1165
+#. 5.8/applet.js:1120 4.8/applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "除錯專用，請勿碰觸！"
 
-#: applet.js:1254
+#. 5.8/applet.js:1209 4.8/applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect 版本：{version}"
 
-#: applet.js:1261
+#. 5.8/applet.js:1221 4.8/applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "本機 ID: {own_id}"
 
-#: applet.js:1263
+#. 5.8/applet.js:1223 4.8/applet.js:1263
 msgid "own ID"
 msgstr "本機 ID"
 
-#: applet.js:1265
+#. 5.8/applet.js:1225 4.8/applet.js:1265
 msgid "Click to copy own ID"
 msgstr "點選以複製本機 ID"
 
-#: applet.js:1275
+#. 5.8/applet.js:1235 4.8/applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "設定 KDE Connect"
 
-#: applet.js:1277
+#. 5.8/applet.js:1237 4.8/applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "點選以開啟 KDE Connect 設定"
 
-#: applet.js:1321
+#. 5.8/applet.js:1283 4.8/applet.js:1321
 msgid "No available devices"
 msgstr "沒有可用的裝置"
 
-#: applet.js:1323
+#. 5.8/applet.js:1285 4.8/applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} 部可用裝置"
 
-#: applet.js:1325
+#. 5.8/applet.js:1287 4.8/applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} 部可用裝置"
 
-#: js/commonUtils.js:223
-msgid "Copied {typestring} to the clipboard"
-msgstr "已將 {typestring} 複製到剪貼簿"
+#. 5.8/js/modules.js:450
+#, fuzzy
+msgid "Module"
+msgstr "功能模組"
 
-#: js/modules.js:656
+#. 5.8/js/modules.js:597
+msgid "Battery Module"
+msgstr "電池模組"
+
+#. 5.8/js/modules.js:646 4.8/js/modules.js:658
 msgid "Charging"
 msgstr "充電中"
 
-#: js/modules.js:739
+#. 5.8/js/modules.js:682
+msgid "Device-Info Module"
+msgstr "裝置資訊模組"
+
+#. 5.8/js/modules.js:731 4.8/js/modules.js:741
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#: js/modules.js:743
+#. 5.8/js/modules.js:735 4.8/js/modules.js:745
 msgid "Device ID"
 msgstr "裝置 ID"
 
-#: js/modules.js:747
+#. 5.8/js/modules.js:739 4.8/js/modules.js:749
 msgid "Click to copy ID"
 msgstr "點選以複製 ID"
 
-#: js/modules.js:820
+#. 5.8/js/modules.js:751
+msgid "Connectivity Module"
+msgstr "連線狀態模組"
+
+#. 5.8/js/modules.js:813 4.8/js/modules.js:822
 msgid "No Signal"
 msgstr "沒有訊號"
 
-#: js/modules.js:823
+#. 5.8/js/modules.js:816 4.8/js/modules.js:825
 msgid "Low"
 msgstr "弱"
 
-#: js/modules.js:826
+#. 5.8/js/modules.js:819 4.8/js/modules.js:828
 msgid "Ok"
 msgstr "普通"
 
-#: js/modules.js:829
+#. 5.8/js/modules.js:822 4.8/js/modules.js:831
 msgid "Good"
 msgstr "良好"
 
-#: js/modules.js:832
+#. 5.8/js/modules.js:825 4.8/js/modules.js:834
 msgid "Excellent"
 msgstr "極佳"
 
-#: js/modules.js:844
+#. 5.8/js/modules.js:837 4.8/js/modules.js:846
 msgid "Unknown"
 msgstr "未知"
 
-#: js/modules.js:898
+#. 5.8/js/modules.js:867
+msgid "FindMyPhone Module"
+msgstr "尋找手機模組"
+
+#. 5.8/js/modules.js:892 4.8/js/modules.js:900
 msgid "Ring device"
 msgstr "尋找裝置"
 
-#: js/modules.js:899
+#. 5.8/js/modules.js:893 4.8/js/modules.js:901
 msgid "Click to ring the device"
 msgstr "點選讓裝置響鈴"
 
-#: js/modules.js:978
+#. 5.8/js/modules.js:907
+msgid "Request Photo Module"
+msgstr "請求照片模組"
+
+#. 5.8/js/modules.js:973 4.8/js/modules.js:980
 msgid "Photo received from '{deviceName}'"
 msgstr "已從「{deviceName}」收到照片"
 
-#: js/modules.js:978 js/modules.js:1154
+#. 5.8/js/modules.js:973 5.8/js/modules.js:1151 4.8/js/modules.js:980
+#. 4.8/js/modules.js:1156
 msgid "Click to open in default application"
 msgstr "點選以使用預設應用程式開啟"
 
-#: js/modules.js:987
+#. 5.8/js/modules.js:982 4.8/js/modules.js:989
 msgid "Request Photo"
 msgstr "請求照片"
 
-#: js/modules.js:988
+#. 5.8/js/modules.js:983 4.8/js/modules.js:990
 msgid "Click to request a photo from the device"
 msgstr "點選以向裝置請求照片"
 
-#: js/modules.js:1038
+#. 5.8/js/modules.js:1009
+msgid "Ping Module"
+msgstr "Ping 模組"
+
+#. 5.8/js/modules.js:1034 4.8/js/modules.js:1040
 msgid "Ping!"
 msgstr "Ping!"
 
-#: js/modules.js:1045
+#. 5.8/js/modules.js:1041 4.8/js/modules.js:1047
 msgid "Sent ping to device '{deviceName}'"
 msgstr "已傳送 ping 到「{deviceName}」"
 
-#: js/modules.js:1051
+#. 5.8/js/modules.js:1047 4.8/js/modules.js:1053
 msgid "Ping Device"
 msgstr "Ping 裝置"
 
-#: js/modules.js:1052
+#. 5.8/js/modules.js:1048 4.8/js/modules.js:1054
 msgid "Click to send a ping to the device"
 msgstr "點選以傳送 ping 到裝置"
 
-#: js/modules.js:1154
+#. 5.8/js/modules.js:1062
+msgid "Share Module"
+msgstr "分享模組"
+
+#. 5.8/js/modules.js:1151 4.8/js/modules.js:1156
 msgid "Share received from '{deviceName}'"
 msgstr "已從「{deviceName}」收到分享內容"
 
-#: js/modules.js:1189
+#. 5.8/js/modules.js:1186 4.8/js/modules.js:1191
 msgid "Share"
 msgstr "分享"
 
-#: js/modules.js:1202
+#. 5.8/js/modules.js:1198 4.8/js/modules.js:1204
 msgid "Send URL"
 msgstr "傳送網址"
 
-#: js/modules.js:1203
+#. 5.8/js/modules.js:1199 4.8/js/modules.js:1205
 msgid "Click to send a URL to the device"
 msgstr "點選以傳送網址到裝置"
 
-#: js/modules.js:1212
+#. 5.8/js/modules.js:1208 4.8/js/modules.js:1214
 msgid "Send Text"
 msgstr "傳送文字"
 
-#: js/modules.js:1213 js/modules.js:1488
+#. 5.8/js/modules.js:1209 5.8/js/modules.js:1553 4.8/js/modules.js:1215
+#. 4.8/js/modules.js:1490
 msgid "Click to send text to the device"
 msgstr "點選以傳送文字到裝置"
 
-#: js/modules.js:1222
+#. 5.8/js/modules.js:1218 4.8/js/modules.js:1224
 msgid "Send File(s)"
 msgstr "傳送檔案"
 
-#: js/modules.js:1223
+#. 5.8/js/modules.js:1219 4.8/js/modules.js:1225
 msgid "Click to send file(s) to the device"
 msgstr "點選以傳送檔案到裝置"
 
-#: js/modules.js:1279
+#. 5.8/js/modules.js:1243
+msgid "SFTP Module"
+msgstr "SFTP 模組"
+
+#. 5.8/js/modules.js:1284 4.8/js/modules.js:1281
 msgid "Unmount"
 msgstr "卸除"
 
-#: js/modules.js:1281
+#. 5.8/js/modules.js:1286 4.8/js/modules.js:1283
 msgid "Mount"
 msgstr "掛載"
 
-#: js/modules.js:1287
+#. 5.8/js/modules.js:1292 4.8/js/modules.js:1289
 msgid "Click to unmount"
 msgstr "點選以卸除"
 
-#: js/modules.js:1289
+#. 5.8/js/modules.js:1294 4.8/js/modules.js:1291
 msgid "Click to mount"
 msgstr "點選以掛載"
 
-#: js/modules.js:1362
+#. 5.8/js/modules.js:1424 4.8/js/modules.js:1364
 msgid "Click to browse files"
 msgstr "點選以瀏覽檔案"
 
-#: js/modules.js:1466
+#. 5.8/js/modules.js:1463
+msgid "SMS Module"
+msgstr "SMS 模組"
+
+#. 5.8/js/modules.js:1532 4.8/js/modules.js:1468
 msgid "SMS"
 msgstr "SMS"
 
-#: js/modules.js:1479
+#. 5.8/js/modules.js:1544 4.8/js/modules.js:1481
 msgid "Launch SMS App"
 msgstr "啟動 SMS 應用程式"
 
-#: js/modules.js:1480
+#. 5.8/js/modules.js:1545 4.8/js/modules.js:1482
 msgid "Click to open the KDE Connect SMS App"
 msgstr "點選以開啟 KDE Connect SMS 應用程式"
 
-#: js/modules.js:1487
+#. 5.8/js/modules.js:1552 4.8/js/modules.js:1489
 msgid "Send SMS"
 msgstr "傳送 SMS"
 
-#: settingsWidgets.py:153
+#. metadata.json->name
+#. 5.8/js/utils.js:24
+msgid "KDE Connect Applet"
+msgstr "KDE Connect 小程式"
+
+#. 5.8/js/utils.js:126 4.8/js/commonUtils.js:223
+msgid "Copied {typestring} to the clipboard"
+msgstr "已將 {typestring} 複製到剪貼簿"
+
+#. 5.8/settingsWidgets.py:153 4.8/settingsWidgets.py:153
 msgid "Move selected entry up"
 msgstr "將選取的項目上移"
 
-#: settingsWidgets.py:160
+#. 5.8/settingsWidgets.py:160 4.8/settingsWidgets.py:160
 msgid "Move selected entry down"
 msgstr "將選取的項目下移"
 
-#: py/dialogs.py:40
+#. 5.8/py/dialogs.py:50 4.8/py/dialogs.py:43
 #, python-brace-format
 msgid "Send URL to '{device_name}'"
 msgstr "傳送網址到「{device_name}」"
 
-#: py/dialogs.py:47 py/dialogs.py:103 py/dialogs.py:166
+#. 5.8/py/dialogs.py:60 5.8/py/dialogs.py:132 5.8/py/dialogs.py:207
+#. 5.8/py/dialogs.py:285 4.8/py/dialogs.py:50 4.8/py/dialogs.py:106
+#. 4.8/py/dialogs.py:169
 msgid "Cancel"
 msgstr "取消"
 
-#: py/dialogs.py:50 py/dialogs.py:106 py/dialogs.py:169
+#. 5.8/py/dialogs.py:65 5.8/py/dialogs.py:137 5.8/py/dialogs.py:212
+#. 4.8/py/dialogs.py:53 4.8/py/dialogs.py:109 4.8/py/dialogs.py:172
 msgid "Send"
 msgstr "傳送"
 
-#: py/dialogs.py:57
+#. 5.8/py/dialogs.py:76 4.8/py/dialogs.py:60
 #, python-brace-format
 msgid "Enter a URL to send to '{device_name}'"
 msgstr "請輸入要傳送到「{device_name}」的網址"
 
-#: py/dialogs.py:61
+#. 5.8/py/dialogs.py:83 4.8/py/dialogs.py:64
 msgid "URL"
 msgstr "網址"
 
-#: py/dialogs.py:96
+#. 5.8/py/dialogs.py:122 4.8/py/dialogs.py:99
 #, python-brace-format
 msgid "Send SMS using '{device_name}'"
 msgstr "使用「{device_name}」傳送 SMS"
 
-#: py/dialogs.py:113
+#. 5.8/py/dialogs.py:147 4.8/py/dialogs.py:116
 msgid "Phone Number:"
 msgstr "電話號碼："
 
-#: py/dialogs.py:117
+#. 5.8/py/dialogs.py:151 4.8/py/dialogs.py:120
 msgid "Phone Number"
 msgstr "電話號碼"
 
-#: py/dialogs.py:119
+#. 5.8/py/dialogs.py:154 4.8/py/dialogs.py:122
 msgid "Message:"
 msgstr "訊息："
 
-#: py/dialogs.py:159
+#. 5.8/py/dialogs.py:197 4.8/py/dialogs.py:162
 #, python-brace-format
 msgid "Send text to '{device_name}'"
 msgstr "傳送文字到「{device_name}」"
 
-#: py/dialogs.py:176
+#. 5.8/py/dialogs.py:222 4.8/py/dialogs.py:179
 msgid "Text to send:"
 msgstr "要傳送的文字："
 
-#: py/dialogs.py:222
+#. 5.8/py/dialogs.py:271
+#, fuzzy, python-brace-format
+msgid "Open remote directory on '{device_name}'"
+msgstr "傳送文字到「{device_name}」"
+
+#. 5.8/py/dialogs.py:290
+msgid "Open"
+msgstr ""
+
+#. 5.8/py/dialogs.py:300
+msgid "Directory to open:"
+msgstr ""
+
+#. 5.8/py/dialogs.py:375 4.8/py/dialogs.py:225
 #, python-brace-format
 msgid "Select files to send to '{deviceName}'"
 msgstr "選取要傳送到「{deviceName}」的檔案"
 
-#: py/dialogs.py:283
+#. 5.8/py/dialogs.py:442 4.8/py/dialogs.py:286
 #, python-brace-format
 msgid "Select where to save photo received from '{deviceName}'"
 msgstr "選取從「{deviceName}」收到的照片要儲存的位置"
 
-#: py/dialogs.py:287
+#. 5.8/py/dialogs.py:449 4.8/py/dialogs.py:290
 msgid "photo.jpg"
 msgstr "photo.jpg"
 
-#: py/dialogs.py:290
+#. 5.8/py/dialogs.py:452 4.8/py/dialogs.py:293
 msgid "JPEG Photo"
 msgstr "JPEG 照片"
-
-#. metadata.json->name
-msgid "KDE Connect Applet"
-msgstr "KDE Connect 小程式"
 
 #. metadata.json->description
 msgid "Enables interacting with devices connected via KDE Connect"
@@ -328,9 +385,9 @@ msgstr "可與透過 KDE Connect 連線的裝置互動"
 
 #. metadata.json->comments
 msgid ""
-"KDE Connect Applet makes it easy to use the various features provided by KDE"
-" Connect to interact with connected devices, like sending files, sending SMS"
-" messages, browsing the storage of the device and more"
+"KDE Connect Applet makes it easy to use the various features provided by KDE "
+"Connect to interact with connected devices, like sending files, sending SMS "
+"messages, browsing the storage of the device and more"
 msgstr ""
 "KDE Connect 小程式讓您能輕鬆使用 KDE Connect 提供的多種功能來與連線裝置互動，"
 "例如傳送檔案、傳送 SMS 訊息、瀏覽裝置儲存空間等"
@@ -343,257 +400,289 @@ msgstr "Johannes Schoeneberger - 作者"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - 小程式靈感來源"
 
-#. settings-schema.json->page_general->title
+#. 5.8->settings-schema.json->page_general->title
+#. 4.8->settings-schema.json->page_general->title
 msgid "General"
 msgstr "一般"
 
-#. settings-schema.json->page_modules->title
+#. 5.8->settings-schema.json->page_modules->title
+#. 4.8->settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "功能模組"
 
-#. settings-schema.json->section_contextmenu->title
+#. 5.8->settings-schema.json->section_contextmenu->title
+#. 4.8->settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "右鍵選單"
 
-#. settings-schema.json->section_panel->title
+#. 5.8->settings-schema.json->section_panel->title
+#. 4.8->settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "面板"
 
-#. settings-schema.json->section_devices->title
+#. 5.8->settings-schema.json->section_devices->title
+#. 4.8->settings-schema.json->section_devices->title
 msgid "Devices"
 msgstr "裝置"
 
-#. settings-schema.json->section_info-modules->title
+#. 5.8->settings-schema.json->section_info-modules->title
+#. 4.8->settings-schema.json->section_info-modules->title
 msgid "Info Modules"
 msgstr "資訊模組"
 
-#. settings-schema.json->section_action-modules->title
+#. 5.8->settings-schema.json->section_action-modules->title
+#. 4.8->settings-schema.json->section_action-modules->title
 msgid "Action Modules"
 msgstr "動作模組"
 
-#. settings-schema.json->section_module_battery->title
+#. 5.8->settings-schema.json->section_module_battery->title
+#. 4.8->settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "電池資訊模組"
 
-#. settings-schema.json->section_module_deviceinfo->title
+#. 5.8->settings-schema.json->section_module_deviceinfo->title
+#. 4.8->settings-schema.json->section_module_deviceinfo->title
 msgid "Device-Info Info Module"
 msgstr "裝置資訊模組"
 
-#. settings-schema.json->section_module_connectivity->title
+#. 5.8->settings-schema.json->section_module_connectivity->title
+#. 4.8->settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "連線狀態資訊模組"
 
-#. settings-schema.json->section_module_findmyphone->title
+#. 5.8->settings-schema.json->section_module_findmyphone->title
+#. 4.8->settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "尋找我的手機動作模組"
 
-#. settings-schema.json->section_module_requestphoto->title
+#. 5.8->settings-schema.json->section_module_requestphoto->title
+#. 4.8->settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "請求照片動作模組"
 
-#. settings-schema.json->section_module_ping->title
+#. 5.8->settings-schema.json->section_module_ping->title
+#. 4.8->settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Ping 動作模組"
 
-#. settings-schema.json->section_module_share->title
+#. 5.8->settings-schema.json->section_module_share->title
+#. 4.8->settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "分享動作模組"
 
-#. settings-schema.json->section_module_sftp->title
+#. 5.8->settings-schema.json->section_module_sftp->title
+#. 4.8->settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "SFTP 動作模組"
 
-#. settings-schema.json->section_module_sms->title
+#. 5.8->settings-schema.json->section_module_sms->title
+#. 4.8->settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "SMS 動作模組"
 
-#. settings-schema.json->switch_show-own-id->description
+#. 5.8->settings-schema.json->switch_show-own-id->description
+#. 4.8->settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "在小程式的右鍵選單中顯示本機 ID"
 
-#. settings-schema.json->switch_show-kdec-version->description
+#. 5.8->settings-schema.json->switch_show-kdec-version->description
+#. 4.8->settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "在小程式的右鍵選單中顯示 KDE Connect 版本"
 
-#. settings-schema.json->switch_show-device-count->description
+#. 5.8->settings-schema.json->switch_show-device-count->description
+#. 4.8->settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "在面板圖示旁顯示已連線的裝置數量"
 
-#. settings-schema.json->switch_show-device-count-tooltip->description
+#. 5.8->settings-schema.json->switch_show-device-count-tooltip->description
+#. 4.8->settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "在小程式的工具提示中顯示裝置數量"
 
-#. settings-schema.json->combobox_icon-type->description
+#. 5.8->settings-schema.json->combobox_icon-type->description
+#. 4.8->settings-schema.json->combobox_icon-type->description
 msgid "Icon type"
 msgstr "圖示類型"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Symbolic"
 msgstr "符號式"
 
-#. settings-schema.json->combobox_icon-type->options
+#. 5.8->settings-schema.json->combobox_icon-type->options
+#. 4.8->settings-schema.json->combobox_icon-type->options
 msgid "Color"
 msgstr "彩色"
 
-#. settings-schema.json->switch_use-custom-icon->description
+#. 5.8->settings-schema.json->switch_use-custom-icon->description
+#. 4.8->settings-schema.json->switch_use-custom-icon->description
 msgid "Use custom icon"
 msgstr "使用自訂圖示"
 
-#. settings-schema.json->icon_custom-icon->description
+#. 5.8->settings-schema.json->icon_custom-icon->description
+#. 4.8->settings-schema.json->icon_custom-icon->description
 msgid "Custom icon to use"
 msgstr "要使用的自訂圖示"
 
-#. settings-schema.json->button_open-kdec-settings->description
+#. 5.8->settings-schema.json->switch_different-icon-no-connected-
+#. devices->description
+msgid "Display a different icon when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->icon_no-connected-devices->description
+msgid "Icon to use when no devices are connected"
+msgstr ""
+
+#. 5.8->settings-schema.json->button_open-kdec-settings->description
+#. 4.8->settings-schema.json->button_open-kdec-settings->description
 msgid "Open KDE Connect Configuration"
 msgstr "開啟 KDE Connect 設定"
 
-#. settings-schema.json->switch_expand-only-device->description
+#. 5.8->settings-schema.json->switch_expand-only-device->description
+#. 4.8->settings-schema.json->switch_expand-only-device->description
 msgid ""
 "Expand the device sub menu automatically, if only one device is available"
-msgstr ""
-"若只有一部裝置可用，則自動展開裝置子選單"
+msgstr "若只有一部裝置可用，則自動展開裝置子選單"
 
-#. settings-schema.json->orderlist_device-order->columns->title
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Name"
 msgstr "名稱"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "Expand"
 msgstr "展開"
 
-#. settings-schema.json->orderlist_device-order->columns->title
+#. 5.8->settings-schema.json->orderlist_device-order->columns->title
+#. 4.8->settings-schema.json->orderlist_device-order->columns->title
 msgid "UUID"
 msgstr "UUID"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "Enabled"
 msgstr "啟用"
 
-#. settings-schema.json->oderlist_info-modules->columns->title
-#. settings-schema.json->oderlist_action-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 5.8->settings-schema.json->oderlist_action-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_info-modules->columns->title
+#. 4.8->settings-schema.json->oderlist_action-modules->columns->title
 msgid "ID"
 msgstr "ID"
 
-#. settings-schema.json->module_battery_description->description
+#. 5.8->settings-schema.json->module_battery_description->description
+#. 4.8->settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "顯示裝置目前的電池電量與充電狀態"
 
-#. settings-schema.json->module_deviceinfo_description->description
+#. 5.8->settings-schema.json->module_deviceinfo_description->description
+#. 4.8->settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "顯示裝置圖示及其 ID"
 
-#. settings-schema.json->module_connectivity_description->description
+#. 5.8->settings-schema.json->module_connectivity_description->description
+#. 4.8->settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "顯示裝置目前連線狀態與網路類型"
 
-#. settings-schema.json->module_connectivity_showNetworkType->description
+#. 5.8->settings-schema.json->module_connectivity_showNetworkType->description
+#. 4.8->settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "顯示行動網路類型"
 
-#. settings-schema.json->module_findmyphone_description->description
+#. 5.8->settings-schema.json->module_findmyphone_description->description
+#. 4.8->settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
-msgstr ""
-"讓裝置響鈴，方便在遺失或放錯位置時尋找裝置"
+msgstr "讓裝置響鈴，方便在遺失或放錯位置時尋找裝置"
 
-#. settings-schema.json->module_requestphoto_description->description
+#. 5.8->settings-schema.json->module_requestphoto_description->description
+#. 4.8->settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
-msgstr ""
-"讓您能向遠端裝置請求照片並將其儲存在此裝置上"
+msgstr "讓您能向遠端裝置請求照片並將其儲存在此裝置上"
 
-#. settings-schema.json->module_requestphoto_saveToDir->description
+#. 5.8->settings-schema.json->module_requestphoto_saveToDir->description
+#. 4.8->settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "將收到的照片直接儲存到目錄"
 
-#. settings-schema.json->module_requestphoto_saveDirectory->description
+#. 5.8->settings-schema.json->module_requestphoto_saveDirectory->description
+#. 4.8->settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "儲存收到照片的目錄"
 
-#. settings-schema.json->module_ping_description->description
+#. 5.8->settings-schema.json->module_ping_description->description
+#. 4.8->settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr "讓您能對裝置發送 ping 以確認其連線狀態"
 
-#. settings-schema.json->module_ping_useCustomMessage->description
+#. 5.8->settings-schema.json->module_ping_useCustomMessage->description
+#. 4.8->settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "使用自訂訊息進行 ping"
 
-#. settings-schema.json->module_ping_customMessage->description
+#. 5.8->settings-schema.json->module_ping_customMessage->description
+#. 4.8->settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "自訂訊息"
 
-#. settings-schema.json->module_share_description->description
+#. 5.8->settings-schema.json->module_share_description->description
+#. 4.8->settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "讓您能分享網址、檔案或文字到裝置"
 
-#. settings-schema.json->module_share_useSubMenu->description
-#. settings-schema.json->module_sms_useSubMenu->description
+#. 5.8->settings-schema.json->module_share_useSubMenu->description
+#. 5.8->settings-schema.json->module_sms_useSubMenu->description
+#. 4.8->settings-schema.json->module_share_useSubMenu->description
+#. 4.8->settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "在子選單中顯示選單選項"
 
-#. settings-schema.json->module_share_enableSendURL->description
+#. 5.8->settings-schema.json->module_share_enableSendURL->description
+#. 4.8->settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "啟用傳送網址的選單選項"
 
-#. settings-schema.json->module_share_enableSendText->description
+#. 5.8->settings-schema.json->module_share_enableSendText->description
+#. 4.8->settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "啟用傳送文字的選單選項"
 
-#. settings-schema.json->module_share_enableSendFiles->description
+#. 5.8->settings-schema.json->module_share_enableSendFiles->description
+#. 4.8->settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "啟用傳送檔案的選單選項"
 
-#. settings-schema.json->module_sftp_description->description
-msgid "Lets you remotely browse the storage selected on the device"
+#. 5.8->settings-schema.json->module_sftp_description->description
+#. 4.8->settings-schema.json->module_sftp_description->description
+#, fuzzy
+msgid "Lets you remotely browse the storage of the device"
 msgstr "讓您能遠端瀏覽在裝置上選取的儲存空間"
 
-#. settings-schema.json->module_sms_description->description
+#. 5.8->settings-schema.json->module_sftp_selectFirstDirectory->description
+msgid "Select the first directory automatically"
+msgstr ""
+
+#. 5.8->settings-schema.json->module_sms_description->description
+#. 4.8->settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "讓您能從裝置遠端傳送 SMS 訊息"
 
-#. settings-schema.json->module_sms_enableSendSMS->description
+#. 5.8->settings-schema.json->module_sms_enableSendSMS->description
+#. 4.8->settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "啟用傳送 SMS 訊息的選單選項"
 
-#. settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 5.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
+#. 4.8->settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "啟用啟動 KDE Connect SMS 應用程式的選單選項"
-
-#: display name of module battery
-msgid "Battery Module"
-msgstr "電池模組"
-
-#: display name of module deviceinfo
-msgid "Device-Info Module"
-msgstr "裝置資訊模組"
-
-#: display name of module connectivity
-msgid "Connectivity Module"
-msgstr "連線狀態模組"
-
-#: display name of module findmyphone
-msgid "FindMyPhone Module"
-msgstr "尋找手機模組"
-
-#: display name of module requestphoto
-msgid "Request Photo Module"
-msgstr "請求照片模組"
-
-#: display name of module ping
-msgid "Ping Module"
-msgstr "Ping 模組"
-
-#: display name of module share
-msgid "Share Module"
-msgstr "分享模組"
-
-#: display name of module sftp
-msgid "SFTP Module"
-msgstr "SFTP 模組"
-
-#: display name of module sms
-msgid "SMS Module"
-msgstr "SMS 模組"


### PR DESCRIPTION
New version of the KDE Connect applet with following changes:

- CLEANUP: Remove unnecessary polyfill function for Cinnamon 5.8 code.
- FIX: Phones using the wrong Icon in the device info module.
- CHANGE: Add option to display a different icon when no devices are connected.
- FIX: Update wording for SFTP module description due to changes in how KDE Connect works.

This should also close issue #6254.