### PR TITLE
[notifications-enhanced@hilyxx] Version 1.3.1

### DIFF
--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/applet.js
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/applet.js
@@ -18,6 +18,8 @@ const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 const UUID = "notifications-enhanced@hilyxx";
 Gettext.bindtextdomain(UUID, GLib.get_user_data_dir() + "/locale");
 
+const interfaceSettings = new Gio.Settings({schema_id: 'org.cinnamon.desktop.interface'});
+
 function _(str) {
     return Gettext.dgettext(UUID, str);
 }
@@ -122,6 +124,11 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         if (this._normalBlinkTimeout) {
             Mainloop.source_remove(this._normalBlinkTimeout);
             this._normalBlinkTimeout = null;
+        }
+
+        if (this._warmupTimeoutId) {
+            Mainloop.source_remove(this._warmupTimeoutId);
+            this._warmupTimeoutId = null;
         }
 
         // Only used in cinnamon 6.6 and later
@@ -277,7 +284,17 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
                 this.notifications.splice(existing_index, 1);
             } else {
                 notification._inNotificationBin = true;
-                global.reparentActor(notification.actor, this._notificationbin);
+               
+                let parent = notification.actor.get_parent();
+                
+                if (parent && parent !== this._notificationbin) {
+                    parent.remove_child(notification.actor);
+                }
+                
+                if (notification.actor.get_parent() !== this._notificationbin) {
+                    this._notificationbin.add_child(notification.actor);
+                }
+                
                 notification._timeLabel.show();
             }
             this.update_list();
@@ -293,13 +310,24 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         this._notificationbin.add(notification.actor);
         notification.actor._parent_container = this._notificationbin;
         notification.actor.add_style_class_name('notification-applet-padding');
+        // Cache each notification subtree in an offscreen texture.
+        notification.actor.set_offscreen_redirect(imports.gi.Clutter.OffscreenRedirect.ALWAYS);
+
+        this._cacheSlotSeq = (this._cacheSlotSeq || 0) + 1;
+        notification.actor.add_style_class_name('notification-cache-slot-' + this._cacheSlotSeq);
 
         // Enable middle-click to close notifications.
         notification.actor.connect('button-press-event', (actor, event) => {
             if (event.get_button && event.get_button() === 2) {
-                notification.destroy(NotificationDestroyedReason.DISMISSED);
+                this._notificationbin.remove_actor(notification.actor);
+        
+                 notification.destroy(NotificationDestroyedReason.DISMISSED);
+        
+                 return true;
             }
+            return false;
         });
+
         // Register for destruction.
         notification.connect('scrolling-changed', (notif, scrolling) => { this.menu.passEvents = scrolling });
         notification.connect('destroy', () => {
@@ -399,10 +427,42 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
             this.menu_label.label.set_text(stringify(count));
             this._notificationbin.queue_relayout();
 
+            // Pre-render the menu off-screen after list changes, so the first
+            // click doesn't pay the one-time cairo rasterization of the new
+            // notification (and of the resized menu background).
+            this._scheduleMenuWarmup();
+
         } catch (e) {
             global.logError(e);
         }
      }
+
+    // St rasterizes CSS backgrounds on the CPU during the first paint of a
+    // theme node at a given size.
+    _scheduleMenuWarmup() {
+        if (this._warmupTimeoutId) {
+            Mainloop.source_remove(this._warmupTimeoutId);
+            this._warmupTimeoutId = 0;
+        }
+        this._warmupTimeoutId = Mainloop.timeout_add(1500, () => {
+            this._warmupTimeoutId = 0;
+            if (this._is_destroyed || this.menu.isOpen || this.menu.actor.visible)
+                return false;
+            let actor = this.menu.actor;
+            let oldOpacity = actor.opacity;
+            actor.opacity = 1;
+            actor.reactive = false;
+            actor.show();
+            Mainloop.timeout_add(100, () => {
+                if (!this.menu.isOpen)
+                    actor.hide();
+                actor.opacity = oldOpacity;
+                actor.reactive = true;
+                return false;
+            });
+            return false;
+        });
+    }
 
      _clear_all() {
         let count = this.notifications.length;
@@ -423,15 +483,9 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
             orderedNotifications.reverse();
         }
 
-        // Remove all children without destroying them.
-        let children = this._notificationbin.get_children();
-        for (let i = 0; i < children.length; i++) {
-            this._notificationbin.remove_child(children[i]);
-        }
-
-        // Add them back in desired order.
         for (let i = 0; i < orderedNotifications.length; i++) {
-            this._notificationbin.add_child(orderedNotifications[i].actor);
+            let actor = orderedNotifications[i].actor;
+            this._notificationbin.set_child_at_index(actor, i);
         }
     }
 
@@ -558,16 +612,23 @@ function stringify(count) {
 }
 
 function timeify(orig_time) {
-    let settings = new Gio.Settings({schema_id: 'org.cinnamon.desktop.interface'});
-    let use_24h = settings.get_boolean('clock-use-24h');
+    let use_24h = interfaceSettings.get_boolean('clock-use-24h');
     let now = new Date();
     let diff = Math.floor((now.getTime() - orig_time.getTime()) / 1000); // get diff in seconds
-    let str;
-    if (use_24h) {
-        str = orig_time.toLocaleFormat('%x, %T');
-    } else {
-        str = orig_time.toLocaleFormat('%x, %r');
-    }
+    
+    let options = {
+        year: 'numeric', 
+        month: 'numeric', 
+        day: 'numeric',
+        hour: '2-digit', 
+        minute: '2-digit', 
+        second: '2-digit',
+        hour12: !use_24h
+    };
+    
+    let formatter = new Intl.DateTimeFormat('default', options);
+    let str = formatter.format(orig_time);
+
     switch (true) {
         case (diff <= 15): {
             str += " (" + _("just now") + ")";

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/metadata.json
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/metadata.json
@@ -3,7 +3,7 @@
     "name": "Notifications-Enhanced",
     "description": "A notification applet but with more options",
     "website": "https://github.com/linuxmint/cinnamon-spices-applets",
-    "version": "1.3",
+    "version": "1.3.1",
     "author": "hilyxx",
     "role": "notifications"
 }

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/ca.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: 2026-08-04 01:57+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:43
+#. applet.js:45
 msgid "Notifications applet conflict"
 msgstr "Conflicte amb la miniaplicació de notificacions"
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
@@ -32,54 +32,54 @@ msgstr ""
 "Elimina'l i reinicia Cinnamon abans d'utilitzar la miniaplicació "
 "Notifications-Enhanced."
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "No molestar"
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr "No hi ha notificacions"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "Netejar notificacions"
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "Activar notificacions"
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "Configuració de notificacions"
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notificació"
 msgstr[1] "%d notificacions"
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr "Notificacions"
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "Notificacions desactivades"
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr "ara mateix"
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "fa %d segon"
 msgstr[1] "fa %d segons"
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/es.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: 2026-08-04 01:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:43
+#. applet.js:45
 msgid "Notifications applet conflict"
 msgstr "Conflicto del applet de notificaciones"
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
@@ -31,54 +31,54 @@ msgstr ""
 "Elimínalo y reinicia Cinnamon antes de usar el applet Notificaciones-"
 "Mejoradas."
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "No molestar"
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr "Sin notificaciones"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "Borrar notificaciones"
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "Habilitar notificaciones"
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "Configuración de notificaciones"
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notificación"
 msgstr[1] "%d notificaciones"
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr "Notificaciones"
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "Notificaciones desactivadas"
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr "ahora mismo"
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "hace %d segundo"
 msgstr[1] "hace %d segundos"
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/fi.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: 2026-08-04 02:03+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,12 +18,12 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:43
+#. applet.js:45
 #, fuzzy
 msgid "Notifications applet conflict"
 msgstr "Ilmoitukset pois"
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
@@ -32,54 +32,54 @@ msgstr ""
 "Poista se ja käynnistä Cinnamon uudelleen ennen kuin käytät Notifications-"
 "Enhanced-sovelmaa."
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "Älä häiritse"
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr "Ei ilmoituksia"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "Tyhjennä ilmoitukset"
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "Näytä ilmoitukset"
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "Ilmoitusten asetukset"
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d ilmoitus"
 msgstr[1] "%d ilmoitusta"
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr "Ilmoitukset"
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "Ilmoitukset pois"
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr "juuri nyt"
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d sekunti sitten"
 msgstr[1] "%d sekuntia sitten"
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/fr.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/fr.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:43
+#. applet.js:45
 msgid "Notifications applet conflict"
 msgstr "Conflit d'applets de notifications"
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
@@ -31,54 +31,54 @@ msgstr ""
 "Retirez-le et redémarrez Cinnamon avant d'utiliser l'applet Notifications-"
 "Enhanced."
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "Ne pas déranger"
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr "Aucune notification"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "Effacer les notifications"
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "Activer les notifications"
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "Paramètres des notifications"
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notification"
 msgstr[1] "%d notifications"
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr "Notifications"
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "Notifications désactivées"
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr "à l'instant"
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "il y a %d seconde"
 msgstr[1] "il y a %d secondes"
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/hu.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: 2026-08-04 02:05+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,12 +18,12 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:43
+#. applet.js:45
 #, fuzzy
 msgid "Notifications applet conflict"
 msgstr "Értesítések letiltva"
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
@@ -32,54 +32,54 @@ msgstr ""
 "Távolítsa el, majd indítsa újra a Cinnamont a Notifications-Enhanced "
 "kisalkalmazás használata előtt."
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "Ne zavarj"
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr "Nincsenek értesítések"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "Értesítések törlése"
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "Értesítések engedélyezése"
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "Értesítési beállítások"
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d értesítés"
 msgstr[1] "%d értesítések"
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr "Értesítések"
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "Értesítések letiltva"
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr "épp most"
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d másodperce"
 msgstr[1] "%d másodperce"
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/it.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/it.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: 2026-08-04 02:05+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:43
+#. applet.js:45
 msgid "Notifications applet conflict"
 msgstr "Conflitto dell'applet di notifica"
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
@@ -31,54 +31,54 @@ msgstr ""
 "Rimuoverlo e riavviare Cinnamon prima di utilizzare l'applet Notifiche "
 "Migliorate."
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "Non disturbare"
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr "Nessuna notifica"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "Svuota notifiche"
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "Abilita notifiche"
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "Impostazioni notifica"
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notifica"
 msgstr[1] "%d notifiche"
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr "Notifiche"
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "Notifiche disattivate"
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr "adesso"
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d secondo fa"
 msgstr[1] "%d secondi fa"
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/nl.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: 2026-08-04 02:07+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:43
+#. applet.js:45
 msgid "Notifications applet conflict"
 msgstr "Conflict meldingen-applet"
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
@@ -31,54 +31,54 @@ msgstr ""
 "Verwijder dit en herstart Cinnamon voordat je de Verbeterde Meldingen-applet "
 "gebruikt."
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "Niet storen"
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr "Geen meldingen"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "Wis meldingen"
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "Schakel meldingen in"
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "Melding Instellingen"
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d melding"
 msgstr[1] "%d meldingen"
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr "Meldingen"
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "Meldingen uitgeschakeld"
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr "zojuist"
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d seconde geleden"
 msgstr[1] "%d seconden geleden"
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/notifications-enhanced@hilyxx.pot
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/notifications-enhanced@hilyxx.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
+"Project-Id-Version: notifications-enhanced@hilyxx 1.3.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,64 +18,64 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#. applet.js:43
+#. applet.js:45
 msgid "Notifications applet conflict"
 msgstr ""
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
 msgstr ""
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr ""
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr ""
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr ""
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr ""
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr ""
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr ""
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr ""
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr ""
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/pt_BR.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/pt_BR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: 2026-08-04 02:11+0200\n"
 "Last-Translator: Renan Lazarotto <renanlazarotto@gmail.com>\n"
 "Language-Team: Renan Lazarotto <renanlazarotto@gmail.com>\n"
@@ -19,12 +19,12 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:43
+#. applet.js:45
 #, fuzzy
 msgid "Notifications applet conflict"
 msgstr "Notificações desabilitadas"
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
@@ -32,54 +32,54 @@ msgstr ""
 "Conflito detectado: notifications@cinnamon.org está ativo.\n"
 "Remova-o e reinicie o Cinnamon antes de usar o applet Notifications-Enhanced."
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "Não perturbe"
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr "Sem notificações"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "Limpar notificações"
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "Habilitar notificações"
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "Configurações de notificação"
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d notificação"
 msgstr[1] "%d notificações"
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr "Notificações"
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "Notificações desabilitadas"
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr "agora"
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "há %d segundo"
 msgstr[1] "há %d segundos"
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/vi.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/vi.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.22\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/issues\n"
-"POT-Creation-Date: 2025-08-05 12:43+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -18,64 +19,65 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. applet.js:44
+#. applet.js:45
 msgid "Notifications applet conflict"
 msgstr "Xung đột applet thông báo"
 
-#. applet.js:45
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
 msgstr ""
 "Phát hiện xung đột: notifications@cinnamon.org đang hoạt động.\n"
-"Hãy gỡ bỏ và khởi động lại Cinnamon trước khi sử dụng applet Notifications-Enhanced."
+"Hãy gỡ bỏ và khởi động lại Cinnamon trước khi sử dụng applet Notifications-"
+"Enhanced."
 
-#. applet.js:120
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "Không làm phiền"
 
-#. applet.js:126
+#. applet.js:177
 msgid "No notifications"
 msgstr "Không có thông báo"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:134
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "Xóa thông báo"
 
-#. applet.js:157
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "Bật thông báo"
 
-#. applet.js:168
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "Cài đặt thông báo"
 
-#. applet.js:257 applet.js:431
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d thông báo"
 
-#. applet.js:287
+#. applet.js:392
 msgid "Notifications"
 msgstr "Thông báo"
 
-#. applet.js:300
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "Thông báo bị tắt"
 
-#. applet.js:447
+#. applet.js:634
 msgid "just now"
 msgstr "vừa xong"
 
-#. applet.js:450
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "cách đây %d giây"
 
-#. applet.js:454
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"
@@ -109,6 +111,11 @@ msgstr "Hiển thị"
 msgid "Show the number of notifications"
 msgstr "Hiển thị số lượng thông báo"
 
+#. settings-schema.json->showNewestFirst->description
+#, fuzzy
+msgid "Show newest notifications first"
+msgstr "Hiển thị thông báo"
+
 #. settings-schema.json->showEmptyTray->description
 msgid "Show notification tray"
 msgstr "Hiển thị khay thông báo"
@@ -122,8 +129,12 @@ msgid "Always show 'Do Not Disturb' icon"
 msgstr "Luôn hiển thị biểu tượng 'Không làm phiền'"
 
 #. settings-schema.json->showDisturbIcon->tooltip
-msgid "Check this to show the 'Do Not Disturb icon' on the panel even when the 'Show notification tray' option is disabled."
-msgstr "Chọn để hiển thị biểu tượng 'Không làm phiền' trên panel ngay cả khi tùy chọn 'Hiển thị khay thông báo' bị tắt."
+msgid ""
+"Check this to show the 'Do Not Disturb icon' on the panel even when the "
+"'Show notification tray' option is disabled."
+msgstr ""
+"Chọn để hiển thị biểu tượng 'Không làm phiền' trên panel ngay cả khi tùy "
+"chọn 'Hiển thị khay thông báo' bị tắt."
 
 #. settings-schema.json->showNotificationSettings->description
 msgid "Show notification settings in the menu"

--- a/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/zh_TW.po
+++ b/notifications-enhanced@hilyxx/files/notifications-enhanced@hilyxx/po/zh_TW.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: notifications-enhanced@hilyxx 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-08-04 01:50+0200\n"
+"POT-Creation-Date: 2026-08-24 14:54+0200\n"
 "PO-Revision-Date: 2026-08-04 02:13+0200\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.6\n"
 
-#. applet.js:43
+#. applet.js:45
 msgid "Notifications applet conflict"
 msgstr "通知小程式發生衝突"
 
-#. applet.js:44
+#. applet.js:46
 msgid ""
 "Conflict detected: notifications@cinnamon.org is active.\n"
 "Remove it and restart Cinnamon before using Notifications-Enhanced applet."
@@ -30,52 +30,52 @@ msgstr ""
 "偵測到衝突：notifications@cinnamon.org 目前為啟用狀態。\n"
 "請移除該小程式並重新啟動 Cinnamon，再使用 Notifications-Enhanced 小程式。"
 
-#. applet.js:164
+#. applet.js:171
 msgid "Do not disturb"
 msgstr "請勿打擾"
 
-#. applet.js:170
+#. applet.js:177
 msgid "No notifications"
 msgstr "沒有任何通知"
 
 #. settings-schema.json->keyClear->description
-#. applet.js:178
+#. applet.js:185
 msgid "Clear notifications"
 msgstr "清除通知"
 
-#. applet.js:193
+#. applet.js:200
 msgid "Enable notifications"
 msgstr "啟用通知"
 
-#. applet.js:204
+#. applet.js:211
 msgid "Notification Settings"
 msgstr "通知設定"
 
-#. applet.js:327 applet.js:558
+#. applet.js:355 applet.js:611
 #, javascript-format
 msgid "%d notification"
 msgid_plural "%d notifications"
 msgstr[0] "%d 則通知"
 
-#. applet.js:364
+#. applet.js:392
 msgid "Notifications"
 msgstr "通知"
 
-#. applet.js:377
+#. applet.js:405
 msgid "Notifications disabled"
 msgstr "通知已停用"
 
-#. applet.js:574
+#. applet.js:634
 msgid "just now"
 msgstr "剛剛"
 
-#. applet.js:577
+#. applet.js:637
 #, javascript-format
 msgid "%d second ago"
 msgid_plural "%d seconds ago"
 msgstr[0] "%d 秒前"
 
-#. applet.js:581
+#. applet.js:641
 #, javascript-format
 msgid "%d minute ago"
 msgid_plural "%d minutes ago"


### PR DESCRIPTION
- clean up actor and stop event propagation on middle-click **Fix** #8988 
- Use Intl.DateTimeFormat in timeify() and cache Gio.Settings instance
- Replace deprecated global.reparentActor with standard Clutter API
- Use set_child_at_index in _reorderNotifications to prevent UI reflows
- Pre-renders the menu off-screen after notification list changes. This avoids the heavy Cairo rasterization delays when the user opens the menu.(rumours86). **Merge and close** #8987 