### PR TITLE
[cpufreq@mtwebster] Add fixed units setting

### DIFF
--- a/cpufreq@mtwebster/files/cpufreq@mtwebster/applet.js
+++ b/cpufreq@mtwebster/files/cpufreq@mtwebster/applet.js
@@ -45,7 +45,12 @@ if (typeof require !== 'undefined') {
 
 const DEFAULT_STYLE = "2";
 const DEFAULT_DIGIT_TYPE = "0";
+const DEFAULT_DIGIT_UNITS = "0";
 const DEFAULT_CPUS = "0";
+const FIXED_FREQ_UNITS = {
+    1: { label: 'MHz', divisor: 1000 },
+    2: { label: 'GHz', divisor: 1000000 }
+};
 // global settings variables;
 
 let refresh_time = 2000;
@@ -55,6 +60,7 @@ let graph_width = '6';
 let lower_border = 20;
 let upper_border = 80;
 let digit_type = DEFAULT_DIGIT_TYPE;
+let digit_units = DEFAULT_DIGIT_UNITS;
 let cpus_to_monitor = DEFAULT_CPUS;
 let text_color = '#FFFF80';
 let low_color = '#00FF00'; // green
@@ -93,7 +99,7 @@ function rd_frm_file(file) {
 function rd_nums_frm_file(file) {
     return parseInts(rd_frm_file(file));
 }
-function num_to_freq_panel(num) {
+function num_to_freq_panel_auto(num) {
     num = Math.round(num);
     let units;
     if (num < 1000) {
@@ -109,6 +115,17 @@ function num_to_freq_panel(num) {
         units = 'THz';
     }
     return formatNumPanel(num) + ' ' + units;
+}
+function num_to_freq_panel_fixed(num) {
+    let unit = FIXED_FREQ_UNITS[digit_units];
+    if (!unit)
+        return num_to_freq_panel(num);
+    return formatNumPanel(Math.round(num) / unit.divisor) + ' ' + unit.label;
+}
+function num_to_freq_panel(num) {
+    if (digit_units > 0)
+        return num_to_freq_panel_fixed(num)
+    return num_to_freq_panel_auto(num)
 }
 function num_to_freq_menu(num) {
     num = Math.round(num);
@@ -491,6 +508,11 @@ MyApplet.prototype = {
             this.rebuild,
             null);
         this.settings.bindProperty(Settings.BindingDirection.IN,
+            "digit-units",
+            "digit_units",
+            this.rebuild,
+            null);
+        this.settings.bindProperty(Settings.BindingDirection.IN,
             "cpus-to-monitor",
             "cpus",
             this.rebuild,
@@ -551,6 +573,7 @@ MyApplet.prototype = {
         lower_border = this.lower_border;
         upper_border = this.upper_border;
         digit_type = this.digit_type;
+        digit_units = this.digit_units;
         text_color = this.text_color;
         low_color = this.low_color;
         mid_color = this.med_color;

--- a/cpufreq@mtwebster/files/cpufreq@mtwebster/po/cpufreq@mtwebster.pot
+++ b/cpufreq@mtwebster/files/cpufreq@mtwebster/po/cpufreq@mtwebster.pot
@@ -101,6 +101,27 @@ msgstr ""
 msgid "Clock speed"
 msgstr ""
 
+#. cpufreq@mtwebster->settings-schema.json->digit-units->description
+msgid "Clock speed units:"
+msgstr ""
+
+#. cpufreq@mtwebster->settings-schema.json->digit-units->tooltip
+msgid ""
+"Always show the clock speed in the same units."
+msgstr ""
+
+#. cpufreq@mtwebster->settings-schema.json->digit-units->options
+msgid "Auto"
+msgstr ""
+
+#. cpufreq@mtwebster->settings-schema.json->digit-units->options
+msgid "MHz"
+msgstr ""
+
+#. cpufreq@mtwebster->settings-schema.json->digit-units->options
+msgid "GHz"
+msgstr ""
+
 #. cpufreq@mtwebster->settings-schema.json->high-color->description
 msgid "The high level color for each graph bar:"
 msgstr ""

--- a/cpufreq@mtwebster/files/cpufreq@mtwebster/settings-schema.json
+++ b/cpufreq@mtwebster/files/cpufreq@mtwebster/settings-schema.json
@@ -38,6 +38,19 @@
         "indent": true,
         "tooltip": "Display the clock speed or a percentage of the maximum clock speed."
     },
+    "digit-units": {
+        "type": "combobox",
+        "default": 0,
+        "description": "Clock speed units:",
+        "options": {
+            "Auto": 0,
+            "MHz": 1,
+            "GHz": 2
+        },
+        "indent": true,
+        "dependency": "digit-type=0",
+        "tooltip": "Always show the clock speed in the same units."
+    },
     "graph-width": {
         "type": "scale",
         "default": 4,


### PR DESCRIPTION
When the CPU dynamically switches core frequency (e.g., from 400MHz to 4.54GHz), the digit count, and therefore the text width changes constantly. This pull request adds an option to display the clock speed either automatically or in fixed units.
Before
<img width="521" height="28" alt="Screenshot from 2026-09-07 08-24-35" src="https://github.com/user-attachments/assets/9454f03d-92bc-4868-8ce4-f9bdeaf37b85" />
after
<img width="435" height="35" alt="Screenshot from 2026-09-07 08-25-14" src="https://github.com/user-attachments/assets/cf9af424-447d-4ad3-a233-0dc3a009e984" />

@mtwebster have a look, please 