### PR TITLE
sound150@claudiux: Keep sliders within popup menu

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/6.6/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.6/applet.js
@@ -226,6 +226,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         this.alreadyCalledBysetAppletTooltip = false;
 
         this._appVolumeSection = new PopupMenu.PopupMenuSection();
+        this._appVolumeSection.actor.clip_to_allocation = true;
 
         this.real_ui_scale = 1.0;
         this.menuWidth = 450;
@@ -555,6 +556,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, this.orientation);
+        this.menu.box.clip_to_allocation = true;
         this.menuManager.addMenu(this.menu);
         this._resizer = new Applet.PopupResizeHandler(
             this.menu.actor,
@@ -1407,7 +1409,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
 
     on_applet_added_to_panel() {
         this.themeNode = null;
-        this.menu.actor.set_width(this.popup_width);
+        this._setMenuWidth();
         this.title_text_old = "";
         this.startingUp = true;
         if (this._playerctl)
@@ -1583,12 +1585,16 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         else
             this._remove_OsdWithNumberATJosephMcc_button.actor.hide();
         this._balanceSection._onValueInit();
-        this.menu.actor.set_width(this.popup_width);
+        this._setMenuWidth();
     }
 
     _openMenu() {
-        this.menu.actor.set_width(this.popup_width);
+        this._setMenuWidth();
         this.menu.toggle(true);
+    }
+
+    _setMenuWidth() {
+        this.menu.actor.set_width(Math.round(Math.max(this.popup_width, 300) * this.real_ui_scale));
     }
 
     _toggle_out_mute() {

--- a/sound150@claudiux/files/sound150@claudiux/6.6/lib/balanceSlider.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.6/lib/balanceSlider.js
@@ -30,6 +30,7 @@ class BalanceSlider extends PopupMenu.PopupSliderMenuItem {
         });
         if (this._slider)
             this.removeActor(this._slider);
+        this._slider.style = "min-width: 6em;";
         this.addActor(this.icon, {span: 0});
         this.addActor(this._slider, {
             span: -1,

--- a/sound150@claudiux/files/sound150@claudiux/6.6/lib/volumeSlider.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.6/lib/volumeSlider.js
@@ -105,6 +105,7 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
 
         if (this._slider)
             this.removeActor(this._slider);
+        this._slider.style = "min-width: 6em;";
         //this.addActor(this.icon, {span: 0});
         this.addActor(this.button.actor, {
             span: 0

--- a/sound150@claudiux/files/sound150@claudiux/6.7/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.7/applet.js
@@ -229,6 +229,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         this.alreadyCalledBysetAppletTooltip = false;
 
         this._appVolumeSection = new PopupMenu.PopupMenuSection();
+        this._appVolumeSection.actor.clip_to_allocation = true;
 
         this.real_ui_scale = 1.0;
         this.menuWidth = 450;
@@ -558,6 +559,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, this.orientation);
+        this.menu.box.clip_to_allocation = true;
         this.menuManager.addMenu(this.menu);
         this._resizer = new Applet.PopupResizeHandler(
             this.menu.actor,
@@ -1410,7 +1412,7 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
 
     on_applet_added_to_panel() {
         this.themeNode = null;
-        this.menu.actor.set_width(this.popup_width);
+        this._setMenuWidth();
         this.title_text_old = "";
         this.startingUp = true;
         if (this._playerctl)
@@ -1586,12 +1588,16 @@ var Sound150Applet = class Sound150Applet extends Applet.TextIconApplet {
         else
             this._remove_OsdWithNumberATJosephMcc_button.actor.hide();
         this._balanceSection._onValueInit();
-        this.menu.actor.set_width(this.popup_width);
+        this._setMenuWidth();
     }
 
     _openMenu() {
-        this.menu.actor.set_width(this.popup_width);
+        this._setMenuWidth();
         this.menu.toggle(true);
+    }
+
+    _setMenuWidth() {
+        this.menu.actor.set_width(Math.round(Math.max(this.popup_width, 300) * this.real_ui_scale));
     }
 
     _toggle_out_mute() {

--- a/sound150@claudiux/files/sound150@claudiux/6.7/lib/balanceSlider.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.7/lib/balanceSlider.js
@@ -32,6 +32,7 @@ var BalanceSlider = class BalanceSlider extends PopupMenu.PopupSliderMenuItem {
         });
         if (this._slider)
             this.removeActor(this._slider);
+        this._slider.style = "min-width: 6em;";
         this.addActor(this.icon, {span: 0});
         this.addActor(this._slider, {
             span: -1,

--- a/sound150@claudiux/files/sound150@claudiux/6.7/lib/volumeSlider.js
+++ b/sound150@claudiux/files/sound150@claudiux/6.7/lib/volumeSlider.js
@@ -107,6 +107,7 @@ var VolumeSlider = class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
 
         if (this._slider)
             this.removeActor(this._slider);
+        this._slider.style = "min-width: 6em;";
         //this.addActor(this.icon, {span: 0});
         this.addActor(this.button.actor, {
             span: 0

--- a/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v16.5.2~20260909
+  * Keeps popup menu contents inside the menu width.
+
 ### v16.5.1~20260908
   * Avoids synchronous cover image loading.
 

--- a/sound150@claudiux/files/sound150@claudiux/metadata.json
+++ b/sound150@claudiux/files/sound150@claudiux/metadata.json
@@ -5,7 +5,7 @@
   "max-instances": "1",
   "description": "Enhanced sound applet",
   "hide-configuration": false,
-  "version": "16.5.1",
+  "version": "16.5.2",
   "cinnamon-version": [
     "2.8",
     "3.0",


### PR DESCRIPTION
Fixes a layout problem I noticed on a small/scaled tablet display where the Sound150 popup contents could draw past the right side of the menu.

The slider rows were using Cinnamon's generic popup slider minimum width, which was too wide for this menu layout. This sets the Sound150 volume and balance sliders to the same 6em minimum used by Cinnamon's stock sound applet. It also clips the menu content box and the nested Applications section to their allocation, and applies the saved menu width through one scale-aware helper so the popup width is consistent when the applet is added or opened.

Tested with node --check for the touched JS files and ./validate-spice sound150@claudiux.