### PR TITLE
Sensors d3cold support

### DIFF
--- a/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
+++ b/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v5.11.5~20260825
+  * Add Nvidia D3cold support.
+
 ### v5.11.4~20260508
   * Installing dependencies: Use pkgcli when available.
 

--- a/Sensors@claudiux/files/Sensors@claudiux/applet.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/applet.js
@@ -268,7 +268,9 @@ class SensorsApplet extends Applet.Applet {
       this.strictly_positive_fan ? 1 : 0,
       this.strictly_positive_volt ? 1 : 0
     );
-    this.reaper.reap_nvidia_smi();
+    this.reaper.reap_nvidia_smi(
+      this.no_check_gpu_if_d3cold ? 1 : 0
+    )
 
     // Events:
     this._connectIds = [];
@@ -428,6 +430,7 @@ class SensorsApplet extends Applet.Applet {
     this.s.bind("numberOfTempSensors", "numberOfTempSensors");
     this.s.bind("temp_disks", "temp_disks", this._on_temp_disks_modified.bind(this));
     this.s.bind("journalize_temp", "journalize_temp");
+    this.s.bind("no_check_gpu_if_d3cold", "no_check_gpu_if_d3cold");
 
     // Fan tab
     this.s.bind("show_fan", "show_fan", () => { this.populate_fan_sensors_in_settings() });
@@ -589,7 +592,9 @@ class SensorsApplet extends Applet.Applet {
         this.strictly_positive_fan ? 1 : 0,
         this.strictly_positive_volt ? 1 : 0
       );
-      this.reaper.reap_nvidia_smi();
+      this.reaper.reap_nvidia_smi(
+        this.no_check_gpu_if_d3cold ? 1 : 0
+      )
     } else {
       this.set_applet_label(_("Suspended"));
     }

--- a/Sensors@claudiux/files/Sensors@claudiux/lib/sensorsReaper.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/lib/sensorsReaper.js
@@ -181,7 +181,7 @@ class SensorsReaper {
                     }
                   });
                 }
-                testProcess.send_signal(9)
+                testProcess.send_signal(9);
               });
             subProcess.send_signal(9);
           }

--- a/Sensors@claudiux/files/Sensors@claudiux/lib/sensorsReaper.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/lib/sensorsReaper.js
@@ -8,6 +8,9 @@ const Util = require("./lib/util");
 const {to_string} = require("./lib/to-string");
 const {readFileAsync} = require("./lib/readFileAsync");
 
+// A default low temperature to return when in d3cold
+const d3cold_temperature = "35";
+
 const {
   UUID,
   HOME_DIR,
@@ -40,11 +43,11 @@ class SensorsReaper {
     this.applet = applet;
     this.refresh_interval = refresh_interval; // seconds
     this.last_attempt_DateTime= undefined;  // the last time we checked sensors
-
+    this.nvidia_cards = {};
     this.sensors_json_data = {};
     this.sensors_program = ""+GLib.find_program_in_path("sensors");
     this.get_sensors_command();
-
+   
     // Support for the Nvidia System Management Interface (nvidia-smi)
     // The Nvidia System Management Interface docs are at
     //   https://developer.nvidia.com/system-management-interface
@@ -129,7 +132,7 @@ class SensorsReaper {
             if (versionCompare(version, "550.107.02") >= 0) {
               this.nvidia_smi_version = version;
               this.nvidia_smi_command =
-                `${this.nvidia_smi_program} --format=csv,noheader --query-gpu=name,pci.bus_id,temperature.gpu`;
+                `${this.nvidia_smi_program} --format=csv,noheader --query-gpu=name,pci.bus_id,temperature.gpu,index`;
             }
             // Test the command because Nvidia doesn't guarantee backwards compatability
             let testProcess = Util.spawnCommandLineAsyncIO(this.nvidia_smi_command,
@@ -142,8 +145,43 @@ class SensorsReaper {
                   this.nvidia_smi_version = undefined;
                 } else {
                   global.log(`Nvidia SMI v${this.nvidia_smi_version} command: ${this.nvidia_smi_command}`);
+                  //global.log(`Searching Nvidia power state`);
+
+                  // Gather all Nvidia cards data
+                  let lines = stdout.split('\n');
+                  lines.forEach((element) => {
+                    if(element.indexOf(",") > -1) {
+                      try {
+                        
+                        const nvidia_information = element.split(', ');
+                        const nvidia_bus_id = nvidia_information[1];
+                        const nvidia_sysfs_path = `/sys/bus/pci/devices/${nvidia_bus_id.replace(/^0{8}/, "0000")}/power_state`;
+                        const nvidia_device_name = nvidia_information[0];
+                        const nvidia_device_id = nvidia_information[3]
+
+                        // Check if everything's correct
+                        if (GLib.file_test(nvidia_sysfs_path, GLib.FileTest.EXISTS)) {
+                          global.log(`Found Nvidia power state on ${nvidia_sysfs_path}, device name ${nvidia_device_name}, bus id ${nvidia_bus_id}`)
+                          
+                          // Add card
+                          this.nvidia_cards[nvidia_device_id] = {
+                            "bus_id": nvidia_bus_id,
+                            "sysfs": Gio.File.new_for_path(nvidia_sysfs_path),
+                            "name": nvidia_device_name
+                          }
+                          global.log(this.nvidia_cards);
+                        }
+                        else {
+                          global.logError(`Could not find power_state handle or information for Nvidia card at ${nvidia_sysfs_path}, is sysfs mounted on /sys?`)
+                        }
+                      }
+                      catch (e) {
+                        global.logError(`Could not parse sysfs path for Nvidia power state: ${e}`)
+                      }
+                    }
+                  });
                 }
-                testProcess.send_signal(9);
+                testProcess.send_signal(9)
               });
             subProcess.send_signal(9);
           }
@@ -189,33 +227,104 @@ class SensorsReaper {
 
   }
 
-  reap_nvidia_smi() {
-    if (this.nvidia_smi_command != undefined) {
-      let subProcess = Util.spawnCommandLineAsyncIO(this.nvidia_smi_command, (stdout, stderr, exitCode) => {
-        if (exitCode === 0) {
-          let results = {};
+  get_nvidia_smi_data(id, results) {
+    return new Promise((resolve, reject) => {
+      let subProcess = Util.spawnCommandLineAsyncIO(
+        `${this.nvidia_smi_command} -i ${id}`,
+        (stdout, stderr, exitCode) => {
+          try {
+            if (exitCode === 0) {
+              let output = stdout
+                .replaceAll(", ", ",")
+                .replaceAll("\r", "")
+                .replaceAll(" %", "");
 
-          let output = stdout.replaceAll(", ", ",").replaceAll("\r", "").replaceAll(" %", "");
-          if (output.endsWith("\n"))
-            output = output.substring(0, output.length - 1)
+              if (output.endsWith("\n"))
+                output = output.substring(0, output.length - 1);
 
-          let lines = output.split("\n");
-          lines.forEach(element => {
-            let values = element.split(",");
-            results[values[1]] = {
-              "Adapter": values[0],
-              "temp1": {
-                "temp1_input": values[2]
-              },
-            };
-          });
-          this._sensors_reaped(JSON.stringify(results));
-        } else {
-          global.logError(`Nvidia SMI call failed with code ${exitCode}: ${stdout}, ${stderr}`);
+              let lines = output.split("\n");
+
+              lines.forEach(element => {
+                let values = element.split(",");
+
+                results[values[1]] = {
+                  "Adapter": values[0],
+                  "temp1": {
+                    "temp1_input": values[2]
+                  }
+                };
+              });
+              resolve(results);
+            } else {
+              const error = new Error(
+                `Nvidia SMI call failed with code ${exitCode}: ${stdout}, ${stderr}`
+              );
+              reject(error);
+            }
+          } catch (e) {
+            reject(e);
+          } finally {
+            subProcess.send_signal(9);
+          }
         }
-        subProcess.send_signal(9);
-      });
-    }
+      );
+    });
+  }
+
+  reap_nvidia_smi(no_check_gpu_if_d3cold=0) {
+    let results = {};
+   
+    if (this.nvidia_smi_command != undefined) {
+
+      if (this.nvidia_cards != null) {
+
+          Promise.all(Object.keys(this.nvidia_cards).map((id) => {
+
+            return new Promise((resolve, reject) => {
+
+              // Don't bother Nvidia card if in d3cold state
+              if(no_check_gpu_if_d3cold == 1) {
+                readFileAsync(this.nvidia_cards[id].sysfs).then((power_state) => {
+                  if (power_state.startsWith("D3cold")) {
+                    results[this.nvidia_cards[id].bus_id] = {
+                      "Adapter": this.nvidia_cards[id].name,
+                      "temp1": {
+                        "temp1_input": d3cold_temperature
+                      }
+                    }
+                    global.log(`Adapter ${this.nvidia_cards[id].name} in D3cold state, returning a default low temperature of ${d3cold_temperature}`)
+                    resolve();
+                  }
+                  else {
+                    //global.log(`${this.nvidia_cards[id].name} is active, retrieve its state`);
+                    this.get_nvidia_smi_data(id, results).then(() => {
+                      resolve();
+                    }).catch((error) => {
+                      reject(`Error ${error} while retrieving data from adapter ${this.nvidia_cards[id].name}`);                      
+                    });
+                  }
+                }).catch((error) => {
+                  reject(`Error ${error} while reading sysfs for adapter ${this.nvidia_cards[id].name}`);
+                })              
+              }
+              else {
+                // Just retrieve data from card
+                this.get_nvidia_smi_data(id, results).then(() => {
+                  resolve();
+                }).catch((error) => {
+                  reject(`Error ${error} while retrieving data from adapter ${this.nvidia_cards[id].name}`);                      
+                });
+              }
+            });
+          })).then(() => {
+            this._sensors_reaped(JSON.stringify(results));
+          }).catch((error) => {
+            global.logError(`ERROR ${error}`);
+          });
+
+        }
+
+      }    
   }
 
   async _sensors_reaped(output) {

--- a/Sensors@claudiux/files/Sensors@claudiux/metadata.json
+++ b/Sensors@claudiux/files/Sensors@claudiux/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "Sensors@claudiux",
   "name": "Sensors Monitor",
   "description": "Displays the values of many computer sensors concerning Temperatures (CPU - GPU - Power Supply), Fan Speed, Voltages, Intrusions. Notifies you with color changes when a value reaches or exceeds its limit.",
-  "version": "5.11.4",
+  "version": "5.11.5",
   "max-instances": 1,
   "cinnamon-version": [
     "3.8",

--- a/Sensors@claudiux/files/Sensors@claudiux/po/Sensors@claudiux.pot
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/Sensors@claudiux.pot
@@ -1,189 +1,190 @@
-# SENSORS MONITOR
-# This file is put in the public domain.
-# claudiux, 2020
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Sensors@claudiux 5.11.3\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
-"issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-24 12:45+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #. metadata.json->name
-#. applet.js:232
+#: applet.js:232
 msgid "Sensors Monitor"
 msgstr ""
 
-#. applet.js:594
+#: applet.js:595
 msgid "Suspended"
 msgstr ""
 
-#. applet.js:936 applet.js:978
+#: applet.js:937 applet.js:979
 msgid "high:"
 msgstr ""
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#: applet.js:937 applet.js:940 applet.js:979 applet.js:981 applet.js:1022
 msgid "n/a"
 msgstr ""
 
-#. applet.js:939 applet.js:980
+#: applet.js:940 applet.js:981
 msgid "crit:"
 msgstr ""
 
-#. applet.js:1021 applet.js:1065
+#: applet.js:1022 applet.js:1066
 msgid "min:"
 msgstr ""
 
-#. applet.js:1067
+#: applet.js:1068
 msgid "max:"
 msgstr ""
 
-#. applet.js:1096
+#: applet.js:1097
 msgid "No intrusion detected"
 msgstr ""
 
-#. applet.js:1096
+#: applet.js:1097
 msgid "INTRUSION DETECTED!"
 msgstr ""
 
-#. applet.js:1116
+#: applet.js:1117
 msgid "Must be configured!"
 msgstr ""
 
-#. applet.js:1518
+#: applet.js:1519
 msgid "Settings"
 msgstr ""
 
-#. applet.js:1518
+#: applet.js:1519
 msgid ":"
 msgstr ""
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#: applet.js:1526
 msgid "⚙ General"
 msgstr ""
 
-#. applet.js:1542
+#: applet.js:1543
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr ""
 
-#. applet.js:1559
+#: applet.js:1560
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr ""
 
-#. applet.js:1576
+#: applet.js:1577
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr ""
 
-#. applet.js:1593
+#: applet.js:1594
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr ""
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#: applet.js:1630
 msgid "Run xsensors"
 msgstr ""
 
-#. applet.js:1638
+#: applet.js:1639
 msgid "Suspend Sensors"
 msgstr ""
 
-#. applet.js:1649
+#: applet.js:1650
 msgid "Reload this applet"
 msgstr ""
 
-#. applet.js:2005
+#: applet.js:2006
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr ""
 
-#. lib/checkDependencies.js:371
+#: lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr ""
 
-#. lib/checkDependencies.js:372
+#: lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr ""
 
-#. lib/checkDependencies.js:401
+#: lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
 msgstr ""
 
-#. lib/checkDependencies.js:403
+#: lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr ""
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#: lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#: lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr ""
 
-#. lib/checkDependencies.js:419
+#: lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr ""
 
-#. lib/util.js:244
+#: lib/util.js:244
 #, javascript-format
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#. scripts/xs.py:206
+#: scripts/xs.py:206
 msgid "Previous instance"
 msgstr ""
 
-#. scripts/xs.py:210
+#: scripts/xs.py:210
 msgid "Next instance"
 msgstr ""
 
-#. scripts/xs.py:219
+#: scripts/xs.py:219
 msgid "More options"
 msgstr ""
 
-#. scripts/xs.py:225
+#: scripts/xs.py:225
 msgid "Import from a file"
 msgstr ""
 
-#. scripts/xs.py:230
+#: scripts/xs.py:230
 msgid "Export to a file"
 msgstr ""
 
-#. scripts/xs.py:235
+#: scripts/xs.py:235
 msgid "Reset to defaults"
 msgstr ""
 
-#. scripts/xs.py:244
+#: scripts/xs.py:244
 #, python-format
 msgid "Reload %s"
 msgstr ""
 
-#. scripts/xs.py:425
+#: scripts/xs.py:425
 #, python-format
 msgid "Settings for %s"
 msgstr ""
 
-#. scripts/xs.py:517
+#: scripts/xs.py:517
 msgid "Select or enter file to export to"
 msgstr ""
 
-#. scripts/xs.py:525 scripts/xs.py:546
+#: scripts/xs.py:525 scripts/xs.py:546
 msgid "JSON files"
 msgstr ""
 
-#. scripts/xs.py:539
+#: scripts/xs.py:539
 msgid "Select a JSON file to import"
 msgstr ""
 
@@ -448,8 +449,7 @@ msgstr ""
 
 #. settings-schema.json->keep_size->tooltip
 msgid ""
-"Checked: The size of this applet remains constant, once all your preferences "
-"have been defined.\n"
+"Checked: The size of this applet remains constant, once all your preferences have been defined.\n"
 "Unchecked: The size of this applet is optimized, but it may change."
 msgstr ""
 
@@ -557,8 +557,8 @@ msgstr ""
 
 #. settings-schema.json->do_not_check_dependencies->tooltip
 msgid ""
-"If you do not want to install certain dependencies (e.g., fonts), check this "
-"box. Be careful with dependencies that are necessary for this applet to "
+"If you do not want to install certain dependencies (e.g., fonts), check this"
+" box. Be careful with dependencies that are necessary for this applet to "
 "function properly."
 msgstr ""
 
@@ -668,6 +668,16 @@ msgid ""
 "limit are recorded in the system journal."
 msgstr ""
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr ""
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -745,8 +755,7 @@ msgstr ""
 
 #. settings-schema.json->temp_sensors->tooltip
 msgid ""
-"Double-click on a line to change 'Shown name', 'High', 'Critical' or "
-"'Formula'.\n"
+"Double-click on a line to change 'Shown name', 'High', 'Critical' or 'Formula'.\n"
 "To reset a 'Shown name', copy/paste the 'Sensor name'.\n"
 "'High' and 'Critical' (optional) must be valid numbers.\n"
 "'Formula' (optional):\n"
@@ -777,8 +786,7 @@ msgstr ""
 
 #. settings-schema.json->temp_disks->tooltip
 msgid ""
-"Disk name: The name of the disk, as returned by the 'lsblk' command. Please "
-"see help.\n"
+"Disk name: The name of the disk, as returned by the 'lsblk' command. Please see help.\n"
 "High and Critical values: Cf. technical manual of your disk."
 msgstr ""
 
@@ -894,7 +902,8 @@ msgid "Log intrusions"
 msgstr ""
 
 #. settings-schema.json->journalize_intrusion->tooltip
-msgid "When this option is checked, intrusions are recorded in the system log."
+msgid ""
+"When this option is checked, intrusions are recorded in the system log."
 msgstr ""
 
 #. settings-schema.json->intrusion_sensors->tooltip
@@ -946,7 +955,6 @@ msgid ""
 msgstr ""
 
 #. settings-schema.json->report->description
-#. scripts/show_sensor_values.sh:5
 msgid "Example of sensor values from this computer"
 msgstr ""
 

--- a/Sensors@claudiux/files/Sensors@claudiux/po/Sensors@claudiux.pot
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/Sensors@claudiux.pot
@@ -1,190 +1,190 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# SENSORS MONITOR
+# This file is put in the public domain.
+# claudiux, 2020
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-24 12:45+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: Sensors@claudiux 5.11.5\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #. metadata.json->name
-#: applet.js:232
+#. applet.js:232
 msgid "Sensors Monitor"
 msgstr ""
 
-#: applet.js:595
+#. applet.js:599
 msgid "Suspended"
 msgstr ""
 
-#: applet.js:937 applet.js:979
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr ""
 
-#: applet.js:937 applet.js:940 applet.js:979 applet.js:981 applet.js:1022
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr ""
 
-#: applet.js:940 applet.js:981
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr ""
 
-#: applet.js:1022 applet.js:1066
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr ""
 
-#: applet.js:1068
+#. applet.js:1072
 msgid "max:"
 msgstr ""
 
-#: applet.js:1097
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr ""
 
-#: applet.js:1097
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr ""
 
-#: applet.js:1117
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr ""
 
-#: applet.js:1519
+#. applet.js:1523
 msgid "Settings"
 msgstr ""
 
-#: applet.js:1519
+#. applet.js:1523
 msgid ":"
 msgstr ""
 
 #. settings-schema.json->page_General->title
-#: applet.js:1526
+#. applet.js:1530
 msgid "⚙ General"
 msgstr ""
 
-#: applet.js:1543
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr ""
 
-#: applet.js:1560
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr ""
 
-#: applet.js:1577
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr ""
 
-#: applet.js:1594
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr ""
 
 #. settings-schema.json->xsensors->description
-#: applet.js:1630
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr ""
 
-#: applet.js:1639
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr ""
 
-#: applet.js:1650
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr ""
 
-#: applet.js:2006
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr ""
 
-#: lib/checkDependencies.js:376
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr ""
 
-#: lib/checkDependencies.js:377
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr ""
 
-#: lib/checkDependencies.js:407
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
 msgstr ""
 
-#: lib/checkDependencies.js:409
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr ""
 
-#: lib/checkDependencies.js:413 lib/checkDependencies.js:423
-#: lib/checkDependencies.js:432
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr ""
 
-#: lib/checkDependencies.js:425 lib/checkDependencies.js:434
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr ""
 
-#: lib/util.js:244
+#. lib/util.js:244
 #, javascript-format
 msgid "Execution of '%s' failed:"
 msgstr ""
 
-#: scripts/xs.py:206
+#. scripts/xs.py:206
 msgid "Previous instance"
 msgstr ""
 
-#: scripts/xs.py:210
+#. scripts/xs.py:210
 msgid "Next instance"
 msgstr ""
 
-#: scripts/xs.py:219
+#. scripts/xs.py:219
 msgid "More options"
 msgstr ""
 
-#: scripts/xs.py:225
+#. scripts/xs.py:225
 msgid "Import from a file"
 msgstr ""
 
-#: scripts/xs.py:230
+#. scripts/xs.py:230
 msgid "Export to a file"
 msgstr ""
 
-#: scripts/xs.py:235
+#. scripts/xs.py:235
 msgid "Reset to defaults"
 msgstr ""
 
-#: scripts/xs.py:244
+#. scripts/xs.py:244
 #, python-format
 msgid "Reload %s"
 msgstr ""
 
-#: scripts/xs.py:425
+#. scripts/xs.py:425
 #, python-format
 msgid "Settings for %s"
 msgstr ""
 
-#: scripts/xs.py:517
+#. scripts/xs.py:517
 msgid "Select or enter file to export to"
 msgstr ""
 
-#: scripts/xs.py:525 scripts/xs.py:546
+#. scripts/xs.py:525 scripts/xs.py:546
 msgid "JSON files"
 msgstr ""
 
-#: scripts/xs.py:539
+#. scripts/xs.py:539
 msgid "Select a JSON file to import"
 msgstr ""
 
@@ -449,7 +449,8 @@ msgstr ""
 
 #. settings-schema.json->keep_size->tooltip
 msgid ""
-"Checked: The size of this applet remains constant, once all your preferences have been defined.\n"
+"Checked: The size of this applet remains constant, once all your preferences "
+"have been defined.\n"
 "Unchecked: The size of this applet is optimized, but it may change."
 msgstr ""
 
@@ -557,8 +558,8 @@ msgstr ""
 
 #. settings-schema.json->do_not_check_dependencies->tooltip
 msgid ""
-"If you do not want to install certain dependencies (e.g., fonts), check this"
-" box. Be careful with dependencies that are necessary for this applet to "
+"If you do not want to install certain dependencies (e.g., fonts), check this "
+"box. Be careful with dependencies that are necessary for this applet to "
 "function properly."
 msgstr ""
 
@@ -755,7 +756,8 @@ msgstr ""
 
 #. settings-schema.json->temp_sensors->tooltip
 msgid ""
-"Double-click on a line to change 'Shown name', 'High', 'Critical' or 'Formula'.\n"
+"Double-click on a line to change 'Shown name', 'High', 'Critical' or "
+"'Formula'.\n"
 "To reset a 'Shown name', copy/paste the 'Sensor name'.\n"
 "'High' and 'Critical' (optional) must be valid numbers.\n"
 "'Formula' (optional):\n"
@@ -786,7 +788,8 @@ msgstr ""
 
 #. settings-schema.json->temp_disks->tooltip
 msgid ""
-"Disk name: The name of the disk, as returned by the 'lsblk' command. Please see help.\n"
+"Disk name: The name of the disk, as returned by the 'lsblk' command. Please "
+"see help.\n"
 "High and Critical values: Cf. technical manual of your disk."
 msgstr ""
 
@@ -902,8 +905,7 @@ msgid "Log intrusions"
 msgstr ""
 
 #. settings-schema.json->journalize_intrusion->tooltip
-msgid ""
-"When this option is checked, intrusions are recorded in the system log."
+msgid "When this option is checked, intrusions are recorded in the system log."
 msgstr ""
 
 #. settings-schema.json->intrusion_sensors->tooltip
@@ -955,6 +957,7 @@ msgid ""
 msgstr ""
 
 #. settings-schema.json->report->description
+#. scripts/show_sensor_values.sh:5
 msgid "Example of sensor values from this computer"
 msgstr ""
 

--- a/Sensors@claudiux/files/Sensors@claudiux/po/ca.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Sensors@claudiux 3.7.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2025-09-28 16:06+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -23,103 +23,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Monitor de sensors"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Suspès"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "alt:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "n/a"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "crít:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "mín:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "màx:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "No s'ha detectat intrusió"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "INTRUSIÓ DETECTADA!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "S'ha de configurar!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Opcions"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ General"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Sensors de temperatura"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Sensors de ventilador"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Sensors de voltatge"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Sensors d'intrusió"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Executar xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Suspendre sensors"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Refresca aquesta miniaplicació"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Segur que voleu eliminar '%s'?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "La miniaplicació %s funciona correctament."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Totes les dependències estan instal·lades"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -127,15 +127,16 @@ msgstr ""
 "Sembla que us falta instal·lar alguns paquets necessaris perquè aquesta "
 "miniaplicació funcioni de manera completa."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Si us plau, instal·leu els paquets següents:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Algunes dependències no estan instal·lades!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Instal·leu aquests paquets ara"
 
@@ -693,6 +694,19 @@ msgstr ""
 "Si es marca aquesta opció, les temperatures excessivament altes queden "
 "registrades al system journal."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Deixar de comprovar la temperatura de la GPU si està en estat D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Si aquesta opció està marcada, per evitar despertar la targeta GPU per "
+"comprovar-ne la temperatura, no comproveu la seva temperatura si està en "
+"mode d’estalvi d’energia."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1055,13 +1069,3 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Elimineu la miniaplicació temperature@fevimu del panell"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Deixar de comprovar la temperatura de la GPU si està en estat D3cold"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Si aquesta opció està marcada, per evitar despertar la targeta GPU per comprovar-ne la temperatura, no comproveu la seva temperatura si està en mode d’estalvi d’energia."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/ca.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/ca.po
@@ -1055,3 +1055,13 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Elimineu la miniaplicació temperature@fevimu del panell"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Deixar de comprovar la temperatura de la GPU si està en estat D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Si aquesta opció està marcada, per evitar despertar la targeta GPU per comprovar-ne la temperatura, no comproveu la seva temperatura si està en mode d’estalvi d’energia."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/cn.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/cn.po
@@ -1010,3 +1010,13 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "从面板中删除 temperature@fevimu 小程序"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "如果 GPU 处于 D3cold 状态，则停止检查其温度"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "如果选中此选项，为避免唤醒 GPU 显卡来检查其温度，当 GPU 处于省电模式时不要检查其温度。"

--- a/Sensors@claudiux/files/Sensors@claudiux/po/cn.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/cn.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,117 +22,118 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "传感器监测"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "悬浮"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "高:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "n/a"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "crit:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "分钟:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "最大:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "未检测到入侵"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "检测到入侵！"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "必须配置！"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "设置"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ 通用"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s 温度传感器"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s 风扇传感器"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s 电压传感器"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s 入侵传感器"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "运行xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "悬挂传感器"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "重新加载此小程序"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "您确定要删除吗'%s'?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "小程序%s功能齐全。"
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "所有依赖项均已安装"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
 msgstr "您似乎缺少此小程序具有所有功能所需的一些程序。"
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "请安装这些软件包："
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "某些依赖项尚未安装！"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "立即安装这些软件包"
 
@@ -676,6 +677,18 @@ msgid ""
 "limit are recorded in the system journal."
 msgstr "选中此选项后，超过高或临界限制的温度将记录在系统日志中。"
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "如果 GPU 处于 D3cold 状态，则停止检查其温度"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"如果选中此选项，为避免唤醒 GPU 显卡来检查其温度，当 GPU 处于省电模式时不要检"
+"查其温度。"
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -847,9 +860,9 @@ msgid ""
 "  You can use the 4 operations (+-*/) and parentheses.\n"
 "  Example: $*1.1+0.5"
 msgstr ""
-"双击一行以更改“显示名称”、“最小值”或“公式”。\\n要重置“显示的名称”,请复制/粘"
-"贴“传感器名称”。\\'Min'（可选）必须是有效数字。\\'Formula'（可选）：\\n使用"
-"$作为传感器返回的值。\\n您可以使用4个操作(+-*/）和括号。\\n示例:$*1.1+0.5"
+"双击一行以更改“显示名称”、“最小值”或“公式”。\\n要重置“显示的名称”,请复制/粘贴"
+"“传感器名称”。\\'Min'（可选）必须是有效数字。\\'Formula'（可选）：\\n使用$作"
+"为传感器返回的值。\\n您可以使用4个操作(+-*/）和括号。\\n示例:$*1.1+0.5"
 
 #. settings-schema.json->chars_volt->tooltip
 msgid "The first emoji in this list is used for voltage"
@@ -905,9 +918,9 @@ msgid ""
 "  Example: $*1.1+0.5"
 msgstr ""
 "双击一行以更改“显示名称”、“最小值”、“最大值”或“公式”。\\n要重置“显示的名称”,"
-"请复制/粘贴“传感器名称”。\\'Min'和'Max'（可选）必须是有效数"
-"字。\\'Formula'（可选）：\\n使用$作为传感器返回的值。\\n您可以使用4个操作(+-"
-"*/）和括号。\\n示例:$*1.1+0.5"
+"请复制/粘贴“传感器名称”。\\'Min'和'Max'（可选）必须是有效数字。"
+"\\'Formula'（可选）：\\n使用$作为传感器返回的值。\\n您可以使用4个操作(+-*/）"
+"和括号。\\n示例:$*1.1+0.5"
 
 #. settings-schema.json->show_intrusion_name->tooltip
 #. settings-schema.json->show_custom_name->tooltip
@@ -1010,13 +1023,3 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "从面板中删除 temperature@fevimu 小程序"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "如果 GPU 处于 D3cold 状态，则停止检查其温度"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "如果选中此选项，为避免唤醒 GPU 显卡来检查其温度，当 GPU 处于省电模式时不要检查其温度。"

--- a/Sensors@claudiux/files/Sensors@claudiux/po/cs.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/cs.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Sensors@claudiux Czech 5.8.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2025-09-14 13:25+0200\n"
 "Last-Translator: Bohuslav Kotál <fotobob1@centrum.cz>\n"
 "Language-Team: \n"
@@ -20,118 +20,119 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Sledování senzorů"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Zastaveno"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "vysoká:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "n/a"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "krit:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "min:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "max:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Narušení nedetekováno"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "DETEKOVÁNO NARUŠENÍ!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Musí být nastaveno!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Předvolby"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Obecné"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Teplotní senzory"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Senzory větráků"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Napěťové senzory"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Senzory narušení"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Spustit xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Pozastavit Sledování senzorů"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Znovunačíst tento applet"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Opravdu odstranit '%s'?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "Applet %s je plně funkční."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Všechny závislosti jsou nainstalované"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
 msgstr ""
 "Zdá se, že chybí některé z programů vyžadovaných pro plnou funkčnost appletu."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Je nutné instalovat následující balíčky:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Některé závislosti nejsou nainstalované!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Balíčky nainstalovat nyní"
 
@@ -685,6 +686,19 @@ msgstr ""
 "Pokud je tato volba aktivní, bude do systémového žurnálu zapsáno překročení "
 "teplotních limitů."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Přestat kontrolovat teplotu GPU, pokud je ve stavu D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Pokud je tato možnost zaškrtnuta, aby se zabránilo probouzení grafické karty "
+"GPU kvůli kontrole její teploty, nekontrolujte její teplotu, pokud je v "
+"úsporném režimu."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1052,13 +1066,3 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Odstranit z panelu applet temperature@fevimu"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Přestat kontrolovat teplotu GPU, pokud je ve stavu D3cold"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Pokud je tato možnost zaškrtnuta, aby se zabránilo probouzení grafické karty GPU kvůli kontrole její teploty, nekontrolujte její teplotu, pokud je v úsporném režimu."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/cs.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/cs.po
@@ -1052,3 +1052,13 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Odstranit z panelu applet temperature@fevimu"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Přestat kontrolovat teplotu GPU, pokud je ve stavu D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Pokud je tato možnost zaškrtnuta, aby se zabránilo probouzení grafické karty GPU kvůli kontrole její teploty, nekontrolujte její teplotu, pokud je v úsporném režimu."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/da.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/da.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2026-04-29 17:27+0200\n"
 "Last-Translator: Alan Mortensen <over.tackiness223@passinbox.com>\n"
 "Language-Team: \n"
@@ -25,103 +25,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Sensorovervågning"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Hviletilstand"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "høj:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "—"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "krit:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "min:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "max:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Ingen indtrængen detekteret"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "INDTRÆNGEN DETEKTERET!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Skal konfigureres!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Indstillinger"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Generelt"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Temperatursensorer"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Ventilatorsensorer"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Spændingssensorer"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Indtrængningssensorer"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Kør xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Suspendér Sensorovervågning"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Genindlæs panelprogrammet"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Er du sikker på at du vil fjerne “%s”?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "Panelprogrammet %s er fuldt fungerende."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Alle afhængigheder er installeret"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -129,15 +129,16 @@ msgstr ""
 "Det lader til, nogle programmer mangler for at give panelprogrammet alle "
 "dets funktioner."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Installér disse pakker:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Nogle afhængigheder er ikke installeret!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Installér disse pakker nu"
 
@@ -694,6 +695,20 @@ msgstr ""
 "Når denne indstilling er markeret, registreres temperaturer, der overskrider "
 "den øvre eller kritiske grænse, i systemloggen."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr ""
+"Stop med at kontrollere GPU-temperaturen, hvis den er i D3cold-tilstand"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Hvis denne indstilling er markeret, skal GPU-kortet ikke vækkes for at "
+"kontrollere dets temperatur; kontrollér ikke temperaturen, hvis det er i "
+"strømsparetilstand."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1054,13 +1069,3 @@ msgstr "Åbn HTML-farver-websiden"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Fjern panelprogrammet temperature@fevimu fra panelet"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Stop med at kontrollere GPU-temperaturen, hvis den er i D3cold-tilstand"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Hvis denne indstilling er markeret, skal GPU-kortet ikke vækkes for at kontrollere dets temperatur; kontrollér ikke temperaturen, hvis det er i strømsparetilstand."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/da.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/da.po
@@ -1054,3 +1054,13 @@ msgstr "Åbn HTML-farver-websiden"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Fjern panelprogrammet temperature@fevimu fra panelet"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Stop med at kontrollere GPU-temperaturen, hvis den er i D3cold-tilstand"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Hvis denne indstilling er markeret, skal GPU-kortet ikke vækkes for at kontrollere dets temperatur; kontrollér ikke temperaturen, hvis det er i strømsparetilstand."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/de.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/de.po
@@ -1050,3 +1050,13 @@ msgstr "Website mit HTML-Farben öffnen"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Applet temperature@fevimu vom Panel entfernen"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "GPU-Temperatur nicht mehr prüfen, wenn sich die GPU im D3cold-Zustand befindet"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Wenn diese Option aktiviert ist, soll die GPU-Karte nicht zum Prüfen ihrer Temperatur aufgeweckt werden. Prüfen Sie die Temperatur nicht, wenn sie sich im Energiesparmodus befindet."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/de.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2026-05-07 19:55+0200\n"
 "Last-Translator: Michael Härtl <haertl.mike@gmail.com>\n"
 "Language-Team: \n"
@@ -24,103 +24,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Sensorüberwachung"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Pausiert"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "hoch:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "-"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "krit:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "min:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "max:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Kein Einbruch entdeckt"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "EINBRUCH ENTDECKT!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Muss konfiguriert werden!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Einstellungen"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Allgemein"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Temperatursensoren"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Lüftersensoren"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Spannungssensoren"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Einbruchsensoren"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Xsensors starten"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Sensoren pausieren"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Applet neu laden"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Sind Sie sicher, dass Sie \"%s\" entfernen wollen?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "Das %s-Applet ist voll funktionsfähig."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Alle Abhängigkeiten installiert"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -128,15 +128,16 @@ msgstr ""
 "Es scheinen einige Programme zu fehlen, die dieses Applet für den vollen "
 "Funktionsumfang benötigt."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Bitte installieren Sie diese Pakete:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Einige Abhängigkeiten sind nicht installiert!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Installieren Sie diese Pakete jetzt"
 
@@ -693,6 +694,21 @@ msgstr ""
 "Wenn diese Option aktiviert ist, werden Temperaturen die den hohen oder "
 "kritischen Grenzwert überschreiten im Systemjournal festgehalten."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr ""
+"GPU-Temperatur nicht mehr prüfen, wenn sich die GPU im D3cold-Zustand "
+"befindet"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Wenn diese Option aktiviert ist, soll die GPU-Karte nicht zum Prüfen ihrer "
+"Temperatur aufgeweckt werden. Prüfen Sie die Temperatur nicht, wenn sie sich "
+"im Energiesparmodus befindet."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1050,13 +1066,3 @@ msgstr "Website mit HTML-Farben öffnen"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Applet temperature@fevimu vom Panel entfernen"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "GPU-Temperatur nicht mehr prüfen, wenn sich die GPU im D3cold-Zustand befindet"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Wenn diese Option aktiviert ist, soll die GPU-Karte nicht zum Prüfen ihrer Temperatur aufgeweckt werden. Prüfen Sie die Temperatur nicht, wenn sie sich im Energiesparmodus befindet."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/es.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/es.po
@@ -1067,3 +1067,13 @@ msgstr "Abrir la página web de colores HTML"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Retire la applet temperature@fevimu del panel"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Dejar de comprobar la temperatura de la GPU si está en estado D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Si se marca esta opción, para evitar despertar la tarjeta GPU para comprobar su temperatura, no compruebe su temperatura si está en modo de ahorro de energía."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/es.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2026-04-26 01:30+0200\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -24,103 +24,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Monitor de sensores"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Suspendido"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "alto:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "n/a"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "crít:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "min:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "max:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "No se detectó intrusión"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "¡INTRUSIÓN DETECTADA!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "¡Debe estar configurado!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Ajustes"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ General"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Sensores de temperatura"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Sensores de ventilador"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Sensores de voltaje"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Sensores de intrusión"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Lanzar xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Suspender sensores"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Recargar este applet"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "¿Está seguro de que desea eliminar \"%s\"?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "%s es completamente funcional."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Todas las dependencias están instaladas"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -128,15 +128,16 @@ msgstr ""
 "Parece que le faltan algunos de los programas necesarios para que este "
 "applet tenga todas sus características."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Por favor, instale estos paquetes:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "¡Algunas dependencias no están instaladas!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Instale estos paquetes ahora"
 
@@ -700,6 +701,19 @@ msgstr ""
 "Cuando se marca esta opción, las temperaturas que superan el límite alto o "
 "crítico se registran en el diario del sistema."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Dejar de comprobar la temperatura de la GPU si está en estado D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Si se marca esta opción, para evitar despertar la tarjeta GPU para comprobar "
+"su temperatura, no compruebe su temperatura si está en modo de ahorro de "
+"energía."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1067,13 +1081,3 @@ msgstr "Abrir la página web de colores HTML"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Retire la applet temperature@fevimu del panel"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Dejar de comprobar la temperatura de la GPU si está en estado D3cold"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Si se marca esta opción, para evitar despertar la tarjeta GPU para comprobar su temperatura, no compruebe su temperatura si está en modo de ahorro de energía."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/fr.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/fr.po
@@ -1070,3 +1070,13 @@ msgstr "Ouvrir la page web des couleurs HTML"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Retirer du panneau l'applet temperature@fevimu"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Arrêter de vérifier la température du GPU s’il est à l’état D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Si cette option est cochée, afin d’éviter de réveiller la carte GPU pour vérifier sa température, ne vérifiez pas sa température si elle est en mode d’économie d’énergie."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/fr.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2026-04-26 01:28+0200\n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -24,103 +24,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Moniteur de Capteurs"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Désactivé"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "élevée :"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "n/a"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "critique :"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "min :"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "max :"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Aucune intrusion détectée"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "INTRUSION DÉTECTÉE !"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Doit être configuré !"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Paramètres"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr " :"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Général"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Capteurs de température"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Capteurs de ventilateur"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Capteurs de tension"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Capteurs d'intrusion"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Lancer xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Désactiver Sensors"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Recharger cette applet"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Êtes-vous sûr de vouloir enlever \"%s\" ?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "L'applet %s est pleinement fonctionnelle."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Toutes les dépendances sont installées"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -128,15 +128,16 @@ msgstr ""
 "Vous semblez ne pas disposer des programmes requis pour bénéficier de toutes "
 "les fonctionnalités de cette applet."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Veuillez installer les paquets suivants :"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Certaines dépendances ne sont pas installées !"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Installer ces paquets maintenant"
 
@@ -700,6 +701,19 @@ msgstr ""
 "Lorsque cette option est cochée, les températures dépassant la limite haute "
 "ou critique sont enregistrées dans le journal du système."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Arrêter de vérifier la température du GPU s’il est à l’état D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Si cette option est cochée, afin d’éviter de réveiller la carte GPU pour "
+"vérifier sa température, ne vérifiez pas sa température si elle est en mode "
+"d’économie d’énergie."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1070,13 +1084,3 @@ msgstr "Ouvrir la page web des couleurs HTML"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Retirer du panneau l'applet temperature@fevimu"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Arrêter de vérifier la température du GPU s’il est à l’état D3cold"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Si cette option est cochée, afin d’éviter de réveiller la carte GPU pour vérifier sa température, ne vérifiez pas sa température si elle est en mode d’économie d’énergie."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/hu.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/hu.po
@@ -1071,3 +1071,13 @@ msgstr "HTML színek weboldalának megnyitása"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Távolítsa el a panelről a temperature@fevimu kisalkalmazást"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "A GPU hőmérsékletének ellenőrzésének leállítása, ha D3cold állapotban van"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Ha ez a beállítás be van jelölve, a GPU-kártya hőmérsékletének ellenőrzéséhez való felébresztésének elkerülése érdekében ne ellenőrizze a hőmérsékletét, ha energiatakarékos módban van."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/hu.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Sensors@claudiux 3.7.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2026-05-11 18:30+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -23,103 +23,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Szenzor Figyelő"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Felfüggesztve"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "magas:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "n/a"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "krit:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "min:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "max:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Nem észleltünk behatolást"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "BEHATOLÁST ÉSZLELTÜNK!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Be kell állítani!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Beállítások"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Általános"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Hőmérséklet szenzorok"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Ventilátor szenzorok"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Feszültség szenzorok"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Behatolás szenzorok"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Xsensors futtatása"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Felfüggesztett Szenzorok"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Kisalkalmazás újratöltése"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Biztosan el akarja távolítani a(z) '%s'-t)"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "A kisalkalmazás %s teljesen működőképes."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Minden függőség telepítve van"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -127,15 +127,16 @@ msgstr ""
 "Úgy tűnik, hogy hiányzik néhány program, amely szükséges ahhoz, hogy a "
 "kisalkalmazás minden funkcióval rendelkezzen."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Kérjük, telepítse ezeket a csomagokat:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Néhány függőség nincs telepítve!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Telepítse ezeket a csomagokat most"
 
@@ -701,6 +702,20 @@ msgstr ""
 "Ha ez az opció be van jelölve, a rendszernaplóban rögzítésre kerülnek a "
 "felső vagy kritikus határértéket meghaladó hőmérsékletek."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr ""
+"A GPU hőmérsékletének ellenőrzésének leállítása, ha D3cold állapotban van"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Ha ez a beállítás be van jelölve, a GPU-kártya hőmérsékletének "
+"ellenőrzéséhez való felébresztésének elkerülése érdekében ne ellenőrizze a "
+"hőmérsékletét, ha energiatakarékos módban van."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1071,13 +1086,3 @@ msgstr "HTML színek weboldalának megnyitása"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Távolítsa el a panelről a temperature@fevimu kisalkalmazást"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "A GPU hőmérsékletének ellenőrzésének leállítása, ha D3cold állapotban van"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Ha ez a beállítás be van jelölve, a GPU-kártya hőmérsékletének ellenőrzéséhez való felébresztésének elkerülése érdekében ne ellenőrizze a hőmérsékletét, ha energiatakarékos módban van."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/it.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2025-08-27 18:03+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -24,103 +24,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Monitoraggio Sensori"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Sospeso"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "alto:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "n/d"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "crit:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "min:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "max:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Nessuna intrusione rilevata"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "INTRUSIONE RILEVATA!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Deve essere configurato!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Impostazioni"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Generale"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Sensori di temperatura"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Sensori delle ventole"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Sensori di tensione"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Sensori di intrusione"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Esegui xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Sospendi i sensori"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Ricarica questa applet"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Rimuovere '%s'?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "L'applet %s è totalmente funzionante."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Tutte le dipendenze sono installate"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -128,15 +128,16 @@ msgstr ""
 "Sembra che manchino alcuni dei programmi necessari affinché questa applet "
 "abbia tutte le sue funzionalità."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Si prega di installare questi pacchetti:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Alcune dipendenze non sono installate!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Installa questi pacchetti ora"
 
@@ -692,6 +693,20 @@ msgstr ""
 "Quando questa opzione è selezionata, le temperature che superano il limite "
 "massimo o critico vengono registrate nel giornale di sistema."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr ""
+"Smetti di controllare la temperatura della GPU se si trova nello stato D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Se questa opzione è selezionata, per evitare di riattivare la scheda GPU per "
+"controllarne la temperatura, non controllarne la temperatura se si trova in "
+"modalità di risparmio energetico."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1062,13 +1077,3 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Rimuovere dal pannello l'applet temperature@fevimu"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Smetti di controllare la temperatura della GPU se si trova nello stato D3cold"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Se questa opzione è selezionata, per evitare di riattivare la scheda GPU per controllarne la temperatura, non controllarne la temperatura se si trova in modalità di risparmio energetico."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/it.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/it.po
@@ -1062,3 +1062,13 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Rimuovere dal pannello l'applet temperature@fevimu"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Smetti di controllare la temperatura della GPU se si trova nello stato D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Se questa opzione è selezionata, per evitare di riattivare la scheda GPU per controllarne la temperatura, non controllarne la temperatura se si trova in modalità di risparmio energetico."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/nl.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2025-05-13 14:30+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -24,103 +24,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Sensoren Monitor"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Opgeschort"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "hoog:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "n.v.t"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "kritiek:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "min:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "max:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Geen verstoring gedetecteerd"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "VERSTORING GEDETECTEERD!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Moet worden ingesteld!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Instellingen"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Algemeen"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Temperatuursensoren"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Ventilatorsensoren"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Spanningssensoren"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Inbraaksensoren"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Uitvoeren xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Opschorten van sensors"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Herlaad deze hulptoepassing"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Weet u zeker dat u '%s' wilt verwijderen?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "De hulptoepassing %s is volledig functioneel."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Alle afhankelijkheden zijn geïnstalleerd"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -128,15 +128,16 @@ msgstr ""
 "U lijkt een aantal van de programma's te missen die nodig zijn voor deze "
 "hulptoepassing om alle functies te hebben."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Installeer deze pakketten:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Sommige afhankelijkheden zijn niet geïnstalleerd!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Installeer deze pakketten nu"
 
@@ -698,6 +699,21 @@ msgstr ""
 "Wanneer deze optie is aangevinkt, worden temperaturen die de hoge of "
 "kritieke limiet overschrijden in het systeemlogboek geregistreerd."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr ""
+"Stop met het controleren van de GPU-temperatuur als deze zich in de D3cold-"
+"status bevindt"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Als deze optie is ingeschakeld, controleer de temperatuur van de GPU niet "
+"wanneer deze zich in de energiebesparingsmodus bevindt, om te voorkomen dat "
+"de GPU-kaart wordt gewekt om de temperatuur te controleren."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1056,13 +1072,3 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Verwijder van het paneel de temperature@fevimu hulptoepassing"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Stop met het controleren van de GPU-temperatuur als deze zich in de D3cold-status bevindt"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Als deze optie is ingeschakeld, controleer de temperatuur van de GPU niet wanneer deze zich in de energiebesparingsmodus bevindt, om te voorkomen dat de GPU-kaart wordt gewekt om de temperatuur te controleren."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/nl.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/nl.po
@@ -1056,3 +1056,13 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Verwijder van het paneel de temperature@fevimu hulptoepassing"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Stop met het controleren van de GPU-temperatuur als deze zich in de D3cold-status bevindt"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Als deze optie is ingeschakeld, controleer de temperatuur van de GPU niet wanneer deze zich in de energiebesparingsmodus bevindt, om te voorkomen dat de GPU-kaart wordt gewekt om de temperatuur te controleren."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/pl.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/pl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Sensors@claudiux 5.4.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Skajmer <skajmer@proton.me>\n"
 "Language-Team: \n"
@@ -23,103 +23,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Monitor czujników"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Wstrzymany"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "wysoki:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "n/d"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "kryt:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "min:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "max:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Nie wykryto naruszeń"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "WYKRYTO NARUSZENIE!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Musi zostać skonfigurowane!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Ustawienia"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Ogólne"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Czujniki temperatury"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Czujniki wentylatorów"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Czujniki napięcia"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Czujniki naruszeń"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Uruchom xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Wstrzymaj czujniki"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Przeładuj ten aplet"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Czy na pewno chcesz usunąć '%s'?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "Aplet %s jest w pełni funkcjonalny."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Wszystkie zależności są zainstalowane"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -127,15 +127,16 @@ msgstr ""
 "Wygląda na to że brakuje niektórych programów wymaganych do działania "
 "wszystkich funkcji tego apletu."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Zainstaluj te pakiety:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Niektóre zależności nie są zainstalowane!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Zainstaluj te pakiety teraz"
 
@@ -688,6 +689,19 @@ msgstr ""
 "Gdy ta opcja jest zaznaczona, temperatury przekraczające wysoki lub "
 "krytyczny limit będą zapisywane w dzienniku systemowym."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Przestań sprawdzać temperaturę GPU, jeśli jest w stanie D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Jeśli ta opcja jest zaznaczona, aby uniknąć wybudzania karty GPU w celu "
+"sprawdzenia jej temperatury, nie sprawdzaj jej temperatury, jeśli jest w "
+"trybie oszczędzania energii."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1054,13 +1068,3 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Usuń z panelu aplet temperature@fevimu"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Przestań sprawdzać temperaturę GPU, jeśli jest w stanie D3cold"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Jeśli ta opcja jest zaznaczona, aby uniknąć wybudzania karty GPU w celu sprawdzenia jej temperatury, nie sprawdzaj jej temperatury, jeśli jest w trybie oszczędzania energii."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/pl.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/pl.po
@@ -1054,3 +1054,13 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Usuń z panelu aplet temperature@fevimu"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Przestań sprawdzać temperaturę GPU, jeśli jest w stanie D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Jeśli ta opcja jest zaznaczona, aby uniknąć wybudzania karty GPU w celu sprawdzenia jej temperatury, nie sprawdzaj jej temperatury, jeśli jest w trybie oszczędzania energii."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/ru.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Sensors@claudiux 5.4.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2026-06-12 00:00+0000\n"
 "Last-Translator: Grom-TS\n"
 "Language-Team: Russian\n"
@@ -22,117 +22,120 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Монитор датчиков"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Приостановлено"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "высокий:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "н/д"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "критический:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "мин.:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "макс.:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Вскрытие не обнаружено"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "ОБНАРУЖЕНО ВСКРЫТИЕ!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Необходимо настроить!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Настройки"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Общие"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s Датчики температуры"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s Датчики вентиляторов"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s Датчики напряжения"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s Датчики вскрытия"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Запустить xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Приостановить мониторинг"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Перезагрузить этот апплет"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Вы уверены, что хотите удалить «%s»?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "Апплет %s полностью работоспособен."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Все зависимости установлены"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
-msgstr "Похоже, что у вас отсутствуют программы, необходимые для работы всех функций этого апплета."
+msgstr ""
+"Похоже, что у вас отсутствуют программы, необходимые для работы всех функций "
+"этого апплета."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Пожалуйста, установите следующие пакеты:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Некоторые зависимости не установлены!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Установить эти пакеты сейчас"
 
@@ -254,7 +257,8 @@ msgstr "Зависимости"
 
 #. settings-schema.json->section_tempDisktemp->title
 msgid "For the time being, disk temperature can only be read by root."
-msgstr "На данный момент температуру диска может считывать только пользователь root."
+msgstr ""
+"На данный момент температуру диска может считывать только пользователь root."
 
 #. settings-schema.json->section_tempDisplay->title
 #. settings-schema.json->section_fanDisplay->title
@@ -551,7 +555,8 @@ msgid ""
 "Whether or not to display the names of the main sensors (those displayed in "
 "the panel) in bold italics in the tooltip."
 msgstr ""
-"Выделять ли названия основных датчиков (отображаемых на панели) жирным курсивом в подсказке."
+"Выделять ли названия основных датчиков (отображаемых на панели) жирным "
+"курсивом в подсказке."
 
 #. settings-schema.json->tooltip_font_size->description
 msgid "Font size (px)"
@@ -575,8 +580,9 @@ msgid ""
 "box. Be careful with dependencies that are necessary for this applet to "
 "function properly."
 msgstr ""
-"Если вы не хотите устанавливать некоторые зависимости (например, шрифты), отметьте этот флажок. "
-"Будьте осторожны с зависимостями, необходимыми для корректной работы этого апплета."
+"Если вы не хотите устанавливать некоторые зависимости (например, шрифты), "
+"отметьте этот флажок. Будьте осторожны с зависимостями, необходимыми для "
+"корректной работы этого апплета."
 
 #. settings-schema.json->make_disktemp_readable_by_user->description
 msgid "Make disk temperature user-readable"
@@ -598,8 +604,7 @@ msgstr "Показывать значения выбранных датчико�
 msgid ""
 "Whether or not to display the values of the sensors selected in the list "
 "below."
-msgstr ""
-"Показывать ли значения датчиков, выбранных в списке ниже."
+msgstr "Показывать ли значения датчиков, выбранных в списке ниже."
 
 #. settings-schema.json->show_temp_name->description
 #. settings-schema.json->show_fan_name->description
@@ -690,6 +695,19 @@ msgid ""
 msgstr ""
 "Если этот параметр включен, температуры, превышающие высокий или критический "
 "порог, записываются в системный журнал."
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Не проверять температуру GPU, если он находится в состоянии D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Если этот параметр включён, чтобы не выводить видеокарту GPU из спящего "
+"состояния для проверки температуры, не проверяйте её температуру, если она "
+"находится в режиме энергосбережения."
 
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
@@ -789,7 +807,8 @@ msgid ""
 "  You can use the 4 operations (+-*/) and parentheses.\n"
 "  Example: $*1.1+0.5"
 msgstr ""
-"Дважды щелкните по строке, чтобы изменить «Отображаемое имя», «Высокое», «Критическое» или «Формулу».\n"
+"Дважды щелкните по строке, чтобы изменить «Отображаемое имя», «Высокое», "
+"«Критическое» или «Формулу».\n"
 "Чтобы сбросить «Отображаемое имя», скопируйте/вставьте «Имя датчика».\n"
 "«Высокое» и «Критическое» (необязательно) должны быть допустимыми числами.\n"
 "«Формула» (необязательно):\n"
@@ -826,7 +845,8 @@ msgid ""
 "High and Critical values: Cf. technical manual of your disk."
 msgstr ""
 "Имя диска: имя диска, возвращаемое командой 'lsblk'. См. справку.\n"
-"Значения «Высокое» и «Критическое»: см. техническую документацию вашего диска."
+"Значения «Высокое» и «Критическое»: см. техническую документацию вашего "
+"диска."
 
 #. settings-schema.json->chars_fan->tooltip
 msgid "The first emoji in this list is used for fan"
@@ -870,7 +890,8 @@ msgid ""
 "  You can use the 4 operations (+-*/) and parentheses.\n"
 "  Example: $*1.1+0.5"
 msgstr ""
-"Дважды щелкните по строке, чтобы изменить «Отображаемое имя», «Мин.» или «Формулу».\n"
+"Дважды щелкните по строке, чтобы изменить «Отображаемое имя», «Мин.» или "
+"«Формулу».\n"
 "Чтобы сбросить «Отображаемое имя», скопируйте/вставьте «Имя датчика».\n"
 "«Мин.» (необязательно) должен быть допустимым числом.\n"
 "«Формула» (необязательно):\n"
@@ -936,7 +957,8 @@ msgid ""
 "  You can use the 4 operations (+-*/) and parentheses.\n"
 "  Example: $*1.1+0.5"
 msgstr ""
-"Дважды щелкните по строке, чтобы изменить «Отображаемое имя», «Мин.», «Макс.» или «Формулу».\n"
+"Дважды щелкните по строке, чтобы изменить «Отображаемое имя», «Мин.», "
+"«Макс.» или «Формулу».\n"
 "Чтобы сбросить «Отображаемое имя», скопируйте/вставьте «Имя датчика».\n"
 "«Мин.» и «Макс.» (необязательно) должны быть допустимыми числами.\n"
 "«Формула» (необязательно):\n"
@@ -950,8 +972,8 @@ msgid ""
 " Whether or not to display into this applet label the 'Shown name' of the "
 "sensors selected in the list below. Without effect in vertical panels."
 msgstr ""
-"Отображать ли в метке этого апплета «Отображаемое имя» выбранных ниже датчиков. "
-"Без эффекта в вертикальных панелях."
+"Отображать ли в метке этого апплета «Отображаемое имя» выбранных ниже "
+"датчиков. Без эффекта в вертикальных панелях."
 
 #. settings-schema.json->chars_intrusion->tooltip
 msgid "The first emoji in this list is used for intrusion"
@@ -1026,7 +1048,8 @@ msgid ""
 "Add a line by custom sensor to set the type, the name and the path of the "
 "file to monitor (/sys/class/...)."
 msgstr ""
-"Добавьте строку для пользовательского датчика, чтобы указать тип, имя и путь к файлу для мониторинга (/sys/class/...)."
+"Добавьте строку для пользовательского датчика, чтобы указать тип, имя и путь "
+"к файлу для мониторинга (/sys/class/...)."
 
 #. settings-schema.json->report->description
 #. scripts/show_sensor_values.sh:5
@@ -1048,13 +1071,3 @@ msgstr "Открыть веб-страницу HTML Colors"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Удалить с панели апплет temperature@fevimu"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Не проверять температуру GPU, если он находится в состоянии D3cold"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Если этот параметр включён, чтобы не выводить видеокарту GPU из спящего состояния для проверки температуры, не проверяйте её температуру, если она находится в режиме энергосбережения."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/ru.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/ru.po
@@ -1048,3 +1048,13 @@ msgstr "Открыть веб-страницу HTML Colors"
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Удалить с панели апплет temperature@fevimu"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Не проверять температуру GPU, если он находится в состоянии D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Если этот параметр включён, чтобы не выводить видеокарту GPU из спящего состояния для проверки температуры, не проверяйте её температуру, если она находится в режиме энергосбережения."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/tr.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2021-01-04 11:39+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
@@ -24,104 +24,104 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Sensörler Monitörü"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr ""
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "yüksek:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "d/y"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "kritik:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "asg:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "azm:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "İzinsiz giriş tespit edilmedi"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "GİRİŞ TESPİT EDİLDİ!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Yapılandırılmalıdır!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Ayarlar"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Genel"
 
-#. applet.js:1542
+#. applet.js:1547
 #, fuzzy, javascript-format
 msgid "%s Temperature sensors"
 msgstr "Sıcaklık sensörleri"
 
-#. applet.js:1559
+#. applet.js:1564
 #, fuzzy, javascript-format
 msgid "%s Fan sensors"
 msgstr "Fan sensörleri"
 
-#. applet.js:1576
+#. applet.js:1581
 #, fuzzy, javascript-format
 msgid "%s Voltage sensors"
 msgstr "Voltaj sensörleri"
 
-#. applet.js:1593
+#. applet.js:1598
 #, fuzzy, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "İzinsiz giriş sensörleri"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Xsensorleri çalıştır"
 
-#. applet.js:1638
+#. applet.js:1643
 #, fuzzy
 msgid "Suspend Sensors"
 msgstr "Xsensorleri çalıştır"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Bu uygulamayı yeniden yükleyin"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "'%s'yi kaldırmak istediğinizden emin misiniz?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "%s uygulaması tamamen işlevseldir."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Tüm bağımlılıklar yüklü"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -129,15 +129,16 @@ msgstr ""
 "Bu uygulamanın tüm özelliklerine sahip olması için gereken programlardan "
 "bazılarını kaçırıyorsunuz."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr ""
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Bazı bağımlılıklar kurulu değil!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr ""
 
@@ -698,6 +699,19 @@ msgid ""
 "limit are recorded in the system journal."
 msgstr ""
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "GPU D3cold durumundaysa sıcaklığını kontrol etmeyi durdur"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Bu seçenek işaretlenirse, sıcaklığını kontrol etmek için GPU kartını "
+"uyandırmaktan kaçınmak amacıyla, güç tasarrufu modundaysa sıcaklığını "
+"kontrol etmeyin."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1015,13 +1029,3 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Panelden temperature@fevimu uygulamasını kaldırın"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "GPU D3cold durumundaysa sıcaklığını kontrol etmeyi durdur"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Bu seçenek işaretlenirse, sıcaklığını kontrol etmek için GPU kartını uyandırmaktan kaçınmak amacıyla, güç tasarrufu modundaysa sıcaklığını kontrol etmeyin."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/tr.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/tr.po
@@ -1015,3 +1015,13 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Panelden temperature@fevimu uygulamasını kaldırın"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "GPU D3cold durumundaysa sıcaklığını kontrol etmeyi durdur"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Bu seçenek işaretlenirse, sıcaklığını kontrol etmek için GPU kartını uyandırmaktan kaçınmak amacıyla, güç tasarrufu modundaysa sıcaklığını kontrol etmeyin."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/vi.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/vi.po
@@ -1054,3 +1054,13 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Xóa tiểu dụng temperature@fevimu khỏi bảng"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Ngừng kiểm tra nhiệt độ GPU nếu GPU đang ở trạng thái D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "Nếu tùy chọn này được chọn, để tránh đánh thức card GPU nhằm kiểm tra nhiệt độ, không kiểm tra nhiệt độ của GPU khi GPU đang ở chế độ tiết kiệm điện."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/vi.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Sensors@claudiux 5.4.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -23,103 +23,103 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "Trình giám sát cảm biến"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "Đã tạm dừng"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "cao:"
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "không có"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "nguy hiểm:"
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "thấp:"
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "cao:"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "Không phát hiện xâm nhập"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "PHÁT HIỆN XÂM NHẬP!"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "Cần được cấu hình!"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "Cài đặt"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr ":"
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ Chung"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "Cảm biến nhiệt độ %s"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "Cảm biến quạt %s"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "Cảm biến điện áp %s"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "Cảm biến xâm nhập %s"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "Chạy xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "Tạm dừng cảm biến"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "Tải lại applet này"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "Bạn có chắc muốn xóa '%s' không?"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "Applet %s đang hoạt động đầy đủ."
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "Tất cả các gói phụ thuộc đã được cài đặt"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -127,15 +127,16 @@ msgstr ""
 "Có vẻ bạn đang thiếu một số chương trình cần thiết để applet này hoạt động "
 "đầy đủ."
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "Vui lòng cài đặt các gói sau:"
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "Một số gói phụ thuộc chưa được cài đặt!"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "Cài đặt các gói này ngay"
 
@@ -687,6 +688,18 @@ msgstr ""
 "Khi được bật, các giá trị nhiệt độ vượt ngưỡng cao hoặc tới hạn sẽ được ghi "
 "lại trong nhật ký hệ thống."
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "Ngừng kiểm tra nhiệt độ GPU nếu GPU đang ở trạng thái D3cold"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"Nếu tùy chọn này được chọn, để tránh đánh thức card GPU nhằm kiểm tra nhiệt "
+"độ, không kiểm tra nhiệt độ của GPU khi GPU đang ở chế độ tiết kiệm điện."
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1054,13 +1067,3 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "Xóa tiểu dụng temperature@fevimu khỏi bảng"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "Ngừng kiểm tra nhiệt độ GPU nếu GPU đang ở trạng thái D3cold"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "Nếu tùy chọn này được chọn, để tránh đánh thức card GPU nhằm kiểm tra nhiệt độ, không kiểm tra nhiệt độ của GPU khi GPU đang ở chế độ tiết kiệm điện."

--- a/Sensors@claudiux/files/Sensors@claudiux/po/zh_TW.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/zh_TW.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Sensors@claudiux 5.4.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2026-04-26 01:27+0200\n"
+"POT-Creation-Date: 2026-08-29 09:24-0400\n"
 "PO-Revision-Date: 2025-08-31 23:55+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -21,117 +21,118 @@ msgstr ""
 msgid "Sensors Monitor"
 msgstr "感測器監視器"
 
-#. applet.js:594
+#. applet.js:599
 msgid "Suspended"
 msgstr "已暫停"
 
-#. applet.js:936 applet.js:978
+#. applet.js:941 applet.js:983
 msgid "high:"
 msgstr "高："
 
-#. applet.js:936 applet.js:939 applet.js:978 applet.js:980 applet.js:1021
+#. applet.js:941 applet.js:944 applet.js:983 applet.js:985 applet.js:1026
 msgid "n/a"
 msgstr "無資料"
 
-#. applet.js:939 applet.js:980
+#. applet.js:944 applet.js:985
 msgid "crit:"
 msgstr "臨界："
 
-#. applet.js:1021 applet.js:1065
+#. applet.js:1026 applet.js:1070
 msgid "min:"
 msgstr "最低："
 
-#. applet.js:1067
+#. applet.js:1072
 msgid "max:"
 msgstr "最高："
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "No intrusion detected"
 msgstr "未偵測到入侵"
 
-#. applet.js:1096
+#. applet.js:1101
 msgid "INTRUSION DETECTED!"
 msgstr "偵測到入侵！"
 
-#. applet.js:1116
+#. applet.js:1121
 msgid "Must be configured!"
 msgstr "必須進行設定！"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid "Settings"
 msgstr "設定"
 
-#. applet.js:1518
+#. applet.js:1523
 msgid ":"
 msgstr "："
 
 #. settings-schema.json->page_General->title
-#. applet.js:1525
+#. applet.js:1530
 msgid "⚙ General"
 msgstr "⚙ 一般"
 
-#. applet.js:1542
+#. applet.js:1547
 #, javascript-format
 msgid "%s Temperature sensors"
 msgstr "%s 個溫度感測器"
 
-#. applet.js:1559
+#. applet.js:1564
 #, javascript-format
 msgid "%s Fan sensors"
 msgstr "%s 個風扇感測器"
 
-#. applet.js:1576
+#. applet.js:1581
 #, javascript-format
 msgid "%s Voltage sensors"
 msgstr "%s 個電壓感測器"
 
-#. applet.js:1593
+#. applet.js:1598
 #, javascript-format
 msgid "%s Intrusion sensors"
 msgstr "%s 個入侵感測器"
 
 #. settings-schema.json->xsensors->description
-#. applet.js:1629
+#. applet.js:1634
 msgid "Run xsensors"
 msgstr "執行 xsensors"
 
-#. applet.js:1638
+#. applet.js:1643
 msgid "Suspend Sensors"
 msgstr "暫停感測器"
 
-#. applet.js:1649
+#. applet.js:1654
 msgid "Reload this applet"
 msgstr "重新載入這個小程式"
 
-#. applet.js:2005
+#. applet.js:2010
 #, javascript-format
 msgid "Are you sure you want to remove '%s'?"
 msgstr "確定要移除 '%s' 嗎？"
 
-#. lib/checkDependencies.js:371
+#. lib/checkDependencies.js:376
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "小程式 %s 功能完整。"
 
-#. lib/checkDependencies.js:372
+#. lib/checkDependencies.js:377
 msgid "All dependencies are installed"
 msgstr "所有相依性套件均已安裝"
 
-#. lib/checkDependencies.js:401
+#. lib/checkDependencies.js:407
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
 msgstr "似乎缺少這個小程式完整功能所需的部分程式。"
 
-#. lib/checkDependencies.js:403
+#. lib/checkDependencies.js:409
 msgid "Please install these packages:"
 msgstr "請安裝下列套件："
 
-#. lib/checkDependencies.js:407 lib/checkDependencies.js:417
+#. lib/checkDependencies.js:413 lib/checkDependencies.js:423
+#. lib/checkDependencies.js:432
 msgid "Some dependencies are not installed!"
 msgstr "部分相依性套件尚未安裝！"
 
-#. lib/checkDependencies.js:419
+#. lib/checkDependencies.js:425 lib/checkDependencies.js:434
 msgid "Install these packages now"
 msgstr "立即安裝這些套件"
 
@@ -674,6 +675,18 @@ msgid ""
 "limit are recorded in the system journal."
 msgstr "勾選此選項時，超過高溫或臨界限制的溫度將記錄於系統日誌中。"
 
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "如果 GPU 處於 D3cold 狀態，則停止檢查其溫度"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr ""
+"如果勾選此選項，為避免喚醒 GPU 顯示卡來檢查其溫度，當它處於省電模式時不要檢查"
+"其溫度。"
+
 #. settings-schema.json->btn_renew_temp_sensors_list->description
 #. settings-schema.json->btn_renew_fan_sensors_list->description
 #. settings-schema.json->btn_renew_volt_sensors_list->description
@@ -1029,13 +1042,3 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "從面板移除 temperature@fevimu 小程式"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->description
-msgid "Stop checking GPU temperature if in D3cold state"
-msgstr "如果 GPU 處於 D3cold 狀態，則停止檢查其溫度"
-
-#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
-msgid ""
-"If this option is checked, to avoid waking up GPU card to check its "
-"temperature, don't check it's temperature if it's in powersave mode"
-msgstr "如果勾選此選項，為避免喚醒 GPU 顯示卡來檢查其溫度，當它處於省電模式時不要檢查其溫度。"

--- a/Sensors@claudiux/files/Sensors@claudiux/po/zh_TW.po
+++ b/Sensors@claudiux/files/Sensors@claudiux/po/zh_TW.po
@@ -1029,3 +1029,13 @@ msgstr ""
 #. settings-schema.json->remove_temperatureATfevimu->description
 msgid "Remove from panel the temperature@fevimu applet"
 msgstr "從面板移除 temperature@fevimu 小程式"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->description
+msgid "Stop checking GPU temperature if in D3cold state"
+msgstr "如果 GPU 處於 D3cold 狀態，則停止檢查其溫度"
+
+#. settings-schema.json->no_check_gpu_if_d3cold->tooltip
+msgid ""
+"If this option is checked, to avoid waking up GPU card to check its "
+"temperature, don't check it's temperature if it's in powersave mode"
+msgstr "如果勾選此選項，為避免喚醒 GPU 顯示卡來檢查其溫度，當它處於省電模式時不要檢查其溫度。"

--- a/Sensors@claudiux/files/Sensors@claudiux/settings-schema.json
+++ b/Sensors@claudiux/files/Sensors@claudiux/settings-schema.json
@@ -162,7 +162,8 @@
         "show_unit",
         "show_unit_letter",
         "always_show_unit_in_line",
-        "journalize_temp"
+        "journalize_temp",
+        "no_check_gpu_if_d3cold"
       ]
     },
     "section_tempSensors": {
@@ -584,6 +585,12 @@
     "default": false,
     "description": "Log high and critical temperatures",
     "tooltip": "When this option is checked, temperatures exceeding the high or critical limit are recorded in the system journal."
+  },
+  "no_check_gpu_if_d3cold": {
+    "type": "switch",
+    "default": false,
+    "description": "Stop checking GPU temperature if in D3cold state",
+    "tooltip": "If this option is checked, to avoid waking up GPU card to check its temperature, don't check it's temperature if it's in powersave mode"
   },
   "btn_renew_temp_sensors_list": {
     "type": "button",


### PR DESCRIPTION
When using the nvidia-smi command to retrieve GPU temperature, that wakes up the card for a short while. This is not ideal power-wise, and in laptops this can pose battery usage times problems. For example, in a Legion, that goes from 3h to 1h and a half for a RTX 5080. Remembering to manually suspend the temperature check is not ideal.
So this adds a switch on the temperature page that allows you to stop checking for GPU temperature if the state of the cards goes into D3cold, returning a default low value. You have to set the temperature check interval to a value greater than the idle time for the card or it will never go in D3cold.

The translations .po files have been done by ChatGPT.