### PR TITLE
[FM-Radio@hilyxx] - v1.3.3 - Fix Gst.init crash

### DIFF
--- a/FM-Radio@hilyxx/CHANGELOG.md
+++ b/FM-Radio@hilyxx/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.3
+
+* Add try/catch fallback for Gst.init to fix GJS strict type crashes
+
 ## 1.3.1 - 1.3.2
 
 * Small code refactor (Optimize startup performance and disk reads)

--- a/FM-Radio@hilyxx/files/FM-Radio@hilyxx/metadata.json
+++ b/FM-Radio@hilyxx/files/FM-Radio@hilyxx/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "FM-Radio@hilyxx",
     "name": "FM Radio",
     "description": "A stupidly simple radio player for Cinnamon",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "max-instances": 1,
     "multiversion": true,
     "cinnamon-version": [

--- a/FM-Radio@hilyxx/files/FM-Radio@hilyxx/radio.js
+++ b/FM-Radio@hilyxx/files/FM-Radio@hilyxx/radio.js
@@ -142,7 +142,13 @@ const RadioPlayer = class RadioPlayer {
     _initPipeline() {
         if (this.playbin && this.sink) return;
 
-        Gst.init([]);
+         // Gst.init(null) prevents a complete session crash on older GJS (e.g., Linux Mint).
+        // The fallback to [] handles strict type errors on newer GJS (e.g., Arch/CachyOS).
+        try {
+            Gst.init(null);
+        } catch (e) {
+            Gst.init([]);
+        }
         
         this.playbin = Gst.ElementFactory.make("playbin", "fmradio");
         


### PR DESCRIPTION
- add try/catch fallback for Gst.init to fix GJS strict type crashes.
Older GJS (Mint/Ubuntu) needs null to avoid crashing with []. Strict GJS (CachyOS/Arch) rejects null and needs []. The try/catch block handles both cases.

I hope this will be the last update needed to fix this issue.