### PR TITLE
sound150@claudiux: disable player integration when player controls are off

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/6.6/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.6/applet.js
@@ -319,13 +319,16 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         this.settings.bind("ignoredOutputDevices", "ignoredOutputDevices", () => {this._on_reload_this_applet_pressed();});
         this.settings.bind("runAsync", "runAsync");
         this.settings.bind("shortenArtistTitle", "shortenArtistTitle");
+        this.settings.bind("playerControl", "playerControl", () => {
+            this._on_reload_this_applet_pressed();
+        });
         this.settings.bind("doNotUsePlayerctld", "doNotUsePlayerctld", () => {
             this._on_reload_this_applet_pressed();
         });
-        if (this.doNotUsePlayerctld)
-            kill_playerctld();
-        else
+        if (this._playerctl)
             run_playerctld();
+        else
+            kill_playerctld();
         this.settings.bind("showMediaOptical", "showMediaOptical", () => {
             SHOW_MEDIA_OPTICAL = this.showMediaOptical;
             this._on_reload_this_applet_pressed();
@@ -403,9 +406,6 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             else this.unregisterSystrayIcons();
         });
 
-        this.settings.bind("playerControl", "playerControl", () => {
-            this.on_settings_changed()
-        });
         this.settings.bind("extendedPlayerControl", "extendedPlayerControl", () => {
             for (let i in this._players)
                 this._players[i].onSettingsChanged();
@@ -581,46 +581,48 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         this._playerItems = [];
         this._activePlayer = null;
 
-        Interfaces.getDBusAsync((proxy, error) => {
-            if (error) {
-                // ?? what else should we do if we fail completely here?
-                throw error;
-            }
-
-            this._dbus = proxy;
-
-            // player DBus name pattern
-            let name_regex = /^org\.mpris\.MediaPlayer2\./;
-            // load players
-            this._dbus.ListNamesRemote((names) => {
-                for (let n in names[0]) {
-                    let name = names[0][n];
-                    if (name_regex.test(name)) {
-                        //~ logDebug("name1: " + name);
-                        this._dbus.GetNameOwnerRemote(name, (owner) => this._addPlayer(name, owner[0]));
-                    }
+        if (this.playerControl) {
+            Interfaces.getDBusAsync((proxy, error) => {
+                if (error) {
+                    // ?? what else should we do if we fail completely here?
+                    throw error;
                 }
-            });
 
-            // watch players
-            this._ownerChangedId = this._dbus.connectSignal("NameOwnerChanged",
-                (proxy, sender, [name, old_owner, new_owner]) => {
-                    if (name_regex.test(name)) {
-                        //~ logDebug("name2: " + name);
-                        if (new_owner && !old_owner) {
-                            //~ logDebug("_addPlayer");
-                            this._addPlayer(name, new_owner);
-                        } else if (old_owner && !new_owner) {
-                            //~ logDebug("_removePlayer");
-                            this._removePlayer(name, old_owner);
-                        } else {
-                            //~ logDebug("_changePlayerOwner");
-                            this._changePlayerOwner(name, old_owner, new_owner);
+                this._dbus = proxy;
+
+                // player DBus name pattern
+                let name_regex = /^org\.mpris\.MediaPlayer2\./;
+                // load players
+                this._dbus.ListNamesRemote((names) => {
+                    for (let n in names[0]) {
+                        let name = names[0][n];
+                        if (name_regex.test(name)) {
+                            //~ logDebug("name1: " + name);
+                            this._dbus.GetNameOwnerRemote(name, (owner) => this._addPlayer(name, owner[0]));
                         }
                     }
-                }
-            );
-        });
+                });
+
+                // watch players
+                this._ownerChangedId = this._dbus.connectSignal("NameOwnerChanged",
+                    (proxy, sender, [name, old_owner, new_owner]) => {
+                        if (name_regex.test(name)) {
+                            //~ logDebug("name2: " + name);
+                            if (new_owner && !old_owner) {
+                                //~ logDebug("_addPlayer");
+                                this._addPlayer(name, new_owner);
+                            } else if (old_owner && !new_owner) {
+                                //~ logDebug("_removePlayer");
+                                this._removePlayer(name, old_owner);
+                            } else {
+                                //~ logDebug("_changePlayerOwner");
+                                this._changePlayerOwner(name, old_owner, new_owner);
+                            }
+                        }
+                    }
+                );
+            });
+        }
 
         //~ // Mixer control:
         //~ this._control = new Cvc.MixerControl({
@@ -1212,9 +1214,11 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         Main.keybindingManager.addHotKey("sound-open-" + this.instance_id, this.keyOpen, () => {
             this._openMenu()
         });
-        Main.keybindingManager.addHotKey("switch-player-" + this.instance_id, this.keySwitchPlayer, () => {
-            this._switchToNextPlayer()
-        });
+        if (this.playerControl) {
+            Main.keybindingManager.addHotKey("switch-player-" + this.instance_id, this.keySwitchPlayer, () => {
+                this._switchToNextPlayer()
+            });
+        }
 
         Main.keybindingManager.addHotKey("raise-volume-" + this.instance_id, "AudioRaiseVolume", () => {
             //~ this.set_applet_tooltip("");
@@ -1227,32 +1231,16 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             this.setAppletTooltip();
         });
         Main.keybindingManager.addHotKey("volume-mute-" + this.instance_id, "AudioMute", () => this._toggle_out_mute());
-        Main.keybindingManager.addHotKey("pause-" + this.instance_id, "AudioPlay", () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
+        if (this.playerControl) {
+            Main.keybindingManager.addHotKey("pause-" + this.instance_id, "AudioPlay", () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
 
-        Main.keybindingManager.addHotKey("audio-next-" + this.instance_id, "AudioNext", () => {
-            if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                GLib.file_set_contents(RUNTIME_DIR + "/R30Next", "");
-            } else {
-                this._players[this._activePlayer]._mediaServerPlayer.NextRemote()
-            }
-        });
-        Main.keybindingManager.addHotKey("audio-prev-" + this.instance_id, "AudioPrev", () => {
-            if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                GLib.file_set_contents(RUNTIME_DIR + "/R30Previous", "");
-            } else {
-                this._players[this._activePlayer]._mediaServerPlayer.PreviousRemote()
-            }
-        });
-        Main.keybindingManager.addHotKey("audio-stop-" + this.instance_id, "AudioStop", () => {
-            if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                GLib.file_set_contents(RUNTIME_DIR + "/R30Stop", "");
-            } else {
-                this._players[this._activePlayer]._mediaServerPlayer.StopRemote()
-            }
-        });
+            Main.keybindingManager.addHotKey("audio-next-" + this.instance_id, "AudioNext",
+                () => this._sendPlayerCommand("Next"));
+            Main.keybindingManager.addHotKey("audio-prev-" + this.instance_id, "AudioPrev",
+                () => this._sendPlayerCommand("Previous"));
+            Main.keybindingManager.addHotKey("audio-stop-" + this.instance_id, "AudioStop",
+                () => this._sendPlayerCommand("Stop"));
+        }
 
         if (!this.redefine_volume_keybindings) return;
 
@@ -1268,25 +1256,19 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         Main.keybindingManager.removeHotKey("volume-mute");
         Main.keybindingManager.removeHotKey("volume-up");
         Main.keybindingManager.removeHotKey("volume-down");
-        Main.keybindingManager.removeHotKey("pause");
-        Main.keybindingManager.removeHotKey("audio-stop");
-
-        Main.keybindingManager.removeHotKey("audio-next");
-        Main.keybindingManager.removeHotKey("audio-prev");
+        if (this.playerControl) {
+            Main.keybindingManager.removeHotKey("pause");
+            Main.keybindingManager.removeHotKey("audio-stop");
+            Main.keybindingManager.removeHotKey("audio-next");
+            Main.keybindingManager.removeHotKey("audio-prev");
+        }
         Main.keybindingManager.removeHotKey("mic-mute");
 
-        if (this.audio_stop.length > 2)
+        if (this.playerControl && this.audio_stop.length > 2)
             Main.keybindingManager.addHotKey("audio-stop", this.audio_stop,
-                () => {
-                    if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                        GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                        GLib.file_set_contents(RUNTIME_DIR + "/R30Stop", "");
-                    } else {
-                        this._players[this._activePlayer]._mediaServerPlayer.StopRemote()
-                    }
-                });
+                () => this._sendPlayerCommand("Stop"));
 
-        if (this.pause_on_off.length > 2)
+        if (this.playerControl && this.pause_on_off.length > 2)
             Main.keybindingManager.addHotKey("pause", this.pause_on_off,
                 () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
         if (this.volume_mute.length > 2)
@@ -1295,30 +1277,51 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             Main.keybindingManager.addHotKey("volume-up", this.volume_up, () => this._volumeChange(Clutter.ScrollDirection.UP));
         if (this.volume_down.length > 2)
             Main.keybindingManager.addHotKey("volume-down", this.volume_down, () => this._volumeChange(Clutter.ScrollDirection.DOWN));
-        if (this.audio_next.length > 2)
-            Main.keybindingManager.addHotKey("audio-next", this.audio_next, () => {
-                if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Next", "");
-                } else {
-                    this._players[this._activePlayer]._mediaServerPlayer.NextRemote()
-                }
-            });
+        if (this.playerControl && this.audio_next.length > 2)
+            Main.keybindingManager.addHotKey("audio-next", this.audio_next,
+                () => this._sendPlayerCommand("Next"));
 
-        if (this.audio_prev.length > 2)
-            Main.keybindingManager.addHotKey("audio-prev", this.audio_prev, () => {
-                if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Previous", "");
-                } else {
-                    this._players[this._activePlayer]._mediaServerPlayer.PreviousRemote()
-                }
-            });
+        if (this.playerControl && this.audio_prev.length > 2)
+            Main.keybindingManager.addHotKey("audio-prev", this.audio_prev,
+                () => this._sendPlayerCommand("Previous"));
         if (this.mic_mute.length > 2)
             Main.keybindingManager.addHotKey("mic-mute", this.mic_mute, () => {
                 this._toggle_in_mute()
             });
     } // End of _setKeybinding
+
+    _sendPlayerCommand(command) {
+        let player = this._players[this._activePlayer];
+        if (!player) return;
+
+        if (player._name.toLowerCase() !== "mpv") {
+            player._mediaServerPlayer[command + "Remote"]();
+            return;
+        }
+
+        let socket = Gio.File.new_for_path(R30MPVSOCKET);
+        socket.query_info_async(Gio.FILE_ATTRIBUTE_STANDARD_TYPE, Gio.FileQueryInfoFlags.NONE, GLib.PRIORITY_DEFAULT, null, (file, result) => {
+            try {
+                file.query_info_finish(result);
+            } catch (e) {
+                if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND))
+                    logError(e);
+                player._mediaServerPlayer[command + "Remote"]();
+                return;
+            }
+
+            let commandFile = Gio.File.new_for_path(RUNTIME_DIR + "/R30" + command);
+            let bytes = new GLib.Bytes(new TextEncoder().encode(""));
+            commandFile.replace_contents_bytes_async(bytes, null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null, (file, result) => {
+                try {
+                    file.replace_contents_finish(result);
+                } catch (e) {
+                    logError(e);
+                    player._mediaServerPlayer[command + "Remote"]();
+                }
+            });
+        });
+    }
 
     _on_maxVolume_changed(value) {
         if (value > 100) {
@@ -2251,7 +2254,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             }
             this.setAppletText(this.player);
         }
-        if (!this.doNotUsePlayerctld && !this._playerctl) {
+        if (this.playerControl && !this.doNotUsePlayerctld && !this._playerctl) {
             if (tooltips.length != 0) tooltips.push("");
             tooltips.push(_("The 'playerctl' package is required!"));
             tooltips.push(_("Please select 'Install playerctl' in this menu"));
@@ -2300,6 +2303,8 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
     }
 
     _addPlayer(busName, owner) {
+        if (!this.playerControl) return;
+
         if (this._players[owner]) {
             let prevName = this._players[owner]._busName;
             // HAVE: ADDING: ACTION:
@@ -2481,7 +2486,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             this._remove_OsdWithNumberATJosephMcc_button.actor.hide();
 
         //button Install playerctl (when it isn't installed)
-        if (this._playerctl === null && !this.doNotUsePlayerctld) {
+        if (this.playerControl && this._playerctl === null && !this.doNotUsePlayerctld) {
             let _install_playerctl_button = this.menu.addAction(_("Install playerctl"), () => {
                 Util.spawnCommandLineAsync("/usr/bin/env bash -C '%s/install_playerctl.sh'".format(PATH2SCRIPTS));
             });
@@ -2870,7 +2875,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             if (this._recordingAppsNum++ === 0) {
                 this._inputSection.actor.show();
                 if (this.mute_in_switch) this.mute_in_switch.actor.show();
-                if (!this.doNotUsePlayerctld)
+                if (this._playerctl)
                     run_playerctld();
             }
         }
@@ -3145,7 +3150,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
     }
 
     get _playerctl() {
-        return !this.doNotUsePlayerctld && GLib.find_program_in_path("playerctl");
+        return this.playerControl && !this.doNotUsePlayerctld && GLib.find_program_in_path("playerctl");
     }
 
     get _imagemagick() {

--- a/sound150@claudiux/files/sound150@claudiux/6.7/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.7/applet.js
@@ -322,13 +322,16 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         this.settings.bind("ignoredOutputDevices", "ignoredOutputDevices", () => {this._on_reload_this_applet_pressed();});
         this.settings.bind("runAsync", "runAsync");
         this.settings.bind("shortenArtistTitle", "shortenArtistTitle");
+        this.settings.bind("playerControl", "playerControl", () => {
+            this._on_reload_this_applet_pressed();
+        });
         this.settings.bind("doNotUsePlayerctld", "doNotUsePlayerctld", () => {
             this._on_reload_this_applet_pressed();
         });
-        if (this.doNotUsePlayerctld)
-            kill_playerctld();
-        else
+        if (this._playerctl)
             run_playerctld();
+        else
+            kill_playerctld();
         this.settings.bind("showMediaOptical", "showMediaOptical", () => {
             SHOW_MEDIA_OPTICAL = this.showMediaOptical;
             this._on_reload_this_applet_pressed();
@@ -406,9 +409,6 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             else this.unregisterSystrayIcons();
         });
 
-        this.settings.bind("playerControl", "playerControl", () => {
-            this.on_settings_changed()
-        });
         this.settings.bind("extendedPlayerControl", "extendedPlayerControl", () => {
             for (let i in this._players)
                 this._players[i].onSettingsChanged();
@@ -584,46 +584,48 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         this._playerItems = [];
         this._activePlayer = null;
 
-        Interfaces.getDBusAsync((proxy, error) => {
-            if (error) {
-                // ?? what else should we do if we fail completely here?
-                throw error;
-            }
-
-            this._dbus = proxy;
-
-            // player DBus name pattern
-            let name_regex = /^org\.mpris\.MediaPlayer2\./;
-            // load players
-            this._dbus.ListNamesRemote((names) => {
-                for (let n in names[0]) {
-                    let name = names[0][n];
-                    if (name_regex.test(name)) {
-                        //~ logDebug("name1: " + name);
-                        this._dbus.GetNameOwnerRemote(name, (owner) => this._addPlayer(name, owner[0]));
-                    }
+        if (this.playerControl) {
+            Interfaces.getDBusAsync((proxy, error) => {
+                if (error) {
+                    // ?? what else should we do if we fail completely here?
+                    throw error;
                 }
-            });
 
-            // watch players
-            this._ownerChangedId = this._dbus.connectSignal("NameOwnerChanged",
-                (proxy, sender, [name, old_owner, new_owner]) => {
-                    if (name_regex.test(name)) {
-                        //~ logDebug("name2: " + name);
-                        if (new_owner && !old_owner) {
-                            //~ logDebug("_addPlayer");
-                            this._addPlayer(name, new_owner);
-                        } else if (old_owner && !new_owner) {
-                            //~ logDebug("_removePlayer");
-                            this._removePlayer(name, old_owner);
-                        } else {
-                            //~ logDebug("_changePlayerOwner");
-                            this._changePlayerOwner(name, old_owner, new_owner);
+                this._dbus = proxy;
+
+                // player DBus name pattern
+                let name_regex = /^org\.mpris\.MediaPlayer2\./;
+                // load players
+                this._dbus.ListNamesRemote((names) => {
+                    for (let n in names[0]) {
+                        let name = names[0][n];
+                        if (name_regex.test(name)) {
+                            //~ logDebug("name1: " + name);
+                            this._dbus.GetNameOwnerRemote(name, (owner) => this._addPlayer(name, owner[0]));
                         }
                     }
-                }
-            );
-        });
+                });
+
+                // watch players
+                this._ownerChangedId = this._dbus.connectSignal("NameOwnerChanged",
+                    (proxy, sender, [name, old_owner, new_owner]) => {
+                        if (name_regex.test(name)) {
+                            //~ logDebug("name2: " + name);
+                            if (new_owner && !old_owner) {
+                                //~ logDebug("_addPlayer");
+                                this._addPlayer(name, new_owner);
+                            } else if (old_owner && !new_owner) {
+                                //~ logDebug("_removePlayer");
+                                this._removePlayer(name, old_owner);
+                            } else {
+                                //~ logDebug("_changePlayerOwner");
+                                this._changePlayerOwner(name, old_owner, new_owner);
+                            }
+                        }
+                    }
+                );
+            });
+        }
 
         //~ // Mixer control:
         //~ this._control = new Cvc.MixerControl({
@@ -1215,9 +1217,11 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         Main.keybindingManager.addHotKey("sound-open-" + this.instance_id, this.keyOpen, () => {
             this._openMenu()
         });
-        Main.keybindingManager.addHotKey("switch-player-" + this.instance_id, this.keySwitchPlayer, () => {
-            this._switchToNextPlayer()
-        });
+        if (this.playerControl) {
+            Main.keybindingManager.addHotKey("switch-player-" + this.instance_id, this.keySwitchPlayer, () => {
+                this._switchToNextPlayer()
+            });
+        }
 
         Main.keybindingManager.addHotKey("raise-volume-" + this.instance_id, "AudioRaiseVolume", () => {
             //~ this.set_applet_tooltip("");
@@ -1230,32 +1234,16 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             this.setAppletTooltip();
         });
         Main.keybindingManager.addHotKey("volume-mute-" + this.instance_id, "AudioMute", () => this._toggle_out_mute());
-        Main.keybindingManager.addHotKey("pause-" + this.instance_id, "AudioPlay", () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
+        if (this.playerControl) {
+            Main.keybindingManager.addHotKey("pause-" + this.instance_id, "AudioPlay", () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
 
-        Main.keybindingManager.addHotKey("audio-next-" + this.instance_id, "AudioNext", () => {
-            if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                GLib.file_set_contents(RUNTIME_DIR + "/R30Next", "");
-            } else {
-                this._players[this._activePlayer]._mediaServerPlayer.NextRemote()
-            }
-        });
-        Main.keybindingManager.addHotKey("audio-prev-" + this.instance_id, "AudioPrev", () => {
-            if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                GLib.file_set_contents(RUNTIME_DIR + "/R30Previous", "");
-            } else {
-                this._players[this._activePlayer]._mediaServerPlayer.PreviousRemote()
-            }
-        });
-        Main.keybindingManager.addHotKey("audio-stop-" + this.instance_id, "AudioStop", () => {
-            if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                GLib.file_set_contents(RUNTIME_DIR + "/R30Stop", "");
-            } else {
-                this._players[this._activePlayer]._mediaServerPlayer.StopRemote()
-            }
-        });
+            Main.keybindingManager.addHotKey("audio-next-" + this.instance_id, "AudioNext",
+                () => this._sendPlayerCommand("Next"));
+            Main.keybindingManager.addHotKey("audio-prev-" + this.instance_id, "AudioPrev",
+                () => this._sendPlayerCommand("Previous"));
+            Main.keybindingManager.addHotKey("audio-stop-" + this.instance_id, "AudioStop",
+                () => this._sendPlayerCommand("Stop"));
+        }
 
         if (!this.redefine_volume_keybindings) return;
 
@@ -1271,25 +1259,19 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         Main.keybindingManager.removeHotKey("volume-mute");
         Main.keybindingManager.removeHotKey("volume-up");
         Main.keybindingManager.removeHotKey("volume-down");
-        Main.keybindingManager.removeHotKey("pause");
-        Main.keybindingManager.removeHotKey("audio-stop");
-
-        Main.keybindingManager.removeHotKey("audio-next");
-        Main.keybindingManager.removeHotKey("audio-prev");
+        if (this.playerControl) {
+            Main.keybindingManager.removeHotKey("pause");
+            Main.keybindingManager.removeHotKey("audio-stop");
+            Main.keybindingManager.removeHotKey("audio-next");
+            Main.keybindingManager.removeHotKey("audio-prev");
+        }
         Main.keybindingManager.removeHotKey("mic-mute");
 
-        if (this.audio_stop.length > 2)
+        if (this.playerControl && this.audio_stop.length > 2)
             Main.keybindingManager.addHotKey("audio-stop", this.audio_stop,
-                () => {
-                    if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                        GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                        GLib.file_set_contents(RUNTIME_DIR + "/R30Stop", "");
-                    } else {
-                        this._players[this._activePlayer]._mediaServerPlayer.StopRemote()
-                    }
-                });
+                () => this._sendPlayerCommand("Stop"));
 
-        if (this.pause_on_off.length > 2)
+        if (this.playerControl && this.pause_on_off.length > 2)
             Main.keybindingManager.addHotKey("pause", this.pause_on_off,
                 () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
         if (this.volume_mute.length > 2)
@@ -1298,30 +1280,51 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             Main.keybindingManager.addHotKey("volume-up", this.volume_up, () => this._volumeChange(Clutter.ScrollDirection.UP));
         if (this.volume_down.length > 2)
             Main.keybindingManager.addHotKey("volume-down", this.volume_down, () => this._volumeChange(Clutter.ScrollDirection.DOWN));
-        if (this.audio_next.length > 2)
-            Main.keybindingManager.addHotKey("audio-next", this.audio_next, () => {
-                if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Next", "");
-                } else {
-                    this._players[this._activePlayer]._mediaServerPlayer.NextRemote()
-                }
-            });
+        if (this.playerControl && this.audio_next.length > 2)
+            Main.keybindingManager.addHotKey("audio-next", this.audio_next,
+                () => this._sendPlayerCommand("Next"));
 
-        if (this.audio_prev.length > 2)
-            Main.keybindingManager.addHotKey("audio-prev", this.audio_prev, () => {
-                if (this._players[this._activePlayer]._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Previous", "");
-                } else {
-                    this._players[this._activePlayer]._mediaServerPlayer.PreviousRemote()
-                }
-            });
+        if (this.playerControl && this.audio_prev.length > 2)
+            Main.keybindingManager.addHotKey("audio-prev", this.audio_prev,
+                () => this._sendPlayerCommand("Previous"));
         if (this.mic_mute.length > 2)
             Main.keybindingManager.addHotKey("mic-mute", this.mic_mute, () => {
                 this._toggle_in_mute()
             });
     } // End of _setKeybinding
+
+    _sendPlayerCommand(command) {
+        let player = this._players[this._activePlayer];
+        if (!player) return;
+
+        if (player._name.toLowerCase() !== "mpv") {
+            player._mediaServerPlayer[command + "Remote"]();
+            return;
+        }
+
+        let socket = Gio.File.new_for_path(R30MPVSOCKET);
+        socket.query_info_async(Gio.FILE_ATTRIBUTE_STANDARD_TYPE, Gio.FileQueryInfoFlags.NONE, GLib.PRIORITY_DEFAULT, null, (file, result) => {
+            try {
+                file.query_info_finish(result);
+            } catch (e) {
+                if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND))
+                    logError(e);
+                player._mediaServerPlayer[command + "Remote"]();
+                return;
+            }
+
+            let commandFile = Gio.File.new_for_path(RUNTIME_DIR + "/R30" + command);
+            let bytes = new GLib.Bytes(new TextEncoder().encode(""));
+            commandFile.replace_contents_bytes_async(bytes, null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null, (file, result) => {
+                try {
+                    file.replace_contents_finish(result);
+                } catch (e) {
+                    logError(e);
+                    player._mediaServerPlayer[command + "Remote"]();
+                }
+            });
+        });
+    }
 
     _on_maxVolume_changed(value) {
         if (value > 100) {
@@ -2254,7 +2257,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             }
             this.setAppletText(this.player);
         }
-        if (!this.doNotUsePlayerctld && !this._playerctl) {
+        if (this.playerControl && !this.doNotUsePlayerctld && !this._playerctl) {
             if (tooltips.length != 0) tooltips.push("");
             tooltips.push(_("The 'playerctl' package is required!"));
             tooltips.push(_("Please select 'Install playerctl' in this menu"));
@@ -2303,6 +2306,8 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
     }
 
     _addPlayer(busName, owner) {
+        if (!this.playerControl) return;
+
         if (this._players[owner]) {
             let prevName = this._players[owner]._busName;
             // HAVE: ADDING: ACTION:
@@ -2484,7 +2489,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             this._remove_OsdWithNumberATJosephMcc_button.actor.hide();
 
         //button Install playerctl (when it isn't installed)
-        if (this._playerctl === null && !this.doNotUsePlayerctld) {
+        if (this.playerControl && this._playerctl === null && !this.doNotUsePlayerctld) {
             let _install_playerctl_button = this.menu.addAction(_("Install playerctl"), () => {
                 Util.spawnCommandLineAsync("/usr/bin/env bash -C '%s/install_playerctl.sh'".format(PATH2SCRIPTS));
             });
@@ -2873,7 +2878,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             if (this._recordingAppsNum++ === 0) {
                 this._inputSection.actor.show();
                 if (this.mute_in_switch) this.mute_in_switch.actor.show();
-                if (!this.doNotUsePlayerctld)
+                if (this._playerctl)
                     run_playerctld();
             }
         }
@@ -3148,7 +3153,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
     }
 
     get _playerctl() {
-        return !this.doNotUsePlayerctld && GLib.find_program_in_path("playerctl");
+        return this.playerControl && !this.doNotUsePlayerctld && GLib.find_program_in_path("playerctl");
     }
 
     get _imagemagick() {


### PR DESCRIPTION
This changes Sound150 so turning off Control Players disables the player-control path instead of only hiding the player UI.

@claudiux

I ran into a reproducible desktop stall while browser media was ending or looping. Removing Sound150 from the panel made it stop. Putting Sound150 back with player controls disabled helped, but the applet could still initialize MPRIS player tracking and activate playerctld.

The patch keeps the volume side alone. Volume keys, mixer controls, microphone controls, and 150% max volume behavior are left in place. The change is limited to player-control behavior:

- do not start playerctld unless player controls are enabled
- do not subscribe to MPRIS player name changes unless player controls are enabled
- do not bind player transport keys unless player controls are enabled
- do not show the playerctl install prompt unless player controls are enabled
- replace the touched Radio3.0 mpv socket checks and command-file writes with async Gio calls

Tested locally on Linux Mint Cinnamon 6.6 with Control Players off, doNotUsePlayerctld on, and max volume at 150%. Sound150 reloads without starting playerctld, and the browser media stall is gone on my system.

Also ran:

node --check sound150@claudiux/files/sound150@claudiux/6.6/applet.js
node --check sound150@claudiux/files/sound150@claudiux/6.7/applet.js
./validate-spice sound150@claudiux
