### PR TITLE
Quick Alarm v1.5.0

### DIFF
--- a/quick-alarm@andreas-glaser/README.md
+++ b/quick-alarm@andreas-glaser/README.md
@@ -1,6 +1,8 @@
-# Quick Alarm
+# Quick Alarm (Cinnamon Applet)
 
 Queue alarms fast from your Cinnamon panel. Click the applet icon, type a time, press Enter.
+
+![Screenshot](screenshot.png)
 
 ## Usage
 
@@ -9,22 +11,47 @@ Queue alarms fast from your Cinnamon panel. Click the applet icon, type a time, 
 3. Press Enter (or Ctrl+Enter to add another without closing).
 
 ### Examples
-
 - `in 10m tea`
 - `after 5m - stretch`
 - `5 seconds`
-- `11:59am meeting`
-- `tomorrow 11:30 standup`
+- `Stretch 30m`
+- `11:59am claude`
+- `claude at 11:59 am`
+- `tomorrow 11:30 - reset`
 
 ### What happens when it fires
-
 - A fullscreen overlay appears showing the time, label, and how long ago it fired.
 - Plays an alarm sound.
 - Click anywhere, press Escape/Enter/Space, or click Dismiss to close.
+- If several alarms fire together, fullscreen alarms are shown one at a time.
+
+### Sleep / wake behavior
+If your computer wakes after an alarm time:
+- If it’s only slightly overdue, it fires immediately.
+- If it’s overdue by more than a short grace window, you get a “Missed alarm” notification (no sound) and it’s removed from the queue.
+
+Queued alarms are saved automatically and restored after logging in or rebooting. Restored overdue alarms follow the same grace-window behavior.
+
+## Local Install (Linux Mint / Cinnamon)
+```bash
+tools/install.sh
+```
+
+Restart Cinnamon (Alt+F2 → `r`), then add the applet from:
+Panel Settings → Applets
 
 ## Settings
-
+- **Show remaining time**: display countdown beside the panel icon (default: off)
+- **Use a custom icon**: replace the default alarm icon with any icon file or theme icon name (default: off)
 - **Fullscreen notification**: show fullscreen overlay when alarm fires (default: on)
 - **Alarm sound mode**: chime once, or ring for a duration
 - **Ring duration**: how long "ring" mode plays sounds
 - **Open shortcut**: global hotkey to open the applet menu (default: Super+Alt+A)
+
+## Development
+- Build output: `tools/build.sh` → `applet/quick-alarm@andreas-glaser/`
+- Tests: `tests/run.sh` (requires `gjs`)
+- Release zip: `tools/release.sh`
+
+## Cinnamon Spices
+Publishing notes: `docs/dev/release.md`

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/applet.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/applet.js
@@ -4,7 +4,6 @@ const MessageTray = imports.ui.messageTray;
 const PopupMenu = imports.ui.popupMenu;
 const Settings = imports.ui.settings;
 const St = imports.gi.St;
-const Util = imports.misc.util;
 const GLib = imports.gi.GLib;
 const AppletManager = imports.ui.appletManager;
 const Clutter = imports.gi.Clutter;
@@ -20,34 +19,29 @@ let AlarmText = null;
 let EntryKeys = null;
 let Hotkeys = null;
 let Icon = null;
+let AlarmPersistence = null;
+let SoundSchedule = null;
 
 function _spawnWithExitCallback(argv, onExit) {
-  const pid = Util.spawn(argv);
-  if (!pid) return 0;
-
-  if (onExit) {
+  const process = Gio.Subprocess.new(argv, Gio.SubprocessFlags.NONE);
+  process.wait_async(null, (proc, result) => {
+    let successful = false;
     try {
-      GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, (childPid) => {
-        try {
-          GLib.spawn_close_pid(childPid);
-        } catch (e) {
-          // ignore
-        }
-        try {
-          onExit(childPid);
-        } catch (e) {
-          // ignore
-        }
-      });
+      proc.wait_finish(result);
+      successful = proc.get_successful();
     } catch (e) {
-      // ignore
+      // Treat failed waits as unsuccessful exits.
     }
-  }
-
-  return pid;
+    try {
+      if (onExit) onExit(proc, successful);
+    } catch (e) {
+      // ignore callback failures
+    }
+  });
+  return process;
 }
 
-function _playChime({ onPid, onExit } = {}) {
+function _playChime({ onProcess, onExit, excludedCommands = null } = {}) {
   const candidates = [
     {
       cmd: "paplay",
@@ -68,19 +62,22 @@ function _playChime({ onPid, onExit } = {}) {
 
   for (const candidate of candidates) {
     try {
+      if (excludedCommands && excludedCommands.has(candidate.cmd)) continue;
       if (!GLib.find_program_in_path(candidate.cmd)) continue;
       const argv = candidate.argv();
       if (!argv) continue;
 
-      const pid = _spawnWithExitCallback(argv, (childPid) => onExit && onExit(childPid));
-      if (onPid && pid) onPid(pid);
-      return pid;
+      const process = _spawnWithExitCallback(argv, (proc, successful) => {
+        if (onExit) onExit(proc, successful, candidate.cmd);
+      });
+      if (onProcess) onProcess(process);
+      return process;
     } catch (e) {
       // try next candidate
     }
   }
 
-  return 0;
+  return null;
 }
 
 function QuickAlarmApplet(metadata, orientation, panelHeight, instanceId) {
@@ -119,11 +116,11 @@ QuickAlarmApplet.prototype = {
   },
 
   _updateIcon() {
-    const resolved = Icon.resolveIcon(this._useCustomIcon, this._customIcon, {
-      isAbsolutePath: (p) => GLib.path_is_absolute(p),
-      themeLookupIcon: (n) => Gtk.IconTheme.get_default().lookup_icon(n, 16, 0),
-    });
     try {
+      const resolved = Icon.resolveIcon(this._useCustomIcon, this._customIcon, {
+        isAbsolutePath: (p) => GLib.path_is_absolute(p),
+        themeLookupIcon: (n) => Gtk.IconTheme.get_default().lookup_icon(n, 16, 0),
+      });
       const methods = {
         symbolic_name: "set_applet_icon_symbolic_name",
         name: "set_applet_icon_name",
@@ -223,6 +220,16 @@ QuickAlarmApplet.prototype = {
     return "";
   },
 
+  _persistAlarms() {
+    if (this._suppressAlarmPersistence || !this.settings || !this._service) return;
+    try {
+      const stored = AlarmPersistence.serializeAlarms(this._service.list());
+      this.settings.setValue("savedAlarms", stored);
+    } catch (e) {
+      global.logWarning("quick-alarm: could not save alarms: " + e);
+    }
+  },
+
   _setEntryText(text) {
     if (this._entry.set_text) return this._entry.set_text(text);
     if (this._entry.clutter_text && this._entry.clutter_text.set_text)
@@ -239,17 +246,26 @@ QuickAlarmApplet.prototype = {
     this._openShortcut = "";
     this._openHotkeyName = `${metadata.uuid}-open-${instanceId}`;
     this._activeSoundTimers = new Set();
-    this._activeAudioPids = new Set();
+    this._activeAudioProcesses = new Set();
     this._blinkTimerId = 0;
     this._ringEndTimerId = 0;
     this._countdownTimerId = 0;
+    this._fullscreenAgoTimerId = 0;
+    this._fullscreenLayoutIdleId = 0;
+    this._nextAlarmIdleId = 0;
+    this._missedAlarmIdleId = 0;
     this._isRinging = false;
     this._ringToken = 0;
     this._panelState = "idle";
     this._fullscreenOverlay = null;
+    this._pendingFullscreenAlarms = [];
+    this._pendingMissedAlarms = [];
+    this._previousKeyFocus = null;
     this._useCustomIcon = false;
     this._customIcon = "alarm-symbolic";
     this._iconIsSymbolic = true;
+    this._suppressAlarmPersistence = true;
+    this._isShuttingDown = false;
 
     this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
     this.settings.bind("soundMode", "_soundMode");
@@ -276,7 +292,9 @@ QuickAlarmApplet.prototype = {
     this.menu.actor.add_style_class_name("qa-menu");
 
     this._cinnamonThemeSettings = new Gio.Settings({ schema_id: "org.cinnamon.theme" });
-    this._cinnamonThemeSettings.connect("changed::name", () => this._applyThemeClass());
+    this._cinnamonThemeChangedId = this._cinnamonThemeSettings.connect("changed::name", () =>
+      this._applyThemeClass(),
+    );
     this._applyThemeClass();
 
     const gearIcon = new St.Icon({
@@ -325,7 +343,7 @@ QuickAlarmApplet.prototype = {
 
     this._entry = new St.Entry({
       style_class: "qa-entry",
-      hint_text: "Type: in 10m tea  •  11am standup  •  Ctrl+Enter adds another",
+      hint_text: this._("Type: in 10m tea  •  11am standup  •  Ctrl+Enter adds another"),
       track_hover: true,
       can_focus: true,
     });
@@ -363,10 +381,23 @@ QuickAlarmApplet.prototype = {
     this.menu.addMenuItem(this._listSection);
 
     this._service = new AlarmService(
-      () => this._render(),
+      () => {
+        if (this._isShuttingDown) return;
+        this._persistAlarms();
+        this._render();
+      },
       (alarm) => this._fire(alarm),
-      { onMissed: (alarm) => this._missed(alarm) },
+      { onMissed: (alarm) => this._queueMissedAlarm(alarm) },
     );
+
+    try {
+      const restored = AlarmPersistence.deserializeAlarms(this.settings.getValue("savedAlarms"));
+      this._service.restore(restored);
+    } catch (e) {
+      global.logWarning("quick-alarm: could not restore alarms: " + e);
+    }
+    this._suppressAlarmPersistence = false;
+    this._persistAlarms();
 
     this._entryText = this._entry.clutter_text;
     this._entryText.connect("key-press-event", (_actor, event) => {
@@ -418,6 +449,16 @@ QuickAlarmApplet.prototype = {
   },
 
   on_applet_removed_from_panel() {
+    // The queue has already been persisted. Do not overwrite it with the
+    // service's empty shutdown state during logout or a Cinnamon restart.
+    this._suppressAlarmPersistence = true;
+    this._isShuttingDown = true;
+    this._pendingFullscreenAlarms = [];
+    this._pendingMissedAlarms = [];
+    if (this._nextAlarmIdleId) GLib.source_remove(this._nextAlarmIdleId);
+    this._nextAlarmIdleId = 0;
+    if (this._missedAlarmIdleId) GLib.source_remove(this._missedAlarmIdleId);
+    this._missedAlarmIdleId = 0;
     this._stopAllSounds();
     this._hideFullscreenOverlay();
     this._service.destroy();
@@ -426,6 +467,13 @@ QuickAlarmApplet.prototype = {
     } catch (e) {
       // ignore
     }
+    try {
+      if (this._cinnamonThemeSettings && this._cinnamonThemeChangedId)
+        this._cinnamonThemeSettings.disconnect(this._cinnamonThemeChangedId);
+    } catch (e) {
+      // ignore
+    }
+    this._cinnamonThemeChangedId = 0;
     try {
       if (Main.keybindingManager && this._openHotkeyName)
         Main.keybindingManager.removeHotKey(this._openHotkeyName);
@@ -450,10 +498,13 @@ QuickAlarmApplet.prototype = {
       }
 
       const label = AlarmText.getStoredLabel(parsed.label);
-      this._service.add(parsed.due, label, parsed.showSeconds);
+      const id = this._service.add(parsed.due, label, parsed.showSeconds);
+      if (!id) {
+        this._errorLabel.text = this._("Too many alarms queued.");
+        return;
+      }
       this._setEntryText("");
       this._errorLabel.text = "";
-      this._render();
       if (closeMenu) {
         this.menu.close();
       } else {
@@ -466,6 +517,12 @@ QuickAlarmApplet.prototype = {
   },
 
   _fire(alarm) {
+    if (this._isShuttingDown) return;
+    if (this._fullscreenOverlay || this._nextAlarmIdleId) {
+      this._pendingFullscreenAlarms.push(alarm);
+      return;
+    }
+
     this._stopAllSounds();
     this._playAlarmSound();
 
@@ -499,19 +556,44 @@ QuickAlarmApplet.prototype = {
     this._notificationSource.notify(notification);
   },
 
+  _queueMissedAlarm(alarm) {
+    if (this._isShuttingDown) return;
+    this._pendingMissedAlarms.push(alarm);
+    if (this._missedAlarmIdleId) return;
+
+    this._missedAlarmIdleId = GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+      this._missedAlarmIdleId = 0;
+      if (this._isShuttingDown) return GLib.SOURCE_REMOVE;
+
+      const missed = this._pendingMissedAlarms.splice(0);
+      if (missed.length === 1) {
+        this._missed(missed[0]);
+      } else if (missed.length > 1) {
+        const notification = new MessageTray.Notification(
+          this._notificationSource,
+          this._("Missed alarms"),
+          this._("%d alarms were missed.").replace("%d", missed.length),
+        );
+        notification.setTransient(true);
+        this._notificationSource.notify(notification);
+      }
+      return GLib.SOURCE_REMOVE;
+    });
+  },
+
   _stopAllSounds() {
     this._ringToken++;
     for (const id of this._activeSoundTimers) GLib.source_remove(id);
     this._activeSoundTimers.clear();
 
-    for (const pid of this._activeAudioPids) {
+    for (const process of this._activeAudioProcesses) {
       try {
-        Util.spawn(["kill", "-TERM", String(pid)]);
+        process.force_exit();
       } catch (e) {
         // ignore
       }
     }
-    this._activeAudioPids.clear();
+    this._activeAudioProcesses.clear();
 
     this._isRinging = false;
     if (this._ringEndTimerId) GLib.source_remove(this._ringEndTimerId);
@@ -522,17 +604,48 @@ QuickAlarmApplet.prototype = {
 
   _playAlarmSound() {
     if (this._soundMode !== "ring") {
-      _playChime({
-        onPid: (pid) => this._activeAudioPids.add(pid),
-        onExit: (pid) => this._activeAudioPids.delete(pid),
-      });
+      const endAt = Date.now() + 2000;
+      const token = ++this._ringToken;
+      const failedCommands = new Set();
+
       this._startRingingWindow(2000);
+
+      const playFallback = () => {
+        if (token !== this._ringToken || !this._isRinging || Date.now() >= endAt) return;
+
+        const startedAt = Date.now();
+        const process = _playChime({
+          onProcess: (proc) => this._activeAudioProcesses.add(proc),
+          onExit: (proc, successful, command) => {
+            this._activeAudioProcesses.delete(proc);
+            if (successful || token !== this._ringToken || !this._isRinging) return;
+
+            failedCommands.add(command);
+            const delayMs = SoundSchedule.getRingRetryDelay(startedAt, Date.now());
+            if (Date.now() + delayMs >= endAt) return;
+
+            let timerId = 0;
+            timerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delayMs, () => {
+              this._activeSoundTimers.delete(timerId);
+              playFallback();
+              return GLib.SOURCE_REMOVE;
+            });
+            this._activeSoundTimers.add(timerId);
+          },
+          excludedCommands: failedCommands,
+        });
+        if (!process) global.logWarning("quick-alarm: no alarm sound player is available");
+      };
+
+      playFallback();
       return;
     }
 
-    const seconds = Math.max(1, Number(this._ringSeconds) || 1);
+    const configuredSeconds = Number(this._ringSeconds);
+    const seconds = Math.min(120, Math.max(1, Number.isFinite(configuredSeconds) ? configuredSeconds : 1));
     const endAt = Date.now() + seconds * 1000;
     const token = ++this._ringToken;
+    const failedCommands = new Set();
 
     this._startRingingWindow(seconds * 1000);
 
@@ -541,13 +654,28 @@ QuickAlarmApplet.prototype = {
       if (!this._isRinging) return;
       if (Date.now() >= endAt) return;
 
-      _playChime({
-        onPid: (pid) => this._activeAudioPids.add(pid),
-        onExit: (pid) => {
-          this._activeAudioPids.delete(pid);
-          playNext();
+      const startedAt = Date.now();
+      const process = _playChime({
+        onProcess: (proc) => this._activeAudioProcesses.add(proc),
+        onExit: (proc, successful, command) => {
+          this._activeAudioProcesses.delete(proc);
+          if (!successful) failedCommands.add(command);
+          if (token !== this._ringToken || !this._isRinging) return;
+
+          const delayMs = SoundSchedule.getRingRetryDelay(startedAt, Date.now());
+          if (Date.now() + delayMs >= endAt) return;
+
+          let timerId = 0;
+          timerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delayMs, () => {
+            this._activeSoundTimers.delete(timerId);
+            playNext();
+            return GLib.SOURCE_REMOVE;
+          });
+          this._activeSoundTimers.add(timerId);
         },
+        excludedCommands: failedCommands,
       });
+      if (!process) global.logWarning("quick-alarm: no alarm sound player is available");
     };
 
     playNext();
@@ -557,24 +685,46 @@ QuickAlarmApplet.prototype = {
     return TimeAgo.formatTimeAgo(dueDate, Date.now(), (s) => this._(s));
   },
 
-  _showFullscreenOverlay(alarm) {
+  _dismissFullscreenAlarm() {
+    this._stopAllSounds();
     this._hideFullscreenOverlay();
 
+    if (this._isShuttingDown || this._pendingFullscreenAlarms.length === 0) return;
+    const nextAlarm = this._pendingFullscreenAlarms.shift();
+    this._nextAlarmIdleId = GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+      this._nextAlarmIdleId = 0;
+      this._fire(nextAlarm);
+      return GLib.SOURCE_REMOVE;
+    });
+  },
+
+  _showFullscreenOverlay(alarm) {
     const monitor = Main.layoutManager.primaryMonitor;
+    const monitors =
+      Main.layoutManager.monitors && Main.layoutManager.monitors.length > 0
+        ? Main.layoutManager.monitors
+        : [monitor];
+    const minX = Math.min(...monitors.map((m) => m.x));
+    const minY = Math.min(...monitors.map((m) => m.y));
+    const maxX = Math.max(...monitors.map((m) => m.x + m.width));
+    const maxY = Math.max(...monitors.map((m) => m.y + m.height));
+    this._previousKeyFocus = global.stage.get_key_focus();
 
     // Create fullscreen overlay container
     this._fullscreenOverlay = new St.Widget({
       reactive: true,
-      x: monitor.x,
-      y: monitor.y,
-      width: monitor.width,
-      height: monitor.height,
+      can_focus: true,
+      x: minX,
+      y: minY,
+      width: maxX - minX,
+      height: maxY - minY,
       style_class: "qa-fullscreen-overlay",
     });
 
     // Central card
     const card = new St.BoxLayout({
       vertical: true,
+      opacity: 0,
       style_class: "qa-fullscreen-card",
     });
 
@@ -628,8 +778,7 @@ QuickAlarmApplet.prototype = {
       can_focus: true,
     });
     dismissBtn.connect("clicked", () => {
-      this._stopAllSounds();
-      this._hideFullscreenOverlay();
+      this._dismissFullscreenAlarm();
     });
 
     card.add_child(icon);
@@ -638,18 +787,11 @@ QuickAlarmApplet.prototype = {
     card.add_child(agoLabel);
     card.add_child(dismissBtn);
 
-    // Center the card
-    card.set_position(
-      Math.floor((monitor.width - card.width) / 2),
-      Math.floor((monitor.height - card.height) / 2),
-    );
-
     this._fullscreenOverlay.add_child(card);
 
     // Dismiss on background click
     this._fullscreenOverlay.connect("button-press-event", () => {
-      this._stopAllSounds();
-      this._hideFullscreenOverlay();
+      this._dismissFullscreenAlarm();
       return Clutter.EVENT_STOP;
     });
 
@@ -657,8 +799,7 @@ QuickAlarmApplet.prototype = {
     this._fullscreenKeyHandler = this._fullscreenOverlay.connect("key-press-event", (_actor, event) => {
       const symbol = event.get_key_symbol();
       if (symbol === Clutter.KEY_Escape || symbol === Clutter.KEY_Return || symbol === Clutter.KEY_space) {
-        this._stopAllSounds();
-        this._hideFullscreenOverlay();
+        this._dismissFullscreenAlarm();
         return Clutter.EVENT_STOP;
       }
       return Clutter.EVENT_PROPAGATE;
@@ -667,27 +808,45 @@ QuickAlarmApplet.prototype = {
     Main.layoutManager.addChrome(this._fullscreenOverlay, { visibleInFullscreen: true });
     global.stage.set_key_focus(this._fullscreenOverlay);
 
-    // Re-center after card gets its natural size
-    GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
-      if (this._fullscreenOverlay && card) {
-        card.set_position(
-          Math.floor((monitor.width - card.width) / 2),
-          Math.floor((monitor.height - card.height) / 2),
-        );
-      }
+    // Wait until Cinnamon has attached and laid out the card before reading
+    // its dimensions. The captured overlay identity prevents a dismissed
+    // alarm's callback from touching a newer overlay or a destroyed card.
+    const overlay = this._fullscreenOverlay;
+    this._fullscreenLayoutIdleId = GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+      this._fullscreenLayoutIdleId = 0;
+      if (this._fullscreenOverlay !== overlay || !card.get_stage()) return GLib.SOURCE_REMOVE;
+
+      card.set_position(
+        monitor.x - minX + Math.floor((monitor.width - card.width) / 2),
+        monitor.y - minY + Math.floor((monitor.height - card.height) / 2),
+      );
+      card.opacity = 255;
       return GLib.SOURCE_REMOVE;
     });
   },
 
   _hideFullscreenOverlay() {
+    if (this._fullscreenLayoutIdleId) {
+      GLib.source_remove(this._fullscreenLayoutIdleId);
+      this._fullscreenLayoutIdleId = 0;
+    }
     if (this._fullscreenAgoTimerId) {
       GLib.source_remove(this._fullscreenAgoTimerId);
       this._fullscreenAgoTimerId = 0;
     }
     if (this._fullscreenOverlay) {
+      const previousFocus = this._previousKeyFocus;
       Main.layoutManager.removeChrome(this._fullscreenOverlay);
       this._fullscreenOverlay.destroy();
       this._fullscreenOverlay = null;
+      this._previousKeyFocus = null;
+      if (!this._isShuttingDown && previousFocus) {
+        try {
+          global.stage.set_key_focus(previousFocus);
+        } catch (e) {
+          // The previously focused actor may have been destroyed.
+        }
+      }
     }
   },
 
@@ -796,5 +955,7 @@ function main(metadata, orientation, panelHeight, instanceId) {
   EntryKeys = imports.lib.entryKeys;
   Hotkeys = imports.lib.hotkeys;
   Icon = imports.lib.icon;
+  AlarmPersistence = imports.lib.alarmPersistence;
+  SoundSchedule = imports.lib.soundSchedule;
   return new QuickAlarmApplet(metadata, orientation, panelHeight, instanceId);
 }

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/alarmLimits.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/alarmLimits.js
@@ -1,0 +1,2 @@
+var MAX_ALARMS = 1000;
+var MAX_TEXT_LENGTH = 4096;

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/alarmPersistence.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/alarmPersistence.js
@@ -1,0 +1,45 @@
+const Limits = imports.lib.alarmLimits;
+
+const MAX_DATE_MS = 8640000000000000;
+
+function _isValidDueMs(value) {
+  return Number.isSafeInteger(value) && value > 0 && value <= MAX_DATE_MS;
+}
+
+function serializeAlarms(alarms) {
+  if (!Array.isArray(alarms)) return [];
+
+  const stored = [];
+  for (const alarm of alarms) {
+    if (stored.length >= Limits.MAX_ALARMS) break;
+    if (!alarm || !alarm.due || typeof alarm.due.getTime !== "function") continue;
+
+    const dueMs = alarm.due.getTime();
+    if (!_isValidDueMs(dueMs)) continue;
+
+    const label = typeof alarm.label === "string" ? alarm.label.slice(0, Limits.MAX_TEXT_LENGTH) : "";
+    stored.push({ dueMs, label, showSeconds: alarm.showSeconds === true });
+  }
+  return stored;
+}
+
+function deserializeAlarms(value) {
+  if (!Array.isArray(value)) return [];
+
+  const alarms = [];
+  for (const stored of value) {
+    if (alarms.length >= Limits.MAX_ALARMS) break;
+    if (!stored || typeof stored !== "object" || !_isValidDueMs(stored.dueMs)) continue;
+
+    const label = typeof stored.label === "string" ? stored.label.slice(0, Limits.MAX_TEXT_LENGTH) : "";
+    alarms.push({
+      due: new Date(stored.dueMs),
+      label,
+      showSeconds: stored.showSeconds === true,
+    });
+  }
+  return alarms;
+}
+
+var serializeAlarms = serializeAlarms;
+var deserializeAlarms = deserializeAlarms;

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/hotkeys.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/hotkeys.js
@@ -7,7 +7,7 @@ var syncHotkey = function ({ keybindingManager, name, accel, onActivate, onError
     // ignore
   }
 
-  const normalized = (accel || "").trim();
+  const normalized = typeof accel === "string" ? accel.trim() : "";
   if (!normalized) return { added: false };
 
   try {
@@ -18,4 +18,3 @@ var syncHotkey = function ({ keybindingManager, name, accel, onActivate, onError
     return { added: false, error: e };
   }
 };
-

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/icon.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/icon.js
@@ -12,7 +12,7 @@
 function resolveIcon(useCustom, value, env) {
   var DEFAULT = { method: "symbolic_name", value: "alarm-symbolic" };
 
-  if (!useCustom || !value || value === "") return DEFAULT;
+  if (!useCustom || typeof value !== "string" || value === "") return DEFAULT;
 
   var isSymbolic = value.indexOf("-symbolic") !== -1;
 

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/soundSchedule.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/soundSchedule.js
@@ -1,0 +1,9 @@
+function getRingRetryDelay(startedAtMs, nowMs, minIntervalMs = 500) {
+  const started = Number(startedAtMs);
+  const now = Number(nowMs);
+  const minimum = Math.max(1, Number(minIntervalMs) || 500);
+  if (!Number.isFinite(started) || !Number.isFinite(now)) return minimum;
+  return Math.max(1, minimum - Math.max(0, now - started));
+}
+
+var getRingRetryDelay = getRingRetryDelay;

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/time.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/lib/time.js
@@ -1,3 +1,5 @@
+const Limits = imports.lib.alarmLimits;
+
 function _pad2(n) {
   return String(n).padStart(2, "0");
 }
@@ -88,12 +90,14 @@ function _parseRelative(spec) {
     matchedAny = true;
     const value = Number(r[1]);
     const unit = r[2];
-    if (!Number.isFinite(value) || value < 0) return null;
-    if (unit.startsWith("h")) totalMs += value * 60 * 60 * 1000;
-    else if (unit.startsWith("m")) totalMs += value * 60 * 1000;
-    else {
-      totalMs += value * 1000;
-    }
+    if (!Number.isSafeInteger(value) || value < 0) return null;
+    let unitMs = 1000;
+    if (unit.startsWith("h")) unitMs = 60 * 60 * 1000;
+    else if (unit.startsWith("m")) unitMs = 60 * 1000;
+
+    const incrementMs = value * unitMs;
+    if (!Number.isSafeInteger(incrementMs) || !Number.isSafeInteger(totalMs + incrementMs)) return null;
+    totalMs += incrementMs;
     rest = rest.slice(r[0].length);
     restOrig = restOrig.slice(r[0].length);
   }
@@ -120,6 +124,10 @@ function parseAlarmSpec(input, now = new Date(), t = null) {
     ].join("\n");
   }
   if (!raw) return { ok: false, error: errorWithExamples("Enter a time.") };
+  if (raw.length > Limits.MAX_TEXT_LENGTH)
+    return { ok: false, error: errorWithExamples("Input is too long.") };
+  if (!now || typeof now.getTime !== "function" || !Number.isFinite(now.getTime()))
+    return { ok: false, error: errorWithExamples("Could not parse that.") };
 
   const split = _splitLabel(raw);
   let spec = _normalizeSpec(split.spec);
@@ -161,9 +169,12 @@ function parseAlarmSpec(input, now = new Date(), t = null) {
     rel = _tryRelativeWithLabelFirst(spec);
   }
   if (rel) {
+    const dueMs = now.getTime() + rel.delayMs;
+    if (!Number.isSafeInteger(dueMs) || dueMs > 8640000000000000)
+      return { ok: false, error: errorWithExamples("Duration is too large.") };
     return {
       ok: true,
-      due: new Date(now.getTime() + rel.delayMs),
+      due: new Date(dueMs),
       label: split.label || rel.label || "",
       showSeconds: !!rel.showSeconds,
     };

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/metadata.json
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/metadata.json
@@ -2,6 +2,6 @@
   "uuid": "quick-alarm@andreas-glaser",
   "name": "Quick Alarm",
   "description": "Queue alarms quickly.",
-  "version": 12,
+  "version": 13,
   "max-instances": 1
 }

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/de.po
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/de.po
@@ -5,8 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: quick-alarm@andreas-glaser\n"
-"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/issues\n"
-"POT-Creation-Date: 2026-01-26\n"
+"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/"
+"issues\n"
+"POT-Creation-Date: 2026-08-28\n"
 "PO-Revision-Date: 2026-01-26\n"
 "Last-Translator: Andreas Glaser\n"
 "Language-Team: German\n"
@@ -17,6 +18,9 @@ msgstr ""
 
 msgid "Quick Alarm"
 msgstr "Quick Alarm"
+
+msgid "Type: in 10m tea  •  11am standup  •  Ctrl+Enter adds another"
+msgstr ""
 
 msgid "Alarm"
 msgstr "Alarm"
@@ -32,6 +36,15 @@ msgstr "Gib eine Zeit ein."
 
 msgid "Could not parse that."
 msgstr "Konnte das nicht verstehen."
+
+msgid "Input is too long."
+msgstr ""
+
+msgid "Duration is too large."
+msgstr ""
+
+msgid "Too many alarms queued."
+msgstr ""
 
 msgid "That time already passed today."
 msgstr "Diese Zeit ist heute bereits vorbei."
@@ -62,3 +75,9 @@ msgstr "vor %d Stunden"
 
 msgid "Missed alarm"
 msgstr "Verpasster Alarm"
+
+msgid "Missed alarms"
+msgstr ""
+
+msgid "%d alarms were missed."
+msgstr ""

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/es.po
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/es.po
@@ -5,8 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: quick-alarm@andreas-glaser\n"
-"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/issues\n"
-"POT-Creation-Date: 2026-01-26\n"
+"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/"
+"issues\n"
+"POT-Creation-Date: 2026-08-28\n"
 "PO-Revision-Date: 2026-01-26\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
@@ -17,6 +18,9 @@ msgstr ""
 
 msgid "Quick Alarm"
 msgstr "Quick Alarm"
+
+msgid "Type: in 10m tea  •  11am standup  •  Ctrl+Enter adds another"
+msgstr ""
 
 msgid "Alarm"
 msgstr "Alarma"
@@ -32,6 +36,15 @@ msgstr "Introduce una hora."
 
 msgid "Could not parse that."
 msgstr "No se pudo interpretar."
+
+msgid "Input is too long."
+msgstr ""
+
+msgid "Duration is too large."
+msgstr ""
+
+msgid "Too many alarms queued."
+msgstr ""
 
 msgid "That time already passed today."
 msgstr "Esa hora ya pasó hoy."
@@ -62,3 +75,9 @@ msgstr "hace %d horas"
 
 msgid "Missed alarm"
 msgstr "Alarma perdida"
+
+msgid "Missed alarms"
+msgstr ""
+
+msgid "%d alarms were missed."
+msgstr ""

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/fr.po
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/fr.po
@@ -5,8 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: quick-alarm@andreas-glaser\n"
-"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/issues\n"
-"POT-Creation-Date: 2026-01-26\n"
+"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/"
+"issues\n"
+"POT-Creation-Date: 2026-08-28\n"
 "PO-Revision-Date: 2026-01-26\n"
 "Last-Translator: \n"
 "Language-Team: French\n"
@@ -17,6 +18,9 @@ msgstr ""
 
 msgid "Quick Alarm"
 msgstr "Quick Alarm"
+
+msgid "Type: in 10m tea  •  11am standup  •  Ctrl+Enter adds another"
+msgstr ""
 
 msgid "Alarm"
 msgstr "Alarme"
@@ -32,6 +36,15 @@ msgstr "Saisissez une heure."
 
 msgid "Could not parse that."
 msgstr "Impossible d'interpréter."
+
+msgid "Input is too long."
+msgstr ""
+
+msgid "Duration is too large."
+msgstr ""
+
+msgid "Too many alarms queued."
+msgstr ""
 
 msgid "That time already passed today."
 msgstr "Cette heure est déjà passée aujourd'hui."
@@ -62,3 +75,9 @@ msgstr "il y a %d heures"
 
 msgid "Missed alarm"
 msgstr "Alarme manquée"
+
+msgid "Missed alarms"
+msgstr ""
+
+msgid "%d alarms were missed."
+msgstr ""

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/hu.po
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: quick-alarm@andreas-glaser\n"
 "Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/"
 "issues\n"
-"POT-Creation-Date: 2026-01-26\n"
+"POT-Creation-Date: 2026-08-28\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,6 +19,9 @@ msgstr ""
 
 msgid "Quick Alarm"
 msgstr "Gyors riasztás"
+
+msgid "Type: in 10m tea  •  11am standup  •  Ctrl+Enter adds another"
+msgstr ""
 
 msgid "Alarm"
 msgstr "Riasztás"
@@ -34,6 +37,15 @@ msgstr "Adjon meg egy időpontot."
 
 msgid "Could not parse that."
 msgstr "Nem sikerült elemezni."
+
+msgid "Input is too long."
+msgstr ""
+
+msgid "Duration is too large."
+msgstr ""
+
+msgid "Too many alarms queued."
+msgstr ""
 
 msgid "That time already passed today."
 msgstr "Ez az idő mára elmúlt."
@@ -64,3 +76,9 @@ msgstr "%d órával ezelőtt"
 
 msgid "Missed alarm"
 msgstr "Elmulasztott riasztás"
+
+msgid "Missed alarms"
+msgstr ""
+
+msgid "%d alarms were missed."
+msgstr ""

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/it.po
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/it.po
@@ -5,8 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: quick-alarm@andreas-glaser\n"
-"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/issues\n"
-"POT-Creation-Date: 2026-01-26\n"
+"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/"
+"issues\n"
+"POT-Creation-Date: 2026-08-28\n"
 "PO-Revision-Date: 2026-01-26\n"
 "Last-Translator: \n"
 "Language-Team: Italian\n"
@@ -17,6 +18,9 @@ msgstr ""
 
 msgid "Quick Alarm"
 msgstr "Quick Alarm"
+
+msgid "Type: in 10m tea  •  11am standup  •  Ctrl+Enter adds another"
+msgstr ""
 
 msgid "Alarm"
 msgstr "Sveglia"
@@ -32,6 +36,15 @@ msgstr "Inserisci un orario."
 
 msgid "Could not parse that."
 msgstr "Impossibile interpretare."
+
+msgid "Input is too long."
+msgstr ""
+
+msgid "Duration is too large."
+msgstr ""
+
+msgid "Too many alarms queued."
+msgstr ""
 
 msgid "That time already passed today."
 msgstr "Quell'orario è già passato oggi."
@@ -62,3 +75,9 @@ msgstr "%d ore fa"
 
 msgid "Missed alarm"
 msgstr "Sveglia persa"
+
+msgid "Missed alarms"
+msgstr ""
+
+msgid "%d alarms were missed."
+msgstr ""

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/pt_BR.po
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/pt_BR.po
@@ -5,8 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: quick-alarm@andreas-glaser\n"
-"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/issues\n"
-"POT-Creation-Date: 2026-01-26\n"
+"Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/"
+"issues\n"
+"POT-Creation-Date: 2026-08-28\n"
 "PO-Revision-Date: 2026-01-26\n"
 "Last-Translator: \n"
 "Language-Team: Brazilian Portuguese\n"
@@ -17,6 +18,9 @@ msgstr ""
 
 msgid "Quick Alarm"
 msgstr "Quick Alarm"
+
+msgid "Type: in 10m tea  •  11am standup  •  Ctrl+Enter adds another"
+msgstr ""
 
 msgid "Alarm"
 msgstr "Alarme"
@@ -32,6 +36,15 @@ msgstr "Digite um horário."
 
 msgid "Could not parse that."
 msgstr "Não foi possível interpretar."
+
+msgid "Input is too long."
+msgstr ""
+
+msgid "Duration is too large."
+msgstr ""
+
+msgid "Too many alarms queued."
+msgstr ""
 
 msgid "That time already passed today."
 msgstr "Esse horário já passou hoje."
@@ -62,3 +75,9 @@ msgstr "há %d horas"
 
 msgid "Missed alarm"
 msgstr "Alarme perdido"
+
+msgid "Missed alarms"
+msgstr ""
+
+msgid "%d alarms were missed."
+msgstr ""

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/quick-alarm@andreas-glaser.pot
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/po/quick-alarm@andreas-glaser.pot
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: quick-alarm@andreas-glaser\n"
 "Report-Msgid-Bugs-To: https://github.com/andreas-glaser/quick-alarm-cinnamon/issues\n"
-"POT-Creation-Date: 2026-01-26\n"
+"POT-Creation-Date: 2026-08-28\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,6 +16,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 msgid "Quick Alarm"
+msgstr ""
+
+msgid "Type: in 10m tea  •  11am standup  •  Ctrl+Enter adds another"
 msgstr ""
 
 msgid "Alarm"
@@ -31,6 +34,15 @@ msgid "Enter a time."
 msgstr ""
 
 msgid "Could not parse that."
+msgstr ""
+
+msgid "Input is too long."
+msgstr ""
+
+msgid "Duration is too large."
+msgstr ""
+
+msgid "Too many alarms queued."
 msgstr ""
 
 msgid "That time already passed today."
@@ -61,4 +73,10 @@ msgid "%d hours ago"
 msgstr ""
 
 msgid "Missed alarm"
+msgstr ""
+
+msgid "Missed alarms"
+msgstr ""
+
+msgid "%d alarms were missed."
 msgstr ""

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/services/alarmService.js
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/services/alarmService.js
@@ -1,12 +1,21 @@
 const GLib = imports.gi.GLib;
 const Reconcile = imports.lib.alarmReconcile;
+const Limits = imports.lib.alarmLimits;
+
+const MAX_TIMER_DELAY_MS = 24 * 60 * 60 * 1000;
 
 function AlarmService(onChanged, onFire, opts = {}) {
   this._onChanged = onChanged;
   this._onFire = onFire;
   this._onMissed = typeof opts.onMissed === "function" ? opts.onMissed : null;
-  this._missedGraceMs = Math.max(0, Number(opts.missedGraceMs) || 2 * 60 * 1000);
-  this._reconcileTickSeconds = Math.max(2, Number(opts.reconcileTickSeconds) || 10);
+  this._missedGraceMs =
+    opts.missedGraceMs === undefined ? 2 * 60 * 1000 : Math.max(0, Number(opts.missedGraceMs) || 0);
+  this._reconcileTickSeconds =
+    opts.reconcileTickSeconds === undefined ? 10 : Math.max(2, Number(opts.reconcileTickSeconds) || 2);
+  const requestedMaxAlarms = Number(opts.maxAlarms);
+  this._maxAlarms = Number.isFinite(requestedMaxAlarms)
+    ? Math.min(Limits.MAX_ALARMS, Math.max(1, Math.floor(requestedMaxAlarms)))
+    : Limits.MAX_ALARMS;
   this._glib = opts.glib || GLib;
   this._nowMs = typeof opts.nowMsFn === "function" ? opts.nowMsFn : () => Date.now();
   this._nextId = 1;
@@ -30,19 +39,38 @@ AlarmService.prototype.list = function () {
 };
 
 AlarmService.prototype._schedule = function (id, dueMs) {
-  const delayMs = Math.max(1, dueMs - this._nowMs());
+  const delayMs = Math.min(MAX_TIMER_DELAY_MS, Math.max(1, dueMs - this._nowMs()));
   return this._glib.timeout_add(this._glib.PRIORITY_DEFAULT, delayMs, () => {
     const alarm = this._alarms.get(id);
     if (!alarm) return this._glib.SOURCE_REMOVE;
+    const nowMs = this._nowMs();
 
+    // Keep individual GLib timeouts bounded. This avoids integer overflow for
+    // alarms far in the future while the normal reconcile loop handles clock
+    // changes and suspend/resume between chunks.
+    if (alarm.dueMs > nowMs) {
+      alarm.timerId = this._schedule(id, alarm.dueMs);
+      return this._glib.SOURCE_REMOVE;
+    }
+
+    const state = Reconcile.classifyAlarmDueState({
+      dueMs: alarm.dueMs,
+      nowMs,
+      graceMs: this._missedGraceMs,
+    });
     this._alarms.delete(id);
     try {
-      this._onFire({
+      const payload = {
         id,
         due: new Date(alarm.dueMs),
         label: alarm.label,
         showSeconds: !!alarm.showSeconds,
-      });
+      };
+      if (state === "missed") {
+        if (this._onMissed) this._onMissed(payload);
+      } else {
+        this._onFire(payload);
+      }
     } finally {
       this._onChanged();
     }
@@ -51,13 +79,48 @@ AlarmService.prototype._schedule = function (id, dueMs) {
 };
 
 AlarmService.prototype.add = function (dueDate, label, showSeconds) {
+  if (this._alarms.size >= this._maxAlarms) return 0;
+  if (!dueDate || typeof dueDate.getTime !== "function") return 0;
   const dueMs = dueDate.getTime();
+  if (!Number.isSafeInteger(dueMs)) return 0;
   const id = this._nextId++;
   const timerId = this._schedule(id, dueMs);
 
-  this._alarms.set(id, { id, dueMs, label, timerId, showSeconds: !!showSeconds });
+  const safeLabel = typeof label === "string" ? label.slice(0, Limits.MAX_TEXT_LENGTH) : "";
+  this._alarms.set(id, { id, dueMs, label: safeLabel, timerId, showSeconds: !!showSeconds });
   this._onChanged();
   return id;
+};
+
+AlarmService.prototype.restore = function (alarms) {
+  if (!Array.isArray(alarms) || alarms.length === 0) return 0;
+
+  let restored = 0;
+  for (const alarm of alarms) {
+    if (this._alarms.size >= this._maxAlarms) break;
+    if (!alarm || !alarm.due || typeof alarm.due.getTime !== "function") continue;
+    const dueMs = alarm.due.getTime();
+    if (!Number.isSafeInteger(dueMs)) continue;
+
+    const id = this._nextId++;
+    const timerId = this._schedule(id, dueMs);
+    this._alarms.set(id, {
+      id,
+      dueMs,
+      label: typeof alarm.label === "string" ? alarm.label.slice(0, Limits.MAX_TEXT_LENGTH) : "",
+      timerId,
+      showSeconds: alarm.showSeconds === true,
+    });
+    restored++;
+  }
+
+  if (restored === 0) return 0;
+
+  // Reconcile synchronously before the event loop can fire overdue one-shot
+  // timers, preserving the normal grace-window behavior after a restart.
+  const reconciled = this._reconcile();
+  if (!reconciled) this._onChanged();
+  return restored;
 };
 
 AlarmService.prototype.remove = function (id) {
@@ -124,6 +187,7 @@ AlarmService.prototype._reconcile = function () {
   }
 
   if (changed) this._onChanged();
+  return changed;
 };
 
 AlarmService.prototype.reconcileNow = function () {

--- a/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/settings-schema.json
+++ b/quick-alarm@andreas-glaser/files/quick-alarm@andreas-glaser/settings-schema.json
@@ -60,5 +60,9 @@
     "step": 1,
     "units": "s",
     "description": "Ring duration (seconds)"
+  },
+  "savedAlarms": {
+    "type": "generic",
+    "default": []
   }
 }


### PR DESCRIPTION
## Changes in v1.5.0


### Added
- Alarm queues now survive logout, Cinnamon restarts, and system reboots. Requested by [@sphh](https://github.com/sphh) in [linuxmint/cinnamon-spices-applets#8990](https://github.com/linuxmint/cinnamon-spices-applets/issues/8990).

### Fixed
- Late timer callbacks now honor the missed-alarm grace window after suspend or event-loop delays.
- Multiple fullscreen alarms that fire together are shown sequentially instead of overwriting each other.
- Multiple missed alarms are summarized in one notification instead of flooding the notification tray.
- Alarm audio uses owned subprocesses and rate-limited retries, preventing stale-PID termination and rapid respawn loops.
- Invalid oversized durations and excessive queue input are rejected safely.

### Security
- Hardened release workflows against shell injection and pinned external GitHub Actions.
- Added path validation around destructive build and publishing operations.

---
Automated update from tag `v1.5.0` in https://github.com/andreas-glaser/quick-alarm-cinnamon