### PR TITLE
sound150@claudiux: harden player transport controls

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/6.6/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.6/applet.js
@@ -596,7 +596,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                 this._dbus.ListNamesRemote((names) => {
                     for (let n in names[0]) {
                         let name = names[0][n];
-                        if (name_regex.test(name)) {
+                        if (name_regex.test(name) && !this._ignorePlayerName(name)) {
                             //~ logDebug("name1: " + name);
                             this._dbus.GetNameOwnerRemote(name, (owner) => this._addPlayer(name, owner[0]));
                         }
@@ -606,7 +606,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                 // watch players
                 this._ownerChangedId = this._dbus.connectSignal("NameOwnerChanged",
                     (proxy, sender, [name, old_owner, new_owner]) => {
-                        if (name_regex.test(name)) {
+                        if (name_regex.test(name) && !this._ignorePlayerName(name)) {
                             //~ logDebug("name2: " + name);
                             if (new_owner && !old_owner) {
                                 //~ logDebug("_addPlayer");
@@ -1232,7 +1232,8 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         });
         Main.keybindingManager.addHotKey("volume-mute-" + this.instance_id, "AudioMute", () => this._toggle_out_mute());
         if (this.playerControl) {
-            Main.keybindingManager.addHotKey("pause-" + this.instance_id, "AudioPlay", () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
+            Main.keybindingManager.addHotKey("pause-" + this.instance_id, "AudioPlay",
+                () => this._sendPlayerCommand("PlayPause"));
 
             Main.keybindingManager.addHotKey("audio-next-" + this.instance_id, "AudioNext",
                 () => this._sendPlayerCommand("Next"));
@@ -1270,7 +1271,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
 
         if (this.playerControl && this.pause_on_off.length > 2)
             Main.keybindingManager.addHotKey("pause", this.pause_on_off,
-                () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
+                () => this._sendPlayerCommand("PlayPause"));
         if (this.volume_mute.length > 2)
             Main.keybindingManager.addHotKey("volume-mute", this.volume_mute, () => this._toggle_out_mute()); //(...args) => this._mutedChanged(...args, "_output"));
         if (this.volume_up.length > 2)
@@ -1292,10 +1293,17 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
 
     _sendPlayerCommand(command) {
         let player = this._players[this._activePlayer];
-        if (!player) return;
+        if (!player || !player._mediaServerPlayer) return;
 
-        if (player._name.toLowerCase() !== "mpv") {
-            player._mediaServerPlayer[command + "Remote"]();
+        let remoteCommand = player._mediaServerPlayer[command + "Remote"];
+        if (!remoteCommand) return;
+
+        let sendRemoteCommand = () => {
+            try { remoteCommand.call(player._mediaServerPlayer); } catch(e) { logError(e); }
+        };
+
+        if (player._name.toLowerCase() !== "mpv" || command === "PlayPause") {
+            sendRemoteCommand();
             return;
         }
 
@@ -1306,7 +1314,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             } catch (e) {
                 if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND))
                     logError(e);
-                player._mediaServerPlayer[command + "Remote"]();
+                sendRemoteCommand();
                 return;
             }
 
@@ -1317,7 +1325,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                     file.replace_contents_finish(result);
                 } catch (e) {
                     logError(e);
-                    player._mediaServerPlayer[command + "Remote"]();
+                    sendRemoteCommand();
                 }
             });
         });
@@ -1773,9 +1781,9 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                 volumeChange = true;
             } else if (this.horizontalScroll && player !== null && player._playerStatus !== "Stopped") {
                 if (direction == Clutter.ScrollDirection.LEFT) {
-                    this._players[this._activePlayer]._mediaServerPlayer.PreviousRemote();
+                    this._sendPlayerCommand("Previous");
                 } else if (direction == Clutter.ScrollDirection.RIGHT) {
-                    this._players[this._activePlayer]._mediaServerPlayer.NextRemote();
+                    this._sendPlayerCommand("Next");
                 }
             }
         }
@@ -1878,7 +1886,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                 else if (this.middleShiftClickAction === "in_mute")
                     this._toggle_in_mute();
                 else if (this.middleShiftClickAction === "player")
-                    this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote();
+                    this._sendPlayerCommand("PlayPause");
             } else {
                 if (this.middleClickAction === "mute") {
                     if (this._input && this._output && this._output.is_muted === this._input.is_muted)
@@ -1888,13 +1896,13 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                     this._toggle_out_mute();
                 else if (this.middleClickAction === "in_mute")
                     this._toggle_in_mute();
-                else if (this.middleClickAction === "player" && this._players[this._activePlayer])
-                    this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote();
+                else if (this.middleClickAction === "player")
+                    this._sendPlayerCommand("PlayPause");
             }
         } else if (buttonId === 8) { // previous and next track on mouse buttons 4 and 5 (8 and 9 by X11 numbering)
-            this._players[this._activePlayer]._mediaServerPlayer.PreviousRemote();
+            this._sendPlayerCommand("Previous");
         } else if (buttonId === 9) {
-            this._players[this._activePlayer]._mediaServerPlayer.NextRemote();
+            this._sendPlayerCommand("Next");
         } else {
             return Applet.Applet.prototype._onButtonPressEvent.call(this, actor, event);
         }
@@ -2302,8 +2310,12 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             /^org\.mpris\.MediaPlayer2\.vlc-\d+$/.test(busName);
     }
 
+    _ignorePlayerName(busName) {
+        return busName === "org.mpris.MediaPlayer2.playerctld";
+    }
+
     _addPlayer(busName, owner) {
-        if (!this.playerControl) return;
+        if (!this.playerControl || this._ignorePlayerName(busName)) return;
 
         if (this._players[owner]) {
             let prevName = this._players[owner]._busName;

--- a/sound150@claudiux/files/sound150@claudiux/6.6/lib/s150PopupMenu.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.6/lib/s150PopupMenu.js
@@ -381,34 +381,17 @@ class Player extends PopupMenu.PopupMenuSection {
                     this._seeker._setPosition(0);
                 }
 
-                if (this._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Previous", "");
-                } else
-                    this._mediaServerPlayer.PreviousRemote();
+                this._sendPlayerCommand("Previous");
             });
         this._playButton = new ControlButton("media-playback-start",
             _("Play"),
-            () => this._mediaServerPlayer.PlayPauseRemote());
+            () => this._sendPlayerCommand("PlayPause"));
         this._stopButton = new ControlButton("media-playback-stop",
             _("Stop"),
-            () => {
-                if (this._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Stop", "");
-                } else {
-                    this._mediaServerPlayer.StopRemote()
-                }
-            });
+            () => this._sendPlayerCommand("Stop"));
         this._nextButton = new ControlButton("media-skip-forward",
             _("Next"),
-            () => {
-                if (this._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Next", "");
-                } else
-                    this._mediaServerPlayer.NextRemote();
-            });
+            () => this._sendPlayerCommand("Next"));
 
         try {
             this.trackInfo.add_actor(trackControls);
@@ -436,6 +419,7 @@ class Player extends PopupMenu.PopupMenuSection {
         // Position slider
         if (this._mediaServerPlayer) {
             this._seeker = new Seeker(
+                this._applet,
                 this._mediaServerPlayer,
                 this._prop,
                 this._name.toLowerCase()
@@ -485,6 +469,45 @@ class Player extends PopupMenu.PopupMenuSection {
         }
     }
 
+    _sendPlayerCommand(command, fallback) {
+        if (!fallback) {
+            if (!this._mediaServerPlayer) return;
+
+            let remoteCommand = this._mediaServerPlayer[command + "Remote"];
+            if (!remoteCommand) return;
+
+            fallback = () => remoteCommand.call(this._mediaServerPlayer);
+        }
+
+        if (this._name.toLowerCase() !== "mpv" || command === "PlayPause") {
+            try { fallback() } catch(e) { global.logError(e); }
+            return;
+        }
+
+        let socket = Gio.File.new_for_path(R30MPVSOCKET);
+        socket.query_info_async(Gio.FILE_ATTRIBUTE_STANDARD_TYPE, Gio.FileQueryInfoFlags.NONE, GLib.PRIORITY_DEFAULT, null, (file, result) => {
+            try {
+                file.query_info_finish(result);
+            } catch (e) {
+                if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND))
+                    global.logError(e);
+                try { fallback() } catch(e) { global.logError(e); }
+                return;
+            }
+
+            let commandFile = Gio.File.new_for_path(RUNTIME_DIR + "/R30" + command);
+            let bytes = new GLib.Bytes(new TextEncoder().encode(""));
+            commandFile.replace_contents_bytes_async(bytes, null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null, (file, result) => {
+                try {
+                    file.replace_contents_finish(result);
+                } catch (e) {
+                    global.logError(e);
+                    try { fallback() } catch(e) { global.logError(e); }
+                }
+            });
+        });
+    }
+
     _showCanRaise() {
         let btn = new ControlButton("go-up", _("Open Player"), () => {
             if (this._name.toLowerCase() === "spotify") {
@@ -500,11 +523,7 @@ class Player extends PopupMenu.PopupMenuSection {
 
     _showCanQuit() {
         let btn = new ControlButton("window-close", _("Quit Player"), () => {
-            if (this._name.toLowerCase() === "mpv" &&
-                GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                GLib.file_set_contents(RUNTIME_DIR + "/R30Stop", "");
-            } else
-                this._mediaServer.QuitRemote();
+            this._sendPlayerCommand("Stop", () => this._mediaServer.QuitRemote());
             this._applet.menu.close();
         }, true);
         this._playerBox.add_actor(btn.actor);
@@ -1090,10 +1109,11 @@ class Player extends PopupMenu.PopupMenuSection {
 Signals.addSignalMethods(Player.prototype);
 
 class Seeker extends Slider.Slider {
-    constructor(mediaServerPlayer, props, playerName) {
+    constructor(applet, mediaServerPlayer, props, playerName) {
         super(0, true);
 
         this.destroyed = false;
+        this._applet = applet;
 
         this.actor.set_direction(St.TextDirection.LTR); // Do not invert on RTL layout
         //~ this.actor.expand = true;
@@ -1112,6 +1132,7 @@ class Seeker extends Slider.Slider {
         this._timeoutId = null;
         this._timeoutId_timerCallback = null;
         this._timerTicker = 0;
+        this._positionQueryPending = false;
 
         this._mediaServerPlayer = mediaServerPlayer;
         this._prop = props;
@@ -1245,7 +1266,8 @@ class Seeker extends Slider.Slider {
 
     play() {
         if (this.destroyed) return;
-        run_playerctld();
+        if (this._applet._playerctl)
+            run_playerctld();
         this.status = "Playing";
         this._getCanSeek();
     }
@@ -1257,7 +1279,8 @@ class Seeker extends Slider.Slider {
             this._updateTimer();
         else
             this._updateValue();
-        run_playerctld();
+        if (this._applet._playerctl)
+            run_playerctld();
     }
 
     stop() {
@@ -1484,9 +1507,12 @@ class Seeker extends Slider.Slider {
     }
 
     _getPosition() {
-        if (this.destroyed) return;
+        if (this.destroyed || this._positionQueryPending || !this._prop) return;
 
+        this._positionQueryPending = true;
         this._prop.GetRemote(MEDIA_PLAYER_2_PLAYER_NAME, "Position", (position, error) => {
+            this._positionQueryPending = false;
+            if (this.destroyed) return;
             //~ logDebug("_getPosition dbus !error: "+!error);
             if (!error && position[0]) {
                 //~ logDebug("_getPosition position: "+position[0].get_int64());
@@ -1520,6 +1546,14 @@ class Seeker extends Slider.Slider {
         if (this._seekChangedId) {
             this._mediaServerPlayer.disconnectSignal(this._seekChangedId);
             this._seekChangedId = null;
+        }
+        if (this._timeoutId) {
+            source_remove(this._timeoutId);
+            this._timeoutId = null;
+        }
+        if (this._timeoutId_timerCallback) {
+            source_remove(this._timeoutId_timerCallback);
+            this._timeoutId_timerCallback = null;
         }
 
         this.disconnectAll(); //??? Seems cause of bugs.

--- a/sound150@claudiux/files/sound150@claudiux/6.7/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.7/applet.js
@@ -599,7 +599,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                 this._dbus.ListNamesRemote((names) => {
                     for (let n in names[0]) {
                         let name = names[0][n];
-                        if (name_regex.test(name)) {
+                        if (name_regex.test(name) && !this._ignorePlayerName(name)) {
                             //~ logDebug("name1: " + name);
                             this._dbus.GetNameOwnerRemote(name, (owner) => this._addPlayer(name, owner[0]));
                         }
@@ -609,7 +609,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                 // watch players
                 this._ownerChangedId = this._dbus.connectSignal("NameOwnerChanged",
                     (proxy, sender, [name, old_owner, new_owner]) => {
-                        if (name_regex.test(name)) {
+                        if (name_regex.test(name) && !this._ignorePlayerName(name)) {
                             //~ logDebug("name2: " + name);
                             if (new_owner && !old_owner) {
                                 //~ logDebug("_addPlayer");
@@ -1235,7 +1235,8 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         });
         Main.keybindingManager.addHotKey("volume-mute-" + this.instance_id, "AudioMute", () => this._toggle_out_mute());
         if (this.playerControl) {
-            Main.keybindingManager.addHotKey("pause-" + this.instance_id, "AudioPlay", () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
+            Main.keybindingManager.addHotKey("pause-" + this.instance_id, "AudioPlay",
+                () => this._sendPlayerCommand("PlayPause"));
 
             Main.keybindingManager.addHotKey("audio-next-" + this.instance_id, "AudioNext",
                 () => this._sendPlayerCommand("Next"));
@@ -1273,7 +1274,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
 
         if (this.playerControl && this.pause_on_off.length > 2)
             Main.keybindingManager.addHotKey("pause", this.pause_on_off,
-                () => this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote());
+                () => this._sendPlayerCommand("PlayPause"));
         if (this.volume_mute.length > 2)
             Main.keybindingManager.addHotKey("volume-mute", this.volume_mute, () => this._toggle_out_mute()); //(...args) => this._mutedChanged(...args, "_output"));
         if (this.volume_up.length > 2)
@@ -1295,10 +1296,17 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
 
     _sendPlayerCommand(command) {
         let player = this._players[this._activePlayer];
-        if (!player) return;
+        if (!player || !player._mediaServerPlayer) return;
 
-        if (player._name.toLowerCase() !== "mpv") {
-            player._mediaServerPlayer[command + "Remote"]();
+        let remoteCommand = player._mediaServerPlayer[command + "Remote"];
+        if (!remoteCommand) return;
+
+        let sendRemoteCommand = () => {
+            try { remoteCommand.call(player._mediaServerPlayer); } catch(e) { logError(e); }
+        };
+
+        if (player._name.toLowerCase() !== "mpv" || command === "PlayPause") {
+            sendRemoteCommand();
             return;
         }
 
@@ -1309,7 +1317,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             } catch (e) {
                 if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND))
                     logError(e);
-                player._mediaServerPlayer[command + "Remote"]();
+                sendRemoteCommand();
                 return;
             }
 
@@ -1320,7 +1328,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                     file.replace_contents_finish(result);
                 } catch (e) {
                     logError(e);
-                    player._mediaServerPlayer[command + "Remote"]();
+                    sendRemoteCommand();
                 }
             });
         });
@@ -1776,9 +1784,9 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                 volumeChange = true;
             } else if (this.horizontalScroll && player !== null && player._playerStatus !== "Stopped") {
                 if (direction == Clutter.ScrollDirection.LEFT) {
-                    this._players[this._activePlayer]._mediaServerPlayer.PreviousRemote();
+                    this._sendPlayerCommand("Previous");
                 } else if (direction == Clutter.ScrollDirection.RIGHT) {
-                    this._players[this._activePlayer]._mediaServerPlayer.NextRemote();
+                    this._sendPlayerCommand("Next");
                 }
             }
         }
@@ -1881,7 +1889,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                 else if (this.middleShiftClickAction === "in_mute")
                     this._toggle_in_mute();
                 else if (this.middleShiftClickAction === "player")
-                    this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote();
+                    this._sendPlayerCommand("PlayPause");
             } else {
                 if (this.middleClickAction === "mute") {
                     if (this._input && this._output && this._output.is_muted === this._input.is_muted)
@@ -1891,13 +1899,13 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
                     this._toggle_out_mute();
                 else if (this.middleClickAction === "in_mute")
                     this._toggle_in_mute();
-                else if (this.middleClickAction === "player" && this._players[this._activePlayer])
-                    this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote();
+                else if (this.middleClickAction === "player")
+                    this._sendPlayerCommand("PlayPause");
             }
         } else if (buttonId === 8) { // previous and next track on mouse buttons 4 and 5 (8 and 9 by X11 numbering)
-            this._players[this._activePlayer]._mediaServerPlayer.PreviousRemote();
+            this._sendPlayerCommand("Previous");
         } else if (buttonId === 9) {
-            this._players[this._activePlayer]._mediaServerPlayer.NextRemote();
+            this._sendPlayerCommand("Next");
         } else {
             return Applet.Applet.prototype._onButtonPressEvent.call(this, actor, event);
         }
@@ -2305,8 +2313,12 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
             /^org\.mpris\.MediaPlayer2\.vlc-\d+$/.test(busName);
     }
 
+    _ignorePlayerName(busName) {
+        return busName === "org.mpris.MediaPlayer2.playerctld";
+    }
+
     _addPlayer(busName, owner) {
-        if (!this.playerControl) return;
+        if (!this.playerControl || this._ignorePlayerName(busName)) return;
 
         if (this._players[owner]) {
             let prevName = this._players[owner]._busName;

--- a/sound150@claudiux/files/sound150@claudiux/6.7/lib/s150PopupMenu.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.7/lib/s150PopupMenu.js
@@ -382,34 +382,17 @@ var Player = class Player extends PopupMenu.PopupMenuSection {
                     this._seeker._setPosition(0);
                 }
 
-                if (this._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Previous", "");
-                } else
-                    this._mediaServerPlayer.PreviousRemote();
+                this._sendPlayerCommand("Previous");
             });
         this._playButton = new ControlButton("media-playback-start",
             _("Play"),
-            () => this._mediaServerPlayer.PlayPauseRemote());
+            () => this._sendPlayerCommand("PlayPause"));
         this._stopButton = new ControlButton("media-playback-stop",
             _("Stop"),
-            () => {
-                if (this._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Stop", "");
-                } else {
-                    this._mediaServerPlayer.StopRemote()
-                }
-            });
+            () => this._sendPlayerCommand("Stop"));
         this._nextButton = new ControlButton("media-skip-forward",
             _("Next"),
-            () => {
-                if (this._name.toLowerCase() === "mpv" &&
-                    GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                    GLib.file_set_contents(RUNTIME_DIR + "/R30Next", "");
-                } else
-                    this._mediaServerPlayer.NextRemote();
-            });
+            () => this._sendPlayerCommand("Next"));
 
         try {
             this.trackInfo.add_actor(trackControls);
@@ -437,6 +420,7 @@ var Player = class Player extends PopupMenu.PopupMenuSection {
         // Position slider
         if (this._mediaServerPlayer) {
             this._seeker = new Seeker(
+                this._applet,
                 this._mediaServerPlayer,
                 this._prop,
                 this._name.toLowerCase()
@@ -486,6 +470,45 @@ var Player = class Player extends PopupMenu.PopupMenuSection {
         }
     }
 
+    _sendPlayerCommand(command, fallback) {
+        if (!fallback) {
+            if (!this._mediaServerPlayer) return;
+
+            let remoteCommand = this._mediaServerPlayer[command + "Remote"];
+            if (!remoteCommand) return;
+
+            fallback = () => remoteCommand.call(this._mediaServerPlayer);
+        }
+
+        if (this._name.toLowerCase() !== "mpv" || command === "PlayPause") {
+            try { fallback() } catch(e) { global.logError(e); }
+            return;
+        }
+
+        let socket = Gio.File.new_for_path(R30MPVSOCKET);
+        socket.query_info_async(Gio.FILE_ATTRIBUTE_STANDARD_TYPE, Gio.FileQueryInfoFlags.NONE, GLib.PRIORITY_DEFAULT, null, (file, result) => {
+            try {
+                file.query_info_finish(result);
+            } catch (e) {
+                if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND))
+                    global.logError(e);
+                try { fallback() } catch(e) { global.logError(e); }
+                return;
+            }
+
+            let commandFile = Gio.File.new_for_path(RUNTIME_DIR + "/R30" + command);
+            let bytes = new GLib.Bytes(new TextEncoder().encode(""));
+            commandFile.replace_contents_bytes_async(bytes, null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null, (file, result) => {
+                try {
+                    file.replace_contents_finish(result);
+                } catch (e) {
+                    global.logError(e);
+                    try { fallback() } catch(e) { global.logError(e); }
+                }
+            });
+        });
+    }
+
     _showCanRaise() {
         let btn = new ControlButton("go-up", _("Open Player"), () => {
             if (this._name.toLowerCase() === "spotify") {
@@ -501,11 +524,7 @@ var Player = class Player extends PopupMenu.PopupMenuSection {
 
     _showCanQuit() {
         let btn = new ControlButton("window-close", _("Quit Player"), () => {
-            if (this._name.toLowerCase() === "mpv" &&
-                GLib.file_test(R30MPVSOCKET, GLib.FileTest.EXISTS)) {
-                GLib.file_set_contents(RUNTIME_DIR + "/R30Stop", "");
-            } else
-                this._mediaServer.QuitRemote();
+            this._sendPlayerCommand("Stop", () => this._mediaServer.QuitRemote());
             this._applet.menu.close();
         }, true);
         this._playerBox.add_actor(btn.actor);
@@ -1091,10 +1110,11 @@ var Player = class Player extends PopupMenu.PopupMenuSection {
 Signals.addSignalMethods(Player.prototype);
 
 var Seeker = class Seeker extends Slider.Slider {
-    constructor(mediaServerPlayer, props, playerName) {
+    constructor(applet, mediaServerPlayer, props, playerName) {
         super(0, true);
 
         this.destroyed = false;
+        this._applet = applet;
 
         this.actor.set_direction(St.TextDirection.LTR); // Do not invert on RTL layout
         //~ this.actor.expand = true;
@@ -1113,6 +1133,7 @@ var Seeker = class Seeker extends Slider.Slider {
         this._timeoutId = null;
         this._timeoutId_timerCallback = null;
         this._timerTicker = 0;
+        this._positionQueryPending = false;
 
         this._mediaServerPlayer = mediaServerPlayer;
         this._prop = props;
@@ -1246,7 +1267,8 @@ var Seeker = class Seeker extends Slider.Slider {
 
     play() {
         if (this.destroyed) return;
-        run_playerctld();
+        if (this._applet._playerctl)
+            run_playerctld();
         this.status = "Playing";
         this._getCanSeek();
     }
@@ -1258,7 +1280,8 @@ var Seeker = class Seeker extends Slider.Slider {
             this._updateTimer();
         else
             this._updateValue();
-        run_playerctld();
+        if (this._applet._playerctl)
+            run_playerctld();
     }
 
     stop() {
@@ -1485,9 +1508,12 @@ var Seeker = class Seeker extends Slider.Slider {
     }
 
     _getPosition() {
-        if (this.destroyed) return;
+        if (this.destroyed || this._positionQueryPending || !this._prop) return;
 
+        this._positionQueryPending = true;
         this._prop.GetRemote(MEDIA_PLAYER_2_PLAYER_NAME, "Position", (position, error) => {
+            this._positionQueryPending = false;
+            if (this.destroyed) return;
             //~ logDebug("_getPosition dbus !error: "+!error);
             if (!error && position[0]) {
                 //~ logDebug("_getPosition position: "+position[0].get_int64());
@@ -1521,6 +1547,14 @@ var Seeker = class Seeker extends Slider.Slider {
         if (this._seekChangedId) {
             this._mediaServerPlayer.disconnectSignal(this._seekChangedId);
             this._seekChangedId = null;
+        }
+        if (this._timeoutId) {
+            source_remove(this._timeoutId);
+            this._timeoutId = null;
+        }
+        if (this._timeoutId_timerCallback) {
+            source_remove(this._timeoutId_timerCallback);
+            this._timeoutId_timerCallback = null;
         }
 
         this.disconnectAll(); //??? Seems cause of bugs.


### PR DESCRIPTION
This is a follow-up to #9017.

@claudiux

With player controls enabled, browser MPRIS players can change state quickly while the applet is creating and destroying player controls. This hardens that path and avoids a couple of feedback loops I could reproduce locally.

I have been working through several related Sound150 issues in separate branches because I hit a lot of problems with media handling on my system. I am trying to keep the pull requests small and limited so they are easier to review, instead of dumping all of the fixes into one large change. Hopefully this gets the player-control side stable soon.

The patch keeps the existing player UI and volume behavior. It changes the player-control path only:

- ignore org.mpris.MediaPlayer2.playerctld as a controllable player
- guard player transport commands when the active player disappears
- route hotkey, mouse, scroll, and popup transport commands through one helper path
- keep the Radio3.0/mpv command-file path async
- make the seeker respect the playerctld setting before launching playerctld
- remove seeker timeout sources when the seeker is destroyed
- avoid overlapping Position property requests

Tested locally on Linux Mint Cinnamon 6.6 with Control Players on, doNotUsePlayerctld on, album art display off, and external commands set to async. Browser media controls still work, and the playerctld/MPRIS churn that reproduced the desktop stall is gone on my system.

Also ran:

node --check sound150@claudiux/files/sound150@claudiux/6.6/applet.js
node --check sound150@claudiux/files/sound150@claudiux/6.6/lib/s150PopupMenu.js
node --check sound150@claudiux/files/sound150@claudiux/6.7/applet.js
node --check sound150@claudiux/files/sound150@claudiux/6.7/lib/s150PopupMenu.js
./validate-spice sound150@claudiux
